### PR TITLE
fix: add DATABASE_URL to Prisma datasource for migrate deploy

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,10 +5,9 @@ generator client {
 
 datasource db {
   provider   = "postgresql"
+  url        = env("DATABASE_URL")
   extensions = [pgcrypto]
 }
-
-// NOTE: La connection URL est configuree dans prisma/prisma.config.ts (Prisma 7+)
 
 // ═══════════════════════════════════════════════════════════════
 // ENUMS


### PR DESCRIPTION
The Prisma schema datasource block was missing `url = env("DATABASE_URL")`. Prisma 7 `migrate deploy` requires this even when the env var is set.

Generated with Claude Code