### PR TITLE
docs(security): full-project audit 2026-04-15 — US-SEC-001 + US-SEC-002

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ releases, so entries are grouped by merged PR and calendar date.
 
 ## [Unreleased]
 
+### Security backlog (from 2026-04-15 audit — see docs/security/audit-2026-04-15.md)
+
+- **US-SEC-001 (HIGH)** — Restrict insulin-therapy mutations to NURSE+
+  (currently VIEWER can self-mutate their ISF/ICR/settings consumed by
+  calculateBolus). Fix planned in a follow-up PR.
+- **US-SEC-002 (MEDIUM)** — Add `deletedAt: null` filter at the service
+  layer for `objectives` / `export` / `mydiabby-sync` patient queries
+  (defense-in-depth on RGPD Art. 17 soft-delete).
+
 ## 2026-04-15 — OpenAPI 3.1 spec (starter coverage)
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -766,6 +766,8 @@ pnpm test:e2e                          # Playwright sur pages et API routes
 Les items suivants ont été identifiés lors des reviews mais reportés pour ne pas bloquer les phases en cours.
 
 ### Priorité haute (avant mise en production)
+- [ ] **US-SEC-001 — RBAC sur insulin-therapy mutations (HIGH)** — VIEWER (patient) peut muter ses propres ISF/ICR/settings consommés par calculateBolus → biais auto-induit. Fix: `requireRole(NURSE)` sur `settings` PUT, `sensitivity-factors` POST, `carb-ratios` POST. Voir `docs/security/audit-2026-04-15.md`
+- [ ] **US-SEC-002 — Soft-delete au service layer (MEDIUM)** — `objectives.service.ts:93`, `export.service.ts:80`, `mydiabby-sync.service.ts:424,477` queryent patient sans `deletedAt:null`. Defense-in-depth ADR #4. Quick fix + Prisma `$extends` hook futur. Voir `docs/security/audit-2026-04-15.md`
 - [x] **Unifier CLINICAL_BOUNDS et INSULIN_BOUNDS** — source unique dans `src/lib/clinical-bounds.ts`, alias `INSULIN_BOUNDS` déprécié dans `insulin-therapy.service.ts`
 - [x] **Slot overlap detection ISF/ICR** — `createIsf`/`createIcr` utilisent `hasTimeSlotOverlap` (`src/lib/services/time-slot-utils.ts`) avec support du passage minuit
 - [x] **IOB (Insulin On Board) implémentation** — decay linéaire dans `insulin.service.ts:301-337`, `IobSettings.actionDurationHours` configurable, filtre `wasDelivered=true`
@@ -808,4 +810,4 @@ Les items suivants ont été identifiés lors des reviews mais reportés pour ne
 
 ---
 
-*Dernière mise à jour : 2026-04-14 — Backlog priorité basse (logger, GDPR cache, PeriodType enum) ; 865 tests*
+*Dernière mise à jour : 2026-04-15 — Audit sécurité full-project (US-SEC-001 HIGH + US-SEC-002 MEDIUM)*

