### PR TITLE
feat: complete Phase 3 & 4 — pump events + basal config routes

### DIFF
--- a/src/app/api/insulin-therapy/basal-config/pump-slots/route.ts
+++ b/src/app/api/insulin-therapy/basal-config/pump-slots/route.ts
@@ -8,7 +8,7 @@
 
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
-import { requireAuth, AuthError } from "@/lib/auth"
+import { requireAuth, requireRole, AuthError } from "@/lib/auth"
 import { resolvePatientId } from "@/lib/access-control"
 import { requireGdprConsent } from "@/lib/gdpr"
 import { insulinTherapyService, INSULIN_BOUNDS } from "@/lib/services/insulin-therapy.service"
@@ -21,6 +21,9 @@ const createSlotSchema = z.object({
   startTime: z.string().regex(timeRegex, "Format HH:MM required"),
   endTime: z.string().regex(timeRegex, "Format HH:MM required"),
   rate: z.number().min(INSULIN_BOUNDS.BASAL_MIN).max(INSULIN_BOUNDS.BASAL_MAX),
+}).refine((d) => d.startTime !== d.endTime, {
+  message: "startTime and endTime must be different — a zero-duration slot is invalid",
+  path: ["endTime"],
 })
 
 const deleteSlotSchema = z.object({
@@ -68,11 +71,11 @@ export async function GET(req: NextRequest) {
 
 /**
  * POST /api/insulin-therapy/basal-config/pump-slots
- * Create a new pump basal slot.
+ * Create a new pump basal slot. Requires NURSE+ role.
  */
 export async function POST(req: NextRequest) {
   try {
-    const user = requireAuth(req)
+    const user = requireRole(req, "NURSE")
     const hasConsent = await requireGdprConsent(user.id)
     if (!hasConsent) {
       return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
@@ -120,11 +123,11 @@ export async function POST(req: NextRequest) {
 
 /**
  * DELETE /api/insulin-therapy/basal-config/pump-slots?id=
- * Delete a pump basal slot by UUID.
+ * Delete a pump basal slot by UUID. Requires NURSE+ role.
  */
 export async function DELETE(req: NextRequest) {
   try {
-    const user = requireAuth(req)
+    const user = requireRole(req, "NURSE")
     const hasConsent = await requireGdprConsent(user.id)
     if (!hasConsent) {
       return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })

--- a/src/app/api/insulin-therapy/basal-config/pump-slots/route.ts
+++ b/src/app/api/insulin-therapy/basal-config/pump-slots/route.ts
@@ -1,0 +1,155 @@
+/**
+ * @module /api/insulin-therapy/basal-config/pump-slots
+ * @description Pump basal slot routes — GET (list), POST (create), DELETE (remove).
+ * US-402 — Pump basal slots define hourly basal rates for insulin pump delivery.
+ * Rate validated within clinical bounds (BASAL_MIN: 0.05, BASAL_MAX: 10.0 U/h).
+ * All operations require auth + GDPR consent + audit logging.
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireAuth, AuthError } from "@/lib/auth"
+import { resolvePatientId } from "@/lib/access-control"
+import { requireGdprConsent } from "@/lib/gdpr"
+import { insulinTherapyService, INSULIN_BOUNDS } from "@/lib/services/insulin-therapy.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+
+const timeRegex = /^([01]\d|2[0-3]):[0-5]\d$/
+
+const createSlotSchema = z.object({
+  patientId: z.number().int().positive().optional(),
+  startTime: z.string().regex(timeRegex, "Format HH:MM required"),
+  endTime: z.string().regex(timeRegex, "Format HH:MM required"),
+  rate: z.number().min(INSULIN_BOUNDS.BASAL_MIN).max(INSULIN_BOUNDS.BASAL_MAX),
+})
+
+const deleteSlotSchema = z.object({
+  id: z.string().uuid(),
+})
+
+/**
+ * GET /api/insulin-therapy/basal-config/pump-slots?patientId=
+ * Returns all pump basal slots for a patient's basal configuration.
+ */
+export async function GET(req: NextRequest) {
+  try {
+    const user = requireAuth(req)
+    const hasConsent = await requireGdprConsent(user.id)
+    if (!hasConsent) {
+      return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
+    }
+
+    const patientIdParam = req.nextUrl.searchParams.get("patientId")
+    const patientId = await resolvePatientId(
+      user.id, user.role,
+      patientIdParam ? parseInt(patientIdParam, 10) : undefined,
+    )
+    if (!patientId) {
+      return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    }
+
+    const ctx = extractRequestContext(req)
+    const settings = await insulinTherapyService.getSettings(patientId, user.id, ctx)
+    if (!settings) {
+      return NextResponse.json({ error: "settingsNotFound" }, { status: 404 })
+    }
+
+    const config = await insulinTherapyService.getBasalConfig(settings.id)
+    return NextResponse.json(config?.pumpSlots ?? [])
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    console.error("[pump-slots GET]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}
+
+/**
+ * POST /api/insulin-therapy/basal-config/pump-slots
+ * Create a new pump basal slot.
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const user = requireAuth(req)
+    const hasConsent = await requireGdprConsent(user.id)
+    if (!hasConsent) {
+      return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
+    }
+
+    const body = await req.json()
+    const parsed = createSlotSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+
+    const { patientId: pidParam, ...slotInput } = parsed.data
+    const patientId = await resolvePatientId(user.id, user.role, pidParam)
+    if (!patientId) {
+      return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    }
+
+    const settings = await insulinTherapyService.getSettings(patientId, user.id)
+    if (!settings) {
+      return NextResponse.json({ error: "settingsNotFound" }, { status: 404 })
+    }
+
+    const config = await insulinTherapyService.getBasalConfig(settings.id)
+    if (!config) {
+      return NextResponse.json({ error: "basalConfigNotFound" }, { status: 404 })
+    }
+
+    const slot = await insulinTherapyService.createPumpSlot(
+      config.id, slotInput, user.id,
+    )
+
+    return NextResponse.json(slot, { status: 201 })
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    console.error("[pump-slots POST]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}
+
+/**
+ * DELETE /api/insulin-therapy/basal-config/pump-slots?id=
+ * Delete a pump basal slot by UUID.
+ */
+export async function DELETE(req: NextRequest) {
+  try {
+    const user = requireAuth(req)
+    const hasConsent = await requireGdprConsent(user.id)
+    if (!hasConsent) {
+      return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
+    }
+
+    const params = Object.fromEntries(req.nextUrl.searchParams)
+    const parsed = deleteSlotSchema.safeParse(params)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+
+    const result = await insulinTherapyService.deletePumpSlot(
+      parsed.data.id, user.id,
+    )
+
+    return NextResponse.json(result)
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    console.error("[pump-slots DELETE]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/app/api/insulin-therapy/basal-config/pump-slots/route.ts
+++ b/src/app/api/insulin-therapy/basal-config/pump-slots/route.ts
@@ -28,6 +28,7 @@ const createSlotSchema = z.object({
 
 const deleteSlotSchema = z.object({
   id: z.string().uuid(),
+  patientId: z.coerce.number().int().positive().optional(),
 })
 
 /**
@@ -57,8 +58,8 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: "settingsNotFound" }, { status: 404 })
     }
 
-    const config = await insulinTherapyService.getBasalConfig(settings.id)
-    return NextResponse.json(config?.pumpSlots ?? [])
+    // M3 fix: getSettings already includes basalConfiguration.pumpSlots — no second query
+    return NextResponse.json(settings.basalConfiguration?.pumpSlots ?? [])
   } catch (error) {
     if (error instanceof AuthError) {
       return NextResponse.json({ error: error.message }, { status: error.status })
@@ -96,18 +97,20 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
     }
 
-    const settings = await insulinTherapyService.getSettings(patientId, user.id)
+    const ctx = extractRequestContext(req)
+    const settings = await insulinTherapyService.getSettings(patientId, user.id, ctx)
     if (!settings) {
       return NextResponse.json({ error: "settingsNotFound" }, { status: 404 })
     }
 
-    const config = await insulinTherapyService.getBasalConfig(settings.id)
+    // M3 fix: reuse basalConfiguration from getSettings (already included)
+    const config = settings.basalConfiguration
     if (!config) {
       return NextResponse.json({ error: "basalConfigNotFound" }, { status: 404 })
     }
 
     const slot = await insulinTherapyService.createPumpSlot(
-      config.id, slotInput, user.id,
+      config.id, slotInput, user.id, ctx,
     )
 
     return NextResponse.json(slot, { status: 201 })
@@ -142,8 +145,27 @@ export async function DELETE(req: NextRequest) {
       )
     }
 
+    // B1 fix: verify slot belongs to caller's patient before deleting
+    const patientId = await resolvePatientId(user.id, user.role, parsed.data.patientId)
+    if (!patientId) {
+      return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    }
+
+    const ctx = extractRequestContext(req)
+    const settings = await insulinTherapyService.getSettings(patientId, user.id, ctx)
+    if (!settings?.basalConfiguration) {
+      return NextResponse.json({ error: "basalConfigNotFound" }, { status: 404 })
+    }
+
+    const slotBelongs = settings.basalConfiguration.pumpSlots.some(
+      (s) => s.id === parsed.data.id,
+    )
+    if (!slotBelongs) {
+      return NextResponse.json({ error: "slotNotFound" }, { status: 404 })
+    }
+
     const result = await insulinTherapyService.deletePumpSlot(
-      parsed.data.id, user.id,
+      parsed.data.id, user.id, ctx,
     )
 
     return NextResponse.json(result)

--- a/src/app/api/insulin-therapy/basal-config/route.ts
+++ b/src/app/api/insulin-therapy/basal-config/route.ts
@@ -1,0 +1,113 @@
+/**
+ * @module /api/insulin-therapy/basal-config
+ * @description Basal configuration routes — GET (read), PUT (upsert).
+ * US-402 — Basal configuration (pump & injections).
+ * Supports pump, single_injection, and split_injection delivery types.
+ * All operations require auth + GDPR consent + audit logging.
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { BasalConfigType } from "@prisma/client"
+import { requireAuth, AuthError } from "@/lib/auth"
+import { resolvePatientId } from "@/lib/access-control"
+import { requireGdprConsent } from "@/lib/gdpr"
+import { insulinTherapyService } from "@/lib/services/insulin-therapy.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+
+const upsertSchema = z.object({
+  patientId: z.number().int().positive().optional(),
+  configType: z.nativeEnum(BasalConfigType),
+  totalDailyDose: z.number().min(0).max(200).optional(),
+  morningDose: z.number().min(0).max(100).optional(),
+  eveningDose: z.number().min(0).max(100).optional(),
+  dailyDose: z.number().min(0).max(200).optional(),
+})
+
+/**
+ * GET /api/insulin-therapy/basal-config?patientId=
+ * Returns basal configuration with pump slots for a patient.
+ */
+export async function GET(req: NextRequest) {
+  try {
+    const user = requireAuth(req)
+    const hasConsent = await requireGdprConsent(user.id)
+    if (!hasConsent) {
+      return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
+    }
+
+    const patientIdParam = req.nextUrl.searchParams.get("patientId")
+    const patientId = await resolvePatientId(
+      user.id, user.role,
+      patientIdParam ? parseInt(patientIdParam, 10) : undefined,
+    )
+    if (!patientId) {
+      return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    }
+
+    const ctx = extractRequestContext(req)
+    const settings = await insulinTherapyService.getSettings(patientId, user.id, ctx)
+    if (!settings) {
+      return NextResponse.json({ error: "settingsNotFound" }, { status: 404 })
+    }
+
+    const config = await insulinTherapyService.getBasalConfig(settings.id)
+    return NextResponse.json(config ?? { message: "noBasalConfig" })
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    console.error("[basal-config GET]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}
+
+/**
+ * PUT /api/insulin-therapy/basal-config
+ * Create or update basal configuration for a patient.
+ */
+export async function PUT(req: NextRequest) {
+  try {
+    const user = requireAuth(req)
+    const hasConsent = await requireGdprConsent(user.id)
+    if (!hasConsent) {
+      return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
+    }
+
+    const body = await req.json()
+    const parsed = upsertSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+
+    const { patientId: pidParam, ...configInput } = parsed.data
+    const patientId = await resolvePatientId(user.id, user.role, pidParam)
+    if (!patientId) {
+      return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    }
+
+    const settings = await insulinTherapyService.getSettings(patientId, user.id)
+    if (!settings) {
+      return NextResponse.json({ error: "settingsNotFound" }, { status: 404 })
+    }
+
+    const result = await insulinTherapyService.upsertBasalConfig(
+      settings.id,
+      { ...configInput, settingsId: settings.id },
+      user.id,
+    )
+
+    return NextResponse.json(result)
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    console.error("[basal-config PUT]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/app/api/insulin-therapy/basal-config/route.ts
+++ b/src/app/api/insulin-therapy/basal-config/route.ts
@@ -9,7 +9,7 @@
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
 import { BasalConfigType } from "@prisma/client"
-import { requireAuth, AuthError } from "@/lib/auth"
+import { requireAuth, requireRole, AuthError } from "@/lib/auth"
 import { resolvePatientId } from "@/lib/access-control"
 import { requireGdprConsent } from "@/lib/gdpr"
 import { insulinTherapyService } from "@/lib/services/insulin-therapy.service"
@@ -52,7 +52,10 @@ export async function GET(req: NextRequest) {
     }
 
     const config = await insulinTherapyService.getBasalConfig(settings.id)
-    return NextResponse.json(config ?? { message: "noBasalConfig" })
+    if (!config) {
+      return NextResponse.json({ error: "basalConfigNotFound" }, { status: 404 })
+    }
+    return NextResponse.json(config)
   } catch (error) {
     if (error instanceof AuthError) {
       return NextResponse.json({ error: error.message }, { status: error.status })
@@ -69,7 +72,7 @@ export async function GET(req: NextRequest) {
  */
 export async function PUT(req: NextRequest) {
   try {
-    const user = requireAuth(req)
+    const user = requireRole(req, "NURSE")
     const hasConsent = await requireGdprConsent(user.id)
     if (!hasConsent) {
       return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })

--- a/src/app/api/insulin-therapy/basal-config/route.ts
+++ b/src/app/api/insulin-therapy/basal-config/route.ts
@@ -93,7 +93,8 @@ export async function PUT(req: NextRequest) {
       return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
     }
 
-    const settings = await insulinTherapyService.getSettings(patientId, user.id)
+    const ctx = extractRequestContext(req)
+    const settings = await insulinTherapyService.getSettings(patientId, user.id, ctx)
     if (!settings) {
       return NextResponse.json({ error: "settingsNotFound" }, { status: 404 })
     }
@@ -102,6 +103,7 @@ export async function PUT(req: NextRequest) {
       settings.id,
       { ...configInput, settingsId: settings.id },
       user.id,
+      ctx,
     )
 
     return NextResponse.json(result)

--- a/src/app/api/pump-events/route.ts
+++ b/src/app/api/pump-events/route.ts
@@ -1,0 +1,164 @@
+/**
+ * @module /api/pump-events
+ * @description Pump event routes — GET (list), POST (create), DELETE (remove).
+ * US-304 — Insulin flow & pump events.
+ * Pump events track alarms, suspends, resets, bolus deliveries from insulin pumps.
+ * All operations require auth + GDPR consent + audit logging.
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import type { Prisma } from "@prisma/client"
+import { requireAuth, AuthError } from "@/lib/auth"
+import { resolvePatientId } from "@/lib/access-control"
+import { requireGdprConsent } from "@/lib/gdpr"
+import { glycemiaService } from "@/lib/services/glycemia.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+
+const querySchema = z.object({
+  patientId: z.coerce.number().int().positive().optional(),
+  from: z.coerce.date(),
+  to: z.coerce.date(),
+  eventType: z.string().max(50).optional(),
+})
+
+const createSchema = z.object({
+  patientId: z.number().int().positive().optional(),
+  timestamp: z.coerce.date(),
+  eventType: z.string().min(1).max(50),
+  data: z.record(z.string(), z.unknown()).optional(),
+})
+
+const deleteSchema = z.object({
+  id: z.number().int().positive(),
+})
+
+/**
+ * GET /api/pump-events?from=&to=&patientId=&eventType=
+ * Returns pump events for a patient within a date range.
+ */
+export async function GET(req: NextRequest) {
+  try {
+    const user = requireAuth(req)
+    const hasConsent = await requireGdprConsent(user.id)
+    if (!hasConsent) {
+      return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
+    }
+
+    const params = Object.fromEntries(req.nextUrl.searchParams)
+    const parsed = querySchema.safeParse(params)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+
+    const { from, to, eventType, patientId: pidParam } = parsed.data
+    const patientId = await resolvePatientId(user.id, user.role, pidParam)
+    if (!patientId) {
+      return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    }
+
+    const ctx = extractRequestContext(req)
+    const events = await glycemiaService.getPumpEvents(
+      patientId, from, to, user.id, ctx, eventType,
+    )
+
+    return NextResponse.json(events)
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    if (msg.includes("Period cannot exceed")) {
+      return NextResponse.json({ error: msg }, { status: 400 })
+    }
+    console.error("[pump-events GET]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}
+
+/**
+ * POST /api/pump-events
+ * Create a new pump event for a patient.
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const user = requireAuth(req)
+    const hasConsent = await requireGdprConsent(user.id)
+    if (!hasConsent) {
+      return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
+    }
+
+    const body = await req.json()
+    const parsed = createSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+
+    const { patientId: pidParam, data, ...rest } = parsed.data
+    const patientId = await resolvePatientId(user.id, user.role, pidParam)
+    if (!patientId) {
+      return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    }
+
+    const ctx = extractRequestContext(req)
+    const eventInput = {
+      ...rest,
+      data: data as Prisma.InputJsonValue | undefined,
+    }
+    const event = await glycemiaService.createPumpEvent(
+      patientId, eventInput, user.id, ctx,
+    )
+
+    return NextResponse.json(event, { status: 201 })
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    console.error("[pump-events POST]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}
+
+/**
+ * DELETE /api/pump-events?id=
+ * Delete a pump event by ID.
+ */
+export async function DELETE(req: NextRequest) {
+  try {
+    const user = requireAuth(req)
+    const hasConsent = await requireGdprConsent(user.id)
+    if (!hasConsent) {
+      return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
+    }
+
+    const params = Object.fromEntries(req.nextUrl.searchParams)
+    const parsed = deleteSchema.safeParse(params)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+
+    const ctx = extractRequestContext(req)
+    const result = await glycemiaService.deletePumpEvent(
+      parsed.data.id, user.id, ctx,
+    )
+
+    return NextResponse.json(result)
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    console.error("[pump-events DELETE]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/app/api/pump-events/route.ts
+++ b/src/app/api/pump-events/route.ts
@@ -30,7 +30,8 @@ const createSchema = z.object({
 })
 
 const deleteSchema = z.object({
-  id: z.number().int().positive(),
+  id: z.coerce.number().int().positive(),
+  patientId: z.coerce.number().int().positive().optional(),
 })
 
 /**
@@ -147,7 +148,22 @@ export async function DELETE(req: NextRequest) {
       )
     }
 
+    // S1 fix: verify the pump event belongs to the caller's patient
+    const patientId = await resolvePatientId(user.id, user.role, parsed.data.patientId)
+    if (!patientId) {
+      return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    }
+
     const ctx = extractRequestContext(req)
+
+    // Verify event ownership before deleting
+    const ownershipOk = await glycemiaService.verifyPumpEventOwnership(
+      parsed.data.id, patientId,
+    )
+    if (!ownershipOk) {
+      return NextResponse.json({ error: "pumpEventNotFound" }, { status: 404 })
+    }
+
     const result = await glycemiaService.deletePumpEvent(
       parsed.data.id, user.id, ctx,
     )

--- a/src/app/api/pump-events/route.ts
+++ b/src/app/api/pump-events/route.ts
@@ -9,24 +9,33 @@
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
 import type { Prisma } from "@prisma/client"
-import { requireAuth, AuthError } from "@/lib/auth"
+import { requireAuth, requireRole, AuthError } from "@/lib/auth"
 import { resolvePatientId } from "@/lib/access-control"
 import { requireGdprConsent } from "@/lib/gdpr"
 import { glycemiaService } from "@/lib/services/glycemia.service"
 import { extractRequestContext } from "@/lib/services/audit.service"
 
+/** Allowed pump event types — aligns with device data standards */
+const PUMP_EVENT_TYPES = [
+  "alarm", "suspend", "resume", "prime", "rewind",
+  "bolusDelivery", "basalChange", "cartridgeChange", "cannulaChange",
+] as const
+
 const querySchema = z.object({
   patientId: z.coerce.number().int().positive().optional(),
   from: z.coerce.date(),
   to: z.coerce.date(),
-  eventType: z.string().max(50).optional(),
+  eventType: z.enum(PUMP_EVENT_TYPES).optional(),
 })
 
 const createSchema = z.object({
   patientId: z.number().int().positive().optional(),
   timestamp: z.coerce.date(),
-  eventType: z.string().min(1).max(50),
-  data: z.record(z.string(), z.unknown()).optional(),
+  eventType: z.enum(PUMP_EVENT_TYPES),
+  data: z.record(z.string(), z.unknown()).optional().refine(
+    (d) => !d || JSON.stringify(d).length <= 4096,
+    { message: "data payload must be under 4KB" },
+  ),
 })
 
 const deleteSchema = z.object({
@@ -82,11 +91,11 @@ export async function GET(req: NextRequest) {
 
 /**
  * POST /api/pump-events
- * Create a new pump event for a patient.
+ * Create a new pump event for a patient. Requires NURSE+ role.
  */
 export async function POST(req: NextRequest) {
   try {
-    const user = requireAuth(req)
+    const user = requireRole(req, "NURSE")
     const hasConsent = await requireGdprConsent(user.id)
     if (!hasConsent) {
       return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
@@ -128,12 +137,12 @@ export async function POST(req: NextRequest) {
 }
 
 /**
- * DELETE /api/pump-events?id=
- * Delete a pump event by ID.
+ * DELETE /api/pump-events?id=&patientId=
+ * Delete a pump event by ID. Requires NURSE+ role.
  */
 export async function DELETE(req: NextRequest) {
   try {
-    const user = requireAuth(req)
+    const user = requireRole(req, "NURSE")
     const hasConsent = await requireGdprConsent(user.id)
     if (!hasConsent) {
       return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })

--- a/src/lib/services/audit.service.ts
+++ b/src/lib/services/audit.service.ts
@@ -67,6 +67,7 @@ export type AuditResource =
   | "SESSION"
   | "MYDIABBY_CREDENTIAL"
   | "MEDICATION"
+  | "PUMP_EVENT"
 
 /**
  * Audit log entry — parameters for logging an action.

--- a/src/lib/services/glycemia.service.ts
+++ b/src/lib/services/glycemia.service.ts
@@ -267,6 +267,22 @@ export const glycemiaService = {
   },
 
   /**
+   * Verify that a pump event belongs to a specific patient.
+   * Used for ownership check before delete operations.
+   * @async
+   * @param {number} eventId - PumpEvent ID
+   * @param {number} patientId - Expected patient ID
+   * @returns {Promise<boolean>} True if event belongs to patient
+   */
+  async verifyPumpEventOwnership(eventId: number, patientId: number): Promise<boolean> {
+    const event = await prisma.pumpEvent.findFirst({
+      where: { id: eventId, patientId },
+      select: { id: true },
+    })
+    return !!event
+  },
+
+  /**
    * Delete a pump event by ID.
    * @async
    * @param {number} id - PumpEvent ID

--- a/src/lib/services/glycemia.service.ts
+++ b/src/lib/services/glycemia.service.ts
@@ -8,6 +8,7 @@
  */
 
 import { prisma } from "@/lib/db/client"
+import type { Prisma } from "@prisma/client"
 import { auditService } from "./audit.service"
 import type { AuditContext } from "./patient.service"
 
@@ -224,5 +225,73 @@ export const glycemiaService = {
     })
 
     return entries
+  },
+
+  /**
+   * Create a new pump event (alarm, suspend, reset, bolus delivery, etc.).
+   * @async
+   * @param {number} patientId - Patient ID
+   * @param {Object} input - Event data (timestamp, eventType, data)
+   * @param {number} auditUserId - User performing create (audit trail)
+   * @param {AuditContext} [ctx] - Request context (IP, User-Agent)
+   * @returns {Promise<Object>} Created PumpEvent
+   */
+  async createPumpEvent(
+    patientId: number,
+    input: { timestamp: Date; eventType: string; data?: Prisma.InputJsonValue },
+    auditUserId: number,
+    ctx?: AuditContext,
+  ) {
+    return prisma.$transaction(async (tx) => {
+      const event = await tx.pumpEvent.create({
+        data: {
+          patientId,
+          timestamp: input.timestamp,
+          eventType: input.eventType,
+          data: input.data ?? undefined,
+        },
+      })
+
+      await auditService.logWithTx(tx, {
+        userId: auditUserId,
+        action: "CREATE",
+        resource: "PUMP_EVENT",
+        resourceId: String(event.id),
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+        metadata: { eventType: input.eventType },
+      })
+
+      return event
+    })
+  },
+
+  /**
+   * Delete a pump event by ID.
+   * @async
+   * @param {number} id - PumpEvent ID
+   * @param {number} auditUserId - User performing delete (audit trail)
+   * @param {AuditContext} [ctx] - Request context (IP, User-Agent)
+   * @returns {Promise<{deleted: true}>}
+   */
+  async deletePumpEvent(
+    id: number,
+    auditUserId: number,
+    ctx?: AuditContext,
+  ) {
+    return prisma.$transaction(async (tx) => {
+      await tx.pumpEvent.delete({ where: { id } })
+
+      await auditService.logWithTx(tx, {
+        userId: auditUserId,
+        action: "DELETE",
+        resource: "PUMP_EVENT",
+        resourceId: String(id),
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+      })
+
+      return { deleted: true }
+    })
   },
 }

--- a/src/lib/services/glycemia.service.ts
+++ b/src/lib/services/glycemia.service.ts
@@ -218,8 +218,8 @@ export const glycemiaService = {
     await auditService.log({
       userId: auditUserId,
       action: "READ",
-      resource: "INSULIN_THERAPY",
-      resourceId: `${patientId}:pumpEvents`,
+      resource: "PUMP_EVENT",
+      resourceId: `${patientId}:list`,
       ipAddress: ctx?.ipAddress,
       userAgent: ctx?.userAgent,
     })

--- a/src/lib/services/insulin-therapy.service.ts
+++ b/src/lib/services/insulin-therapy.service.ts
@@ -242,6 +242,7 @@ export const insulinTherapyService = {
     settingsId: number,
     input: Prisma.BasalConfigurationUncheckedCreateInput,
     auditUserId: number,
+    ctx?: AuditContext,
   ) {
     return prisma.$transaction(async (tx) => {
       const config = await tx.basalConfiguration.upsert({
@@ -254,6 +255,8 @@ export const insulinTherapyService = {
         action: "UPDATE",
         resource: "INSULIN_THERAPY",
         resourceId: `basal:${config.id}`,
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
       })
       return config
     })
@@ -264,8 +267,29 @@ export const insulinTherapyService = {
     basalConfigId: number,
     input: { startTime: string; endTime: string; rate: number },
     auditUserId: number,
+    ctx?: AuditContext,
   ) {
+    const startHour = parseInt(input.startTime.split(":")[0], 10)
+    const endHour = parseInt(input.endTime.split(":")[0], 10)
+
+    if (startHour === endHour && input.startTime === input.endTime) {
+      throw new Error("startTime and endTime must be different — a zero-duration slot is invalid")
+    }
+
     return prisma.$transaction(async (tx) => {
+      // B2 fix: overlap detection — prevents double basal delivery (patient safety)
+      const existing = await tx.pumpBasalSlot.findMany({
+        where: { basalConfigId },
+        select: { startTime: true, endTime: true },
+      })
+      const existingHours = existing.map((s) => ({
+        startHour: s.startTime.getUTCHours(),
+        endHour: s.endTime.getUTCHours(),
+      }))
+      if (hasTimeSlotOverlap(existingHours, startHour, endHour)) {
+        throw new Error("Pump basal slot overlaps with an existing slot — risk of double insulin delivery")
+      }
+
       const slot = await tx.pumpBasalSlot.create({
         data: {
           basalConfigId,
@@ -279,12 +303,14 @@ export const insulinTherapyService = {
         action: "CREATE",
         resource: "INSULIN_THERAPY",
         resourceId: slot.id,
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
       })
       return slot
     })
   },
 
-  async deletePumpSlot(id: string, auditUserId: number) {
+  async deletePumpSlot(id: string, auditUserId: number, ctx?: AuditContext) {
     return prisma.$transaction(async (tx) => {
       await tx.pumpBasalSlot.delete({ where: { id } })
       await auditService.logWithTx(tx, {
@@ -292,6 +318,8 @@ export const insulinTherapyService = {
         action: "DELETE",
         resource: "INSULIN_THERAPY",
         resourceId: id,
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
       })
       return { deleted: true }
     })

--- a/tests/unit/basal-config.service.test.ts
+++ b/tests/unit/basal-config.service.test.ts
@@ -92,7 +92,10 @@ describe("insulinTherapyService — basal config", () => {
       }
 
       const txMock = {
-        pumpBasalSlot: { create: vi.fn().mockResolvedValue(mockSlot) },
+        pumpBasalSlot: {
+          findMany: vi.fn().mockResolvedValue([]),
+          create: vi.fn().mockResolvedValue(mockSlot),
+        },
         auditLog: { create: vi.fn().mockResolvedValue({}) },
       }
       prismaMock.$transaction.mockImplementation(async (cb: any) => cb(txMock))
@@ -104,12 +107,32 @@ describe("insulinTherapyService — basal config", () => {
       )
 
       expect(result.rate).toBe(0.95)
+      expect(txMock.pumpBasalSlot.findMany).toHaveBeenCalled()
       expect(txMock.pumpBasalSlot.create).toHaveBeenCalledWith({
         data: expect.objectContaining({
           basalConfigId: 1,
           rate: 0.95,
         }),
       })
+    })
+
+    it("rejects overlapping pump slots", async () => {
+      const existingSlot = {
+        startTime: new Date("1970-01-01T06:00:00Z"),
+        endTime: new Date("1970-01-01T12:00:00Z"),
+      }
+
+      const txMock = {
+        pumpBasalSlot: {
+          findMany: vi.fn().mockResolvedValue([existingSlot]),
+        },
+        auditLog: { create: vi.fn() },
+      }
+      prismaMock.$transaction.mockImplementation(async (cb: any) => cb(txMock))
+
+      await expect(
+        insulinTherapyService.createPumpSlot(1, { startTime: "08:00", endTime: "14:00", rate: 0.8 }, 1),
+      ).rejects.toThrow("overlaps")
     })
   })
 

--- a/tests/unit/basal-config.service.test.ts
+++ b/tests/unit/basal-config.service.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Test suite: Basal Configuration — GET, UPSERT, Pump Slots CRUD
+ *
+ * Clinical behavior tested:
+ * - Retrieval of basal configuration with pump slots ordered by start time
+ * - Upsert of basal configuration (create or update) with audit trail
+ * - Creation of pump basal slots with time-of-day delivery rates
+ * - Deletion of pump basal slots with audit trail
+ *
+ * Associated risks:
+ * - Incorrect basal rate storage (out of 0.05-10.0 U/h range) could cause
+ *   under/over-delivery of basal insulin
+ * - Missing audit on basal config changes prevents tracing who modified
+ *   critical insulin delivery parameters
+ * - Overlapping pump slots could cause double-delivery in same time window
+ *
+ * Edge cases:
+ * - getBasalConfig when no config exists (returns null)
+ * - upsertBasalConfig creates new when none exists
+ * - deletePumpSlot on non-existent slot (should throw)
+ */
+import { describe, it, expect, vi } from "vitest"
+import { prismaMock } from "../helpers/prisma-mock"
+
+import { insulinTherapyService } from "@/lib/services/insulin-therapy.service"
+
+describe("insulinTherapyService — basal config", () => {
+  describe("getBasalConfig", () => {
+    it("returns config with pump slots", async () => {
+      const mockConfig = {
+        id: 1,
+        settingsId: 10,
+        configType: "pump",
+        totalDailyDose: 24.5,
+        pumpSlots: [
+          { id: "uuid-1", startTime: new Date("1970-01-01T00:00:00Z"), endTime: new Date("1970-01-01T06:00:00Z"), rate: 0.8 },
+          { id: "uuid-2", startTime: new Date("1970-01-01T06:00:00Z"), endTime: new Date("1970-01-01T12:00:00Z"), rate: 1.2 },
+        ],
+      }
+      prismaMock.basalConfiguration.findUnique.mockResolvedValue(mockConfig as any)
+
+      const result = await insulinTherapyService.getBasalConfig(10)
+
+      expect(result).not.toBeNull()
+      expect(result!.pumpSlots).toHaveLength(2)
+      expect(result!.configType).toBe("pump")
+    })
+
+    it("returns null when no config", async () => {
+      prismaMock.basalConfiguration.findUnique.mockResolvedValue(null)
+
+      const result = await insulinTherapyService.getBasalConfig(999)
+      expect(result).toBeNull()
+    })
+  })
+
+  describe("upsertBasalConfig", () => {
+    it("upserts config with audit log", async () => {
+      const mockConfig = {
+        id: 1,
+        settingsId: 10,
+        configType: "pump",
+        totalDailyDose: 24.5,
+      }
+
+      const txMock = {
+        basalConfiguration: { upsert: vi.fn().mockResolvedValue(mockConfig) },
+        auditLog: { create: vi.fn().mockResolvedValue({}) },
+      }
+      prismaMock.$transaction.mockImplementation(async (cb: any) => cb(txMock))
+
+      const result = await insulinTherapyService.upsertBasalConfig(
+        10,
+        { settingsId: 10, configType: "pump", totalDailyDose: 24.5 } as any,
+        1,
+      )
+
+      expect(result.configType).toBe("pump")
+      expect(txMock.basalConfiguration.upsert).toHaveBeenCalled()
+      expect(txMock.auditLog.create).toHaveBeenCalled()
+    })
+  })
+
+  describe("createPumpSlot", () => {
+    it("creates a pump slot with audit log", async () => {
+      const mockSlot = {
+        id: "uuid-new",
+        basalConfigId: 1,
+        startTime: new Date("1970-01-01T08:00:00Z"),
+        endTime: new Date("1970-01-01T12:00:00Z"),
+        rate: 0.95,
+      }
+
+      const txMock = {
+        pumpBasalSlot: { create: vi.fn().mockResolvedValue(mockSlot) },
+        auditLog: { create: vi.fn().mockResolvedValue({}) },
+      }
+      prismaMock.$transaction.mockImplementation(async (cb: any) => cb(txMock))
+
+      const result = await insulinTherapyService.createPumpSlot(
+        1,
+        { startTime: "08:00", endTime: "12:00", rate: 0.95 },
+        1,
+      )
+
+      expect(result.rate).toBe(0.95)
+      expect(txMock.pumpBasalSlot.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          basalConfigId: 1,
+          rate: 0.95,
+        }),
+      })
+    })
+  })
+
+  describe("deletePumpSlot", () => {
+    it("deletes a pump slot with audit log", async () => {
+      const txMock = {
+        pumpBasalSlot: { delete: vi.fn().mockResolvedValue({}) },
+        auditLog: { create: vi.fn().mockResolvedValue({}) },
+      }
+      prismaMock.$transaction.mockImplementation(async (cb: any) => cb(txMock))
+
+      const result = await insulinTherapyService.deletePumpSlot("uuid-1", 1)
+
+      expect(result).toEqual({ deleted: true })
+      expect(txMock.pumpBasalSlot.delete).toHaveBeenCalledWith({ where: { id: "uuid-1" } })
+    })
+
+    it("throws when slot does not exist", async () => {
+      const txMock = {
+        pumpBasalSlot: { delete: vi.fn().mockRejectedValue(new Error("Record not found")) },
+        auditLog: { create: vi.fn() },
+      }
+      prismaMock.$transaction.mockImplementation(async (cb: any) => cb(txMock))
+
+      await expect(insulinTherapyService.deletePumpSlot("nonexistent", 1)).rejects.toThrow("Record not found")
+    })
+  })
+})

--- a/tests/unit/pump-events.service.test.ts
+++ b/tests/unit/pump-events.service.test.ts
@@ -80,6 +80,26 @@ describe("glycemiaService — pump events", () => {
     })
   })
 
+  describe("verifyPumpEventOwnership", () => {
+    it("returns true when event belongs to patient", async () => {
+      prismaMock.pumpEvent.findFirst.mockResolvedValue({ id: 1 } as any)
+
+      const result = await glycemiaService.verifyPumpEventOwnership(1, 10)
+      expect(result).toBe(true)
+      expect(prismaMock.pumpEvent.findFirst).toHaveBeenCalledWith({
+        where: { id: 1, patientId: 10 },
+        select: { id: true },
+      })
+    })
+
+    it("returns false when event does not belong to patient", async () => {
+      prismaMock.pumpEvent.findFirst.mockResolvedValue(null)
+
+      const result = await glycemiaService.verifyPumpEventOwnership(1, 99)
+      expect(result).toBe(false)
+    })
+  })
+
   describe("deletePumpEvent", () => {
     it("deletes a pump event with audit log", async () => {
       const txMock = {

--- a/tests/unit/pump-events.service.test.ts
+++ b/tests/unit/pump-events.service.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Test suite: Pump Events — CREATE and DELETE operations
+ *
+ * Clinical behavior tested:
+ * - Creation of pump events (alarms, suspends, resets, bolus deliveries)
+ *   linked to a patient record with audit trail
+ * - Deletion of pump events with audit trail
+ * - Audit logging for both create and delete operations (HDS compliance)
+ *
+ * Associated risks:
+ * - Missing audit on pump event creation/deletion would break HDS traceability
+ * - Creating pump events for wrong patient = cross-patient data contamination
+ *
+ * Edge cases:
+ * - Create with optional JSON data field (undefined and present)
+ * - Delete non-existent event (should throw)
+ */
+import { describe, it, expect, vi } from "vitest"
+import { prismaMock } from "../helpers/prisma-mock"
+
+import { glycemiaService } from "@/lib/services/glycemia.service"
+
+describe("glycemiaService — pump events", () => {
+  describe("createPumpEvent", () => {
+    it("creates a pump event with audit log", async () => {
+      const mockEvent = {
+        id: 1,
+        patientId: 10,
+        timestamp: new Date("2026-04-01T08:00:00Z"),
+        eventType: "alarm",
+        data: { code: "LOW_RESERVOIR" },
+        createdAt: new Date(),
+      }
+
+      const txMock = {
+        pumpEvent: { create: vi.fn().mockResolvedValue(mockEvent) },
+        auditLog: { create: vi.fn().mockResolvedValue({}) },
+      }
+      prismaMock.$transaction.mockImplementation(async (cb: any) => cb(txMock))
+
+      const result = await glycemiaService.createPumpEvent(
+        10,
+        { timestamp: new Date("2026-04-01T08:00:00Z"), eventType: "alarm", data: { code: "LOW_RESERVOIR" } },
+        1,
+      )
+
+      expect(result).toEqual(mockEvent)
+      expect(txMock.pumpEvent.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          patientId: 10,
+          eventType: "alarm",
+        }),
+      })
+      expect(txMock.auditLog.create).toHaveBeenCalled()
+    })
+
+    it("creates a pump event without optional data field", async () => {
+      const mockEvent = {
+        id: 2,
+        patientId: 10,
+        timestamp: new Date("2026-04-01T09:00:00Z"),
+        eventType: "suspend",
+        data: null,
+        createdAt: new Date(),
+      }
+
+      const txMock = {
+        pumpEvent: { create: vi.fn().mockResolvedValue(mockEvent) },
+        auditLog: { create: vi.fn().mockResolvedValue({}) },
+      }
+      prismaMock.$transaction.mockImplementation(async (cb: any) => cb(txMock))
+
+      const result = await glycemiaService.createPumpEvent(
+        10,
+        { timestamp: new Date("2026-04-01T09:00:00Z"), eventType: "suspend" },
+        1,
+      )
+
+      expect(result.eventType).toBe("suspend")
+    })
+  })
+
+  describe("deletePumpEvent", () => {
+    it("deletes a pump event with audit log", async () => {
+      const txMock = {
+        pumpEvent: { delete: vi.fn().mockResolvedValue({}) },
+        auditLog: { create: vi.fn().mockResolvedValue({}) },
+      }
+      prismaMock.$transaction.mockImplementation(async (cb: any) => cb(txMock))
+
+      const result = await glycemiaService.deletePumpEvent(1, 1)
+
+      expect(result).toEqual({ deleted: true })
+      expect(txMock.pumpEvent.delete).toHaveBeenCalledWith({ where: { id: 1 } })
+      expect(txMock.auditLog.create).toHaveBeenCalled()
+    })
+
+    it("throws when event does not exist", async () => {
+      const txMock = {
+        pumpEvent: { delete: vi.fn().mockRejectedValue(new Error("Record not found")) },
+        auditLog: { create: vi.fn() },
+      }
+      prismaMock.$transaction.mockImplementation(async (cb: any) => cb(txMock))
+
+      await expect(glycemiaService.deletePumpEvent(999, 1)).rejects.toThrow("Record not found")
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- **US-304**: Add `GET/POST/DELETE /api/pump-events` — pump event CRUD with `createPumpEvent` and `deletePumpEvent` service methods, Zod validation, GDPR consent check, HDS audit logging
- **US-402**: Add `GET/PUT /api/insulin-therapy/basal-config` and `GET/POST/DELETE /api/insulin-therapy/basal-config/pump-slots` — basal configuration CRUD with clinical bounds validation (rate: 0.05–10.0 U/h)
- Add `PUMP_EVENT` to `AuditResource` type for HDS traceability
- 10 new unit tests, **810 total passing**, 0 TypeScript errors

## Changes
| File | Change |
|---|---|
| `src/app/api/pump-events/route.ts` | NEW — GET/POST/DELETE pump events |
| `src/app/api/insulin-therapy/basal-config/route.ts` | NEW — GET/PUT basal configuration |
| `src/app/api/insulin-therapy/basal-config/pump-slots/route.ts` | NEW — GET/POST/DELETE pump basal slots |
| `src/lib/services/glycemia.service.ts` | Add `createPumpEvent()`, `deletePumpEvent()` |
| `src/lib/services/audit.service.ts` | Add `PUMP_EVENT` to `AuditResource` |
| `tests/unit/pump-events.service.test.ts` | NEW — 4 tests |
| `tests/unit/basal-config.service.test.ts` | NEW — 6 tests |

## Test plan
- [x] TypeScript compiles with 0 errors (`npx tsc --noEmit`)
- [x] 810 tests pass (`npx vitest run`)
- [ ] Manual: `POST /api/pump-events` creates event + audit log
- [ ] Manual: `GET /api/pump-events?from=&to=` returns filtered events
- [ ] Manual: `PUT /api/insulin-therapy/basal-config` upserts config
- [ ] Manual: `POST /api/insulin-therapy/basal-config/pump-slots` creates slot within bounds
- [ ] Manual: Rate outside [0.05, 10.0] returns 400 validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)