### PR TITLE
feat: Mirror MVP batch C — config seuils + urgences + mode grossesse (9 US)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -789,18 +789,18 @@ pnpm test:e2e                          # Playwright sur pages et API routes
 
 ### Taux de réalisation (2026-05-08)
 
-| Priorité | Total | DONE | IN REVIEW | PARTIAL | NOT STARTED | % Done+Review |
-|----------|-------|------|-----------|---------|-------------|---------------|
-| **MVP**  | 66    | 38   | 9         | 6       | 13          | **71%** |
-| **V1**   | 121   | 0    | 0         | 7       | 114         | **0%**  |
-| **V2**   | 58    | 0    | 0         | 0       | 58          | **0%**  |
-| **V3**   | 8     | 0    | 0         | 0       | 8           | **0%**  |
-| **V4**   | 15    | 0    | 0         | 0       | 15          | **0%**  |
-| **TOTAL**| **268** | **38** | **9**   | **13**  | **208**     | **18%** |
+| Priorité | Total | DONE | PARTIAL | NOT STARTED | % Done |
+|----------|-------|------|---------|-------------|--------|
+| **MVP**  | 66    | 47   | 6       | 13          | **71%** |
+| **V1**   | 121   | 0    | 7       | 114         | **0%**  |
+| **V2**   | 58    | 0    | 0       | 58          | **0%**  |
+| **V3**   | 8     | 0    | 0       | 8           | **0%**  |
+| **V4**   | 15    | 0    | 0       | 15          | **0%**  |
+| **TOTAL**| **268** | **47** | **13**  | **208**     | **22%** |
 
-> `IN REVIEW` = code complet, PR ouverte, CI verte, en attente de merge — compte 100 % à la merge.
+> MVP scope original (63 US) → 47 DONE = **75%**. Avec 3 follow-ups MVP du Batch D ajoutés au scope → 66 US → 71%. À la livraison de Batch D : 50/63 = 79% sur scope original.
 
-### MVP — Effort restant (~44 SP post-merge #343)
+### MVP — Effort restant (~44 SP)
 
 **Batch A — Compléter les PARTIAL (6 US)**
 - US-2047 (UI validation médecin), US-2089 (UI pairing device),
@@ -809,14 +809,14 @@ pnpm test:e2e                          # Playwright sur pages et API routes
 **Batch B — Nouvelles US backoffice (7 US)**
 - US-2025 (QR invite mobile), US-2148 (admin users UI), US-2151 (backup management)
 
-**Batch C — Mirror MVP (9 US) — ✅ IN REVIEW PR #343**
+**Batch C — Mirror MVP (9 US) — ✅ DONE PR #343**
 - US-2214–2217 (config seuils glycémiques/cétones/resucrage),
   US-2224–2226/2230 (urgences inbox + timeline + workflow + push),
   US-2232 (mode grossesse toggle)
 - 1093 tests verts · branch coverage 78% · CI green
 - 5 critical + 10 high fixés en re-review (5 agents)
 
-**Batch D — Follow-ups Mirror MVP (3 US MVP + 1 V1) — 🆕 PR #348 docs**
+**Batch D — Follow-ups Mirror MVP (3 US MVP + 1 V1) — 🆕 PR #348 mergée**
 - 🆕 **US-2265** — Événements `ACCESS_DENIED` audit (2 SP, MVP) · Issue #344
 - 🆕 **US-2266** — Email médecin sur alerte critique (3 SP, MVP) · Issue #345
 - 🆕 **US-2267** — Migrations Prisma versionnées (5 SP, MVP, bloquant audit HDS) · Issue #346
@@ -888,4 +888,4 @@ pnpm test:e2e                          # Playwright sur pages et API routes
 
 ---
 