--- a/docs/security/audit-2026-04-15.md
+++ b/docs/security/audit-2026-04-15.md
@@ -1,0 +1,194 @@
+# Security Audit Report — 2026-04-15
+
+Full-project security audit by `healthcare-security-auditor` agent
+following the merge of PR #108 (OpenAPI 3.1 spec).
+
+**Scope**: complete `src/` tree, ~74 API routes, middleware, services,
+Prisma schema, scripts. Excludes: DoS, secrets-on-disk, rate-limit gaps,
+outdated 3rd-party libs, theoretical race conditions, lack of audit logs,
+documentation files.
+
+**Verdict**: 1 HIGH + 1 MEDIUM finding. The remaining 13 categories
+(crypto primitives, JWT, MFA replay, session revocation, CSRF, input
+validation, code execution, account deletion, public endpoints) were
+verified clean — no concrete vulnerabilities found.
+
+---
+
+## US-SEC-001 — Enforce DOCTOR/NURSE role on insulin-therapy mutations
+
+> Severity: **HIGH** — clinical safety + RBAC violation
+> Confidence: 9/10
+> Category: `authz_missing_role_check`
+
+### Story
+
+> **As** the Diabeo system,
+> **I want** insulin-therapy configuration writes to be restricted to
+> NURSE-or-higher roles,
+> **so that** a patient (VIEWER) cannot self-mutate the parameters used by
+> the bolus calculator and bias their own dose suggestions.
+
+### Background
+
+Three routes use `requireAuth(req)` instead of `requireRole(req, "NURSE")`:
+
+| Route | File | Line | Current guard |
+|---|---|---|---|
+| `PUT /api/insulin-therapy/settings` | `settings/route.ts` | ~40-65 | `requireAuth` |
+| `POST /api/insulin-therapy/sensitivity-factors` | `sensitivity-factors/route.ts` | ~37-64 | `requireAuth` |
+| `POST /api/insulin-therapy/carb-ratios` | `carb-ratios/route.ts` | ~38-65 | `requireAuth` |
+
+`hasMinRole(VIEWER, VIEWER)` returns true through `requireAuth`, and
+`resolvePatientId` for VIEWER auto-resolves their own `patientId` without
+requiring a body parameter. The service layer
+(`insulinTherapyService.upsertSettings` / `createIsf` / `createIcr`)
+performs no role check of its own.
+
+### Reference pattern (correct)
+
+`src/app/api/insulin-therapy/basal-config/route.ts:75` and
+`basal-config/pump-slots/route.ts:79` already use
+`requireRole(req, "NURSE")` — matches the architectural rule in
+`CLAUDE.md` ("InsulinConfig: NURSE création, DOCTOR validation").
+
+### Attack scenario
+
+1. Patient authenticates normally (`POST /api/auth/login`).
+2. Patient calls `POST /api/insulin-therapy/sensitivity-factors`
+   with their own `patientId` (resolved via `getOwnPatientId(userId)` for
+   VIEWER) and a Zod-valid but inappropriate `sensitivityFactorGl`.
+3. Write succeeds — no role check rejects VIEWER.
+4. Subsequent `POST /api/insulin-therapy/calculate-bolus` consumes the
+   modified ISF and emits a dose suggestion biased toward hypoglycemia
+   or under-correction.
+
+### Acceptance criteria
+
+- [ ] PUT `/api/insulin-therapy/settings` rejects VIEWER with 403
+- [ ] POST `/api/insulin-therapy/sensitivity-factors` rejects VIEWER with 403
+- [ ] POST `/api/insulin-therapy/carb-ratios` rejects VIEWER with 403
+- [ ] DOCTOR + NURSE continue to write successfully
+- [ ] `canAccessPatient` IDOR protection preserved (NURSE without
+      `PatientService` link → 404)
+- [ ] Audit log emits `UNAUTHORIZED` for VIEWER attempt
+- [ ] Integration test per route + role matrix
+- [ ] No regression on adjacent `basal-config` / `pump-slots` routes
+
+### Implementation
+
+Replace `requireAuth(req)` with `requireRole(req, "NURSE")` in the three
+handlers. Pure 3-line change per file. Tests should assert:
+
+```ts
+// 1. VIEWER blocked
+expect(res.status).toBe(403)
+// 2. NURSE allowed
+expect(res.status).toBe(200)
+```
+
+### Estimate
+
+~30 min (3 lines × 3 files + 9 test cases + run pnpm test).
+
+---
+
+## US-SEC-002 — Enforce soft-delete filter at the service layer
+
+> Severity: **MEDIUM** — defense-in-depth + RGPD Art. 17 compliance
+> Confidence: 8/10
+> Category: `soft_delete_bypass`
+
+### Story
+
+> **As** the Diabeo data-protection layer,
+> **I want** every Prisma `patient` query to filter `deletedAt: null` by
+> default,
+> **so that** a future route invoking a service without re-running
+> `canAccessPatient` cannot resurface PHI for a patient who exercised
+> their RGPD Art. 17 right to be forgotten.
+
+### Background
+
+ADR #4 mandates soft-delete enforcement. Today three services trust the
+caller's `patientId` without re-filtering:
+
+| File | Line | Query |
+|---|---|---|
+| `src/lib/services/objectives.service.ts` | ~93 | `prisma.patient.findUnique({ where: { id: patientId }, select: { pathology: true } })` |
+| `src/lib/services/export.service.ts` | ~80 | `prisma.patient.findUnique({ where: { userId } })` |
+| `src/lib/services/mydiabby-sync.service.ts` | 424, 477 | `prisma.patient.findUnique(...)` |
+
+Direct exploit is bounded today because the route layer's
+`canAccessPatient` does apply the `deletedAt: null` filter — but the
+service layer is the only guard that survives a route-level regression.
+
+### Acceptance criteria
+
+- [ ] All 3 service-level `patient.findUnique` queries include
+      `deletedAt: null` in the `where` clause
+- [ ] Tests assert: deleted patient → service returns null even with
+      direct service call (bypassing route)
+- [ ] `objectivesService.getAll` returns null for soft-deleted patient
+- [ ] `generateUserExport` returns null for soft-deleted patient
+- [ ] MyDiabby sync skips soft-deleted patients silently
+
+### Implementation
+
+Quick fix: append `deletedAt: null` to the 3 `where` clauses
+(~10 lines total).
+
+Long-term (separate PR): Prisma `$extends` query hook that transparently
+appends `deletedAt: null` to every `patient` find. Pattern:
+
+```ts
+prisma.$extends({
+  query: {
+    patient: {
+      async findUnique({ args, query }) {
+        args.where = { ...args.where, deletedAt: null }
+        return query(args)
+      },
+      // same for findFirst, findMany, count
+    },
+  },
+})
+```
+
+This eliminates the need to remember the filter at every call site —
+matches the existing protection pattern in `audit_immutability.sql`
+(defense at the storage layer).
+
+### Estimate
+
+- Quick fix (3 services): ~20 min
+- Prisma `$extends` hook: ~2 h (covers 4 query methods × 1 model + tests
+  asserting bypass impossibility)
+
+---
+
+## Categories explicitly verified — no findings
+
+| Category | Files inspected |
+|---|---|
+| AES-256-GCM crypto | `src/lib/crypto/health-data.ts`, `fields.ts` |
+| HMAC email lookup | `src/lib/crypto/hmac.ts` |
+| JWT RS256 | `src/lib/auth/jwt.ts`, `src/middleware.ts` |
+| Session revocation | `src/lib/auth/revocation.ts` |
+| MFA TOTP replay | `src/lib/services/mfa.service.ts` |
+| RBAC (other than US-SEC-001) | `src/lib/auth/rbac.ts`, `src/lib/access-control.ts` |
+| CSRF | `src/middleware.ts` |
+| Input validation | All 74 routes (Zod) |
+| Code execution | Full project grep — no `eval`, `Function`, `dangerouslySetInnerHTML` |
+| Account deletion (Art. 17) | `src/lib/services/deletion.service.ts` |
+| Public endpoints | `src/app/api/health`, `src/app/api/openapi.json` |
+| Error responses | All routes — opaque error codes |
+| Login timing oracle | `src/app/api/auth/login/route.ts` (DUMMY_HASH bcrypt) |
+
+## Non-findings explicitly excluded
+
+- MFA routes 401-ing in production (functional bug, not vuln — middleware
+  strips spoofed `x-user-*` headers on `/api/auth/*`).
+- Redis fail-open when *unconfigured* (intentional dev/test behavior;
+  prod must be caught by deployment checks).
+- Rate-limit fail-open on Redis outage (per audit hard exclusions).


### PR DESCRIPTION
## Summary

Doc-only PR — track les findings de l'audit sécurité full-project du 2026-04-15.

### Findings (2 actionables)

**US-SEC-001 (HIGH)** — \`/api/insulin-therapy/{settings,sensitivity-factors,carb-ratios}\` utilisent \`requireAuth\` au lieu de \`requireRole(NURSE)\`. Un patient (VIEWER) peut auto-modifier ses ISF/ICR consommés par \`calculateBolus\` → biais hypoglycémie. Les routes adjacentes (\`basal-config\`, \`pump-slots\`) appliquent déjà \`requireRole(NURSE)\` — l'inconsistance est le bug. Fix : 3 lignes × 3 fichiers.

**US-SEC-002 (MEDIUM)** — \`objectives.service.ts:93\`, \`export.service.ts:80\`, \`mydiabby-sync.service.ts:424,477\` queryent \`patient\` sans \`deletedAt:null\`. Exploit direct borné aujourd'hui (route-layer filtre via \`canAccessPatient\`) mais une régression future réexposerait PHI de patients RGPD Art. 17. Quick fix + Prisma \`\$extends\` hook futur.

### Non-findings (vérifiés clean)

13 catégories vérifiées : crypto AES-GCM, HMAC, JWT RS256, MFA replay, session revocation, CSRF, Zod input validation, code execution, account deletion, endpoints publics, etc.

### Tracking

- **\`docs/security/audit-2026-04-15.md\`** (nouveau) — rapport complet + 2 user stories avec acceptance criteria + estimés
- **\`CLAUDE.md\`** backlog — 2 entrées ajoutées en \"Priorité haute\"
- **\`CHANGELOG.md\`** \`[Unreleased]\` — flags les 2 items

## Test plan

Doc-only. Aucun test à lancer. Review checklist :

- [ ] Les références \`fichier:line\` dans \`audit-2026-04-15.md\` correspondent au code actuel
- [ ] Les acceptance criteria de chaque US sont actionnables
- [ ] CHANGELOG \`[Unreleased]\` correctement structuré

## Suite

US-SEC-001 et US-SEC-002 seront traités dans des PRs dédiées (priorité haute pour US-SEC-001, à planifier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)