-*Dernière mise à jour : 2026-05-08 — Mirror MVP en revue (PR #343, 9 US), 4 follow-ups ajoutés (PR #348, US-2265–US-2268). Total 268 US (217 pro + 51 mirror), MVP 71% (review-incluse) → 75% à la merge de #343, 95% post-Batch D.*
+*Dernière mise à jour : 2026-05-08 — Mirror MVP livré (PR #343, 9 US DONE), 4 follow-ups Batch D ouverts (PR #348, US-2265–US-2268). Total 268 US (217 pro + 51 mirror). MVP 47/66 = 71% (75% sur scope original 63).*

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,22 +1,22 @@
 # Roadmap Diabeo Backoffice — User Stories intégrées
 
-> Dernière mise à jour : 2026-05-08 — Mirror MVP en revue (PR #343), 4 follow-ups ajoutés (PR #348)
-> Total : **268 US** (217 pro + 51 mirror) · MVP completion : **75%** (47/63 DONE / IN REVIEW)
+> Dernière mise à jour : 2026-05-08 — Mirror MVP livré (9 US, PR #343), 4 follow-ups Batch D ouverts (PR #348)
+> Total : **268 US** (217 pro + 51 mirror) · MVP completion : **71%** (47/66 DONE)
 
 ---
 
 ## Taux de réalisation
 
-| Priorité | Total | DONE | IN REVIEW | PARTIAL | NOT STARTED | % Done+Review |
-|----------|-------|------|-----------|---------|-------------|---------------|
-| **MVP**  | 66    | 38   | 9         | 6       | 13          | **71%** |
-| **V1**   | 121   | 0    | 0         | 7       | 114         | **0%**  |
-| **V2**   | 58    | 0    | 0         | 0       | 58          | **0%**  |
-| **V3**   | 8     | 0    | 0         | 0       | 8           | **0%**  |
-| **V4**   | 15    | 0    | 0         | 0       | 15          | **0%**  |
-| **TOTAL**| **268** | **38** | **9**   | **13**  | **208**     | **18%** |
+| Priorité | Total | DONE | PARTIAL | NOT STARTED | % Done |
+|----------|-------|------|---------|-------------|--------|
+| **MVP**  | 66    | 47   | 6       | 13          | **71%** |
+| **V1**   | 121   | 0    | 7       | 114         | **0%**  |
+| **V2**   | 58    | 0    | 0       | 58          | **0%**  |
+| **V3**   | 8     | 0    | 0       | 8           | **0%**  |
+| **V4**   | 15    | 0    | 0       | 15          | **0%**  |
+| **TOTAL**| **268** | **47** | **13**  | **208**     | **22%** |
 
-> **Note** : `IN REVIEW` = code complet, PR ouverte, CI verte, en attente de merge. Compte pour 100 % à la merge — pas avant. Suivi via les PR GitHub (#343 Mirror MVP, #348 follow-ups).
+> MVP scope original (63 US) → 47 DONE = **75%**. Avec ajout de 3 follow-ups MVP du Batch D → 66 US, 71%. Les 3 follow-ups MVP (US-2265/2266/2267) sont à traiter dans le sprint suivant.
 
 ---
 
@@ -175,23 +175,23 @@
 |----|-------|--------|---------------|
 | US-2171 | Base médicamenteuse BDPM | DONE | `bdpm.service.ts`, `atc.service.ts`, modèles Prisma |
 
-### Mirror MVP (9 US — IN REVIEW PR #343)
+### Mirror MVP (9 US — DONE PR #343)
 
 | US | Titre | Statut | Domaine |
 |----|-------|--------|---------|
-| US-2214 | Config cibles glycémiques par patient | IN REVIEW | Config seuils |
-| US-2215 | Config seuils hypo/hyper alertes | IN REVIEW | Config seuils — `AlertThresholdConfig`, cooldown sévérité-aware capé à 15 min sur critique |
-| US-2216 | Seuils cétones | IN REVIEW | Config seuils — `KetoneThreshold`, defaults ISPAD 0.6/1.5/3.0 mmol/L, validateur strict |
-| US-2217 | Protocole resucrage | IN REVIEW | Config seuils — `HypoTreatmentProtocol`, rule of 15/15, allergies/instructions chiffrées |
-| US-2224 | Inbox alertes urgence | IN REVIEW | Urgences — `EmergencyAlert` + RBAC `getAccessiblePatientIds` |
-| US-2225 | Timeline urgence | IN REVIEW | Urgences — snapshot CGM 30 min chiffré base64+AES-256-GCM |
-| US-2226 | Workflow réaction médecin | IN REVIEW | Urgences — `EmergencyAlertAction` append-only, transitions ack/resolve race-safe |
-| US-2230 | Push temps réel urgence | IN REVIEW | Urgences — FCM data-only payload, pas de PHI lockscreen |
-| US-2232 | Toggle mode grossesse | IN REVIEW | Modes contextuels — `Patient.pregnancyMode` + auto-adapt CGM defaults GD, garde active-pregnancy + forceOverride chiffré |
+| US-2214 | Config cibles glycémiques par patient | DONE | Config seuils |
+| US-2215 | Config seuils hypo/hyper alertes | DONE | Config seuils — `AlertThresholdConfig`, cooldown sévérité-aware capé à 15 min sur critique |
+| US-2216 | Seuils cétones | DONE | Config seuils — `KetoneThreshold`, defaults ISPAD 0.6/1.5/3.0 mmol/L, validateur strict |
+| US-2217 | Protocole resucrage | DONE | Config seuils — `HypoTreatmentProtocol`, rule of 15/15, allergies/instructions chiffrées |
+| US-2224 | Inbox alertes urgence | DONE | Urgences — `EmergencyAlert` + RBAC `getAccessiblePatientIds` |
+| US-2225 | Timeline urgence | DONE | Urgences — snapshot CGM 30 min chiffré base64+AES-256-GCM |
+| US-2226 | Workflow réaction médecin | DONE | Urgences — `EmergencyAlertAction` append-only, transitions ack/resolve race-safe |
+| US-2230 | Push temps réel urgence | DONE | Urgences — FCM data-only payload, pas de PHI lockscreen |
+| US-2232 | Toggle mode grossesse | DONE | Modes contextuels — `Patient.pregnancyMode` + auto-adapt CGM defaults GD, garde active-pregnancy + forceOverride chiffré |
 
-**PR #343** — 1093 tests verts · branch coverage 78% · CI green · 5 critical + 10 high fixés en re-review (5 agents). En attente de merge avec autorisation utilisateur.
+**PR #343** — 1093 tests verts · branch coverage 78% · CI green · 5 critical + 10 high fixés en re-review (5 agents).
 
-### Follow-ups Mirror MVP (4 US — IN REVIEW PR #348 docs)
+### Follow-ups Mirror MVP (4 US — PR #348 mergée)
 
 | US | Titre | Priorité | SP | Issue | Domaine roadmap |
 |----|-------|----------|----|-------|------------------|
@@ -407,15 +407,15 @@
 |-------|-------------|--------------|--------|
 | A | Compléter 6 US PARTIAL | ~12 SP | À faire |
 | B | 7 nouvelles US backoffice | ~22 SP | À faire |
-| C | ~~9 US Mirror MVP~~ | ~~42 SP~~ | ✅ IN REVIEW (PR #343) |
+| C | ~~9 US Mirror MVP~~ | ~~42 SP~~ | ✅ DONE (PR #343) |
 | D | **3 follow-ups MVP Mirror** (US-2265/2266/2267) | **10 SP** | 🆕 À faire |
 | **Total** | **16 US restantes (post-merge #343)** | **~44 SP** | |
 
-> Hypothèse : à la merge de #343, le compteur MVP passe à **47/63 = 75%**. Avec batch D (3 follow-ups) → **63/66 = 95%** à viser sprint suivant.
+> Compteurs post-merge : **47/63 = 75%** sur le MVP scope original. Batch D (3 follow-ups MVP US-2265/2266/2267) → cible **50/63 = 79%** au sprint suivant. Reste US-2268 (V1, 8 SP).
 
-### US MVP récemment livrées (en revue ou mergées)
+### US MVP récemment livrées
 
-- 🟡 **Mirror MVP batch (9 US)** — US-2214/2215/2216/2217/2224/2225/2226/2230/2232 (PR #343, **IN REVIEW** 2026-05-08, 1093 tests, coverage 78%)
+- [x] **Mirror MVP batch (9 US)** — US-2214/2215/2216/2217/2224/2225/2226/2230/2232 (PR #343, 2026-05-08, 1093 tests, coverage 78%)
 - [x] US-2133 — Rétention 6 ans audit logs (PR #342, 2026-05-02)
 - [x] US-2136 — Pseudonymisation HMAC firstname/lastname (PR #342, 2026-05-02)
 - [x] US-2017 — Patient onboarding wizard (PR #341, 2026-05-02)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -288,6 +288,9 @@ model User {
   reviewedProposals    AdjustmentProposal[] @relation("ReviewedBy")
   prescribedInsulins   PatientInsulin[]     @relation("PrescribedInsulins")
   mydiabbyCredential   MyDiabbyCredential?
+  acknowledgedAlerts   EmergencyAlert[]      @relation("AlertAcknowledger")
+  resolvedAlerts       EmergencyAlert[]      @relation("AlertResolver")
+  emergencyActions     EmergencyAlertAction[] @relation("EmergencyActionPerformer")
 
   @@index([createdAt])
   @@index([firstnameHmac, lastnameHmac])
@@ -694,11 +697,14 @@ model EmergencyAlert {
   createdAt         DateTime                @default(now()) @map("created_at") @db.Timestamptz()
   updatedAt         DateTime                @updatedAt @map("updated_at") @db.Timestamptz()
 
-  patient Patient                  @relation(fields: [patientId], references: [id], onDelete: Cascade)
-  actions EmergencyAlertAction[]
+  patient            Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  acknowledgedByUser User?   @relation("AlertAcknowledger", fields: [acknowledgedBy], references: [id], onDelete: Restrict)
+  resolvedByUser     User?   @relation("AlertResolver", fields: [resolvedBy], references: [id], onDelete: Restrict)
+  actions            EmergencyAlertAction[]
 
   @@index([patientId, status, triggeredAt])
   @@index([patientId, alertType, status])
+  @@index([patientId, severity, triggeredAt])
   @@index([status, severity, triggeredAt])
   @@index([alertType, triggeredAt])
   @@map("emergency_alerts")
@@ -718,7 +724,8 @@ model EmergencyAlertAction {
   metadata     Json                      @default("{}")
   createdAt    DateTime                  @default(now()) @map("created_at") @db.Timestamptz()
 
-  alert EmergencyAlert @relation(fields: [alertId], references: [id], onDelete: Cascade)
+  alert            EmergencyAlert @relation(fields: [alertId], references: [id], onDelete: Cascade)
+  performedByUser  User           @relation("EmergencyActionPerformer", fields: [performedBy], references: [id], onDelete: Restrict)
 
   @@index([alertId, createdAt])
   @@index([performedBy, createdAt])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -167,6 +167,52 @@ enum InsulinUsage {
   both  // Pour les pré-mélangées (NovoMix, Humalog Mix)
 }
 
+/// Type d'alerte d'urgence générée par seuils CGM/cétones ou saisie manuelle.
+enum EmergencyAlertType {
+  severe_hypo      // CGM < seuil veryLow (par défaut 54 mg/dL)
+  hypo             // CGM < seuil low (par défaut 70 mg/dL)
+  severe_hyper     // CGM > seuil high (par défaut 250 mg/dL)
+  hyper            // CGM > seuil ok (par défaut 180 mg/dL)
+  ketone_dka       // Cétones > seuil DKA (par défaut 3.0 mmol/L)
+  ketone_moderate  // Cétones entre seuils modérés (par défaut 1.5–3.0 mmol/L)
+  manual           // Alerte créée manuellement (patient ou pro)
+}
+
+/// Sévérité clinique d'une alerte — pilote prioritisation push & UI.
+enum EmergencyAlertSeverity {
+  info
+  warning
+  critical
+}
+
+/// Statut workflow alerte urgence.
+enum EmergencyAlertStatus {
+  open
+  acknowledged
+  resolved
+  expired
+}
+
+/// Type de glucide rapide pour protocole resucrage.
+enum HypoSugarType {
+  glucose_tabs
+  juice
+  candy
+  honey
+  sugar_packets
+  other
+}
+
+/// Type d'action prise par un soignant face à une alerte.
+enum EmergencyAlertActionType {
+  acknowledge
+  call_patient
+  adjust_treatment
+  send_message
+  resolve
+  escalate
+}
+
 // ═══════════════════════════════════════════════════════════════
 // 1. DOMAINE UTILISATEUR & AUTHENTIFICATION (7 tables)
 // ═══════════════════════════════════════════════════════════════
@@ -371,11 +417,16 @@ model UiStateSave {
 // ═══════════════════════════════════════════════════════════════
 
 model Patient {
-  id        Int       @id @default(autoincrement())
-  userId    Int       @unique @map("user_id")
-  pathology Pathology
-  createdAt DateTime  @default(now()) @map("created_at")
-  deletedAt DateTime? @map("deleted_at")
+  id             Int       @id @default(autoincrement())
+  userId         Int       @unique @map("user_id")
+  pathology      Pathology
+  /// Mode grossesse (US-2232) — bascule cibles glycémiques sur defaults GD
+  /// (plus stricts — cf. ACOG/ADA). Indépendant de PatientPregnancy.active
+  /// pour permettre activation rapide sans saisir DPA, puis synchronisation
+  /// par la couche service vers PatientPregnancy lorsque les détails sont saisis.
+  pregnancyMode  Boolean   @default(false) @map("pregnancy_mode")
+  createdAt      DateTime  @default(now()) @map("created_at")
+  deletedAt      DateTime? @map("deleted_at")
 
   user                  User                    @relation(fields: [userId], references: [id], onDelete: Cascade)
   medicalData           PatientMedicalData?
@@ -384,6 +435,10 @@ model Patient {
   glycemiaObjectives    GlycemiaObjective[]
   cgmObjectives         CgmObjective?
   annexObjectives       AnnexObjective?
+  ketoneThreshold       KetoneThreshold?
+  hypoTreatmentProtocol HypoTreatmentProtocol?
+  alertThreshold        AlertThresholdConfig?
+  emergencyAlerts       EmergencyAlert[]
   treatments            Treatment[]
   insulinTherapySettings InsulinTherapySettings?
   bolusCalculationLogs  BolusCalculationLog[]
@@ -524,6 +579,150 @@ model AnnexObjective {
   patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
 
   @@map("annex_objectives")
+}
+
+/// US-2215 — Configuration des seuils d'alerte (déclenchement émission EmergencyAlert).
+/// Par défaut, le déclenchement utilise les seuils CGM de CgmObjective. Ce modèle
+/// permet de configurer un comportement différent (ex: alertes sur veryLow/high
+/// uniquement, pas sur low/ok), notification push, email médecin référent, etc.
+model AlertThresholdConfig {
+  id                    Int      @id @default(autoincrement())
+  patientId             Int      @unique @map("patient_id")
+  /// Émettre alertes hypo (CGM < low). Par défaut true.
+  alertOnHypo           Boolean  @default(true) @map("alert_on_hypo")
+  /// Émettre alertes hypo sévère (CGM < veryLow). Par défaut true.
+  alertOnSevereHypo     Boolean  @default(true) @map("alert_on_severe_hypo")
+  /// Émettre alertes hyper (CGM > ok). Par défaut false (trop bruyant).
+  alertOnHyper          Boolean  @default(false) @map("alert_on_hyper")
+  /// Émettre alertes hyper sévère (CGM > high). Par défaut true.
+  alertOnSevereHyper    Boolean  @default(true) @map("alert_on_severe_hyper")
+  /// Notifier médecin référent par push pour alertes critiques.
+  notifyDoctorPush      Boolean  @default(true) @map("notify_doctor_push")
+  /// Notifier médecin référent par email (si critique uniquement).
+  notifyDoctorEmail     Boolean  @default(true) @map("notify_doctor_email")
+  /// Délai en minutes avant ré-alerte sur même type (anti-spam). Min 5, max 1440.
+  cooldownMinutes       Int      @default(30) @map("cooldown_minutes")
+  createdAt             DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt             DateTime @updatedAt @map("updated_at") @db.Timestamptz()
+
+  patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
+
+  @@map("alert_threshold_configs")
+}
+
+/// US-2216 — Seuils cétones par patient.
+/// Référence clinique : ISPAD 2022 + IDF + ADA Diabetes Care 2024.
+/// Cétones légères : 0.6–1.5 mmol/L → surveillance, hydratation.
+/// Cétones modérées : 1.5–3.0 mmol/L → action rapide (insuline + glucides).
+/// Cétones DKA : ≥ 3.0 mmol/L → critère diagnostique DKA (ISPAD 2022).
+model KetoneThreshold {
+  id                    Int      @id @default(autoincrement())
+  patientId             Int      @unique @map("patient_id")
+  /// Limite supérieure cétones « légères » (mmol/L). Par défaut 0.6.
+  lightThreshold        Decimal  @default(0.6) @map("light_threshold") @db.Decimal(3, 1)
+  /// Limite supérieure cétones « modérées » (mmol/L). Par défaut 1.5.
+  moderateThreshold     Decimal  @default(1.5) @map("moderate_threshold") @db.Decimal(3, 1)
+  /// À ce seuil ou au-dessus → DKA (urgence). Par défaut 3.0 (ISPAD 2022).
+  dkaThreshold          Decimal  @default(3.0) @map("dka_threshold") @db.Decimal(3, 1)
+  /// Émettre alerte sur cétones modérées.
+  alertOnModerate       Boolean  @default(true) @map("alert_on_moderate")
+  /// Émettre alerte critique sur DKA.
+  alertOnDka            Boolean  @default(true) @map("alert_on_dka")
+  createdAt             DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt             DateTime @updatedAt @map("updated_at") @db.Timestamptz()
+
+  patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
+
+  @@map("ketone_thresholds")
+}
+
+/// US-2217 — Protocole resucrage configurable par patient.
+/// Référence clinique : ADA — règle des 15/15 (15 g glucides rapides → réévaluation 15 min).
+/// Type de glucide adapté aux préférences/allergies. Quantité standard 15 g pour adulte,
+/// modifiable selon poids/âge/médecin.
+model HypoTreatmentProtocol {
+  id                    Int           @id @default(autoincrement())
+  patientId             Int           @unique @map("patient_id")
+  sugarType             HypoSugarType @default(glucose_tabs) @map("sugar_type")
+  /// Description libre si sugarType = other (ex: "miel + biscotte").
+  sugarTypeOther        String?       @map("sugar_type_other") @db.VarChar(200)
+  /// Grammes de glucides rapides à ingérer. Par défaut 15 g.
+  fastCarbsGrams        Int           @default(15) @map("fast_carbs_grams")
+  /// Délai (minutes) avant re-mesure glycémie. Par défaut 15 min.
+  retestMinutes         Int           @default(15) @map("retest_minutes")
+  /// Allergies à éviter (chiffré AES-256-GCM si non vide).
+  allergies             String?       // chiffré
+  /// Instructions complémentaires destinées au patient (chiffré).
+  instructions          String?       // chiffré
+  createdAt             DateTime      @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt             DateTime      @updatedAt @map("updated_at") @db.Timestamptz()
+
+  patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
+
+  @@map("hypo_treatment_protocols")
+}
+
+/// US-2224/2225/2226 — Alerte d'urgence (hypo, hyper, DKA, etc.).
+/// Workflow : open → acknowledged (par soignant) → resolved.
+/// Push critique envoyé via FCM (US-2230) avec deep link vers timeline.
+///
+/// **Champs chiffrés AES-256-GCM (PHI soignant — RGPD Art. 9 / HDS) :**
+///  - `notes`, `resolutionNotes` (texte libre clinicien),
+///  - `contextSnapshot` (timeline CGM 30 min — données de santé).
+model EmergencyAlert {
+  id                Int                     @id @default(autoincrement())
+  patientId         Int                     @map("patient_id")
+  alertType         EmergencyAlertType      @map("alert_type")
+  severity          EmergencyAlertSeverity  @default(warning)
+  status            EmergencyAlertStatus    @default(open)
+  triggeredAt       DateTime                @default(now()) @map("triggered_at") @db.Timestamptz()
+  /// Valeur glycémie déclencheuse (mg/dL). NULL si manuelle ou cétone.
+  glucoseValueMgdl  Decimal?                @map("glucose_value_mgdl") @db.Decimal(6, 2)
+  /// Valeur cétones déclencheuse (mmol/L). NULL si manuelle ou glycémie.
+  ketoneValueMmol   Decimal?                @map("ketone_value_mmol") @db.Decimal(4, 2)
+  /// Timeline CGM 30 min avant trigger — chiffré base64(AES-256-GCM)
+  /// d'un JSON `[{ts, mgdl}]`. Texte vide / NULL si non renseigné.
+  contextSnapshot   String?                 @map("context_snapshot") @db.Text
+  /// Texte libre clinicien — chiffré AES-256-GCM si non vide.
+  notes             String?                 @db.Text
+  acknowledgedBy    Int?                    @map("acknowledged_by")
+  acknowledgedAt    DateTime?               @map("acknowledged_at") @db.Timestamptz()
+  resolvedBy        Int?                    @map("resolved_by")
+  resolvedAt        DateTime?               @map("resolved_at") @db.Timestamptz()
+  /// Notes de résolution clinicien — chiffré AES-256-GCM si non vide.
+  resolutionNotes   String?                 @map("resolution_notes") @db.Text
+  createdAt         DateTime                @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt         DateTime                @updatedAt @map("updated_at") @db.Timestamptz()
+
+  patient Patient                  @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  actions EmergencyAlertAction[]
+
+  @@index([patientId, status, triggeredAt])
+  @@index([patientId, alertType, status])
+  @@index([status, severity, triggeredAt])
+  @@index([alertType, triggeredAt])
+  @@map("emergency_alerts")
+}
+
+/// US-2226 — Actions effectuées par un soignant face à une alerte (audit + workflow).
+/// Append-only ; jamais supprimé pour traçabilité HDS.
+model EmergencyAlertAction {
+  id           Int                       @id @default(autoincrement())
+  alertId      Int                       @map("alert_id")
+  performedBy  Int                       @map("performed_by")
+  actionType   EmergencyAlertActionType  @map("action_type")
+  /// Notes libres clinicien — chiffré AES-256-GCM si non vide.
+  notes        String?                   @db.Text
+  /// Métadonnées strictement bornées (durée, résultat). Aucune PHI/PII.
+  /// Schéma applicatif : { durationSec?: number, outcome?: string }.
+  metadata     Json                      @default("{}")
+  createdAt    DateTime                  @default(now()) @map("created_at") @db.Timestamptz()
+
+  alert EmergencyAlert @relation(fields: [alertId], references: [id], onDelete: Cascade)
+
+  @@index([alertId, createdAt])
+  @@index([performedBy, createdAt])
+  @@map("emergency_alert_actions")
 }
 
 // ═══════════════════════════════════════════════════════════════

--- a/prisma/sql/emergency_alerts_constraints.sql
+++ b/prisma/sql/emergency_alerts_constraints.sql
@@ -1,0 +1,45 @@
+-- Mirror MVP — Constraints for emergency_alerts and ketone_thresholds.
+-- Apply manually after `prisma db push` / migration:
+--   psql $DATABASE_URL < prisma/sql/emergency_alerts_constraints.sql
+--
+-- Idempotent (uses IF NOT EXISTS / DROP-CREATE patterns where supported).
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1) PARTIAL UNIQUE INDEX — at most one live alert per (patient, alertType).
+-- Source of truth for the cooldown / TOCTOU race protection in
+-- emergency.service.ts → safeCreateAlert (catches P2002).
+-- Without this index, concurrent CGM ingestion bursts can insert duplicate
+-- live alerts for the same patient/type, fanning out duplicate FCM pushes.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE UNIQUE INDEX IF NOT EXISTS emergency_alerts_one_live_per_type
+  ON emergency_alerts (patient_id, alert_type)
+  WHERE status IN ('open', 'acknowledged');
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2) CHECK CONSTRAINT — ketone_thresholds ordering invariant.
+-- Application validator already enforces light < moderate < dka, but a
+-- DB-level CHECK ensures direct SQL writes / future migrations cannot
+-- silently introduce a degenerate configuration that would suppress alerts.
+-- ─────────────────────────────────────────────────────────────────────────────
+ALTER TABLE ketone_thresholds DROP CONSTRAINT IF EXISTS ketone_thresholds_ordering_check;
+ALTER TABLE ketone_thresholds ADD CONSTRAINT ketone_thresholds_ordering_check
+  CHECK (
+    light_threshold > 0
+    AND light_threshold < moderate_threshold
+    AND moderate_threshold < dka_threshold
+    AND dka_threshold <= 10.0
+  );
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 3) CHECK CONSTRAINT — emergency_alerts trigger-value sanity bounds.
+-- Mirrors the application-layer Zod / detect helpers: glucose [40, 600] mg/dL,
+-- ketones [0.1, 10] mmol/L. Sensor errors above these ranges should never
+-- persist as a real alert trigger.
+-- ─────────────────────────────────────────────────────────────────────────────
+ALTER TABLE emergency_alerts DROP CONSTRAINT IF EXISTS emergency_alerts_glucose_bounds;
+ALTER TABLE emergency_alerts ADD CONSTRAINT emergency_alerts_glucose_bounds
+  CHECK (glucose_value_mgdl IS NULL OR (glucose_value_mgdl >= 40 AND glucose_value_mgdl <= 600));
+
+ALTER TABLE emergency_alerts DROP CONSTRAINT IF EXISTS emergency_alerts_ketone_bounds;
+ALTER TABLE emergency_alerts ADD CONSTRAINT emergency_alerts_ketone_bounds
+  CHECK (ketone_value_mmol IS NULL OR (ketone_value_mmol >= 0.1 AND ketone_value_mmol <= 10));

--- a/src/app/api/emergency-alerts/[id]/actions/route.ts
+++ b/src/app/api/emergency-alerts/[id]/actions/route.ts
@@ -1,0 +1,102 @@
+/**
+ * US-2226 — Emergency alert workflow actions log (call patient, adjust treatment, etc.).
+ *
+ * POST → NURSE+ — append a workflow action without changing alert status.
+ *                 The PATCH /[id] endpoint handles status transitions.
+ *
+ * Authorization is enforced BEFORE any audit-emitting read.
+ */
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireRole, AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { emergencyService } from "@/lib/services/emergency.service"
+import { logger } from "@/lib/logger"
+
+interface RouteParams {
+  params: Promise<{ id: string }>
+}
+
+const actionTypeEnum = z.enum([
+  "acknowledge",
+  "call_patient",
+  "adjust_treatment",
+  "send_message",
+  "resolve",
+  "escalate",
+])
+
+const postSchema = z.object({
+  actionType: actionTypeEnum,
+  notes: z.string().max(2000).optional(),
+  metadata: z
+    .object({
+      durationSec: z.number().int().min(0).max(86400).optional(),
+      outcome: z.string().max(50).optional(),
+    })
+    .optional(),
+})
+
+const ACTION_ERROR_CODES = new Set([
+  "alert_not_found",
+  "alert_expired",
+  "patient_deleted",
+])
+
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  try {
+    const user = requireRole(req, "NURSE")
+    const { id: rawId } = await params
+    const id = Number.parseInt(rawId, 10)
+    if (!Number.isInteger(id) || id <= 0) {
+      return NextResponse.json({ error: "invalidAlertId" }, { status: 400 })
+    }
+
+    const body = await req.json()
+    const parsed = postSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+
+    const ref = await emergencyService.loadForAccessCheck(id)
+    if (!ref || ref.patient.deletedAt) {
+      return NextResponse.json({ error: "alertNotFound" }, { status: 404 })
+    }
+    const allowed = await canAccessPatient(user.id, user.role, ref.patientId)
+    if (!allowed) {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+
+    const ctx = extractRequestContext(req)
+    try {
+      const action = await emergencyService.addAction(
+        {
+          alertId: id,
+          performedBy: user.id,
+          actionType: parsed.data.actionType,
+          notes: parsed.data.notes,
+          metadata: parsed.data.metadata,
+        },
+        ctx,
+      )
+      return NextResponse.json(action, { status: 201 })
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "actionFailed"
+      if (ACTION_ERROR_CODES.has(msg)) {
+        const status = msg === "alert_not_found" ? 404 : 409
+        return NextResponse.json({ error: msg }, { status })
+      }
+      throw e
+    }
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error("api", "emergency-alerts/[id]/actions POST failed", {}, error)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/app/api/emergency-alerts/[id]/route.ts
+++ b/src/app/api/emergency-alerts/[id]/route.ts
@@ -1,0 +1,123 @@
+/**
+ * US-2225/2226 — Emergency alert detail (timeline) + workflow transitions.
+ *
+ * GET    → DOCTOR/NURSE/ADMIN  — alert detail with actions log + CGM context.
+ * PATCH  → DOCTOR/NURSE/ADMIN  — acknowledge or resolve (workflow transition).
+ *
+ * Authorization happens BEFORE any audit-emitting read to avoid leaking the
+ * existence of an alert and producing audit entries on forbidden access.
+ */
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireRole, AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { emergencyService } from "@/lib/services/emergency.service"
+import { logger } from "@/lib/logger"
+
+interface RouteParams {
+  params: Promise<{ id: string }>
+}
+
+function parseId(raw: string): number | null {
+  const id = Number.parseInt(raw, 10)
+  return Number.isInteger(id) && id > 0 ? id : null
+}
+
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  try {
+    const user = requireRole(req, "NURSE")
+    const { id: rawId } = await params
+    const id = parseId(rawId)
+    if (id === null) {
+      return NextResponse.json({ error: "invalidAlertId" }, { status: 400 })
+    }
+
+    // Authorization first — no audit on forbidden / not-found probing.
+    const ref = await emergencyService.loadForAccessCheck(id)
+    if (!ref || ref.patient.deletedAt) {
+      return NextResponse.json({ error: "alertNotFound" }, { status: 404 })
+    }
+    const allowed = await canAccessPatient(user.id, user.role, ref.patientId)
+    if (!allowed) {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+
+    const ctx = extractRequestContext(req)
+    const alert = await emergencyService.getDetail(id, user.id, ctx)
+    if (!alert) {
+      return NextResponse.json({ error: "alertNotFound" }, { status: 404 })
+    }
+
+    return NextResponse.json(alert)
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error("api", "emergency-alerts/[id] GET failed", {}, error)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}
+
+const patchSchema = z.object({
+  action: z.enum(["acknowledge", "resolve"]),
+  notes: z.string().max(2000).optional(),
+})
+
+const TRANSITION_ERROR_CODES = new Set([
+  "alert_not_found",
+  "alert_not_open",
+  "alert_already_closed",
+  "patient_deleted",
+])
+
+export async function PATCH(req: NextRequest, { params }: RouteParams) {
+  try {
+    const user = requireRole(req, "NURSE")
+    const { id: rawId } = await params
+    const id = parseId(rawId)
+    if (id === null) {
+      return NextResponse.json({ error: "invalidAlertId" }, { status: 400 })
+    }
+
+    const body = await req.json()
+    const parsed = patchSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+
+    const ref = await emergencyService.loadForAccessCheck(id)
+    if (!ref || ref.patient.deletedAt) {
+      return NextResponse.json({ error: "alertNotFound" }, { status: 404 })
+    }
+    const allowed = await canAccessPatient(user.id, user.role, ref.patientId)
+    if (!allowed) {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+
+    const ctx = extractRequestContext(req)
+    try {
+      const updated =
+        parsed.data.action === "acknowledge"
+          ? await emergencyService.acknowledge(id, user.id, parsed.data.notes, ctx)
+          : await emergencyService.resolve(id, user.id, parsed.data.notes, ctx)
+      return NextResponse.json(updated)
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "transitionFailed"
+      if (TRANSITION_ERROR_CODES.has(msg)) {
+        const status = msg === "alert_not_found" ? 404 : 409
+        return NextResponse.json({ error: msg }, { status })
+      }
+      throw e
+    }
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error("api", "emergency-alerts/[id] PATCH failed", {}, error)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/app/api/emergency-alerts/[id]/route.ts
+++ b/src/app/api/emergency-alerts/[id]/route.ts
@@ -9,7 +9,7 @@
  */
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
-import { requireRole, AuthError } from "@/lib/auth"
+import { requireAuth, requireRole, AuthError } from "@/lib/auth"
 import { canAccessPatient } from "@/lib/access-control"
 import { extractRequestContext } from "@/lib/services/audit.service"
 import { emergencyService } from "@/lib/services/emergency.service"
@@ -26,7 +26,9 @@ function parseId(raw: string): number | null {
 
 export async function GET(req: NextRequest, { params }: RouteParams) {
   try {
-    const user = requireRole(req, "NURSE")
+    // RGPD Art. 15 — VIEWER (patient role) can read their own alerts.
+    // Workflow ops (PATCH) remain NURSE+ via canAccessPatient gate below.
+    const user = requireAuth(req)
     const { id: rawId } = await params
     const id = parseId(rawId)
     if (id === null) {

--- a/src/app/api/emergency-alerts/route.ts
+++ b/src/app/api/emergency-alerts/route.ts
@@ -1,0 +1,162 @@
+/**
+ * US-2224 — Emergency alerts inbox (list + manual create).
+ *
+ * GET   → DOCTOR/NURSE/ADMIN — list alerts with filters & pagination.
+ *         **RBAC scoping**: non-ADMIN callers are restricted to their
+ *         accessible patient portfolio via getAccessiblePatientIds.
+ * POST  → NURSE+ — create a manual alert (cooldown applies; rate limited).
+ */
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireRole, AuthError } from "@/lib/auth"
+import { canAccessPatient, getAccessiblePatientIds } from "@/lib/access-control"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { emergencyService } from "@/lib/services/emergency.service"
+import { logger } from "@/lib/logger"
+
+const statusEnum = z.enum(["open", "acknowledged", "resolved", "expired"])
+const severityEnum = z.enum(["info", "warning", "critical"])
+const alertTypeEnum = z.enum([
+  "severe_hypo",
+  "hypo",
+  "severe_hyper",
+  "hyper",
+  "ketone_dka",
+  "ketone_moderate",
+  "manual",
+])
+
+function parseEnumList<T extends string>(
+  value: string | null,
+  schema: z.ZodType<T>,
+): T[] | undefined {
+  if (!value) return undefined
+  const arr = value.split(",").map((v) => v.trim()).filter(Boolean)
+  if (arr.length === 0) return undefined
+  const parsed = z.array(schema).safeParse(arr)
+  if (!parsed.success) return undefined
+  return parsed.data
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const user = requireRole(req, "NURSE")
+    const sp = req.nextUrl.searchParams
+
+    // Validate scalar query params via Zod for consistent 400 errors.
+    const intSchema = z.coerce.number().int().positive().optional()
+    const dateSchema = z.coerce.date().optional()
+
+    const patientIdParsed = intSchema.safeParse(sp.get("patientId") ?? undefined)
+    const limitParsed = intSchema.safeParse(sp.get("limit") ?? undefined)
+    const cursorParsed = intSchema.safeParse(sp.get("cursor") ?? undefined)
+    const fromParsed = dateSchema.safeParse(sp.get("from") ?? undefined)
+    const toParsed = dateSchema.safeParse(sp.get("to") ?? undefined)
+
+    if (
+      !patientIdParsed.success ||
+      !limitParsed.success ||
+      !cursorParsed.success ||
+      !fromParsed.success ||
+      !toParsed.success
+    ) {
+      return NextResponse.json({ error: "validationFailed" }, { status: 400 })
+    }
+
+    const patientId = patientIdParsed.data
+    let scopePatientIds: number[] | null | undefined
+
+    if (patientId !== undefined) {
+      // Explicit patient filter — verify access individually.
+      const allowed = await canAccessPatient(user.id, user.role, patientId)
+      if (!allowed) {
+        return NextResponse.json({ error: "forbidden" }, { status: 403 })
+      }
+      scopePatientIds = undefined // patientId already constrains the query
+    } else {
+      // No explicit filter — restrict to caller's portfolio.
+      scopePatientIds = await getAccessiblePatientIds(user.id, user.role)
+    }
+
+    const filter = {
+      status: parseEnumList(sp.get("status"), statusEnum),
+      severity: parseEnumList(sp.get("severity"), severityEnum),
+      alertType: parseEnumList(sp.get("alertType"), alertTypeEnum),
+      from: fromParsed.data,
+      to: toParsed.data,
+      patientId,
+      scopePatientIds,
+      limit: limitParsed.data,
+      cursor: cursorParsed.data,
+    }
+
+    const ctx = extractRequestContext(req)
+    const result = await emergencyService.list(filter, user.id, ctx)
+    return NextResponse.json(result)
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error("api", "emergency-alerts GET failed", {}, error)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}
+
+const postSchema = z.object({
+  patientId: z.number().int().positive(),
+  severity: severityEnum.default("warning"),
+  notes: z.string().max(2000).optional(),
+})
+
+const POST_USER_ERROR_CODES = new Set([
+  "patient_not_found",
+  "manual_alert_cooldown",
+])
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = requireRole(req, "NURSE")
+    const body = await req.json()
+    const parsed = postSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+
+    const { patientId, severity, notes } = parsed.data
+    const allowed = await canAccessPatient(user.id, user.role, patientId)
+    if (!allowed) {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+
+    const ctx = extractRequestContext(req)
+    try {
+      const alert = await emergencyService.createManual(
+        { patientId, severity, notes },
+        user.id,
+        ctx,
+      )
+      return NextResponse.json(alert, { status: 201 })
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "serverError"
+      if (msg === "patient_not_found") {
+        return NextResponse.json({ error: msg }, { status: 404 })
+      }
+      if (msg === "manual_alert_cooldown") {
+        return NextResponse.json({ error: msg }, { status: 429 })
+      }
+      if (POST_USER_ERROR_CODES.has(msg)) {
+        return NextResponse.json({ error: msg }, { status: 400 })
+      }
+      throw e
+    }
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error("api", "emergency-alerts POST failed", {}, error)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/app/api/emergency-alerts/route.ts
+++ b/src/app/api/emergency-alerts/route.ts
@@ -1,14 +1,16 @@
 /**
  * US-2224 — Emergency alerts inbox (list + manual create).
  *
- * GET   → DOCTOR/NURSE/ADMIN — list alerts with filters & pagination.
- *         **RBAC scoping**: non-ADMIN callers are restricted to their
- *         accessible patient portfolio via getAccessiblePatientIds.
- * POST  → NURSE+ — create a manual alert (cooldown applies; rate limited).
+ * GET   → all authenticated roles. RBAC scoping:
+ *         - ADMIN: unrestricted
+ *         - DOCTOR/NURSE: portfolio (PatientService membership)
+ *         - VIEWER (patient): own alerts only (RGPD Art. 15 right of access)
+ * POST  → NURSE+ — create a manual alert (cooldown applies). Severity
+ *         "critical" requires DOCTOR/ADMIN role + non-empty notes.
  */
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
-import { requireRole, AuthError } from "@/lib/auth"
+import { requireAuth, requireRole, AuthError } from "@/lib/auth"
 import { canAccessPatient, getAccessiblePatientIds } from "@/lib/access-control"
 import { extractRequestContext } from "@/lib/services/audit.service"
 import { emergencyService } from "@/lib/services/emergency.service"
@@ -26,24 +28,25 @@ const alertTypeEnum = z.enum([
   "manual",
 ])
 
+type EnumListResult<T> = { ok: true; value: T[] | undefined } | { ok: false }
+
 function parseEnumList<T extends string>(
   value: string | null,
   schema: z.ZodType<T>,
-): T[] | undefined {
-  if (!value) return undefined
+): EnumListResult<T> {
+  if (!value) return { ok: true, value: undefined }
   const arr = value.split(",").map((v) => v.trim()).filter(Boolean)
-  if (arr.length === 0) return undefined
+  if (arr.length === 0) return { ok: true, value: undefined }
   const parsed = z.array(schema).safeParse(arr)
-  if (!parsed.success) return undefined
-  return parsed.data
+  if (!parsed.success) return { ok: false }
+  return { ok: true, value: parsed.data }
 }
 
 export async function GET(req: NextRequest) {
   try {
-    const user = requireRole(req, "NURSE")
+    const user = requireAuth(req)
     const sp = req.nextUrl.searchParams
 
-    // Validate scalar query params via Zod for consistent 400 errors.
     const intSchema = z.coerce.number().int().positive().optional()
     const dateSchema = z.coerce.date().optional()
 
@@ -63,25 +66,31 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: "validationFailed" }, { status: 400 })
     }
 
+    const statusList = parseEnumList(sp.get("status"), statusEnum)
+    const severityList = parseEnumList(sp.get("severity"), severityEnum)
+    const alertTypeList = parseEnumList(sp.get("alertType"), alertTypeEnum)
+    if (!statusList.ok || !severityList.ok || !alertTypeList.ok) {
+      return NextResponse.json({ error: "validationFailed" }, { status: 400 })
+    }
+
     const patientId = patientIdParsed.data
     let scopePatientIds: number[] | null | undefined
 
     if (patientId !== undefined) {
-      // Explicit patient filter — verify access individually.
       const allowed = await canAccessPatient(user.id, user.role, patientId)
       if (!allowed) {
         return NextResponse.json({ error: "forbidden" }, { status: 403 })
       }
-      scopePatientIds = undefined // patientId already constrains the query
+      scopePatientIds = undefined
     } else {
-      // No explicit filter — restrict to caller's portfolio.
+      // No explicit filter — RBAC scope applies to every role except ADMIN.
       scopePatientIds = await getAccessiblePatientIds(user.id, user.role)
     }
 
     const filter = {
-      status: parseEnumList(sp.get("status"), statusEnum),
-      severity: parseEnumList(sp.get("severity"), severityEnum),
-      alertType: parseEnumList(sp.get("alertType"), alertTypeEnum),
+      status: statusList.value,
+      severity: severityList.value,
+      alertType: alertTypeList.value,
       from: fromParsed.data,
       to: toParsed.data,
       patientId,
@@ -108,9 +117,11 @@ const postSchema = z.object({
   notes: z.string().max(2000).optional(),
 })
 
-const POST_USER_ERROR_CODES = new Set([
-  "patient_not_found",
-  "manual_alert_cooldown",
+const POST_USER_ERROR_CODES = new Map<string, number>([
+  ["patient_not_found", 404],
+  ["manual_alert_cooldown", 429],
+  ["critical_manual_requires_doctor", 403],
+  ["critical_manual_requires_notes", 400],
 ])
 
 export async function POST(req: NextRequest) {
@@ -134,21 +145,16 @@ export async function POST(req: NextRequest) {
     const ctx = extractRequestContext(req)
     try {
       const alert = await emergencyService.createManual(
-        { patientId, severity, notes },
+        { patientId, severity, notes, callerRole: user.role },
         user.id,
         ctx,
       )
       return NextResponse.json(alert, { status: 201 })
     } catch (e) {
       const msg = e instanceof Error ? e.message : "serverError"
-      if (msg === "patient_not_found") {
-        return NextResponse.json({ error: msg }, { status: 404 })
-      }
-      if (msg === "manual_alert_cooldown") {
-        return NextResponse.json({ error: msg }, { status: 429 })
-      }
-      if (POST_USER_ERROR_CODES.has(msg)) {
-        return NextResponse.json({ error: msg }, { status: 400 })
+      const status = POST_USER_ERROR_CODES.get(msg)
+      if (status) {
+        return NextResponse.json({ error: msg }, { status })
       }
       throw e
     }

--- a/src/app/api/patient/alert-thresholds/route.ts
+++ b/src/app/api/patient/alert-thresholds/route.ts
@@ -1,0 +1,94 @@
+/**
+ * US-2215 — Per-patient alert emission rules (which severities, cooldown, etc.).
+ *
+ * GET  → patient (own) + pros via patientId query param.
+ * PUT  → DOCTOR only.
+ */
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireAuth, requireRole, AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { resolvePatientIdFromQuery } from "@/lib/auth/query-helpers"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import {
+  alertThresholdService,
+  COOLDOWN_BOUNDS,
+} from "@/lib/services/alert-threshold.service"
+import { logger } from "@/lib/logger"
+
+const USER_ERROR_CODES = new Set(["cooldown_out_of_bounds"])
+
+export async function GET(req: NextRequest) {
+  try {
+    const user = requireAuth(req)
+    const res = await resolvePatientIdFromQuery(req, user.id, user.role)
+    if (res.error) {
+      return NextResponse.json(
+        { error: res.error },
+        { status: res.error === "invalidPatientId" ? 400 : 404 },
+      )
+    }
+
+    const ctx = extractRequestContext(req)
+    const data = await alertThresholdService.get(res.patientId, user.id, ctx)
+    if (!data) {
+      return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    }
+    return NextResponse.json(data)
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error("api", "patient/alert-thresholds GET failed", {}, error)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}
+
+const putSchema = z.object({
+  patientId: z.number().int().positive(),
+  alertOnHypo: z.boolean().optional(),
+  alertOnSevereHypo: z.boolean().optional(),
+  alertOnHyper: z.boolean().optional(),
+  alertOnSevereHyper: z.boolean().optional(),
+  notifyDoctorPush: z.boolean().optional(),
+  notifyDoctorEmail: z.boolean().optional(),
+  cooldownMinutes: z.number().int().min(COOLDOWN_BOUNDS.MIN).max(COOLDOWN_BOUNDS.MAX).optional(),
+})
+
+export async function PUT(req: NextRequest) {
+  try {
+    const user = requireRole(req, "DOCTOR")
+    const body = await req.json()
+    const parsed = putSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+
+    const { patientId, ...input } = parsed.data
+    const allowed = await canAccessPatient(user.id, user.role, patientId)
+    if (!allowed) {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+
+    const ctx = extractRequestContext(req)
+    try {
+      const result = await alertThresholdService.upsert(patientId, input, user.id, ctx)
+      return NextResponse.json(result)
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "validationFailed"
+      if (USER_ERROR_CODES.has(msg)) {
+        return NextResponse.json({ error: msg }, { status: 400 })
+      }
+      throw e
+    }
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error("api", "patient/alert-thresholds PUT failed", {}, error)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/app/api/patient/hypo-treatment/route.ts
+++ b/src/app/api/patient/hypo-treatment/route.ts
@@ -1,0 +1,116 @@
+/**
+ * US-2217 — Per-patient hypoglycemia treatment protocol.
+ *
+ * GET  → patient (own) + pros via patientId query param.
+ * PUT  → DOCTOR only.
+ */
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireAuth, requireRole, AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { resolvePatientIdFromQuery } from "@/lib/auth/query-helpers"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import {
+  hypoTreatmentService,
+  HYPO_TREATMENT_BOUNDS,
+} from "@/lib/services/hypo-treatment.service"
+import { logger } from "@/lib/logger"
+
+const USER_ERROR_CODES = new Set([
+  "carbs_out_of_bounds",
+  "retest_out_of_bounds",
+  "sugar_type_other_required",
+])
+
+export async function GET(req: NextRequest) {
+  try {
+    const user = requireAuth(req)
+    const res = await resolvePatientIdFromQuery(req, user.id, user.role)
+    if (res.error) {
+      return NextResponse.json(
+        { error: res.error },
+        { status: res.error === "invalidPatientId" ? 400 : 404 },
+      )
+    }
+
+    const ctx = extractRequestContext(req)
+    const data = await hypoTreatmentService.get(res.patientId, user.id, ctx)
+    if (!data) {
+      return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    }
+    return NextResponse.json(data)
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error("api", "patient/hypo-treatment GET failed", {}, error)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}
+
+const sugarTypeEnum = z.enum([
+  "glucose_tabs",
+  "juice",
+  "candy",
+  "honey",
+  "sugar_packets",
+  "other",
+])
+
+const putSchema = z.object({
+  patientId: z.number().int().positive(),
+  sugarType: sugarTypeEnum.optional(),
+  sugarTypeOther: z.string().max(200).nullable().optional(),
+  fastCarbsGrams: z
+    .number()
+    .int()
+    .min(HYPO_TREATMENT_BOUNDS.CARBS_MIN)
+    .max(HYPO_TREATMENT_BOUNDS.CARBS_MAX)
+    .optional(),
+  retestMinutes: z
+    .number()
+    .int()
+    .min(HYPO_TREATMENT_BOUNDS.RETEST_MIN)
+    .max(HYPO_TREATMENT_BOUNDS.RETEST_MAX)
+    .optional(),
+  allergies: z.string().max(500).nullable().optional(),
+  instructions: z.string().max(1000).nullable().optional(),
+})
+
+export async function PUT(req: NextRequest) {
+  try {
+    const user = requireRole(req, "DOCTOR")
+    const body = await req.json()
+    const parsed = putSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+
+    const { patientId, ...input } = parsed.data
+    const allowed = await canAccessPatient(user.id, user.role, patientId)
+    if (!allowed) {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+
+    const ctx = extractRequestContext(req)
+    try {
+      const result = await hypoTreatmentService.upsert(patientId, input, user.id, ctx)
+      return NextResponse.json(result)
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "validationFailed"
+      if (USER_ERROR_CODES.has(msg)) {
+        return NextResponse.json({ error: msg }, { status: 400 })
+      }
+      throw e
+    }
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error("api", "patient/hypo-treatment PUT failed", {}, error)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/app/api/patient/ketone-thresholds/route.ts
+++ b/src/app/api/patient/ketone-thresholds/route.ts
@@ -1,0 +1,97 @@
+/**
+ * US-2216 — Per-patient ketone thresholds.
+ *
+ * GET  → patient (own) + pros via patientId query param.
+ * PUT  → DOCTOR only (clinical configuration).
+ */
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireAuth, requireRole, AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { resolvePatientIdFromQuery } from "@/lib/auth/query-helpers"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import {
+  ketoneThresholdService,
+  KETONE_BOUNDS,
+} from "@/lib/services/ketone-threshold.service"
+import { logger } from "@/lib/logger"
+
+const USER_ERROR_CODES = new Set([
+  "ketone_threshold_below_min",
+  "ketone_threshold_above_max",
+  "light_must_be_less_than_moderate",
+  "moderate_must_be_lte_dka",
+])
+
+export async function GET(req: NextRequest) {
+  try {
+    const user = requireAuth(req)
+    const res = await resolvePatientIdFromQuery(req, user.id, user.role)
+    if (res.error) {
+      return NextResponse.json(
+        { error: res.error },
+        { status: res.error === "invalidPatientId" ? 400 : 404 },
+      )
+    }
+
+    const ctx = extractRequestContext(req)
+    const data = await ketoneThresholdService.get(res.patientId, user.id, ctx)
+    if (!data) {
+      return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    }
+    return NextResponse.json(data)
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error("api", "patient/ketone-thresholds GET failed", {}, error)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}
+
+const putSchema = z.object({
+  patientId: z.number().int().positive(),
+  lightThreshold: z.number().min(KETONE_BOUNDS.MIN).max(KETONE_BOUNDS.MAX).optional(),
+  moderateThreshold: z.number().min(KETONE_BOUNDS.MIN).max(KETONE_BOUNDS.MAX).optional(),
+  dkaThreshold: z.number().min(KETONE_BOUNDS.MIN).max(KETONE_BOUNDS.MAX).optional(),
+  alertOnModerate: z.boolean().optional(),
+  alertOnDka: z.boolean().optional(),
+})
+
+export async function PUT(req: NextRequest) {
+  try {
+    const user = requireRole(req, "DOCTOR")
+    const body = await req.json()
+    const parsed = putSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+
+    const { patientId, ...input } = parsed.data
+    const allowed = await canAccessPatient(user.id, user.role, patientId)
+    if (!allowed) {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+
+    const ctx = extractRequestContext(req)
+    try {
+      const result = await ketoneThresholdService.upsert(patientId, input, user.id, ctx)
+      return NextResponse.json(result)
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "validationFailed"
+      if (USER_ERROR_CODES.has(msg)) {
+        return NextResponse.json({ error: msg }, { status: 400 })
+      }
+      throw e
+    }
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error("api", "patient/ketone-thresholds PUT failed", {}, error)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/app/api/patient/pregnancy-mode/route.ts
+++ b/src/app/api/patient/pregnancy-mode/route.ts
@@ -1,0 +1,72 @@
+/**
+ * US-2232 — Pregnancy mode toggle.
+ *
+ * Enabling tightens CGM thresholds (GD defaults). Disabling restores standard
+ * defaults. Only DOCTOR can flip the switch (clinical decision).
+ *
+ * Disabling while a `PatientPregnancy.active` record exists is rejected with
+ * 409 unless `forceOverride: true` is sent (audit-tagged for forensics).
+ */
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireRole, AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { pregnancyModeService } from "@/lib/services/pregnancy-mode.service"
+import { logger } from "@/lib/logger"
+
+const putSchema = z.object({
+  patientId: z.number().int().positive(),
+  enabled: z.boolean(),
+  forceOverride: z.boolean().optional(),
+})
+
+const USER_ERROR_CODES = new Map<string, number>([
+  ["patient_not_found", 404],
+  ["active_pregnancy_blocks_toggle_off", 409],
+])
+
+export async function PUT(req: NextRequest) {
+  try {
+    const user = requireRole(req, "DOCTOR")
+    const body = await req.json()
+    const parsed = putSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+
+    const { patientId, enabled, forceOverride } = parsed.data
+    const allowed = await canAccessPatient(user.id, user.role, patientId)
+    if (!allowed) {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+
+    const ctx = extractRequestContext(req)
+    try {
+      const result = await pregnancyModeService.setMode(
+        patientId,
+        enabled,
+        user.id,
+        ctx,
+        { forceOverride },
+      )
+      return NextResponse.json(result)
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "validationFailed"
+      const status = USER_ERROR_CODES.get(msg)
+      if (status) {
+        return NextResponse.json({ error: msg }, { status })
+      }
+      throw e
+    }
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error("api", "patient/pregnancy-mode PUT failed", {}, error)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/app/api/patient/pregnancy-mode/route.ts
+++ b/src/app/api/patient/pregnancy-mode/route.ts
@@ -15,15 +15,22 @@ import { extractRequestContext } from "@/lib/services/audit.service"
 import { pregnancyModeService } from "@/lib/services/pregnancy-mode.service"
 import { logger } from "@/lib/logger"
 
-const putSchema = z.object({
-  patientId: z.number().int().positive(),
-  enabled: z.boolean(),
-  forceOverride: z.boolean().optional(),
-})
+const putSchema = z
+  .object({
+    patientId: z.number().int().positive(),
+    enabled: z.boolean(),
+    forceOverride: z.boolean().optional(),
+    forceOverrideReason: z.string().min(20).max(500).optional(),
+  })
+  .refine(
+    (d) => !d.forceOverride || (d.forceOverrideReason?.trim().length ?? 0) >= 20,
+    { message: "forceOverrideReason required (≥ 20 chars) when forceOverride=true" },
+  )
 
 const USER_ERROR_CODES = new Map<string, number>([
   ["patient_not_found", 404],
   ["active_pregnancy_blocks_toggle_off", 409],
+  ["force_override_reason_required", 400],
 ])
 
 export async function PUT(req: NextRequest) {
@@ -38,7 +45,7 @@ export async function PUT(req: NextRequest) {
       )
     }
 
-    const { patientId, enabled, forceOverride } = parsed.data
+    const { patientId, enabled, forceOverride, forceOverrideReason } = parsed.data
     const allowed = await canAccessPatient(user.id, user.role, patientId)
     if (!allowed) {
       return NextResponse.json({ error: "forbidden" }, { status: 403 })
@@ -51,7 +58,7 @@ export async function PUT(req: NextRequest) {
         enabled,
         user.id,
         ctx,
-        { forceOverride },
+        { forceOverride, forceOverrideReason },
       )
       return NextResponse.json(result)
     } catch (e) {

--- a/src/lib/access-control.ts
+++ b/src/lib/access-control.ts
@@ -104,3 +104,39 @@ export async function resolvePatientId(
   const allowed = await canAccessPatient(userId, role, patientIdParam)
   return allowed ? patientIdParam : null
 }
+
+/**
+ * Resolve the list of patient IDs the caller can access (RBAC scoping for
+ * cross-patient queries like inboxes/dashboards).
+ *
+ * - ADMIN → returns null (caller may query without restriction).
+ * - VIEWER → returns [own patient id] or [] if none.
+ * - DOCTOR/NURSE → returns the patient IDs of every PatientService where
+ *   the caller is a member, excluding soft-deleted patients.
+ *
+ * The caller MUST treat `null` as "no restriction" and an array as a hard
+ * IN-list filter (empty array → no rows).
+ */
+export async function getAccessiblePatientIds(
+  userId: number,
+  role: Role,
+): Promise<number[] | null> {
+  if (role === "ADMIN") return null
+
+  if (role === "VIEWER") {
+    const own = await getOwnPatientId(userId)
+    return own ? [own] : []
+  }
+
+  const links = await prisma.patientService.findMany({
+    where: {
+      patient: { deletedAt: null },
+      service: {
+        members: { some: { userId } },
+      },
+    },
+    select: { patientId: true },
+    distinct: ["patientId"],
+  })
+  return links.map((l) => l.patientId)
+}

--- a/src/lib/services/alert-threshold.service.ts
+++ b/src/lib/services/alert-threshold.service.ts
@@ -1,0 +1,97 @@
+/**
+ * @module alert-threshold.service
+ * @description US-2215 — Per-patient configuration of alert emission rules.
+ *
+ * Backed by AlertThresholdConfig. Defaults come from ADA-aligned CGM thresholds
+ * stored in CgmObjective. This service governs *when* an alert is emitted
+ * (which severity levels, cooldown), not the threshold values themselves.
+ */
+
+import { prisma } from "@/lib/db/client"
+import { auditService } from "./audit.service"
+import type { AuditContext } from "./patient.service"
+
+export const ALERT_THRESHOLD_DEFAULTS = {
+  alertOnHypo: true,
+  alertOnSevereHypo: true,
+  alertOnHyper: false,
+  alertOnSevereHyper: true,
+  notifyDoctorPush: true,
+  notifyDoctorEmail: true,
+  cooldownMinutes: 30,
+} as const
+
+export const COOLDOWN_BOUNDS = {
+  MIN: 5,
+  MAX: 1440,
+} as const
+
+interface AlertThresholdInput {
+  alertOnHypo?: boolean
+  alertOnSevereHypo?: boolean
+  alertOnHyper?: boolean
+  alertOnSevereHyper?: boolean
+  notifyDoctorPush?: boolean
+  notifyDoctorEmail?: boolean
+  cooldownMinutes?: number
+}
+
+export const alertThresholdService = {
+  async get(patientId: number, auditUserId: number, ctx?: AuditContext) {
+    const [record, patient] = await Promise.all([
+      prisma.alertThresholdConfig.findUnique({ where: { patientId } }),
+      prisma.patient.findFirst({
+        where: { id: patientId, deletedAt: null },
+        select: { id: true },
+      }),
+    ])
+
+    if (!patient) return null
+
+    await auditService.log({
+      userId: auditUserId,
+      action: "READ",
+      resource: "PATIENT",
+      resourceId: `${patientId}:alert-thresholds`,
+      ipAddress: ctx?.ipAddress,
+      userAgent: ctx?.userAgent,
+    })
+
+    return record ?? { patientId, ...ALERT_THRESHOLD_DEFAULTS }
+  },
+
+  async upsert(
+    patientId: number,
+    input: AlertThresholdInput,
+    auditUserId: number,
+    ctx?: AuditContext,
+  ) {
+    if (input.cooldownMinutes !== undefined) {
+      if (
+        input.cooldownMinutes < COOLDOWN_BOUNDS.MIN ||
+        input.cooldownMinutes > COOLDOWN_BOUNDS.MAX
+      ) {
+        throw new Error("cooldown_out_of_bounds")
+      }
+    }
+
+    return prisma.$transaction(async (tx) => {
+      const updated = await tx.alertThresholdConfig.upsert({
+        where: { patientId },
+        update: input,
+        create: { patientId, ...ALERT_THRESHOLD_DEFAULTS, ...input },
+      })
+
+      await auditService.logWithTx(tx, {
+        userId: auditUserId,
+        action: "UPDATE",
+        resource: "PATIENT",
+        resourceId: `${patientId}:alert-thresholds`,
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+      })
+
+      return updated
+    })
+  },
+}

--- a/src/lib/services/emergency.service.ts
+++ b/src/lib/services/emergency.service.ts
@@ -42,6 +42,8 @@ import { encryptField, safeDecryptField } from "@/lib/crypto/fields"
 import { auditService } from "./audit.service"
 import { fcmService } from "./fcm.service"
 import { logger } from "@/lib/logger"
+import { ALERT_THRESHOLD_DEFAULTS } from "./alert-threshold.service"
+import { getCgmDefaults } from "./objectives.service"
 import type { AuditContext } from "./patient.service"
 import type {
   EmergencyAlertType,
@@ -65,6 +67,21 @@ const GL_TO_MGDL = 100
 /** Severity-aware cooldown ceiling (minutes). Critical never silenced > 15 min. */
 const CRITICAL_COOLDOWN_CEILING = 15
 
+/**
+ * Sanity bounds on alert trigger values — sensor errors above these ranges
+ * should never be persisted. Mirrors CGM ingestion validation.
+ */
+const GLUCOSE_BOUNDS = { MIN: 40, MAX: 600 } as const
+const KETONE_BOUNDS = { MIN: 0.1, MAX: 10 } as const
+
+/**
+ * Name of the partial unique index on (patient_id, alert_type) WHERE
+ * status IN ('open','acknowledged'). See prisma/sql/emergency_alerts_constraints.sql.
+ * Used to narrow P2002 catching to *this* invariant — any other future
+ * unique-constraint violation must propagate.
+ */
+const LIVE_ALERT_UNIQUE_INDEX = "emergency_alerts_one_live_per_type"
+
 interface DetectFromCgmInput {
   patientId: number
   glucoseValueMgdl: number
@@ -81,6 +98,8 @@ interface CreateManualAlertInput {
   patientId: number
   severity: EmergencyAlertSeverity
   notes?: string
+  /** Caller's role — required to gate critical-severity manual alerts. */
+  callerRole: "ADMIN" | "DOCTOR" | "NURSE" | "VIEWER"
 }
 
 export interface EmergencyAlertListFilter {
@@ -149,8 +168,14 @@ function classifyKetoneAlert(
     alertOnDka: boolean
   },
 ): { type: EmergencyAlertType; severity: EmergencyAlertSeverity } | null {
-  if (ketoneMmol >= thresholds.dkaThreshold && thresholds.alertOnDka) {
-    return { type: "ketone_dka", severity: "critical" }
+  // Clinical safety: a ≥DKA reading is *always* an emergency. We never
+  // downgrade it to "moderate" just because alertOnDka is off — that would
+  // hide a true DKA episode. If alertOnDka is off, suppress the alert
+  // entirely; clinician opted out of DKA notifications (e.g. inpatient).
+  if (ketoneMmol >= thresholds.dkaThreshold) {
+    return thresholds.alertOnDka
+      ? { type: "ketone_dka", severity: "critical" }
+      : null
   }
   if (ketoneMmol >= thresholds.moderateThreshold && thresholds.alertOnModerate) {
     return { type: "ketone_moderate", severity: "warning" }
@@ -185,13 +210,23 @@ async function captureContextSnapshot(
 function decryptSnapshot(encrypted: string | null): CgmSnapshotPoint[] {
   if (!encrypted) return []
   const plaintext = safeDecryptField(encrypted)
-  if (!plaintext) return []
+  if (!plaintext) {
+    // Decryption failure → likely key rotation gone wrong or DB tamper.
+    // Alert ops without leaking ciphertext (HDS / ANSSI RGS).
+    logger.error("emergency", "context_snapshot_decryption_failed")
+    return []
+  }
   try {
     const parsed = JSON.parse(plaintext) as unknown
     if (!Array.isArray(parsed)) return []
     return parsed.filter(
       (p): p is CgmSnapshotPoint =>
-        typeof p === "object" && p !== null && "ts" in p && "mgdl" in p,
+        typeof p === "object" &&
+        p !== null &&
+        "ts" in p &&
+        "mgdl" in p &&
+        typeof (p as { ts: unknown }).ts === "string" &&
+        typeof (p as { mgdl: unknown }).mgdl === "number",
     )
   } catch {
     return []
@@ -298,22 +333,36 @@ async function notifyCriticalAlert(
   }
 }
 
-/** Insert helper that traps the unique-constraint collision (TOCTOU race). */
+/**
+ * Insert helper that traps *only* the live-alert partial-unique-index
+ * collision (TOCTOU race). Any other constraint violation is rethrown to
+ * surface the real bug, never masked behind a "cooldown blocked" no-op.
+ */
 async function safeCreateAlert<T>(
   fn: () => Promise<T>,
 ): Promise<T | null> {
   try {
     return await fn()
   } catch (err) {
-    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
-      return null
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2002"
+    ) {
+      const target = err.meta?.target
+      const targetStr = Array.isArray(target) ? target.join(",") : String(target ?? "")
+      if (targetStr.includes(LIVE_ALERT_UNIQUE_INDEX)) {
+        return null
+      }
     }
     throw err
   }
 }
 
 /**
- * Decrypt user-facing fields on an alert read.
+ * Decrypt user-facing fields on an alert read AND strip the encrypted
+ * `contextSnapshot` ciphertext from the API-bound payload (per project rule
+ * "JAMAIS exposer le Buffer/base64 chiffré dans les API responses" — CLAUDE.md).
+ * Returns a derived `contextSnapshotPoints: CgmSnapshotPoint[]` instead.
  */
 function decryptAlertFields<
   T extends {
@@ -321,16 +370,17 @@ function decryptAlertFields<
     resolutionNotes?: string | null
     contextSnapshot?: string | null
   },
->(alert: T): T & {
+>(alert: T): Omit<T, "contextSnapshot"> & {
   notes: string | null
   resolutionNotes: string | null
   contextSnapshotPoints: CgmSnapshotPoint[]
 } {
+  const { contextSnapshot, ...rest } = alert
   return {
-    ...alert,
+    ...rest,
     notes: safeDecryptField(alert.notes ?? null),
     resolutionNotes: safeDecryptField(alert.resolutionNotes ?? null),
-    contextSnapshotPoints: decryptSnapshot(alert.contextSnapshot ?? null),
+    contextSnapshotPoints: decryptSnapshot(contextSnapshot ?? null),
   }
 }
 
@@ -344,6 +394,14 @@ export const emergencyService = {
     auditUserId: number,
     ctx?: AuditContext,
   ): Promise<{ id: number; alertType: EmergencyAlertType } | null> {
+    // Reject sensor-error values upstream — never persist out-of-range readings.
+    if (
+      input.glucoseValueMgdl < GLUCOSE_BOUNDS.MIN ||
+      input.glucoseValueMgdl > GLUCOSE_BOUNDS.MAX ||
+      !Number.isFinite(input.glucoseValueMgdl)
+    ) {
+      return null
+    }
     const triggeredAt = input.triggeredAt ?? new Date()
     const [cgmObjective, alertConfig, patient] = await Promise.all([
       prisma.cgmObjective.findUnique({ where: { patientId: input.patientId } }),
@@ -358,26 +416,27 @@ export const emergencyService = {
     if (!patient) return null
 
     const isStrict = patient.pregnancyMode || patient.pathology === "GD"
-    const thresholds = cgmObjective
-      ? {
+    // Fallback uses the same getCgmDefaults() as the rest of the system —
+    // single source of truth (objectives.service.ts: ADA / Battelino 2019).
+    const thresholds = (() => {
+      if (cgmObjective) {
+        return {
           veryLowMgdl: cgmObjective.veryLow.toNumber() * GL_TO_MGDL,
           lowMgdl: cgmObjective.low.toNumber() * GL_TO_MGDL,
           okMgdl: cgmObjective.ok.toNumber() * GL_TO_MGDL,
           highMgdl: cgmObjective.high.toNumber() * GL_TO_MGDL,
         }
-      : isStrict
-        ? { veryLowMgdl: 60, lowMgdl: 63, okMgdl: 140, highMgdl: 200 }
-        : { veryLowMgdl: 54, lowMgdl: 70, okMgdl: 180, highMgdl: 250 }
+      }
+      const d = getCgmDefaults(isStrict ? "GD" : patient.pathology)
+      return {
+        veryLowMgdl: d.veryLow * GL_TO_MGDL,
+        lowMgdl: d.low * GL_TO_MGDL,
+        okMgdl: d.ok * GL_TO_MGDL,
+        highMgdl: d.high * GL_TO_MGDL,
+      }
+    })()
 
-    const rules = alertConfig ?? {
-      alertOnHypo: true,
-      alertOnSevereHypo: true,
-      alertOnHyper: false,
-      alertOnSevereHyper: true,
-      notifyDoctorPush: true,
-      notifyDoctorEmail: false,
-      cooldownMinutes: 30,
-    }
+    const rules = alertConfig ?? ALERT_THRESHOLD_DEFAULTS
 
     const classified = classifyCgmAlert(input.glucoseValueMgdl, thresholds, rules)
     if (!classified) return null
@@ -447,6 +506,13 @@ export const emergencyService = {
     auditUserId: number,
     ctx?: AuditContext,
   ): Promise<{ id: number; alertType: EmergencyAlertType } | null> {
+    if (
+      input.ketoneValueMmol < KETONE_BOUNDS.MIN ||
+      input.ketoneValueMmol > KETONE_BOUNDS.MAX ||
+      !Number.isFinite(input.ketoneValueMmol)
+    ) {
+      return null
+    }
     const triggeredAt = input.triggeredAt ?? new Date()
     const [config, alertConfig, patient] = await Promise.all([
       prisma.ketoneThreshold.findUnique({ where: { patientId: input.patientId } }),
@@ -537,6 +603,18 @@ export const emergencyService = {
     auditUserId: number,
     ctx?: AuditContext,
   ) {
+    // Critical-severity manual alerts bypass threshold detection — gate them
+    // on DOCTOR+ role and require justification text to prevent inbox flood
+    // from a NURSE marking everything as "critical".
+    if (input.severity === "critical") {
+      if (input.callerRole !== "ADMIN" && input.callerRole !== "DOCTOR") {
+        throw new Error("critical_manual_requires_doctor")
+      }
+      if (!input.notes?.trim()) {
+        throw new Error("critical_manual_requires_notes")
+      }
+    }
+
     const patient = await prisma.patient.findFirst({
       where: { id: input.patientId, deletedAt: null },
       select: { id: true },
@@ -549,7 +627,7 @@ export const emergencyService = {
       select: { cooldownMinutes: true, notifyDoctorPush: true },
     })
     const cooldown = effectiveCooldown(
-      alertConfig?.cooldownMinutes ?? 30,
+      alertConfig?.cooldownMinutes ?? ALERT_THRESHOLD_DEFAULTS.cooldownMinutes,
       input.severity,
     )
     const blocker = await findCooldownBlocker(
@@ -685,27 +763,21 @@ export const emergencyService = {
   async loadForAccessCheck(alertId: number) {
     return prisma.emergencyAlert.findUnique({
       where: { id: alertId },
-      select: { id: true, patientId: true, status: true, patient: { select: { deletedAt: true } } },
+      select: { id: true, patientId: true, patient: { select: { deletedAt: true } } },
     })
   },
 
   /**
    * Detail view incl. timeline (CGM context window) — US-2225.
    * Caller must have already authorized the alert via loadForAccessCheck.
+   * Single query: filters out soft-deleted patients via the relation.
    */
   async getDetail(alertId: number, auditUserId: number, ctx?: AuditContext) {
-    const alert = await prisma.emergencyAlert.findUnique({
-      where: { id: alertId },
-      include: {
-        actions: { orderBy: { createdAt: "asc" } },
-      },
+    const alert = await prisma.emergencyAlert.findFirst({
+      where: { id: alertId, patient: { deletedAt: null } },
+      include: { actions: { orderBy: { createdAt: "asc" } } },
     })
     if (!alert) return null
-    const softDeleted = await prisma.patient.findFirst({
-      where: { id: alert.patientId, deletedAt: { not: null } },
-      select: { id: true },
-    })
-    if (softDeleted) return null
 
     await auditService.log({
       userId: auditUserId,
@@ -745,14 +817,24 @@ export const emergencyService = {
       if (existing.patient.deletedAt) throw new Error("patient_deleted")
       if (existing.status !== "open") throw new Error("alert_not_open")
 
-      const updated = await tx.emergencyAlert.update({
-        where: { id: alertId },
-        data: {
-          status: "acknowledged",
-          acknowledgedBy: userId,
-          acknowledgedAt: new Date(),
-        },
-      })
+      // Race-safe update: a concurrent acknowledge by another doctor will
+      // throw P2025 (record not found), which we map to alert_not_open.
+      let updated
+      try {
+        updated = await tx.emergencyAlert.update({
+          where: { id: alertId, status: "open" },
+          data: {
+            status: "acknowledged",
+            acknowledgedBy: userId,
+            acknowledgedAt: new Date(),
+          },
+        })
+      } catch (e) {
+        if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2025") {
+          throw new Error("alert_not_open")
+        }
+        throw e
+      }
 
       const encryptedNotes = notes?.trim() ? encryptField(notes.trim()) : null
       await tx.emergencyAlertAction.create({
@@ -804,15 +886,24 @@ export const emergencyService = {
         ? encryptField(resolutionNotes.trim())
         : null
 
-      const updated = await tx.emergencyAlert.update({
-        where: { id: alertId },
-        data: {
-          status: "resolved",
-          resolvedBy: userId,
-          resolvedAt: new Date(),
-          resolutionNotes: encryptedNotes,
-        },
-      })
+      // Race-safe update: only transition from {open, acknowledged}.
+      let updated
+      try {
+        updated = await tx.emergencyAlert.update({
+          where: { id: alertId, status: { in: ["open", "acknowledged"] } },
+          data: {
+            status: "resolved",
+            resolvedBy: userId,
+            resolvedAt: new Date(),
+            resolutionNotes: encryptedNotes,
+          },
+        })
+      } catch (e) {
+        if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2025") {
+          throw new Error("alert_already_closed")
+        }
+        throw e
+      }
 
       await tx.emergencyAlertAction.create({
         data: {

--- a/src/lib/services/emergency.service.ts
+++ b/src/lib/services/emergency.service.ts
@@ -1,0 +1,900 @@
+/**
+ * @module emergency.service
+ * @description US-2224/2225/2226/2230 — Emergency alert workflow.
+ *
+ *  - US-2224: list/create alerts (inbox, scoped to caller's portfolio).
+ *  - US-2225: timeline (CGM context window around the trigger).
+ *  - US-2226: doctor reaction workflow (acknowledge / resolve / actions).
+ *  - US-2230: real-time push via FCM (high-priority + deep link).
+ *
+ * Detection relies on CgmObjective (US-2214 thresholds) + AlertThresholdConfig
+ * (US-2215 emission rules) + KetoneThreshold (US-2216).
+ *
+ * **Boundary semantics (clinical safety)**:
+ *  - Severe hypo: glucose ≤ veryLow (54 mg/dL by default — ADA SoC 2024).
+ *  - Hypo:        veryLow < glucose < low (54 < g < 70).
+ *  - Hyper:       ok < glucose < high (180 < g < 250).
+ *  - Severe hyper: glucose ≥ high (≥ 250 mg/dL).
+ *  - Ketone DKA: ≥ dkaThreshold (3.0 mmol/L — ISPAD 2022 criterion).
+ *
+ * **Severity-aware cooldown**: critical alerts (severe_hypo, severe_hyper,
+ * ketone_dka) re-fire after at most 15 min regardless of cooldownMinutes,
+ * so a deteriorating Level 2 hypo is not silenced.
+ *
+ * **Concurrency**: a partial unique index `(patientId, alertType, status)`
+ * prevents duplicate live alerts. Service catches P2002 from prisma and
+ * treats it as cooldown hit. The serialized check + insert is best-effort
+ * but the DB constraint is the source of truth.
+ *
+ * **Encryption (RGPD Art. 9 + HDS)**:
+ *  - notes / resolutionNotes / contextSnapshot encrypted at rest with
+ *    AES-256-GCM via encryptField.
+ *  - action.notes encrypted similarly.
+ *  - action.metadata strictly bounded — no PII.
+ *
+ * Bolus suggestions are NEVER auto-injected — the doctor workflow only
+ * documents actions, audit trail, and patient notification.
+ */
+
+import { Prisma } from "@prisma/client"
+import { prisma } from "@/lib/db/client"
+import { encryptField, safeDecryptField } from "@/lib/crypto/fields"
+import { auditService } from "./audit.service"
+import { fcmService } from "./fcm.service"
+import { logger } from "@/lib/logger"
+import type { AuditContext } from "./patient.service"
+import type {
+  EmergencyAlertType,
+  EmergencyAlertSeverity,
+  EmergencyAlertStatus,
+  EmergencyAlertActionType,
+} from "@prisma/client"
+
+/** Window (minutes) of CGM context captured for timeline (US-2225). */
+const CONTEXT_WINDOW_MINUTES = 30
+
+/** Maximum CGM points snapshotted with the alert (cap memory). */
+const CONTEXT_MAX_POINTS = 50
+
+/** Maximum bulk page size for inbox. */
+const MAX_LIST_LIMIT = 100
+
+/** mg/dL ↔ g/L conversion factor. */
+const GL_TO_MGDL = 100
+
+/** Severity-aware cooldown ceiling (minutes). Critical never silenced > 15 min. */
+const CRITICAL_COOLDOWN_CEILING = 15
+
+interface DetectFromCgmInput {
+  patientId: number
+  glucoseValueMgdl: number
+  triggeredAt?: Date
+}
+
+interface DetectFromKetoneInput {
+  patientId: number
+  ketoneValueMmol: number
+  triggeredAt?: Date
+}
+
+interface CreateManualAlertInput {
+  patientId: number
+  severity: EmergencyAlertSeverity
+  notes?: string
+}
+
+export interface EmergencyAlertListFilter {
+  status?: EmergencyAlertStatus[]
+  severity?: EmergencyAlertSeverity[]
+  alertType?: EmergencyAlertType[]
+  from?: Date
+  to?: Date
+  patientId?: number
+  /** Caller's accessible patient IDs (RBAC scoping). Required for non-ADMIN. */
+  scopePatientIds?: number[] | null
+  limit?: number
+  cursor?: number
+}
+
+interface AlertActionInput {
+  alertId: number
+  performedBy: number
+  actionType: EmergencyAlertActionType
+  notes?: string
+  /** Strict shape — durationSec / outcome only. No PHI/PII allowed. */
+  metadata?: { durationSec?: number; outcome?: string }
+}
+
+export interface CgmSnapshotPoint {
+  ts: string
+  mgdl: number
+}
+
+/**
+ * Map CGM value (mg/dL) + per-patient thresholds to alert type & severity.
+ * Boundary semantics use ≤ (severe_hypo / severe_hyper) and < (hypo / hyper).
+ * Returns null if no threshold breached.
+ */
+function classifyCgmAlert(
+  glucoseMgdl: number,
+  thresholds: { veryLowMgdl: number; lowMgdl: number; okMgdl: number; highMgdl: number },
+  rules: {
+    alertOnHypo: boolean
+    alertOnSevereHypo: boolean
+    alertOnHyper: boolean
+    alertOnSevereHyper: boolean
+  },
+): { type: EmergencyAlertType; severity: EmergencyAlertSeverity } | null {
+  if (glucoseMgdl <= thresholds.veryLowMgdl && rules.alertOnSevereHypo) {
+    return { type: "severe_hypo", severity: "critical" }
+  }
+  if (glucoseMgdl < thresholds.lowMgdl && rules.alertOnHypo) {
+    return { type: "hypo", severity: "warning" }
+  }
+  if (glucoseMgdl >= thresholds.highMgdl && rules.alertOnSevereHyper) {
+    return { type: "severe_hyper", severity: "critical" }
+  }
+  if (glucoseMgdl > thresholds.okMgdl && rules.alertOnHyper) {
+    return { type: "hyper", severity: "warning" }
+  }
+  return null
+}
+
+function classifyKetoneAlert(
+  ketoneMmol: number,
+  thresholds: {
+    moderateThreshold: number
+    dkaThreshold: number
+    alertOnModerate: boolean
+    alertOnDka: boolean
+  },
+): { type: EmergencyAlertType; severity: EmergencyAlertSeverity } | null {
+  if (ketoneMmol >= thresholds.dkaThreshold && thresholds.alertOnDka) {
+    return { type: "ketone_dka", severity: "critical" }
+  }
+  if (ketoneMmol >= thresholds.moderateThreshold && thresholds.alertOnModerate) {
+    return { type: "ketone_moderate", severity: "warning" }
+  }
+  return null
+}
+
+/**
+ * Capture a snapshot of recent CGM points for timeline display (US-2225).
+ * Returns an encrypted base64 string for at-rest protection of PHI.
+ */
+async function captureContextSnapshot(
+  patientId: number,
+  triggeredAt: Date,
+): Promise<string> {
+  const since = new Date(
+    triggeredAt.getTime() - CONTEXT_WINDOW_MINUTES * 60_000,
+  )
+  const points = await prisma.cgmEntry.findMany({
+    where: { patientId, timestamp: { gte: since, lte: triggeredAt } },
+    orderBy: { timestamp: "asc" },
+    take: CONTEXT_MAX_POINTS,
+    select: { timestamp: true, valueGl: true },
+  })
+  const payload: CgmSnapshotPoint[] = points.map((p) => ({
+    ts: p.timestamp.toISOString(),
+    mgdl: p.valueGl.toNumber() * GL_TO_MGDL,
+  }))
+  return encryptField(JSON.stringify(payload))
+}
+
+function decryptSnapshot(encrypted: string | null): CgmSnapshotPoint[] {
+  if (!encrypted) return []
+  const plaintext = safeDecryptField(encrypted)
+  if (!plaintext) return []
+  try {
+    const parsed = JSON.parse(plaintext) as unknown
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(
+      (p): p is CgmSnapshotPoint =>
+        typeof p === "object" && p !== null && "ts" in p && "mgdl" in p,
+    )
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Effective cooldown — capped at 15 min for critical severity to avoid
+ * silencing deteriorating Level 2 hypo / DKA episodes.
+ */
+function effectiveCooldown(
+  configuredMinutes: number,
+  severity: EmergencyAlertSeverity,
+): number {
+  if (severity === "critical") {
+    return Math.min(configuredMinutes, CRITICAL_COOLDOWN_CEILING)
+  }
+  return configuredMinutes
+}
+
+/**
+ * Check whether an existing live alert blocks re-emission.
+ * Severity-aware: a higher-severity classification can pierce cooldown of
+ * the same alertType (e.g. hypo escalating to severe_hypo).
+ */
+async function findCooldownBlocker(
+  patientId: number,
+  alertType: EmergencyAlertType,
+  cooldownMinutes: number,
+  now: Date,
+): Promise<{ id: number } | null> {
+  const cooldownStart = new Date(now.getTime() - cooldownMinutes * 60_000)
+  const found = await prisma.emergencyAlert.findFirst({
+    where: {
+      patientId,
+      alertType,
+      OR: [
+        { status: { in: ["open", "acknowledged"] } },
+        { status: "resolved", resolvedAt: { gte: cooldownStart } },
+      ],
+    },
+    select: { id: true },
+    orderBy: { triggeredAt: "desc" },
+  })
+  return found
+}
+
+/**
+ * Notify the patient's doctor referent of a critical alert (US-2230).
+ * **Lockscreen privacy**: title/body are intentionally generic; the alert
+ * type & severity are placed in `data` only (not displayed without unlock).
+ * Best-effort: failures are logged but never break the trigger transaction.
+ */
+async function notifyCriticalAlert(
+  alert: {
+    id: number
+    patientId: number
+    alertType: EmergencyAlertType
+    severity: EmergencyAlertSeverity
+  },
+  notifyPush: boolean,
+  senderId: number,
+): Promise<void> {
+  if (!notifyPush) return
+
+  try {
+    const referent = await prisma.patientReferent.findUnique({
+      where: { patientId: alert.patientId },
+      select: { pro: { select: { userId: true } } },
+    })
+
+    const recipients = new Set<number>()
+    const referentUserId = referent?.pro?.userId
+    if (referentUserId) recipients.add(referentUserId)
+
+    if (recipients.size === 0) return
+
+    // Generic lockscreen title/body — alert type only in data payload.
+    const title = "Diabeo — Alerte"
+    const body = "Connectez-vous pour voir les détails."
+
+    await Promise.all(
+      Array.from(recipients).map((userId) =>
+        fcmService.sendToUser({
+          userId,
+          senderId,
+          title,
+          body,
+          data: {
+            kind: "emergency_alert",
+            alertId: String(alert.id),
+            patientId: String(alert.patientId),
+            alertType: alert.alertType,
+            severity: alert.severity,
+            deepLink: `/dashboard/emergencies/${alert.id}`,
+          },
+        }),
+      ),
+    )
+  } catch (err) {
+    logger.error("emergency", "FCM dispatch failed for critical alert", {
+      patientId: alert.patientId,
+    }, err)
+  }
+}
+
+/** Insert helper that traps the unique-constraint collision (TOCTOU race). */
+async function safeCreateAlert<T>(
+  fn: () => Promise<T>,
+): Promise<T | null> {
+  try {
+    return await fn()
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+      return null
+    }
+    throw err
+  }
+}
+
+/**
+ * Decrypt user-facing fields on an alert read.
+ */
+function decryptAlertFields<
+  T extends {
+    notes?: string | null
+    resolutionNotes?: string | null
+    contextSnapshot?: string | null
+  },
+>(alert: T): T & {
+  notes: string | null
+  resolutionNotes: string | null
+  contextSnapshotPoints: CgmSnapshotPoint[]
+} {
+  return {
+    ...alert,
+    notes: safeDecryptField(alert.notes ?? null),
+    resolutionNotes: safeDecryptField(alert.resolutionNotes ?? null),
+    contextSnapshotPoints: decryptSnapshot(alert.contextSnapshot ?? null),
+  }
+}
+
+export const emergencyService = {
+  /**
+   * Detect & emit alert from a freshly-recorded CGM value.
+   * No-op if no threshold breached or cooldown still active.
+   */
+  async detectFromCgm(
+    input: DetectFromCgmInput,
+    auditUserId: number,
+    ctx?: AuditContext,
+  ): Promise<{ id: number; alertType: EmergencyAlertType } | null> {
+    const triggeredAt = input.triggeredAt ?? new Date()
+    const [cgmObjective, alertConfig, patient] = await Promise.all([
+      prisma.cgmObjective.findUnique({ where: { patientId: input.patientId } }),
+      prisma.alertThresholdConfig.findUnique({
+        where: { patientId: input.patientId },
+      }),
+      prisma.patient.findFirst({
+        where: { id: input.patientId, deletedAt: null },
+        select: { id: true, pregnancyMode: true, pathology: true },
+      }),
+    ])
+    if (!patient) return null
+
+    const isStrict = patient.pregnancyMode || patient.pathology === "GD"
+    const thresholds = cgmObjective
+      ? {
+          veryLowMgdl: cgmObjective.veryLow.toNumber() * GL_TO_MGDL,
+          lowMgdl: cgmObjective.low.toNumber() * GL_TO_MGDL,
+          okMgdl: cgmObjective.ok.toNumber() * GL_TO_MGDL,
+          highMgdl: cgmObjective.high.toNumber() * GL_TO_MGDL,
+        }
+      : isStrict
+        ? { veryLowMgdl: 60, lowMgdl: 63, okMgdl: 140, highMgdl: 200 }
+        : { veryLowMgdl: 54, lowMgdl: 70, okMgdl: 180, highMgdl: 250 }
+
+    const rules = alertConfig ?? {
+      alertOnHypo: true,
+      alertOnSevereHypo: true,
+      alertOnHyper: false,
+      alertOnSevereHyper: true,
+      notifyDoctorPush: true,
+      notifyDoctorEmail: false,
+      cooldownMinutes: 30,
+    }
+
+    const classified = classifyCgmAlert(input.glucoseValueMgdl, thresholds, rules)
+    if (!classified) return null
+
+    const cooldown = effectiveCooldown(rules.cooldownMinutes, classified.severity)
+    const blocker = await findCooldownBlocker(
+      input.patientId,
+      classified.type,
+      cooldown,
+      triggeredAt,
+    )
+    if (blocker) return null
+
+    const contextSnapshot = await captureContextSnapshot(input.patientId, triggeredAt)
+
+    const alert = await safeCreateAlert(() =>
+      prisma.$transaction(async (tx) => {
+        const created = await tx.emergencyAlert.create({
+          data: {
+            patientId: input.patientId,
+            alertType: classified.type,
+            severity: classified.severity,
+            status: "open",
+            triggeredAt,
+            glucoseValueMgdl: input.glucoseValueMgdl,
+            contextSnapshot,
+          },
+        })
+        await auditService.logWithTx(tx, {
+          userId: auditUserId,
+          action: "CREATE",
+          resource: "PATIENT",
+          resourceId: `${input.patientId}:emergency-alert:${created.id}`,
+          ipAddress: ctx?.ipAddress,
+          userAgent: ctx?.userAgent,
+          metadata: {
+            alertType: classified.type,
+            severity: classified.severity,
+            glucoseValueMgdl: input.glucoseValueMgdl,
+          },
+        })
+        return created
+      }),
+    )
+
+    if (!alert) return null
+
+    await notifyCriticalAlert(
+      {
+        id: alert.id,
+        patientId: alert.patientId,
+        alertType: alert.alertType,
+        severity: alert.severity,
+      },
+      rules.notifyDoctorPush && classified.severity === "critical",
+      auditUserId,
+    )
+
+    return { id: alert.id, alertType: alert.alertType }
+  },
+
+  /**
+   * Detect & emit alert from a ketone reading.
+   */
+  async detectFromKetone(
+    input: DetectFromKetoneInput,
+    auditUserId: number,
+    ctx?: AuditContext,
+  ): Promise<{ id: number; alertType: EmergencyAlertType } | null> {
+    const triggeredAt = input.triggeredAt ?? new Date()
+    const [config, alertConfig, patient] = await Promise.all([
+      prisma.ketoneThreshold.findUnique({ where: { patientId: input.patientId } }),
+      prisma.alertThresholdConfig.findUnique({
+        where: { patientId: input.patientId },
+      }),
+      prisma.patient.findFirst({
+        where: { id: input.patientId, deletedAt: null },
+        select: { id: true },
+      }),
+    ])
+    if (!patient) return null
+
+    const thresholds = config
+      ? {
+          moderateThreshold: config.moderateThreshold.toNumber(),
+          dkaThreshold: config.dkaThreshold.toNumber(),
+          alertOnModerate: config.alertOnModerate,
+          alertOnDka: config.alertOnDka,
+        }
+      : { moderateThreshold: 1.5, dkaThreshold: 3.0, alertOnModerate: true, alertOnDka: true }
+
+    const classified = classifyKetoneAlert(input.ketoneValueMmol, thresholds)
+    if (!classified) return null
+
+    const baseCooldown = alertConfig?.cooldownMinutes ?? 30
+    const cooldown = effectiveCooldown(baseCooldown, classified.severity)
+    const blocker = await findCooldownBlocker(
+      input.patientId,
+      classified.type,
+      cooldown,
+      triggeredAt,
+    )
+    if (blocker) return null
+
+    const alert = await safeCreateAlert(() =>
+      prisma.$transaction(async (tx) => {
+        const created = await tx.emergencyAlert.create({
+          data: {
+            patientId: input.patientId,
+            alertType: classified.type,
+            severity: classified.severity,
+            status: "open",
+            triggeredAt,
+            ketoneValueMmol: input.ketoneValueMmol,
+          },
+        })
+        await auditService.logWithTx(tx, {
+          userId: auditUserId,
+          action: "CREATE",
+          resource: "PATIENT",
+          resourceId: `${input.patientId}:emergency-alert:${created.id}`,
+          ipAddress: ctx?.ipAddress,
+          userAgent: ctx?.userAgent,
+          metadata: {
+            alertType: classified.type,
+            severity: classified.severity,
+            ketoneValueMmol: input.ketoneValueMmol,
+          },
+        })
+        return created
+      }),
+    )
+
+    if (!alert) return null
+
+    const notifyPush = (alertConfig?.notifyDoctorPush ?? true) && classified.severity === "critical"
+    await notifyCriticalAlert(
+      {
+        id: alert.id,
+        patientId: alert.patientId,
+        alertType: alert.alertType,
+        severity: alert.severity,
+      },
+      notifyPush,
+      auditUserId,
+    )
+
+    return { id: alert.id, alertType: alert.alertType }
+  },
+
+  /**
+   * Manually create an alert (e.g. patient self-report).
+   * Cooldown applies to manual alerts to prevent inbox flooding.
+   */
+  async createManual(
+    input: CreateManualAlertInput,
+    auditUserId: number,
+    ctx?: AuditContext,
+  ) {
+    const patient = await prisma.patient.findFirst({
+      where: { id: input.patientId, deletedAt: null },
+      select: { id: true },
+    })
+    if (!patient) throw new Error("patient_not_found")
+
+    const triggeredAt = new Date()
+    const alertConfig = await prisma.alertThresholdConfig.findUnique({
+      where: { patientId: input.patientId },
+      select: { cooldownMinutes: true, notifyDoctorPush: true },
+    })
+    const cooldown = effectiveCooldown(
+      alertConfig?.cooldownMinutes ?? 30,
+      input.severity,
+    )
+    const blocker = await findCooldownBlocker(
+      input.patientId,
+      "manual",
+      cooldown,
+      triggeredAt,
+    )
+    if (blocker) throw new Error("manual_alert_cooldown")
+
+    const contextSnapshot = await captureContextSnapshot(input.patientId, triggeredAt)
+    const encryptedNotes = input.notes?.trim()
+      ? encryptField(input.notes.trim())
+      : null
+
+    const alert = await safeCreateAlert(() =>
+      prisma.$transaction(async (tx) => {
+        const created = await tx.emergencyAlert.create({
+          data: {
+            patientId: input.patientId,
+            alertType: "manual",
+            severity: input.severity,
+            status: "open",
+            triggeredAt,
+            notes: encryptedNotes,
+            contextSnapshot,
+          },
+        })
+        await auditService.logWithTx(tx, {
+          userId: auditUserId,
+          action: "CREATE",
+          resource: "PATIENT",
+          resourceId: `${input.patientId}:emergency-alert:${created.id}`,
+          ipAddress: ctx?.ipAddress,
+          userAgent: ctx?.userAgent,
+          metadata: { alertType: "manual", severity: input.severity },
+        })
+        return created
+      }),
+    )
+
+    if (!alert) throw new Error("manual_alert_cooldown")
+
+    await notifyCriticalAlert(
+      {
+        id: alert.id,
+        patientId: alert.patientId,
+        alertType: alert.alertType,
+        severity: alert.severity,
+      },
+      (alertConfig?.notifyDoctorPush ?? true) && input.severity === "critical",
+      auditUserId,
+    )
+
+    return decryptAlertFields(alert)
+  },
+
+  /**
+   * RBAC-scoped inbox listing.
+   * Pros (NURSE/DOCTOR/VIEWER) MUST pass `scopePatientIds` (their accessible
+   * patients). ADMIN passes null/undefined for unrestricted access.
+   */
+  async list(filter: EmergencyAlertListFilter, auditUserId: number, ctx?: AuditContext) {
+    const limit = Math.min(filter.limit ?? 25, MAX_LIST_LIMIT)
+
+    // RBAC scope guard — caller MUST pass scope for non-ADMIN.
+    const scopeFilter: Prisma.EmergencyAlertWhereInput = (() => {
+      if (filter.patientId !== undefined) {
+        return { patientId: filter.patientId }
+      }
+      if (filter.scopePatientIds === undefined || filter.scopePatientIds === null) {
+        // ADMIN unrestricted
+        return {}
+      }
+      if (filter.scopePatientIds.length === 0) {
+        // Pro with no patients in portfolio — empty scope.
+        return { patientId: { in: [] } }
+      }
+      return { patientId: { in: filter.scopePatientIds } }
+    })()
+
+    const where: Prisma.EmergencyAlertWhereInput = {
+      patient: { deletedAt: null },
+      ...scopeFilter,
+      ...(filter.status?.length && { status: { in: filter.status } }),
+      ...(filter.severity?.length && { severity: { in: filter.severity } }),
+      ...(filter.alertType?.length && { alertType: { in: filter.alertType } }),
+      ...((filter.from ?? filter.to) && {
+        triggeredAt: {
+          ...(filter.from && { gte: filter.from }),
+          ...(filter.to && { lte: filter.to }),
+        },
+      }),
+    }
+
+    const items = await prisma.emergencyAlert.findMany({
+      where,
+      orderBy: [
+        { severity: "desc" },
+        { triggeredAt: "desc" },
+      ],
+      take: limit + 1,
+      ...(filter.cursor && { cursor: { id: filter.cursor }, skip: 1 }),
+    })
+
+    const hasMore = items.length > limit
+    const page = hasMore ? items.slice(0, limit) : items
+    const nextCursor = hasMore ? (page[page.length - 1]?.id ?? null) : null
+
+    await auditService.log({
+      userId: auditUserId,
+      action: "READ",
+      resource: "PATIENT",
+      resourceId: "emergency-alerts:list",
+      ipAddress: ctx?.ipAddress,
+      userAgent: ctx?.userAgent,
+      metadata: {
+        count: page.length,
+        scoped: filter.scopePatientIds !== undefined && filter.scopePatientIds !== null,
+      },
+    })
+
+    return {
+      items: page.map((a) => decryptAlertFields(a)),
+      nextCursor,
+    }
+  },
+
+  /**
+   * Lightweight loader used for authorization checks — does NOT audit.
+   * Returns minimal fields needed by canAccessPatient.
+   */
+  async loadForAccessCheck(alertId: number) {
+    return prisma.emergencyAlert.findUnique({
+      where: { id: alertId },
+      select: { id: true, patientId: true, status: true, patient: { select: { deletedAt: true } } },
+    })
+  },
+
+  /**
+   * Detail view incl. timeline (CGM context window) — US-2225.
+   * Caller must have already authorized the alert via loadForAccessCheck.
+   */
+  async getDetail(alertId: number, auditUserId: number, ctx?: AuditContext) {
+    const alert = await prisma.emergencyAlert.findUnique({
+      where: { id: alertId },
+      include: {
+        actions: { orderBy: { createdAt: "asc" } },
+      },
+    })
+    if (!alert) return null
+    const softDeleted = await prisma.patient.findFirst({
+      where: { id: alert.patientId, deletedAt: { not: null } },
+      select: { id: true },
+    })
+    if (softDeleted) return null
+
+    await auditService.log({
+      userId: auditUserId,
+      action: "READ",
+      resource: "PATIENT",
+      resourceId: `${alert.patientId}:emergency-alert:${alertId}`,
+      ipAddress: ctx?.ipAddress,
+      userAgent: ctx?.userAgent,
+    })
+
+    return {
+      ...decryptAlertFields(alert),
+      actions: alert.actions.map((a) => ({
+        ...a,
+        notes: safeDecryptField(a.notes),
+      })),
+    }
+  },
+
+  async acknowledge(
+    alertId: number,
+    userId: number,
+    notes: string | undefined,
+    ctx?: AuditContext,
+  ) {
+    return prisma.$transaction(async (tx) => {
+      const existing = await tx.emergencyAlert.findUnique({
+        where: { id: alertId },
+        select: {
+          id: true,
+          status: true,
+          patientId: true,
+          patient: { select: { deletedAt: true } },
+        },
+      })
+      if (!existing) throw new Error("alert_not_found")
+      if (existing.patient.deletedAt) throw new Error("patient_deleted")
+      if (existing.status !== "open") throw new Error("alert_not_open")
+
+      const updated = await tx.emergencyAlert.update({
+        where: { id: alertId },
+        data: {
+          status: "acknowledged",
+          acknowledgedBy: userId,
+          acknowledgedAt: new Date(),
+        },
+      })
+
+      const encryptedNotes = notes?.trim() ? encryptField(notes.trim()) : null
+      await tx.emergencyAlertAction.create({
+        data: {
+          alertId,
+          performedBy: userId,
+          actionType: "acknowledge",
+          notes: encryptedNotes,
+        },
+      })
+
+      await auditService.logWithTx(tx, {
+        userId,
+        action: "UPDATE",
+        resource: "PATIENT",
+        resourceId: `${existing.patientId}:emergency-alert:${alertId}`,
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+        metadata: { transition: "open->acknowledged" },
+      })
+
+      return decryptAlertFields(updated)
+    })
+  },
+
+  async resolve(
+    alertId: number,
+    userId: number,
+    resolutionNotes: string | undefined,
+    ctx?: AuditContext,
+  ) {
+    return prisma.$transaction(async (tx) => {
+      const existing = await tx.emergencyAlert.findUnique({
+        where: { id: alertId },
+        select: {
+          id: true,
+          status: true,
+          patientId: true,
+          patient: { select: { deletedAt: true } },
+        },
+      })
+      if (!existing) throw new Error("alert_not_found")
+      if (existing.patient.deletedAt) throw new Error("patient_deleted")
+      if (existing.status === "resolved" || existing.status === "expired") {
+        throw new Error("alert_already_closed")
+      }
+
+      const encryptedNotes = resolutionNotes?.trim()
+        ? encryptField(resolutionNotes.trim())
+        : null
+
+      const updated = await tx.emergencyAlert.update({
+        where: { id: alertId },
+        data: {
+          status: "resolved",
+          resolvedBy: userId,
+          resolvedAt: new Date(),
+          resolutionNotes: encryptedNotes,
+        },
+      })
+
+      await tx.emergencyAlertAction.create({
+        data: {
+          alertId,
+          performedBy: userId,
+          actionType: "resolve",
+          notes: encryptedNotes,
+        },
+      })
+
+      await auditService.logWithTx(tx, {
+        userId,
+        action: "UPDATE",
+        resource: "PATIENT",
+        resourceId: `${existing.patientId}:emergency-alert:${alertId}`,
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+        metadata: { transition: `${existing.status}->resolved` },
+      })
+
+      return decryptAlertFields(updated)
+    })
+  },
+
+  /**
+   * Append a workflow action without changing the alert status.
+   * Used for "call patient" / "adjust treatment" / "send message" steps.
+   */
+  async addAction(input: AlertActionInput, ctx?: AuditContext) {
+    const alert = await prisma.emergencyAlert.findUnique({
+      where: { id: input.alertId },
+      select: {
+        id: true,
+        patientId: true,
+        status: true,
+        patient: { select: { deletedAt: true } },
+      },
+    })
+    if (!alert) throw new Error("alert_not_found")
+    if (alert.patient.deletedAt) throw new Error("patient_deleted")
+    if (alert.status === "expired") throw new Error("alert_expired")
+
+    const encryptedNotes = input.notes?.trim()
+      ? encryptField(input.notes.trim())
+      : null
+    const safeMetadata = {
+      ...(input.metadata?.durationSec !== undefined && { durationSec: input.metadata.durationSec }),
+      ...(input.metadata?.outcome !== undefined && { outcome: input.metadata.outcome }),
+    }
+
+    return prisma.$transaction(async (tx) => {
+      const action = await tx.emergencyAlertAction.create({
+        data: {
+          alertId: input.alertId,
+          performedBy: input.performedBy,
+          actionType: input.actionType,
+          notes: encryptedNotes,
+          metadata: safeMetadata,
+        },
+      })
+
+      await auditService.logWithTx(tx, {
+        userId: input.performedBy,
+        action: "CREATE",
+        resource: "PATIENT",
+        resourceId: `${alert.patientId}:emergency-alert:${input.alertId}:action`,
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+        metadata: { actionType: input.actionType },
+      })
+
+      return {
+        ...action,
+        notes: safeDecryptField(action.notes),
+      }
+    })
+  },
+}
+
+export const __test__ = {
+  classifyCgmAlert,
+  classifyKetoneAlert,
+  effectiveCooldown,
+  CRITICAL_COOLDOWN_CEILING,
+}

--- a/src/lib/services/hypo-treatment.service.ts
+++ b/src/lib/services/hypo-treatment.service.ts
@@ -1,0 +1,170 @@
+/**
+ * @module hypo-treatment.service
+ * @description US-2217 — Hypoglycemia treatment protocol per patient.
+ *
+ * Clinical reference: ADA "Rule of 15/15" — for non-severe hypoglycemia, ingest
+ * 15 g of fast-acting carbs, retest blood glucose in 15 minutes, repeat if still
+ * < 70 mg/dL. Sugar type adapted to patient preferences/allergies.
+ *
+ * Personal medical content (allergies, instructions) is encrypted at rest.
+ */
+
+import { prisma } from "@/lib/db/client"
+import { encryptField, safeDecryptField } from "@/lib/crypto/fields"
+import { auditService } from "./audit.service"
+import type { AuditContext } from "./patient.service"
+import type { HypoSugarType } from "@prisma/client"
+
+/**
+ * Standard ADA defaults — adult, non-severe hypoglycemia.
+ */
+export const HYPO_TREATMENT_DEFAULTS = {
+  sugarType: "glucose_tabs" as HypoSugarType,
+  fastCarbsGrams: 15,
+  retestMinutes: 15,
+} as const
+
+/**
+ * Clinical bounds — refuse values that could harm a patient.
+ * Carbs: 5–60 g (smaller for children, never above 60 g per ingestion).
+ * Retest: 5–30 minutes — ADA "Rule of 15/15" prescribes 15 min; ceiling at
+ * 30 min accommodates pediatric/elderly variation but never beyond, otherwise
+ * neuroglycopenia risk on Level 1 hypo. Severe hypo (< 54 mg/dL) is out of
+ * scope for self-treatment retest — requires glucagon / emergency response.
+ */
+export const HYPO_TREATMENT_BOUNDS = {
+  CARBS_MIN: 5,
+  CARBS_MAX: 60,
+  RETEST_MIN: 5,
+  RETEST_MAX: 30,
+} as const
+
+interface HypoTreatmentInput {
+  sugarType?: HypoSugarType
+  sugarTypeOther?: string | null
+  fastCarbsGrams?: number
+  retestMinutes?: number
+  allergies?: string | null
+  instructions?: string | null
+}
+
+export function validateHypoTreatment(input: {
+  fastCarbsGrams: number
+  retestMinutes: number
+}): string | null {
+  if (
+    input.fastCarbsGrams < HYPO_TREATMENT_BOUNDS.CARBS_MIN ||
+    input.fastCarbsGrams > HYPO_TREATMENT_BOUNDS.CARBS_MAX
+  ) {
+    return "carbs_out_of_bounds"
+  }
+  if (
+    input.retestMinutes < HYPO_TREATMENT_BOUNDS.RETEST_MIN ||
+    input.retestMinutes > HYPO_TREATMENT_BOUNDS.RETEST_MAX
+  ) {
+    return "retest_out_of_bounds"
+  }
+  return null
+}
+
+export const hypoTreatmentService = {
+  async get(patientId: number, auditUserId: number, ctx?: AuditContext) {
+    const [record, patient] = await Promise.all([
+      prisma.hypoTreatmentProtocol.findUnique({ where: { patientId } }),
+      prisma.patient.findFirst({
+        where: { id: patientId, deletedAt: null },
+        select: { id: true },
+      }),
+    ])
+
+    if (!patient) return null
+
+    await auditService.log({
+      userId: auditUserId,
+      action: "READ",
+      resource: "PATIENT",
+      resourceId: `${patientId}:hypo-treatment`,
+      ipAddress: ctx?.ipAddress,
+      userAgent: ctx?.userAgent,
+    })
+
+    if (!record) {
+      return {
+        patientId,
+        ...HYPO_TREATMENT_DEFAULTS,
+        sugarTypeOther: null,
+        allergies: null,
+        instructions: null,
+      }
+    }
+
+    return {
+      ...record,
+      allergies: safeDecryptField(record.allergies),
+      instructions: safeDecryptField(record.instructions),
+    }
+  },
+
+  async upsert(
+    patientId: number,
+    input: HypoTreatmentInput,
+    auditUserId: number,
+    ctx?: AuditContext,
+  ) {
+    const fastCarbsGrams =
+      input.fastCarbsGrams ?? HYPO_TREATMENT_DEFAULTS.fastCarbsGrams
+    const retestMinutes =
+      input.retestMinutes ?? HYPO_TREATMENT_DEFAULTS.retestMinutes
+
+    const error = validateHypoTreatment({ fastCarbsGrams, retestMinutes })
+    if (error) throw new Error(error)
+
+    if (input.sugarType === "other" && !input.sugarTypeOther?.trim()) {
+      throw new Error("sugar_type_other_required")
+    }
+
+    return prisma.$transaction(async (tx) => {
+      const data = {
+        sugarType: input.sugarType ?? HYPO_TREATMENT_DEFAULTS.sugarType,
+        sugarTypeOther:
+          input.sugarType === "other"
+            ? input.sugarTypeOther?.trim() ?? null
+            : null,
+        fastCarbsGrams,
+        retestMinutes,
+        allergies: input.allergies?.trim()
+          ? encryptField(input.allergies.trim())
+          : null,
+        instructions: input.instructions?.trim()
+          ? encryptField(input.instructions.trim())
+          : null,
+      }
+
+      const updated = await tx.hypoTreatmentProtocol.upsert({
+        where: { patientId },
+        update: data,
+        create: { patientId, ...data },
+      })
+
+      await auditService.logWithTx(tx, {
+        userId: auditUserId,
+        action: "UPDATE",
+        resource: "PATIENT",
+        resourceId: `${patientId}:hypo-treatment`,
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+        metadata: {
+          sugarType: data.sugarType,
+          fastCarbsGrams: data.fastCarbsGrams,
+          retestMinutes: data.retestMinutes,
+        },
+      })
+
+      return {
+        ...updated,
+        allergies: safeDecryptField(updated.allergies),
+        instructions: safeDecryptField(updated.instructions),
+      }
+    })
+  },
+}

--- a/src/lib/services/ketone-threshold.service.ts
+++ b/src/lib/services/ketone-threshold.service.ts
@@ -73,8 +73,12 @@ export function validateKetoneThresholds(input: {
   if (lightThreshold >= moderateThreshold) {
     return "light_must_be_less_than_moderate"
   }
-  if (moderateThreshold > dkaThreshold) {
-    return "moderate_must_be_lte_dka"
+  // Strict ordering aligns with ISPAD distinct moderate/severe bands and
+  // prevents a degenerate config where a clinician sets moderate==dka and
+  // then expects to "downgrade" by toggling alertOnDka — which the classifier
+  // refuses (see emergency.service classifyKetoneAlert clinical safety note).
+  if (moderateThreshold >= dkaThreshold) {
+    return "moderate_must_be_less_than_dka"
   }
   return null
 }

--- a/src/lib/services/ketone-threshold.service.ts
+++ b/src/lib/services/ketone-threshold.service.ts
@@ -1,0 +1,151 @@
+/**
+ * @module ketone-threshold.service
+ * @description US-2216 — Ketone thresholds per patient with clinical defaults.
+ *
+ * Clinical reference: ADA Diabetes Care 2024 — DKA prevention guidelines.
+ *  - Light ketones (0.6–1.5 mmol/L)    → enhanced monitoring
+ *  - Moderate ketones (1.5–3.0 mmol/L) → fast-acting insulin + carbs + hydration
+ *  - DKA threshold (> 3.0 mmol/L)      → emergency, hospital protocol
+ *
+ * Storage layer for evaluation; alert emission lives in emergency.service.ts.
+ * @see CLAUDE.md#audit-traceability — All reads/writes audited
+ */
+
+import { prisma } from "@/lib/db/client"
+import { auditService } from "./audit.service"
+import type { AuditContext } from "./patient.service"
+
+/**
+ * Default ketone thresholds (mmol/L).
+ * - Light: 0.6 mmol/L  → onset of detectable ketones (β-hydroxybutyrate).
+ * - Moderate: 1.5 mmol/L → action required (insulin + carbs + hydration) per ISPAD/IDF.
+ * - DKA: 3.0 mmol/L → impending DKA per ISPAD 2022 (≥ 3.0 is a DKA criterion).
+ */
+export const KETONE_DEFAULTS = {
+  lightThreshold: 0.6,
+  moderateThreshold: 1.5,
+  dkaThreshold: 3.0,
+  alertOnModerate: true,
+  alertOnDka: true,
+} as const
+
+/**
+ * Hard clinical bounds — refuse out-of-range values to protect patients.
+ * Light < Moderate ≤ DKA, all > 0, all ≤ 10 mmol/L (physiological maximum).
+ */
+export const KETONE_BOUNDS = {
+  MIN: 0.1,
+  MAX: 10.0,
+} as const
+
+interface KetoneThresholdInput {
+  lightThreshold?: number
+  moderateThreshold?: number
+  dkaThreshold?: number
+  alertOnModerate?: boolean
+  alertOnDka?: boolean
+}
+
+/**
+ * Validate threshold ordering & clinical bounds.
+ * Returns error message or null when valid.
+ */
+export function validateKetoneThresholds(input: {
+  lightThreshold: number
+  moderateThreshold: number
+  dkaThreshold: number
+}): string | null {
+  const { lightThreshold, moderateThreshold, dkaThreshold } = input
+  if (
+    lightThreshold < KETONE_BOUNDS.MIN ||
+    moderateThreshold < KETONE_BOUNDS.MIN ||
+    dkaThreshold < KETONE_BOUNDS.MIN
+  ) {
+    return "ketone_threshold_below_min"
+  }
+  if (
+    lightThreshold > KETONE_BOUNDS.MAX ||
+    moderateThreshold > KETONE_BOUNDS.MAX ||
+    dkaThreshold > KETONE_BOUNDS.MAX
+  ) {
+    return "ketone_threshold_above_max"
+  }
+  if (lightThreshold >= moderateThreshold) {
+    return "light_must_be_less_than_moderate"
+  }
+  if (moderateThreshold > dkaThreshold) {
+    return "moderate_must_be_lte_dka"
+  }
+  return null
+}
+
+export const ketoneThresholdService = {
+  async get(patientId: number, auditUserId: number, ctx?: AuditContext) {
+    const [record, patient] = await Promise.all([
+      prisma.ketoneThreshold.findUnique({ where: { patientId } }),
+      prisma.patient.findFirst({
+        where: { id: patientId, deletedAt: null },
+        select: { id: true },
+      }),
+    ])
+
+    if (!patient) return null
+
+    await auditService.log({
+      userId: auditUserId,
+      action: "READ",
+      resource: "PATIENT",
+      resourceId: `${patientId}:ketone-thresholds`,
+      ipAddress: ctx?.ipAddress,
+      userAgent: ctx?.userAgent,
+    })
+
+    return record ?? { patientId, ...KETONE_DEFAULTS }
+  },
+
+  async upsert(
+    patientId: number,
+    input: KetoneThresholdInput,
+    auditUserId: number,
+    ctx?: AuditContext,
+  ) {
+    const merged = {
+      lightThreshold: input.lightThreshold ?? KETONE_DEFAULTS.lightThreshold,
+      moderateThreshold:
+        input.moderateThreshold ?? KETONE_DEFAULTS.moderateThreshold,
+      dkaThreshold: input.dkaThreshold ?? KETONE_DEFAULTS.dkaThreshold,
+    }
+    const error = validateKetoneThresholds(merged)
+    if (error) {
+      throw new Error(error)
+    }
+
+    return prisma.$transaction(async (tx) => {
+      const data = {
+        ...merged,
+        ...(input.alertOnModerate !== undefined && {
+          alertOnModerate: input.alertOnModerate,
+        }),
+        ...(input.alertOnDka !== undefined && { alertOnDka: input.alertOnDka }),
+      }
+
+      const updated = await tx.ketoneThreshold.upsert({
+        where: { patientId },
+        update: data,
+        create: { patientId, ...data },
+      })
+
+      await auditService.logWithTx(tx, {
+        userId: auditUserId,
+        action: "UPDATE",
+        resource: "PATIENT",
+        resourceId: `${patientId}:ketone-thresholds`,
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+        metadata: { thresholds: merged },
+      })
+
+      return updated
+    })
+  },
+}

--- a/src/lib/services/objectives.service.ts
+++ b/src/lib/services/objectives.service.ts
@@ -45,13 +45,17 @@ const CGM_DEFAULTS: CgmThresholds = {
 }
 
 /**
- * Tighter CGM defaults for gestational diabetes (ADA/ACOG consensus).
+ * Tighter CGM defaults for gestational diabetes (ADA/ACOG/Battelino 2019 consensus).
  * GD requires stricter control to prevent fetal complications.
+ *  - veryLow=0.60 g/L (60 mg/dL): earlier critical alert in pregnancy where
+ *    < 63 mg/dL is already considered hypoglycemia (Battelino 2019 *Diabetes Care*).
+ *  - high=2.00 g/L (200 mg/dL): clinically significant hyperglycemia in pregnancy.
  * @constant
  * @see https://www.acog.org/ — ACOG gestational diabetes guidelines
+ * @see Battelino T. et al., *Diabetes Care* 2019 — Time in Range targets in pregnancy
  */
 const CGM_DEFAULTS_GD: CgmThresholds = {
-  veryLow: 0.54,
+  veryLow: 0.60,
   low: 0.63,
   ok: 1.40,
   high: 2.00,

--- a/src/lib/services/pregnancy-mode.service.ts
+++ b/src/lib/services/pregnancy-mode.service.ts
@@ -1,0 +1,101 @@
+/**
+ * @module pregnancy-mode.service
+ * @description US-2232 — Toggle pregnancy mode and auto-adapt CGM thresholds.
+ *
+ * Pregnancy mode tightens CGM thresholds per ADA/ACOG guidelines (gestational
+ * diabetes targets are stricter to protect the fetus). Toggling ON copies the
+ * GD defaults into CgmObjective; toggling OFF restores ADA standard defaults.
+ *
+ * The toggle is independent from PatientPregnancy.active (which records the
+ * actual pregnancy) — clinicians can flip the mode quickly, then complete the
+ * pregnancy record later. Email/push notifications are a doctor decision and
+ * are not triggered by this toggle.
+ *
+ * **Safety guard (clinical)**: toggling OFF while PatientPregnancy.active
+ * is true is rejected unless the caller passes `forceOverride: true`. Loosening
+ * thresholds during a confirmed pregnancy is a fetal-risk regression.
+ */
+
+import { prisma } from "@/lib/db/client"
+import { getCgmDefaults } from "./objectives.service"
+import { auditService } from "./audit.service"
+import type { AuditContext } from "./patient.service"
+
+interface SetModeOptions {
+  /** Bypass the active-pregnancy guard when disabling. Audit-tagged. */
+  forceOverride?: boolean
+}
+
+export const pregnancyModeService = {
+  async setMode(
+    patientId: number,
+    enabled: boolean,
+    auditUserId: number,
+    ctx?: AuditContext,
+    options?: SetModeOptions,
+  ) {
+    const patient = await prisma.patient.findFirst({
+      where: { id: patientId, deletedAt: null },
+      select: { id: true, pregnancyMode: true, pathology: true },
+    })
+    if (!patient) throw new Error("patient_not_found")
+
+    if (patient.pregnancyMode === enabled) {
+      return { patientId, pregnancyMode: enabled, thresholdsAdapted: false }
+    }
+
+    // Safety: do not silently widen thresholds during an active pregnancy.
+    if (!enabled && !options?.forceOverride) {
+      const activePregnancy = await prisma.patientPregnancy.findFirst({
+        where: { patientId, active: true },
+        select: { id: true },
+      })
+      if (activePregnancy) {
+        throw new Error("active_pregnancy_blocks_toggle_off")
+      }
+    }
+
+    return prisma.$transaction(async (tx) => {
+      await tx.patient.update({
+        where: { id: patientId },
+        data: { pregnancyMode: enabled },
+      })
+
+      const defaults = getCgmDefaults(
+        enabled || patient.pathology === "GD" ? "GD" : patient.pathology,
+      )
+
+      const cgmData = {
+        veryLow: defaults.veryLow,
+        low: defaults.low,
+        ok: defaults.ok,
+        high: defaults.high,
+        titrLow: defaults.titrLow,
+        titrHigh: defaults.titrHigh,
+      }
+
+      await tx.cgmObjective.upsert({
+        where: { patientId },
+        update: cgmData,
+        create: { patientId, ...cgmData },
+      })
+
+      await auditService.logWithTx(tx, {
+        userId: auditUserId,
+        action: "UPDATE",
+        resource: "PATIENT",
+        resourceId: `${patientId}:pregnancy-mode`,
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+        oldValue: { pregnancyMode: patient.pregnancyMode },
+        newValue: { pregnancyMode: enabled },
+        metadata: {
+          thresholdsAdapted: true,
+          ...(options?.forceOverride && { forceOverride: true }),
+        },
+      })
+
+      return { patientId, pregnancyMode: enabled, thresholdsAdapted: true }
+    })
+  },
+}

--- a/src/lib/services/pregnancy-mode.service.ts
+++ b/src/lib/services/pregnancy-mode.service.ts
@@ -17,6 +17,7 @@
  */
 
 import { prisma } from "@/lib/db/client"
+import { encryptField } from "@/lib/crypto/fields"
 import { getCgmDefaults } from "./objectives.service"
 import { auditService } from "./audit.service"
 import type { AuditContext } from "./patient.service"
@@ -24,6 +25,11 @@ import type { AuditContext } from "./patient.service"
 interface SetModeOptions {
   /** Bypass the active-pregnancy guard when disabling. Audit-tagged. */
   forceOverride?: boolean
+  /**
+   * Required justification when forceOverride=true. Encrypted at rest in
+   * audit metadata. Min 20 chars to force a real medical reason.
+   */
+  forceOverrideReason?: string
 }
 
 export const pregnancyModeService = {
@@ -55,30 +61,50 @@ export const pregnancyModeService = {
       }
     }
 
+    // forceOverride requires a meaningful reason — pure boolean would let
+    // a careless click loosen fetal-protection thresholds without trace.
+    if (options?.forceOverride) {
+      const reason = options.forceOverrideReason?.trim() ?? ""
+      if (reason.length < 20) {
+        throw new Error("force_override_reason_required")
+      }
+    }
+
+    // Compute target defaults once, *outside* the transaction, so we know
+    // up-front whether thresholds will actually change. A toggle-OFF on a
+    // GD-pathology patient is a no-op for thresholds — audit must reflect this.
+    const targetPathology =
+      enabled || patient.pathology === "GD" ? "GD" : patient.pathology
+    const defaults = getCgmDefaults(targetPathology)
+    const currentCgm = await prisma.cgmObjective.findUnique({
+      where: { patientId },
+      select: {
+        veryLow: true, low: true, ok: true, high: true,
+        titrLow: true, titrHigh: true,
+      },
+    })
+    const thresholdsActuallyChange =
+      !currentCgm ||
+      currentCgm.veryLow.toNumber() !== defaults.veryLow ||
+      currentCgm.low.toNumber() !== defaults.low ||
+      currentCgm.ok.toNumber() !== defaults.ok ||
+      currentCgm.high.toNumber() !== defaults.high ||
+      currentCgm.titrLow.toNumber() !== defaults.titrLow ||
+      currentCgm.titrHigh.toNumber() !== defaults.titrHigh
+
     return prisma.$transaction(async (tx) => {
       await tx.patient.update({
         where: { id: patientId },
         data: { pregnancyMode: enabled },
       })
 
-      const defaults = getCgmDefaults(
-        enabled || patient.pathology === "GD" ? "GD" : patient.pathology,
-      )
-
-      const cgmData = {
-        veryLow: defaults.veryLow,
-        low: defaults.low,
-        ok: defaults.ok,
-        high: defaults.high,
-        titrLow: defaults.titrLow,
-        titrHigh: defaults.titrHigh,
+      if (thresholdsActuallyChange) {
+        await tx.cgmObjective.upsert({
+          where: { patientId },
+          update: defaults,
+          create: { patientId, ...defaults },
+        })
       }
-
-      await tx.cgmObjective.upsert({
-        where: { patientId },
-        update: cgmData,
-        create: { patientId, ...cgmData },
-      })
 
       await auditService.logWithTx(tx, {
         userId: auditUserId,
@@ -90,12 +116,23 @@ export const pregnancyModeService = {
         oldValue: { pregnancyMode: patient.pregnancyMode },
         newValue: { pregnancyMode: enabled },
         metadata: {
-          thresholdsAdapted: true,
-          ...(options?.forceOverride && { forceOverride: true }),
+          thresholdsAdapted: thresholdsActuallyChange,
+          pinnedTo: targetPathology,
+          ...(options?.forceOverride && {
+            forceOverride: true,
+            // Encrypt the medical reason — PHI / clinical justification.
+            forceOverrideReason: encryptField(
+              options.forceOverrideReason!.trim(),
+            ),
+          }),
         },
       })
 
-      return { patientId, pregnancyMode: enabled, thresholdsAdapted: true }
+      return {
+        patientId,
+        pregnancyMode: enabled,
+        thresholdsAdapted: thresholdsActuallyChange,
+      }
     })
   },
 }

--- a/tests/unit/access-control.test.ts
+++ b/tests/unit/access-control.test.ts
@@ -57,7 +57,7 @@ describe("canAccessPatient", () => {
 
   it("ADMIN can access any non-deleted patient", async () => {
     prismaMock.patient.findFirst.mockResolvedValue({
-      id: 99, userId: 50, pathology: "DT1", createdAt: new Date(), deletedAt: null,
+      id: 99, userId: 50, pathology: "DT1", pregnancyMode: false, createdAt: new Date(), deletedAt: null,
     })
     const result = await canAccessPatient(1, "ADMIN", 99)
     expect(result).toBe(true)
@@ -71,7 +71,7 @@ describe("canAccessPatient", () => {
 
   it("VIEWER can access own patient record", async () => {
     prismaMock.patient.findFirst.mockResolvedValue({
-      id: 5, userId: 42, pathology: "DT1", createdAt: new Date(), deletedAt: null,
+      id: 5, userId: 42, pathology: "DT1", pregnancyMode: false, createdAt: new Date(), deletedAt: null,
     })
     const result = await canAccessPatient(42, "VIEWER", 5)
     expect(result).toBe(true)

--- a/tests/unit/alert-threshold.service.test.ts
+++ b/tests/unit/alert-threshold.service.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Test suite: Alert Threshold Service (US-2215)
+ *
+ * Clinical behavior tested:
+ * - Defaults emit alerts on hypo / severe hypo / severe hyper but NOT on
+ *   simple hyper, since chronically high values would generate alert fatigue
+ *   and desensitize doctors.
+ * - Cooldown bounds (5–1440 min) prevent two failure modes: < 5 min would
+ *   spam doctors on noisy CGM data; > 24h would silence consecutive episodes
+ *   on different days.
+ * - Audit log entries are emitted on every read & write.
+ *
+ * Associated risks:
+ * - Cooldown of 0 would flood notifications during oscillating glucose.
+ * - Cooldown above 24h would lose visibility on next-day repeat events.
+ * - Disabling notifyDoctorPush silently would prevent escalation reaching
+ *   the referent — this should require an audit trail (covered by audit).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { prismaMock } from "../helpers/prisma-mock"
+
+import {
+  alertThresholdService,
+  ALERT_THRESHOLD_DEFAULTS,
+  COOLDOWN_BOUNDS,
+} from "@/lib/services/alert-threshold.service"
+
+describe("alertThresholdService", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  describe("get", () => {
+    it("returns defaults when no record exists (alert fatigue mitigation)", async () => {
+      prismaMock.alertThresholdConfig.findUnique.mockResolvedValue(null)
+      prismaMock.patient.findFirst.mockResolvedValue({ id: 1 } as never)
+      prismaMock.auditLog.create.mockResolvedValue({} as never)
+
+      const result = await alertThresholdService.get(1, 99)
+      expect(result).toMatchObject({ patientId: 1, ...ALERT_THRESHOLD_DEFAULTS })
+      // Defaults: simple hyper alerts off (alert-fatigue), severe hyper on.
+      expect((result as { alertOnHyper: boolean }).alertOnHyper).toBe(false)
+      expect((result as { alertOnSevereHyper: boolean }).alertOnSevereHyper).toBe(true)
+    })
+
+    it("returns null for soft-deleted patient (defense in depth)", async () => {
+      prismaMock.alertThresholdConfig.findUnique.mockResolvedValue(null)
+      prismaMock.patient.findFirst.mockResolvedValue(null)
+      const result = await alertThresholdService.get(1, 99)
+      expect(result).toBeNull()
+    })
+  })
+
+  describe("upsert", () => {
+    it("rejects cooldown below floor (notification flood risk)", async () => {
+      await expect(
+        alertThresholdService.upsert(1, { cooldownMinutes: COOLDOWN_BOUNDS.MIN - 1 }, 99),
+      ).rejects.toThrow("cooldown_out_of_bounds")
+    })
+
+    it("rejects cooldown above ceiling (24h silence risk)", async () => {
+      await expect(
+        alertThresholdService.upsert(1, { cooldownMinutes: COOLDOWN_BOUNDS.MAX + 1 }, 99),
+      ).rejects.toThrow("cooldown_out_of_bounds")
+    })
+
+    it("upserts within transaction & audits", async () => {
+      const upsertSpy = vi.fn().mockResolvedValue({
+        patientId: 1,
+        ...ALERT_THRESHOLD_DEFAULTS,
+        cooldownMinutes: 60,
+      })
+      const auditSpy = vi.fn().mockResolvedValue({})
+      const mockTx = {
+        alertThresholdConfig: { upsert: upsertSpy },
+        auditLog: { create: auditSpy },
+      }
+      prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+
+      await alertThresholdService.upsert(1, { cooldownMinutes: 60 }, 99)
+      expect(upsertSpy).toHaveBeenCalled()
+      expect(auditSpy).toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/unit/emergency.service.test.ts
+++ b/tests/unit/emergency.service.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Test suite: Emergency Service (US-2224/2225/2226/2230)
+ *
+ * Clinical behavior tested:
+ * - CGM threshold breach correctly classifies severity:
+ *   <54 mg/dL → severe_hypo / critical, <70 → hypo / warning,
+ *   >180 → hyper / warning, >250 → severe_hyper / critical.
+ * - Pregnancy mode activates tighter thresholds even when no CgmObjective
+ *   record exists (fallback path) — protects fetus from hyperglycemia.
+ * - Ketone threshold breach: > moderate (1.5) → warning, > DKA (3.0)
+ *   → critical.
+ * - Cooldown blocks duplicate alerts of the same type within the configured
+ *   window. Distinct types remain emittable to avoid masking new events.
+ * - Workflow transitions (open → acknowledged → resolved) only flow forward;
+ *   re-acking or re-resolving raises an error to keep audit honest.
+ *
+ * Associated risks:
+ * - Misclassifying critical as warning would disable push notifications
+ *   to the referent doctor (notifyDoctorPush only fires on critical).
+ * - Allowing duplicate alerts during a hypo episode would fatigue the
+ *   referent and slow real-emergency response.
+ *
+ * Edge cases:
+ * - Glucose precisely on threshold → not flagged (strict inequality).
+ * - Cooldown applies to *resolved* alerts within window, not just open.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { prismaMock } from "../helpers/prisma-mock"
+
+vi.mock("@/lib/services/fcm.service", () => ({
+  fcmService: {
+    sendToUser: vi.fn().mockResolvedValue({ sent: 1, failed: 0, results: [] }),
+  },
+}))
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}))
+
+import { emergencyService, __test__ } from "@/lib/services/emergency.service"
+
+const { classifyCgmAlert, classifyKetoneAlert, effectiveCooldown, CRITICAL_COOLDOWN_CEILING } = __test__
+
+describe("emergencyService", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  describe("classifyCgmAlert", () => {
+    const thresholds = {
+      veryLowMgdl: 54,
+      lowMgdl: 70,
+      okMgdl: 180,
+      highMgdl: 250,
+    }
+    const allRules = {
+      alertOnHypo: true,
+      alertOnSevereHypo: true,
+      alertOnHyper: true,
+      alertOnSevereHyper: true,
+    }
+
+    it("classifies <54 mg/dL as severe_hypo / critical", () => {
+      expect(classifyCgmAlert(50, thresholds, allRules)).toEqual({
+        type: "severe_hypo",
+        severity: "critical",
+      })
+    })
+
+    it("classifies <70 mg/dL as hypo / warning", () => {
+      expect(classifyCgmAlert(65, thresholds, allRules)).toEqual({
+        type: "hypo",
+        severity: "warning",
+      })
+    })
+
+    it("classifies >250 mg/dL as severe_hyper / critical", () => {
+      expect(classifyCgmAlert(280, thresholds, allRules)).toEqual({
+        type: "severe_hyper",
+        severity: "critical",
+      })
+    })
+
+    it("classifies >180 mg/dL but ≤250 as hyper / warning", () => {
+      expect(classifyCgmAlert(200, thresholds, allRules)).toEqual({
+        type: "hyper",
+        severity: "warning",
+      })
+    })
+
+    it("uses inclusive boundary on critical thresholds (clinical safety)", () => {
+      // ADA SoC 2024 Level 2 hypo "< 54 mg/dL" — inclusive ≤ avoids sensor-
+      // rounding misses. 54 mg/dL exactly is severe_hypo / critical.
+      expect(classifyCgmAlert(54, thresholds, allRules)).toEqual({
+        type: "severe_hypo",
+        severity: "critical",
+      })
+      // 70 not below low (strict <), and > veryLow → null (no hypo).
+      expect(classifyCgmAlert(70, thresholds, allRules)).toBeNull()
+      // 180 not above ok (strict >), and < high → null (no hyper).
+      expect(classifyCgmAlert(180, thresholds, allRules)).toBeNull()
+      // 250 mg/dL is severe_hyper / critical (inclusive ≥).
+      expect(classifyCgmAlert(250, thresholds, allRules)).toEqual({
+        type: "severe_hyper",
+        severity: "critical",
+      })
+    })
+
+    it("returns null when emission disabled even if breach", () => {
+      expect(
+        classifyCgmAlert(200, thresholds, { ...allRules, alertOnHyper: false }),
+      ).toBeNull()
+    })
+  })
+
+  describe("classifyKetoneAlert", () => {
+    const config = {
+      moderateThreshold: 1.5,
+      dkaThreshold: 3.0,
+      alertOnModerate: true,
+      alertOnDka: true,
+    }
+
+    it("classifies ≥ DKA threshold as DKA / critical (ISPAD 2022 inclusive)", () => {
+      expect(classifyKetoneAlert(3.0, config)).toEqual({
+        type: "ketone_dka",
+        severity: "critical",
+      })
+      expect(classifyKetoneAlert(3.5, config)).toEqual({
+        type: "ketone_dka",
+        severity: "critical",
+      })
+    })
+
+    it("classifies ≥ moderate but < DKA as moderate / warning", () => {
+      expect(classifyKetoneAlert(1.5, config)).toEqual({
+        type: "ketone_moderate",
+        severity: "warning",
+      })
+      expect(classifyKetoneAlert(2.5, config)).toEqual({
+        type: "ketone_moderate",
+        severity: "warning",
+      })
+    })
+
+    it("returns null below moderate threshold", () => {
+      expect(classifyKetoneAlert(1.0, config)).toBeNull()
+    })
+  })
+
+  describe("effectiveCooldown (severity-aware)", () => {
+    it("caps critical-severity cooldown at safe ceiling (Level 2 hypo / DKA)", () => {
+      expect(effectiveCooldown(60, "critical")).toBe(CRITICAL_COOLDOWN_CEILING)
+      expect(effectiveCooldown(1440, "critical")).toBe(CRITICAL_COOLDOWN_CEILING)
+    })
+
+    it("respects configured cooldown for warning/info severity", () => {
+      expect(effectiveCooldown(60, "warning")).toBe(60)
+      expect(effectiveCooldown(60, "info")).toBe(60)
+    })
+
+    it("does not raise cooldown when configured below ceiling", () => {
+      // configured < ceiling → keep configured
+      expect(effectiveCooldown(5, "critical")).toBe(5)
+    })
+  })
+
+  describe("detectFromCgm", () => {
+    it("returns null when no threshold breached", async () => {
+      const decimal = (n: number) => ({ toNumber: () => n })
+      prismaMock.cgmObjective.findUnique.mockResolvedValue({
+        veryLow: decimal(0.54), low: decimal(0.70), ok: decimal(1.80),
+        high: decimal(2.50), titrLow: decimal(0.70), titrHigh: decimal(1.80),
+      } as never)
+      prismaMock.alertThresholdConfig.findUnique.mockResolvedValue(null)
+      prismaMock.patient.findFirst.mockResolvedValue({
+        id: 1, pregnancyMode: false, pathology: "DT1",
+      } as never)
+
+      const result = await emergencyService.detectFromCgm(
+        { patientId: 1, glucoseValueMgdl: 120 },
+        99,
+      )
+      expect(result).toBeNull()
+    })
+
+    it("returns null when soft-deleted patient", async () => {
+      prismaMock.patient.findFirst.mockResolvedValue(null)
+      const result = await emergencyService.detectFromCgm(
+        { patientId: 999, glucoseValueMgdl: 30 },
+        99,
+      )
+      expect(result).toBeNull()
+    })
+
+    it("uses pregnancy fallback thresholds when no CgmObjective", async () => {
+      prismaMock.cgmObjective.findUnique.mockResolvedValue(null)
+      prismaMock.alertThresholdConfig.findUnique.mockResolvedValue(null)
+      prismaMock.patient.findFirst.mockResolvedValue({
+        id: 1, pregnancyMode: true, pathology: "DT1",
+      } as never)
+      prismaMock.emergencyAlert.findFirst.mockResolvedValue(null)
+      prismaMock.cgmEntry.findMany.mockResolvedValue([])
+
+      const mockTx = {
+        emergencyAlert: {
+          create: vi.fn().mockResolvedValue({
+            id: 7,
+            patientId: 1,
+            alertType: "severe_hyper",
+            severity: "critical",
+          }),
+        },
+        auditLog: { create: vi.fn().mockResolvedValue({}) },
+      }
+      prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+      prismaMock.patientReferent.findUnique.mockResolvedValue(null)
+
+      // 210 mg/dL ≥ pregnancy high (200) → severe_hyper / critical
+      const result = await emergencyService.detectFromCgm(
+        { patientId: 1, glucoseValueMgdl: 210 },
+        99,
+      )
+      expect(result).toEqual({ id: 7, alertType: "severe_hyper" })
+    })
+
+    it("blocks duplicate alert during cooldown", async () => {
+      const decimal = (n: number) => ({ toNumber: () => n })
+      prismaMock.cgmObjective.findUnique.mockResolvedValue({
+        veryLow: decimal(0.54), low: decimal(0.70), ok: decimal(1.80),
+        high: decimal(2.50), titrLow: decimal(0.70), titrHigh: decimal(1.80),
+      } as never)
+      prismaMock.alertThresholdConfig.findUnique.mockResolvedValue({
+        alertOnHypo: true, alertOnSevereHypo: true,
+        alertOnHyper: false, alertOnSevereHyper: true,
+        notifyDoctorPush: true, notifyDoctorEmail: true, cooldownMinutes: 30,
+      } as never)
+      prismaMock.patient.findFirst.mockResolvedValue({
+        id: 1, pregnancyMode: false, pathology: "DT1",
+      } as never)
+      // Existing live alert blocks emission
+      prismaMock.emergencyAlert.findFirst.mockResolvedValue({ id: 99 } as never)
+
+      const result = await emergencyService.detectFromCgm(
+        { patientId: 1, glucoseValueMgdl: 40 },
+        99,
+      )
+      expect(result).toBeNull()
+    })
+  })
+
+  describe("acknowledge / resolve", () => {
+    it("acknowledge fails for non-open alert (workflow consistency)", async () => {
+      const findUniqueSpy = vi.fn().mockResolvedValue({
+        id: 1, status: "acknowledged", patientId: 1,
+        patient: { deletedAt: null },
+      })
+      const mockTx = {
+        emergencyAlert: { findUnique: findUniqueSpy, update: vi.fn() },
+        emergencyAlertAction: { create: vi.fn() },
+        auditLog: { create: vi.fn() },
+      }
+      prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+
+      await expect(
+        emergencyService.acknowledge(1, 42, undefined),
+      ).rejects.toThrow("alert_not_open")
+    })
+
+    it("rejects acknowledge on soft-deleted patient (RGPD Art. 17)", async () => {
+      const findUniqueSpy = vi.fn().mockResolvedValue({
+        id: 1, status: "open", patientId: 1,
+        patient: { deletedAt: new Date() },
+      })
+      const mockTx = {
+        emergencyAlert: { findUnique: findUniqueSpy, update: vi.fn() },
+        emergencyAlertAction: { create: vi.fn() },
+        auditLog: { create: vi.fn() },
+      }
+      prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+
+      await expect(
+        emergencyService.acknowledge(1, 42, undefined),
+      ).rejects.toThrow("patient_deleted")
+    })
+
+    it("resolve fails when already resolved (idempotency guard)", async () => {
+      const findUniqueSpy = vi.fn().mockResolvedValue({
+        id: 1, status: "resolved", patientId: 1,
+        patient: { deletedAt: null },
+      })
+      const mockTx = {
+        emergencyAlert: { findUnique: findUniqueSpy, update: vi.fn() },
+        emergencyAlertAction: { create: vi.fn() },
+        auditLog: { create: vi.fn() },
+      }
+      prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+
+      await expect(
+        emergencyService.resolve(1, 42, undefined),
+      ).rejects.toThrow("alert_already_closed")
+    })
+
+    it("resolve succeeds from open status", async () => {
+      const updateSpy = vi.fn().mockResolvedValue({
+        id: 1, status: "resolved", patientId: 1, resolvedBy: 42,
+        notes: null, resolutionNotes: null, contextSnapshot: null,
+      })
+      const mockTx = {
+        emergencyAlert: {
+          findUnique: vi.fn().mockResolvedValue({
+            id: 1, status: "open", patientId: 1,
+            patient: { deletedAt: null },
+          }),
+          update: updateSpy,
+        },
+        emergencyAlertAction: { create: vi.fn().mockResolvedValue({}) },
+        auditLog: { create: vi.fn().mockResolvedValue({}) },
+      }
+      prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+
+      const result = await emergencyService.resolve(1, 42, "patient ate carbs")
+      expect(result.status).toBe("resolved")
+      expect(updateSpy).toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/unit/emergency.service.test.ts
+++ b/tests/unit/emergency.service.test.ts
@@ -321,5 +321,302 @@ describe("emergencyService", () => {
       expect(result.status).toBe("resolved")
       expect(updateSpy).toHaveBeenCalled()
     })
+
+    it("returns null detail when patient soft-deleted", async () => {
+      prismaMock.emergencyAlert.findFirst.mockResolvedValue(null as never)
+      const result = await emergencyService.getDetail(1, 99)
+      expect(result).toBeNull()
+    })
+  })
+
+  describe("detection input bounds", () => {
+    it("rejects glucose below physiological floor", async () => {
+      const result = await emergencyService.detectFromCgm(
+        { patientId: 1, glucoseValueMgdl: 30 },
+        99,
+      )
+      expect(result).toBeNull()
+      expect(prismaMock.patient.findFirst).not.toHaveBeenCalled()
+    })
+
+    it("rejects glucose above sensor maximum", async () => {
+      const result = await emergencyService.detectFromCgm(
+        { patientId: 1, glucoseValueMgdl: 700 },
+        99,
+      )
+      expect(result).toBeNull()
+    })
+
+    it("rejects ketone below physiological floor", async () => {
+      const result = await emergencyService.detectFromKetone(
+        { patientId: 1, ketoneValueMmol: 0.05 },
+        99,
+      )
+      expect(result).toBeNull()
+    })
+
+    it("rejects ketone above plausible maximum", async () => {
+      const result = await emergencyService.detectFromKetone(
+        { patientId: 1, ketoneValueMmol: 12 },
+        99,
+      )
+      expect(result).toBeNull()
+    })
+
+    it("rejects NaN glucose (sensor error)", async () => {
+      const result = await emergencyService.detectFromCgm(
+        { patientId: 1, glucoseValueMgdl: NaN },
+        99,
+      )
+      expect(result).toBeNull()
+    })
+  })
+
+  describe("createManual", () => {
+    it("rejects critical severity from a NURSE caller (role gate)", async () => {
+      await expect(
+        emergencyService.createManual(
+          { patientId: 1, severity: "critical", notes: "x".repeat(50), callerRole: "NURSE" },
+          99,
+        ),
+      ).rejects.toThrow("critical_manual_requires_doctor")
+    })
+
+    it("rejects critical severity without notes (justification gate)", async () => {
+      await expect(
+        emergencyService.createManual(
+          { patientId: 1, severity: "critical", callerRole: "DOCTOR" },
+          99,
+        ),
+      ).rejects.toThrow("critical_manual_requires_notes")
+    })
+
+    it("rejects unknown patient", async () => {
+      prismaMock.patient.findFirst.mockResolvedValue(null as never)
+      await expect(
+        emergencyService.createManual(
+          { patientId: 999, severity: "warning", callerRole: "NURSE" },
+          99,
+        ),
+      ).rejects.toThrow("patient_not_found")
+    })
+
+    it("blocks manual create during cooldown", async () => {
+      prismaMock.patient.findFirst.mockResolvedValue({ id: 1 } as never)
+      prismaMock.alertThresholdConfig.findUnique.mockResolvedValue({
+        cooldownMinutes: 30, notifyDoctorPush: true,
+      } as never)
+      prismaMock.emergencyAlert.findFirst.mockResolvedValue({ id: 99 } as never)
+
+      await expect(
+        emergencyService.createManual(
+          { patientId: 1, severity: "warning", callerRole: "NURSE" },
+          99,
+        ),
+      ).rejects.toThrow("manual_alert_cooldown")
+    })
+  })
+
+  describe("list — RBAC scoping", () => {
+    it("ADMIN with no patientId and no scope sees all alerts", async () => {
+      prismaMock.emergencyAlert.findMany.mockResolvedValue([] as never)
+      prismaMock.auditLog.create.mockResolvedValue({} as never)
+
+      const result = await emergencyService.list(
+        { scopePatientIds: null },
+        99,
+      )
+      expect(result.items).toEqual([])
+      const findManyCall = prismaMock.emergencyAlert.findMany.mock.calls.at(-1)?.[0] as
+        | { where?: { patientId?: unknown } }
+        | undefined
+      // No patientId restriction in WHERE clause for ADMIN
+      expect(findManyCall?.where?.patientId).toBeUndefined()
+    })
+
+    it("Pro with empty scope returns no rows", async () => {
+      prismaMock.emergencyAlert.findMany.mockResolvedValue([] as never)
+      prismaMock.auditLog.create.mockResolvedValue({} as never)
+
+      await emergencyService.list({ scopePatientIds: [] }, 99)
+      const findManyCall = prismaMock.emergencyAlert.findMany.mock.calls.at(-1)?.[0] as
+        | { where?: { patientId?: { in?: number[] } } }
+        | undefined
+      expect(findManyCall?.where?.patientId).toEqual({ in: [] })
+    })
+
+    it("Pro with scope IDs constrains query to portfolio", async () => {
+      prismaMock.emergencyAlert.findMany.mockResolvedValue([] as never)
+      prismaMock.auditLog.create.mockResolvedValue({} as never)
+
+      await emergencyService.list({ scopePatientIds: [10, 20, 30] }, 99)
+      const findManyCall = prismaMock.emergencyAlert.findMany.mock.calls.at(-1)?.[0] as
+        | { where?: { patientId?: { in?: number[] } } }
+        | undefined
+      expect(findManyCall?.where?.patientId).toEqual({ in: [10, 20, 30] })
+    })
+
+    it("explicit patientId filter takes precedence over scope", async () => {
+      prismaMock.emergencyAlert.findMany.mockResolvedValue([] as never)
+      prismaMock.auditLog.create.mockResolvedValue({} as never)
+
+      await emergencyService.list(
+        { patientId: 42, scopePatientIds: [10, 20] },
+        99,
+      )
+      const findManyCall = prismaMock.emergencyAlert.findMany.mock.calls.at(-1)?.[0] as
+        | { where?: { patientId?: number } }
+        | undefined
+      expect(findManyCall?.where?.patientId).toBe(42)
+    })
+
+    it("paginates with cursor when items exceed limit", async () => {
+      const items = Array.from({ length: 26 }, (_, i) => ({
+        id: i + 1, patientId: 1, alertType: "hypo",
+        severity: "warning", status: "open",
+        notes: null, resolutionNotes: null, contextSnapshot: null,
+      })) as never
+      prismaMock.emergencyAlert.findMany.mockResolvedValue(items)
+      prismaMock.auditLog.create.mockResolvedValue({} as never)
+
+      const result = await emergencyService.list(
+        { limit: 25, scopePatientIds: null },
+        99,
+      )
+      expect(result.items).toHaveLength(25)
+      expect(result.nextCursor).toBe(25)
+    })
+  })
+
+  describe("addAction", () => {
+    it("rejects action on unknown alert", async () => {
+      prismaMock.emergencyAlert.findUnique.mockResolvedValue(null as never)
+      await expect(
+        emergencyService.addAction({
+          alertId: 999,
+          performedBy: 42,
+          actionType: "call_patient",
+        }),
+      ).rejects.toThrow("alert_not_found")
+    })
+
+    it("rejects action on soft-deleted patient", async () => {
+      prismaMock.emergencyAlert.findUnique.mockResolvedValue({
+        id: 1, patientId: 1, status: "open",
+        patient: { deletedAt: new Date() },
+      } as never)
+      await expect(
+        emergencyService.addAction({
+          alertId: 1,
+          performedBy: 42,
+          actionType: "call_patient",
+        }),
+      ).rejects.toThrow("patient_deleted")
+    })
+
+    it("rejects action on expired alert", async () => {
+      prismaMock.emergencyAlert.findUnique.mockResolvedValue({
+        id: 1, patientId: 1, status: "expired",
+        patient: { deletedAt: null },
+      } as never)
+      await expect(
+        emergencyService.addAction({
+          alertId: 1,
+          performedBy: 42,
+          actionType: "call_patient",
+        }),
+      ).rejects.toThrow("alert_expired")
+    })
+
+    it("encrypts notes & strict-filters metadata before persistence", async () => {
+      prismaMock.emergencyAlert.findUnique.mockResolvedValue({
+        id: 1, patientId: 1, status: "acknowledged",
+        patient: { deletedAt: null },
+      } as never)
+      const createSpy = vi.fn().mockResolvedValue({
+        id: 7, alertId: 1, performedBy: 42, actionType: "call_patient",
+        notes: "ENCRYPTED", metadata: {}, createdAt: new Date(),
+      })
+      const mockTx = {
+        emergencyAlertAction: { create: createSpy },
+        auditLog: { create: vi.fn().mockResolvedValue({}) },
+      }
+      prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+
+      await emergencyService.addAction({
+        alertId: 1,
+        performedBy: 42,
+        actionType: "call_patient",
+        notes: "called pt 14h05",
+        metadata: { durationSec: 120, outcome: "no_answer" },
+      })
+
+      const createCall = createSpy.mock.calls[0]?.[0] as {
+        data?: { notes?: string; metadata?: Record<string, unknown> }
+      }
+      // Notes must be encrypted (base64 of AES-256-GCM)
+      expect(createCall.data?.notes).not.toBe("called pt 14h05")
+      expect(createCall.data?.notes).toBeTruthy()
+      // Metadata strictly bounded — durationSec + outcome only
+      expect(createCall.data?.metadata).toEqual({ durationSec: 120, outcome: "no_answer" })
+    })
+  })
+
+  describe("safeCreateAlert (TOCTOU-narrow P2002)", () => {
+    it("returns null on the live-alert unique-index P2002", async () => {
+      prismaMock.cgmObjective.findUnique.mockResolvedValue(null as never)
+      prismaMock.alertThresholdConfig.findUnique.mockResolvedValue(null as never)
+      prismaMock.patient.findFirst.mockResolvedValue({
+        id: 1, pregnancyMode: false, pathology: "DT1",
+      } as never)
+      prismaMock.emergencyAlert.findFirst.mockResolvedValue(null as never)
+      prismaMock.cgmEntry.findMany.mockResolvedValue([] as never)
+      // Mock the partial-unique-index P2002 collision
+      const p2002 = Object.assign(new Error("Unique"), {
+        code: "P2002",
+        meta: { target: "emergency_alerts_one_live_per_type" },
+      })
+      Object.setPrototypeOf(
+        p2002,
+        (await import("@prisma/client")).Prisma.PrismaClientKnownRequestError.prototype,
+      )
+      prismaMock.$transaction.mockImplementation((async () => {
+        throw p2002
+      }) as any)
+
+      const result = await emergencyService.detectFromCgm(
+        { patientId: 1, glucoseValueMgdl: 40 },
+        99,
+      )
+      expect(result).toBeNull()
+    })
+
+    it("rethrows non-targeted P2002 (e.g. unrelated unique constraint)", async () => {
+      prismaMock.cgmObjective.findUnique.mockResolvedValue(null as never)
+      prismaMock.alertThresholdConfig.findUnique.mockResolvedValue(null as never)
+      prismaMock.patient.findFirst.mockResolvedValue({
+        id: 1, pregnancyMode: false, pathology: "DT1",
+      } as never)
+      prismaMock.emergencyAlert.findFirst.mockResolvedValue(null as never)
+      prismaMock.cgmEntry.findMany.mockResolvedValue([] as never)
+      const p2002 = Object.assign(new Error("Unique"), {
+        code: "P2002",
+        meta: { target: "some_other_unique_index" },
+      })
+      Object.setPrototypeOf(
+        p2002,
+        (await import("@prisma/client")).Prisma.PrismaClientKnownRequestError.prototype,
+      )
+      prismaMock.$transaction.mockImplementation((async () => {
+        throw p2002
+      }) as any)
+
+      await expect(
+        emergencyService.detectFromCgm(
+          { patientId: 1, glucoseValueMgdl: 40 },
+          99,
+        ),
+      ).rejects.toBe(p2002)
+    })
   })
 })

--- a/tests/unit/hypo-treatment.service.test.ts
+++ b/tests/unit/hypo-treatment.service.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Test suite: Hypo Treatment Service (US-2217)
+ *
+ * Clinical behavior tested:
+ * - Defaults align with ADA "Rule of 15/15": 15 g of fast carbs, retest after
+ *   15 minutes. These values are used when no per-patient protocol exists.
+ * - Carbohydrate amount validated to a clinically safe band (5–60 g). Below
+ *   5 g would not raise glycemia; above 60 g triggers rebound hyper.
+ * - Sugar type "other" requires the free-text description (sugarTypeOther),
+ *   otherwise the patient receives an empty instruction screen.
+ * - Allergies and instructions persist encrypted (PHI / clinical content).
+ *
+ * Associated risks:
+ * - Posting carbs > 60 g would expose the patient to rebound hyperglycemia.
+ * - Storing allergies in plaintext would breach HDS / RGPD Art. 9.
+ * - "other" sugar type with empty description would render an unusable
+ *   protocol on the patient mobile app, possibly delaying treatment.
+ *
+ * Edge cases:
+ * - Allergies and instructions explicitly null → must remain null in storage.
+ * - Patient soft-deleted → service returns null.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { prismaMock } from "../helpers/prisma-mock"
+
+vi.mock("@/lib/crypto/fields", () => ({
+  encryptField: vi.fn((value: string) => `enc:${value}`),
+  safeDecryptField: vi.fn((value: string | null) =>
+    value ? value.replace(/^enc:/, "") : null,
+  ),
+}))
+
+import {
+  hypoTreatmentService,
+  validateHypoTreatment,
+  HYPO_TREATMENT_DEFAULTS,
+  HYPO_TREATMENT_BOUNDS,
+} from "@/lib/services/hypo-treatment.service"
+
+describe("hypoTreatmentService", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  describe("validateHypoTreatment", () => {
+    it("accepts defaults (rule of 15/15)", () => {
+      expect(
+        validateHypoTreatment({
+          fastCarbsGrams: HYPO_TREATMENT_DEFAULTS.fastCarbsGrams,
+          retestMinutes: HYPO_TREATMENT_DEFAULTS.retestMinutes,
+        }),
+      ).toBeNull()
+    })
+
+    it("rejects carbs below clinical floor (would not raise glucose)", () => {
+      expect(
+        validateHypoTreatment({
+          fastCarbsGrams: HYPO_TREATMENT_BOUNDS.CARBS_MIN - 1,
+          retestMinutes: 15,
+        }),
+      ).toBe("carbs_out_of_bounds")
+    })
+
+    it("rejects carbs above ceiling (rebound hyperglycemia risk)", () => {
+      expect(
+        validateHypoTreatment({
+          fastCarbsGrams: HYPO_TREATMENT_BOUNDS.CARBS_MAX + 1,
+          retestMinutes: 15,
+        }),
+      ).toBe("carbs_out_of_bounds")
+    })
+
+    it("rejects retest delay above 60 min (no follow-up risk)", () => {
+      expect(
+        validateHypoTreatment({
+          fastCarbsGrams: 15,
+          retestMinutes: HYPO_TREATMENT_BOUNDS.RETEST_MAX + 5,
+        }),
+      ).toBe("retest_out_of_bounds")
+    })
+  })
+
+  describe("get", () => {
+    it("returns defaults for patient without record", async () => {
+      prismaMock.hypoTreatmentProtocol.findUnique.mockResolvedValue(null)
+      prismaMock.patient.findFirst.mockResolvedValue({ id: 1 } as never)
+      prismaMock.auditLog.create.mockResolvedValue({} as never)
+
+      const result = await hypoTreatmentService.get(1, 99)
+      expect(result).toMatchObject({
+        patientId: 1,
+        sugarType: HYPO_TREATMENT_DEFAULTS.sugarType,
+        fastCarbsGrams: HYPO_TREATMENT_DEFAULTS.fastCarbsGrams,
+      })
+    })
+
+    it("decrypts allergies & instructions on read", async () => {
+      prismaMock.hypoTreatmentProtocol.findUnique.mockResolvedValue({
+        id: 1,
+        patientId: 1,
+        sugarType: "juice",
+        sugarTypeOther: null,
+        fastCarbsGrams: 15,
+        retestMinutes: 15,
+        allergies: "enc:peanuts",
+        instructions: "enc:no banana",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as never)
+      prismaMock.patient.findFirst.mockResolvedValue({ id: 1 } as never)
+      prismaMock.auditLog.create.mockResolvedValue({} as never)
+
+      const result = await hypoTreatmentService.get(1, 99)
+      expect(result?.allergies).toBe("peanuts")
+      expect(result?.instructions).toBe("no banana")
+    })
+  })
+
+  describe("upsert", () => {
+    it("requires sugarTypeOther when sugarType=other", async () => {
+      await expect(
+        hypoTreatmentService.upsert(1, { sugarType: "other" }, 99),
+      ).rejects.toThrow("sugar_type_other_required")
+    })
+
+    it("encrypts allergies before storage", async () => {
+      const upsertSpy = vi.fn().mockResolvedValue({
+        patientId: 1,
+        sugarType: "glucose_tabs",
+        sugarTypeOther: null,
+        fastCarbsGrams: 15,
+        retestMinutes: 15,
+        allergies: "enc:peanuts",
+        instructions: null,
+      })
+      const mockTx = {
+        hypoTreatmentProtocol: { upsert: upsertSpy },
+        auditLog: { create: vi.fn().mockResolvedValue({}) },
+      }
+      prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+
+      await hypoTreatmentService.upsert(1, { allergies: "peanuts" }, 99)
+      const call = upsertSpy.mock.calls[0]?.[0] as { create?: { allergies?: string } }
+      expect(call.create?.allergies).toBe("enc:peanuts")
+    })
+
+    it("nullifies sugarTypeOther when sugarType ≠ other", async () => {
+      const upsertSpy = vi.fn().mockResolvedValue({
+        patientId: 1,
+        sugarType: "juice",
+        sugarTypeOther: null,
+        fastCarbsGrams: 15,
+        retestMinutes: 15,
+        allergies: null,
+        instructions: null,
+      })
+      const mockTx = {
+        hypoTreatmentProtocol: { upsert: upsertSpy },
+        auditLog: { create: vi.fn().mockResolvedValue({}) },
+      }
+      prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+
+      await hypoTreatmentService.upsert(
+        1,
+        { sugarType: "juice", sugarTypeOther: "ignored" },
+        99,
+      )
+      const call = upsertSpy.mock.calls[0]?.[0] as { create?: { sugarTypeOther?: string | null } }
+      expect(call.create?.sugarTypeOther).toBeNull()
+    })
+  })
+})

--- a/tests/unit/ketone-threshold.service.test.ts
+++ b/tests/unit/ketone-threshold.service.test.ts
@@ -55,24 +55,23 @@ describe("ketoneThresholdService", () => {
       ).toBe("light_must_be_less_than_moderate")
     })
 
-    it("rejects moderate > DKA (would suppress DKA emergency alerts)", () => {
+    it("rejects moderate >= DKA (would create degenerate config)", () => {
+      // Strict ordering — moderate==DKA is now rejected since the classifier
+      // refuses to downgrade ≥DKA readings to "warning" (clinical safety).
       expect(
         validateKetoneThresholds({
           lightThreshold: 1.0,
           moderateThreshold: 4.0,
           dkaThreshold: 3.0,
         }),
-      ).toBe("moderate_must_be_lte_dka")
-    })
-
-    it("allows moderate equal to DKA (warning + critical share boundary)", () => {
+      ).toBe("moderate_must_be_less_than_dka")
       expect(
         validateKetoneThresholds({
           lightThreshold: 1.5,
           moderateThreshold: 3.0,
           dkaThreshold: 3.0,
         }),
-      ).toBeNull()
+      ).toBe("moderate_must_be_less_than_dka")
     })
 
     it("rejects values below physiological minimum", () => {

--- a/tests/unit/ketone-threshold.service.test.ts
+++ b/tests/unit/ketone-threshold.service.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Test suite: Ketone Threshold Service (US-2216)
+ *
+ * Clinical behavior tested:
+ * - Defaults align with ADA DKA-prevention guidelines (1.5 mmol/L moderate,
+ *   3.0 mmol/L DKA threshold). A patient with no per-patient configuration
+ *   gets these values returned.
+ * - Threshold ordering is enforced: light < moderate ≤ DKA. Inverting them
+ *   would silence alerts above DKA — life-threatening if missed.
+ * - Out-of-range values are rejected (ketones above 10 mmol/L are
+ *   physiologically implausible; below 0.1 below detection limit).
+ * - Audit log entries are emitted for every read & write — HDS traceability.
+ *
+ * Associated risks:
+ * - Setting moderate > DKA would suppress critical-severity alerts on DKA-
+ *   range readings, masking a true emergency.
+ * - Permitting clinical-bound bypass via direct Prisma writes is mitigated
+ *   by the service-layer validator; bypass would let UI submit unsafe values.
+ *
+ * Edge cases:
+ * - Patient soft-deleted → returns null (defense-in-depth alongside RBAC).
+ * - Partial update (only alertOnDka flag) preserves existing thresholds.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { prismaMock } from "../helpers/prisma-mock"
+
+import {
+  ketoneThresholdService,
+  validateKetoneThresholds,
+  KETONE_DEFAULTS,
+  KETONE_BOUNDS,
+} from "@/lib/services/ketone-threshold.service"
+
+describe("ketoneThresholdService", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  describe("validateKetoneThresholds", () => {
+    it("accepts defaults", () => {
+      expect(
+        validateKetoneThresholds({
+          lightThreshold: KETONE_DEFAULTS.lightThreshold,
+          moderateThreshold: KETONE_DEFAULTS.moderateThreshold,
+          dkaThreshold: KETONE_DEFAULTS.dkaThreshold,
+        }),
+      ).toBeNull()
+    })
+
+    it("rejects light >= moderate (would mask high-priority alerts)", () => {
+      expect(
+        validateKetoneThresholds({
+          lightThreshold: 1.6,
+          moderateThreshold: 1.5,
+          dkaThreshold: 3.0,
+        }),
+      ).toBe("light_must_be_less_than_moderate")
+    })
+
+    it("rejects moderate > DKA (would suppress DKA emergency alerts)", () => {
+      expect(
+        validateKetoneThresholds({
+          lightThreshold: 1.0,
+          moderateThreshold: 4.0,
+          dkaThreshold: 3.0,
+        }),
+      ).toBe("moderate_must_be_lte_dka")
+    })
+
+    it("allows moderate equal to DKA (warning + critical share boundary)", () => {
+      expect(
+        validateKetoneThresholds({
+          lightThreshold: 1.5,
+          moderateThreshold: 3.0,
+          dkaThreshold: 3.0,
+        }),
+      ).toBeNull()
+    })
+
+    it("rejects values below physiological minimum", () => {
+      expect(
+        validateKetoneThresholds({
+          lightThreshold: 0.0,
+          moderateThreshold: 1.5,
+          dkaThreshold: 3.0,
+        }),
+      ).toBe("ketone_threshold_below_min")
+    })
+
+    it("rejects values above physiological maximum", () => {
+      expect(
+        validateKetoneThresholds({
+          lightThreshold: 1.0,
+          moderateThreshold: 2.0,
+          dkaThreshold: KETONE_BOUNDS.MAX + 0.1,
+        }),
+      ).toBe("ketone_threshold_above_max")
+    })
+  })
+
+  describe("get", () => {
+    it("returns ADA defaults when no per-patient record exists", async () => {
+      prismaMock.ketoneThreshold.findUnique.mockResolvedValue(null)
+      prismaMock.patient.findFirst.mockResolvedValue({ id: 1 } as never)
+      prismaMock.auditLog.create.mockResolvedValue({} as never)
+
+      const result = await ketoneThresholdService.get(1, 99)
+      expect(result).toMatchObject({ patientId: 1, ...KETONE_DEFAULTS })
+    })
+
+    it("returns null for soft-deleted patient", async () => {
+      prismaMock.ketoneThreshold.findUnique.mockResolvedValue(null)
+      prismaMock.patient.findFirst.mockResolvedValue(null)
+      const result = await ketoneThresholdService.get(99, 1)
+      expect(result).toBeNull()
+    })
+
+    it("emits audit log on read (HDS traceability)", async () => {
+      prismaMock.ketoneThreshold.findUnique.mockResolvedValue(null)
+      prismaMock.patient.findFirst.mockResolvedValue({ id: 1 } as never)
+      const auditSpy = vi.spyOn(prismaMock.auditLog, "create")
+      auditSpy.mockResolvedValue({} as never)
+
+      await ketoneThresholdService.get(1, 42)
+      expect(auditSpy).toHaveBeenCalled()
+      const call = auditSpy.mock.calls.at(-1)?.[0] as { data?: { action?: string; resourceId?: string } }
+      expect(call?.data?.action).toBe("READ")
+      expect(call?.data?.resourceId).toContain("ketone-thresholds")
+    })
+  })
+
+  describe("upsert", () => {
+    it("rejects invalid threshold ordering", async () => {
+      await expect(
+        ketoneThresholdService.upsert(
+          1,
+          { lightThreshold: 4.0, moderateThreshold: 1.5, dkaThreshold: 3.0 },
+          99,
+        ),
+      ).rejects.toThrow("light_must_be_less_than_moderate")
+    })
+
+    it("upserts defaults when only flags provided", async () => {
+      const mockTx = {
+        ketoneThreshold: {
+          upsert: vi
+            .fn()
+            .mockResolvedValue({ patientId: 1, ...KETONE_DEFAULTS, alertOnDka: false }),
+        },
+        auditLog: { create: vi.fn().mockResolvedValue({}) },
+      }
+      prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+
+      const result = await ketoneThresholdService.upsert(1, { alertOnDka: false }, 99)
+      expect(result.alertOnDka).toBe(false)
+      expect(mockTx.ketoneThreshold.upsert).toHaveBeenCalled()
+    })
+
+    it("KETONE_DEFAULTS pass their own validator (light < moderate < DKA)", () => {
+      expect(
+        validateKetoneThresholds({
+          lightThreshold: KETONE_DEFAULTS.lightThreshold,
+          moderateThreshold: KETONE_DEFAULTS.moderateThreshold,
+          dkaThreshold: KETONE_DEFAULTS.dkaThreshold,
+        }),
+      ).toBeNull()
+    })
+  })
+})

--- a/tests/unit/pregnancy-mode.service.test.ts
+++ b/tests/unit/pregnancy-mode.service.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Test suite: Pregnancy Mode Service (US-2232)
+ *
+ * Clinical behavior tested:
+ * - Toggling pregnancy mode ON applies tighter GD CGM thresholds (ACOG/ADA
+ *   targets), even on a Type 1 patient — protects fetus from hyperglycemia.
+ * - Toggling OFF restores baseline thresholds for the patient's pathology.
+ *   For an existing GD patient, GD defaults are kept (toggle is independent).
+ * - No-op when the requested state matches current state — avoids spurious
+ *   audit entries and reduces churn.
+ * - Audit log captures both old & new values for HDS forensics.
+ *
+ * Associated risks:
+ * - Forgetting to update CgmObjective on toggle would leave permissive
+ *   thresholds active during pregnancy and miss hyperglycemic excursions.
+ * - Mass-rollback to baseline on accidental toggle-off should be visible
+ *   in audit (oldValue / newValue captured).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { prismaMock } from "../helpers/prisma-mock"
+
+import { pregnancyModeService } from "@/lib/services/pregnancy-mode.service"
+
+describe("pregnancyModeService.setMode", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("rejects unknown patient", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue(null)
+    await expect(
+      pregnancyModeService.setMode(999, true, 1),
+    ).rejects.toThrow("patient_not_found")
+  })
+
+  it("returns no-op result when state already matches", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({
+      id: 1, pregnancyMode: true, pathology: "GD",
+    } as never)
+
+    const result = await pregnancyModeService.setMode(1, true, 99)
+    expect(result.thresholdsAdapted).toBe(false)
+    // Transaction should NOT have been called (no DB changes)
+    expect(prismaMock.$transaction).not.toHaveBeenCalled()
+  })
+
+  it("applies GD thresholds when enabling on a DT1 patient", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({
+      id: 1, pregnancyMode: false, pathology: "DT1",
+    } as never)
+
+    const upsertSpy = vi.fn().mockResolvedValue({})
+    const updateSpy = vi.fn().mockResolvedValue({})
+    const mockTx = {
+      patient: { update: updateSpy },
+      cgmObjective: { upsert: upsertSpy },
+      auditLog: { create: vi.fn().mockResolvedValue({}) },
+    }
+    prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+
+    await pregnancyModeService.setMode(1, true, 99)
+
+    expect(updateSpy).toHaveBeenCalled()
+    const cgmCall = upsertSpy.mock.calls[0]?.[0] as { create?: { ok?: number; high?: number } }
+    // GD defaults: ok=1.40, high=2.00 (stricter than DT1 1.80/2.50)
+    expect(cgmCall.create?.ok).toBe(1.40)
+    expect(cgmCall.create?.high).toBe(2.00)
+  })
+
+  it("restores standard thresholds when disabling on a DT1 patient", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({
+      id: 1, pregnancyMode: true, pathology: "DT1",
+    } as never)
+
+    const upsertSpy = vi.fn().mockResolvedValue({})
+    const mockTx = {
+      patient: { update: vi.fn().mockResolvedValue({}) },
+      cgmObjective: { upsert: upsertSpy },
+      auditLog: { create: vi.fn().mockResolvedValue({}) },
+    }
+    prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+
+    await pregnancyModeService.setMode(1, false, 99)
+
+    const cgmCall = upsertSpy.mock.calls[0]?.[0] as { create?: { ok?: number; high?: number } }
+    expect(cgmCall.create?.ok).toBe(1.80)
+    expect(cgmCall.create?.high).toBe(2.50)
+  })
+
+  it("blocks toggle-OFF when patient has an active PatientPregnancy", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({
+      id: 1, pregnancyMode: true, pathology: "DT1",
+    } as never)
+    prismaMock.patientPregnancy.findFirst.mockResolvedValue({ id: 99 } as never)
+
+    await expect(
+      pregnancyModeService.setMode(1, false, 42),
+    ).rejects.toThrow("active_pregnancy_blocks_toggle_off")
+  })
+
+  it("allows toggle-OFF with forceOverride and tags audit", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({
+      id: 1, pregnancyMode: true, pathology: "DT1",
+    } as never)
+    prismaMock.patientPregnancy.findFirst.mockResolvedValue({ id: 99 } as never)
+
+    const auditSpy = vi.fn().mockResolvedValue({})
+    const mockTx = {
+      patient: { update: vi.fn().mockResolvedValue({}) },
+      cgmObjective: { upsert: vi.fn().mockResolvedValue({}) },
+      auditLog: { create: auditSpy },
+    }
+    prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+
+    const result = await pregnancyModeService.setMode(1, false, 42, undefined, { forceOverride: true })
+    expect(result.thresholdsAdapted).toBe(true)
+    const auditCall = auditSpy.mock.calls[0]?.[0] as { data?: { metadata?: { forceOverride?: boolean } } }
+    expect(auditCall.data?.metadata?.forceOverride).toBe(true)
+  })
+
+  it("audit log captures oldValue & newValue (HDS forensics)", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({
+      id: 1, pregnancyMode: false, pathology: "DT1",
+    } as never)
+
+    const auditSpy = vi.fn().mockResolvedValue({})
+    const mockTx = {
+      patient: { update: vi.fn().mockResolvedValue({}) },
+      cgmObjective: { upsert: vi.fn().mockResolvedValue({}) },
+      auditLog: { create: auditSpy },
+    }
+    prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+
+    await pregnancyModeService.setMode(1, true, 99)
+
+    const auditCall = auditSpy.mock.calls[0]?.[0] as {
+      data?: { oldValue?: { pregnancyMode?: boolean }; newValue?: { pregnancyMode?: boolean } }
+    }
+    expect(auditCall.data?.oldValue?.pregnancyMode).toBe(false)
+    expect(auditCall.data?.newValue?.pregnancyMode).toBe(true)
+  })
+})

--- a/tests/unit/pregnancy-mode.service.test.ts
+++ b/tests/unit/pregnancy-mode.service.test.ts
@@ -46,6 +46,7 @@ describe("pregnancyModeService.setMode", () => {
     prismaMock.patient.findFirst.mockResolvedValue({
       id: 1, pregnancyMode: false, pathology: "DT1",
     } as never)
+    prismaMock.cgmObjective.findUnique.mockResolvedValue(null as never)
 
     const upsertSpy = vi.fn().mockResolvedValue({})
     const updateSpy = vi.fn().mockResolvedValue({})
@@ -69,6 +70,8 @@ describe("pregnancyModeService.setMode", () => {
     prismaMock.patient.findFirst.mockResolvedValue({
       id: 1, pregnancyMode: true, pathology: "DT1",
     } as never)
+    prismaMock.patientPregnancy.findFirst.mockResolvedValue(null as never)
+    prismaMock.cgmObjective.findUnique.mockResolvedValue(null as never)
 
     const upsertSpy = vi.fn().mockResolvedValue({})
     const mockTx = {
@@ -85,6 +88,41 @@ describe("pregnancyModeService.setMode", () => {
     expect(cgmCall.create?.high).toBe(2.50)
   })
 
+  it("toggle-OFF on GD pathology is no-op for thresholds (audit honest)", async () => {
+    // GD pathology pins thresholds to GD defaults — toggling pregnancyMode off
+    // must NOT widen them. Audit must reflect thresholdsAdapted=false.
+    prismaMock.patient.findFirst.mockResolvedValue({
+      id: 1, pregnancyMode: true, pathology: "GD",
+    } as never)
+    prismaMock.patientPregnancy.findFirst.mockResolvedValue(null as never)
+    prismaMock.cgmObjective.findUnique.mockResolvedValue({
+      veryLow: { toNumber: () => 0.60 },
+      low: { toNumber: () => 0.63 },
+      ok: { toNumber: () => 1.40 },
+      high: { toNumber: () => 2.00 },
+      titrLow: { toNumber: () => 0.63 },
+      titrHigh: { toNumber: () => 1.40 },
+    } as never)
+
+    const upsertSpy = vi.fn().mockResolvedValue({})
+    const auditSpy = vi.fn().mockResolvedValue({})
+    const mockTx = {
+      patient: { update: vi.fn().mockResolvedValue({}) },
+      cgmObjective: { upsert: upsertSpy },
+      auditLog: { create: auditSpy },
+    }
+    prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+
+    const result = await pregnancyModeService.setMode(1, false, 42)
+    expect(result.thresholdsAdapted).toBe(false)
+    expect(upsertSpy).not.toHaveBeenCalled()
+    const auditCall = auditSpy.mock.calls[0]?.[0] as {
+      data?: { metadata?: { thresholdsAdapted?: boolean; pinnedTo?: string } }
+    }
+    expect(auditCall.data?.metadata?.thresholdsAdapted).toBe(false)
+    expect(auditCall.data?.metadata?.pinnedTo).toBe("GD")
+  })
+
   it("blocks toggle-OFF when patient has an active PatientPregnancy", async () => {
     prismaMock.patient.findFirst.mockResolvedValue({
       id: 1, pregnancyMode: true, pathology: "DT1",
@@ -96,11 +134,26 @@ describe("pregnancyModeService.setMode", () => {
     ).rejects.toThrow("active_pregnancy_blocks_toggle_off")
   })
 
-  it("allows toggle-OFF with forceOverride and tags audit", async () => {
+  it("rejects forceOverride without justification reason (≥ 20 chars)", async () => {
     prismaMock.patient.findFirst.mockResolvedValue({
       id: 1, pregnancyMode: true, pathology: "DT1",
     } as never)
     prismaMock.patientPregnancy.findFirst.mockResolvedValue({ id: 99 } as never)
+
+    await expect(
+      pregnancyModeService.setMode(1, false, 42, undefined, {
+        forceOverride: true,
+        forceOverrideReason: "too short",
+      }),
+    ).rejects.toThrow("force_override_reason_required")
+  })
+
+  it("allows toggle-OFF with forceOverride + valid reason and tags audit", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({
+      id: 1, pregnancyMode: true, pathology: "DT1",
+    } as never)
+    prismaMock.patientPregnancy.findFirst.mockResolvedValue({ id: 99 } as never)
+    prismaMock.cgmObjective.findUnique.mockResolvedValue(null as never)
 
     const auditSpy = vi.fn().mockResolvedValue({})
     const mockTx = {
@@ -110,16 +163,25 @@ describe("pregnancyModeService.setMode", () => {
     }
     prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
 
-    const result = await pregnancyModeService.setMode(1, false, 42, undefined, { forceOverride: true })
+    const result = await pregnancyModeService.setMode(1, false, 42, undefined, {
+      forceOverride: true,
+      forceOverrideReason: "patient delivered last week, ending pregnancy mode per Dr X",
+    })
     expect(result.thresholdsAdapted).toBe(true)
-    const auditCall = auditSpy.mock.calls[0]?.[0] as { data?: { metadata?: { forceOverride?: boolean } } }
+    const auditCall = auditSpy.mock.calls[0]?.[0] as {
+      data?: { metadata?: { forceOverride?: boolean; forceOverrideReason?: string } }
+    }
     expect(auditCall.data?.metadata?.forceOverride).toBe(true)
+    // Reason is encrypted in audit metadata — verify encrypted blob present
+    expect(auditCall.data?.metadata?.forceOverrideReason).toBeDefined()
+    expect(auditCall.data?.metadata?.forceOverrideReason).not.toContain("delivered")
   })
 
   it("audit log captures oldValue & newValue (HDS forensics)", async () => {
     prismaMock.patient.findFirst.mockResolvedValue({
       id: 1, pregnancyMode: false, pathology: "DT1",
     } as never)
+    prismaMock.cgmObjective.findUnique.mockResolvedValue(null as never)
 
     const auditSpy = vi.fn().mockResolvedValue({})
     const mockTx = {


### PR DESCRIPTION
## Summary

Implémente le **batch C** de la roadmap MVP : 9 user stories Mirror MVP qui débloquent les fonctionnalités côté patient mobile (côté pro). MVP completion : **60% → 75%**.

| Groupe | US | Description |
|---|---|---|
| Config seuils | US-2214/2215/2216/2217 | Cibles glycémiques, alertes hypo/hyper, seuils cétones, protocole resucrage |
| Urgences | US-2224/2225/2226/2230 | Inbox alertes, timeline, workflow médecin, push FCM |
| Mode contextuel | US-2232 | Toggle mode grossesse + auto-adapt CGM defaults |

## Changements clés

### Modèles & schéma (5 nouveaux)
- `AlertThresholdConfig`, `KetoneThreshold`, `HypoTreatmentProtocol`, `EmergencyAlert`, `EmergencyAlertAction`
- `Patient.pregnancyMode` (boolean)
- 5 nouveaux enums

### Services (5 nouveaux)
- `alert-threshold.service.ts`, `ketone-threshold.service.ts`, `hypo-treatment.service.ts`
- `emergency.service.ts` — détection CGM/cétones, classification clinique, FCM
- `pregnancy-mode.service.ts` — auto-adapt CGM defaults

### API Routes (7 nouvelles)
- `GET/PUT /api/patient/{alert-thresholds,ketone-thresholds,hypo-treatment}`
- `PUT /api/patient/pregnancy-mode`
- `GET/POST /api/emergency-alerts`
- `GET/PATCH /api/emergency-alerts/[id]`
- `POST /api/emergency-alerts/[id]/actions`

## Sécurité & conformité (review multi-agents appliquée)

Suite à un audit `healthcare-security-auditor` + `medical-domain-validator` + `code-reviewer` : **3 Critical / 5 High / 5 Medium fixés** avant merge.

- 🔒 **Chiffrement AES-256-GCM** sur tous les champs PHI : notes, resolutionNotes, contextSnapshot, action.notes, allergies, instructions
- 🔒 **RBAC scoping inbox** via `getAccessiblePatientIds` — empêche cross-tenant leak
- 🔒 **Authorization-before-audit** sur PATCH/actions — pas d'audit sur probing forbidden
- 🔒 **FCM data-only payload** — pas de PHI sur lockscreen, deep link uniquement
- 🔒 **Allowlist d'erreurs métier** — pas de leak Prisma vers client
- 🔒 **Soft-delete RGPD Art. 17** enforcé sur workflow ops

## Sémantique clinique (medical-domain-validator)

- `≤ veryLow` = severe_hypo (ADA SoC 2024 Level 2)
- `≥ high` = severe_hyper (clinical safety inclusive boundary)
- `≥ DKA` = ketone_dka (ISPAD 2022 inclusive criterion)
- **Pregnancy CGM defaults** : 60/63/140/200 mg/dL (Battelino 2019)
- **Cooldown sévérité-aware** : critical capé à 15 min (jamais silencieux > 15 min sur Level 2 hypo / DKA)
- **Toggle-OFF mode grossesse** rejeté si `PatientPregnancy.active = true` (sauf `forceOverride: true` audit-tagué)
- **Retest hypo** capé à 30 min max (rule of 15/15)

## Tests

- ✅ **53 nouveaux tests** unitaires (5 fichiers)
- ✅ **1011 → 1064 tests** au total (toute la suite passe)
- ✅ TypeScript compile clean (`tsc --noEmit`)
- ✅ ESLint 0 errors
- Coverage : classification CGM/cétones, cooldown sévérité-aware, encryption round-trip, soft-delete guard, RBAC scoping, transitions workflow, garde grossesse active

## Test plan

- [ ] Migration Prisma à appliquer en recette : `pnpm prisma db push`
- [ ] Vérifier toutes les nouvelles routes via Postman/curl avec un user DOCTOR
- [ ] Tester le toggle pregnancy ON/OFF → CGM thresholds adaptés
- [ ] Tester la création manuelle d'alerte + acknowledge + resolve
- [ ] Vérifier que le push FCM ne contient pas de PHI sur lockscreen
- [ ] Vérifier qu'un NURSE de service A ne peut pas voir alertes du service B
- [ ] Tester la garde-fou : toggle-OFF mode grossesse avec PatientPregnancy active doit retourner 409

🤖 Generated with [Claude Code](https://claude.com/claude-code)