### PR TITLE
feat(patients): Groupe 2 Batches 1+2 — 5 US Patients avancés

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,11 +10,11 @@
 | Priorité | Total | DONE | PARTIAL | NOT STARTED | % Done |
 |----------|-------|------|---------|-------------|--------|
 | **MVP**  | 68    | 65   | 0       | 3           | **96%** |
-| **V1**   | 143   | 10   | 6       | 127         | **7%**  |
+| **V1**   | 143   | 15   | 4       | 124         | **10%** |
 | **V2**   | 58    | 0    | 0       | 58          | **0%**  |
 | **V3**   | 9     | 0    | 0       | 9           | **0%**  |
 | **V4**   | 16    | 0    | 0       | 16          | **0%**  |
-| **TOTAL**| **294** | **75** | **6**   | **213**     | **26%** |
+| **TOTAL**| **294** | **80** | **4**   | **210**     | **27%** |
 > Note (2026-05-13 session Samir) : Q6 US-2414 supprimée (V1 −1), Q7 module
 > RDV ajouté V1 (+7 US US-2500-2506 = +49 SP), Q8 US-2800 ajoutée V4 (+1).
 > Total : 286 → 294 (+8).
@@ -242,12 +242,15 @@
 
 | US | Titre | Statut |
 |----|-------|--------|
-| US-2019 | Recherche full-text patients | NOT STARTED |
-| US-2021 | Transfert patient entre médecins | NOT STARTED |
-| US-2022 | Tags & catégorisation patients | NOT STARTED |
-| US-2024 | Historique modifications (UI audit) | PARTIAL |
-| US-2026 | INS — Identité Nationale Santé | NOT STARTED |
-| US-2028 | Dossier multi-praticiens | PARTIAL |
+| US-2019 | Recherche full-text patients | DONE (PR #389 — HMAC exact + Pathology + consent filter) |
+| US-2021 | Transfert patient entre médecins | DONE (PR #389 — ADMIN/référent/self-claim only) |
+| US-2022 | Tags & catégorisation patients | DONE (PR #389 — 2 modèles Prisma + 4 routes + anti-PII) |
+| US-2024 | Historique modifications (UI audit) | DONE (PR #389 — PHI redacted, DOCTOR+ only) |
+| US-2026 | INS — Identité Nationale Santé | NOT STARTED (V1, 8 SP — Batch 3 standalone) |
+| US-2028 | Dossier multi-praticiens | DONE (PR #389 — referents view) |
+
+**Batches 1+2 livrés** : 5 US (US-2019, 2021, 2022, 2024, 2028) — PR #389, ~5 SP,
+1282 tests verts, 35 findings de review traités (3 Critical + 11 High + 15 Medium + 8 Low).
 
 ### Groupe 3 — Équipe & Communication (15 US)
 

--- a/prisma/migrations/20260513150000_patient_tags/migration.sql
+++ b/prisma/migrations/20260513150000_patient_tags/migration.sql
@@ -1,28 +1,48 @@
 -- US-2022 — Patient tags (catégorisation libre par cabinet).
 
+-- CreateTable
 CREATE TABLE "patient_tags" (
-  "id"         SERIAL PRIMARY KEY,
-  "service_id" INTEGER NOT NULL,
-  "label"      VARCHAR(50) NOT NULL,
-  "color"      VARCHAR(7)  NOT NULL,
-  "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
-  "created_by" INTEGER,
-  CONSTRAINT "patient_tags_service_id_fkey" FOREIGN KEY ("service_id") REFERENCES "healthcare_services"("id") ON DELETE CASCADE
+    "id" SERIAL NOT NULL,
+    "service_id" INTEGER NOT NULL,
+    "label" VARCHAR(50) NOT NULL,
+    "color" VARCHAR(7) NOT NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "created_by" INTEGER,
+
+    CONSTRAINT "patient_tags_pkey" PRIMARY KEY ("id")
 );
 
-CREATE UNIQUE INDEX "patient_tags_service_id_label_key" ON "patient_tags" ("service_id", "label");
-CREATE INDEX "patient_tags_service_id_idx" ON "patient_tags" ("service_id");
-
+-- CreateTable
 CREATE TABLE "patient_tag_assignments" (
-  "id"          SERIAL PRIMARY KEY,
-  "patient_id"  INTEGER NOT NULL,
-  "tag_id"      INTEGER NOT NULL,
-  "assigned_by" INTEGER,
-  "created_at"  TIMESTAMPTZ NOT NULL DEFAULT now(),
-  CONSTRAINT "patient_tag_assignments_patient_id_fkey" FOREIGN KEY ("patient_id") REFERENCES "patients"("id") ON DELETE CASCADE,
-  CONSTRAINT "patient_tag_assignments_tag_id_fkey"     FOREIGN KEY ("tag_id")     REFERENCES "patient_tags"("id") ON DELETE CASCADE
+    "id" SERIAL NOT NULL,
+    "patient_id" INTEGER NOT NULL,
+    "tag_id" INTEGER NOT NULL,
+    "assigned_by" INTEGER,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "patient_tag_assignments_pkey" PRIMARY KEY ("id")
 );
 
-CREATE UNIQUE INDEX "patient_tag_assignments_patient_id_tag_id_key" ON "patient_tag_assignments" ("patient_id", "tag_id");
-CREATE INDEX "patient_tag_assignments_patient_id_idx" ON "patient_tag_assignments" ("patient_id");
-CREATE INDEX "patient_tag_assignments_tag_id_idx"     ON "patient_tag_assignments" ("tag_id");
+-- CreateIndex
+CREATE UNIQUE INDEX "patient_tags_service_id_label_key" ON "patient_tags"("service_id", "label");
+
+-- CreateIndex
+CREATE INDEX "patient_tags_service_id_idx" ON "patient_tags"("service_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "patient_tag_assignments_patient_id_tag_id_key" ON "patient_tag_assignments"("patient_id", "tag_id");
+
+-- CreateIndex
+CREATE INDEX "patient_tag_assignments_patient_id_idx" ON "patient_tag_assignments"("patient_id");
+
+-- CreateIndex
+CREATE INDEX "patient_tag_assignments_tag_id_idx" ON "patient_tag_assignments"("tag_id");
+
+-- AddForeignKey
+ALTER TABLE "patient_tags" ADD CONSTRAINT "patient_tags_service_id_fkey" FOREIGN KEY ("service_id") REFERENCES "healthcare_services"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "patient_tag_assignments" ADD CONSTRAINT "patient_tag_assignments_patient_id_fkey" FOREIGN KEY ("patient_id") REFERENCES "patients"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "patient_tag_assignments" ADD CONSTRAINT "patient_tag_assignments_tag_id_fkey" FOREIGN KEY ("tag_id") REFERENCES "patient_tags"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260513150000_patient_tags/migration.sql
+++ b/prisma/migrations/20260513150000_patient_tags/migration.sql
@@ -1,0 +1,28 @@
+-- US-2022 — Patient tags (catégorisation libre par cabinet).
+
+CREATE TABLE "patient_tags" (
+  "id"         SERIAL PRIMARY KEY,
+  "service_id" INTEGER NOT NULL,
+  "label"      VARCHAR(50) NOT NULL,
+  "color"      VARCHAR(7)  NOT NULL,
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "created_by" INTEGER,
+  CONSTRAINT "patient_tags_service_id_fkey" FOREIGN KEY ("service_id") REFERENCES "healthcare_services"("id") ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX "patient_tags_service_id_label_key" ON "patient_tags" ("service_id", "label");
+CREATE INDEX "patient_tags_service_id_idx" ON "patient_tags" ("service_id");
+
+CREATE TABLE "patient_tag_assignments" (
+  "id"          SERIAL PRIMARY KEY,
+  "patient_id"  INTEGER NOT NULL,
+  "tag_id"      INTEGER NOT NULL,
+  "assigned_by" INTEGER,
+  "created_at"  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT "patient_tag_assignments_patient_id_fkey" FOREIGN KEY ("patient_id") REFERENCES "patients"("id") ON DELETE CASCADE,
+  CONSTRAINT "patient_tag_assignments_tag_id_fkey"     FOREIGN KEY ("tag_id")     REFERENCES "patient_tags"("id") ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX "patient_tag_assignments_patient_id_tag_id_key" ON "patient_tag_assignments" ("patient_id", "tag_id");
+CREATE INDEX "patient_tag_assignments_patient_id_idx" ON "patient_tag_assignments" ("patient_id");
+CREATE INDEX "patient_tag_assignments_tag_id_idx"     ON "patient_tag_assignments" ("tag_id");

--- a/prisma/migrations/20260513170000_patient_tags_refinements/migration.sql
+++ b/prisma/migrations/20260513170000_patient_tags_refinements/migration.sql
@@ -1,0 +1,35 @@
+-- US-2022 — Refinements PR #389 review:
+--  * M7: HealthcareService → PatientTag : Restrict (was Cascade)
+--  * M8: Drop redundant index on patient_tags(service_id) (covered by unique)
+--  * M9: Add composite index (patient_id, created_at) on assignments
+--  * M10: Add FK relations for created_by / assigned_by → users(id) with SetNull
+
+-- DropIndex (redundant — covered by patient_tags_service_id_label_key)
+DROP INDEX IF EXISTS "patient_tags_service_id_idx";
+
+-- DropIndex (replaced by composite below)
+DROP INDEX IF EXISTS "patient_tag_assignments_patient_id_idx";
+
+-- CreateIndex
+CREATE INDEX "patient_tag_assignments_patient_id_created_at_idx"
+    ON "patient_tag_assignments"("patient_id", "created_at");
+
+-- Switch service→tags FK to Restrict (was Cascade). Drop then re-add.
+ALTER TABLE "patient_tags"
+    DROP CONSTRAINT "patient_tags_service_id_fkey";
+ALTER TABLE "patient_tags"
+    ADD CONSTRAINT "patient_tags_service_id_fkey"
+        FOREIGN KEY ("service_id") REFERENCES "healthcare_services"("id")
+        ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey created_by → users(id) (was unconstrained Int)
+ALTER TABLE "patient_tags"
+    ADD CONSTRAINT "patient_tags_created_by_fkey"
+        FOREIGN KEY ("created_by") REFERENCES "users"("id")
+        ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey assigned_by → users(id) (was unconstrained Int)
+ALTER TABLE "patient_tag_assignments"
+    ADD CONSTRAINT "patient_tag_assignments_assigned_by_fkey"
+        FOREIGN KEY ("assigned_by") REFERENCES "users"("id")
+        ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -504,6 +504,8 @@ model Patient {
   documents             MedicalDocument[]
   appointments          Appointment[]
   patientInsulins       PatientInsulin[]
+  /// US-2022 — Tags posés sur ce patient au sein de son/ses cabinet(s).
+  tagAssignments        PatientTagAssignment[]
 
   @@index([deletedAt])
   @@map("patients")
@@ -1297,6 +1299,8 @@ model HealthcareService {
   members         HealthcareMember[]
   patientServices PatientService[]
   referents       PatientReferent[]
+  /// US-2022 — Tags (catégorisation libre) appartenant à ce cabinet.
+  patientTags     PatientTag[]
 
   @@unique([name, establishment])
   @@index([type])
@@ -1351,6 +1355,44 @@ model PatientReferent {
   service HealthcareService? @relation(fields: [serviceId], references: [id])
 
   @@map("patient_referent")
+}
+
+/// US-2022 — Tags libres (catégorisation) appliqués par un cabinet. Portée
+/// `serviceId` : chaque HealthcareService maintient son propre vocabulaire.
+/// `label` est libre (max 50 char), `color` est un code hex `#RRGGBB`.
+model PatientTag {
+  id        Int      @id @default(autoincrement())
+  serviceId Int      @map("service_id")
+  label     String   @db.VarChar(50)
+  color     String   @db.VarChar(7) // #RRGGBB
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  createdBy Int?     @map("created_by")
+
+  service     HealthcareService     @relation(fields: [serviceId], references: [id], onDelete: Cascade)
+  assignments PatientTagAssignment[]
+
+  @@unique([serviceId, label])
+  @@index([serviceId])
+  @@map("patient_tags")
+}
+
+/// US-2022 — Affectation d'un tag à un patient (jointure M:N). Un tag ne peut
+/// être posé qu'une fois sur un patient donné. Pas de soft-delete : la
+/// dissociation est immédiate (`DELETE` ligne).
+model PatientTagAssignment {
+  id         Int      @id @default(autoincrement())
+  patientId  Int      @map("patient_id")
+  tagId      Int      @map("tag_id")
+  assignedBy Int?     @map("assigned_by")
+  createdAt  DateTime @default(now()) @map("created_at") @db.Timestamptz()
+
+  patient Patient    @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  tag     PatientTag @relation(fields: [tagId], references: [id], onDelete: Cascade)
+
+  @@unique([patientId, tagId])
+  @@index([patientId])
+  @@index([tagId])
+  @@map("patient_tag_assignments")
 }
 
 // ═══════════════════════════════════════════════════════════════

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -333,6 +333,8 @@ model User {
   statusTransitionedBy User?                 @relation("UserStatusChangedBy", fields: [statusChangedBy], references: [id], onDelete: Restrict)
   triggeredBackups     BackupLog[]           @relation("BackupTriggeredBy")
   managedServices      HealthcareService[]   @relation("HealthcareServiceManager")
+  createdPatientTags   PatientTag[]          @relation("PatientTagCreator")
+  assignedPatientTags  PatientTagAssignment[] @relation("PatientTagAssigner")
 
   @@index([createdAt])
   @@index([firstnameHmac, lastnameHmac])
@@ -1359,7 +1361,12 @@ model PatientReferent {
 
 /// US-2022 — Tags libres (catégorisation) appliqués par un cabinet. Portée
 /// `serviceId` : chaque HealthcareService maintient son propre vocabulaire.
-/// `label` est libre (max 50 char), `color` est un code hex `#RRGGBB`.
+/// `label` est libre (max 50 char, validé anti-PII côté service), `color`
+/// est un code hex `#RRGGBB`.
+///
+/// `onDelete: Restrict` sur `service` : la suppression d'un cabinet doit
+/// passer par un nettoyage explicite des tags (qui passe par le service
+/// layer, donc audit log). Évite un drop silencieux des assignments + tags.
 model PatientTag {
   id        Int      @id @default(autoincrement())
   serviceId Int      @map("service_id")
@@ -1368,11 +1375,14 @@ model PatientTag {
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz()
   createdBy Int?     @map("created_by")
 
-  service     HealthcareService     @relation(fields: [serviceId], references: [id], onDelete: Cascade)
+  service     HealthcareService      @relation(fields: [serviceId], references: [id], onDelete: Restrict)
+  /// FK explicite vers User pour l'audit-trail du créateur. SetNull à
+  /// l'anonymisation RGPD (le user reste en base anonymisé, pas hard-deleté
+  /// — mais defense-in-depth si un futur path supprime physiquement).
+  creator     User?                  @relation("PatientTagCreator", fields: [createdBy], references: [id], onDelete: SetNull)
   assignments PatientTagAssignment[]
 
   @@unique([serviceId, label])
-  @@index([serviceId])
   @@map("patient_tags")
 }
 
@@ -1386,12 +1396,15 @@ model PatientTagAssignment {
   assignedBy Int?     @map("assigned_by")
   createdAt  DateTime @default(now()) @map("created_at") @db.Timestamptz()
 
-  patient Patient    @relation(fields: [patientId], references: [id], onDelete: Cascade)
-  tag     PatientTag @relation(fields: [tagId], references: [id], onDelete: Cascade)
+  patient  Patient    @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  tag      PatientTag @relation(fields: [tagId], references: [id], onDelete: Cascade)
+  assigner User?      @relation("PatientTagAssigner", fields: [assignedBy], references: [id], onDelete: SetNull)
 
   @@unique([patientId, tagId])
-  @@index([patientId])
   @@index([tagId])
+  /// Composite index pour l'historique chronologique des affectations
+  /// (alternative à `@@index([patientId])`, le préfixe couvre les WHERE).
+  @@index([patientId, createdAt])
   @@map("patient_tag_assignments")
 }
 

--- a/src/app/api/healthcare/services/[id]/tags/[tagId]/route.ts
+++ b/src/app/api/healthcare/services/[id]/tags/[tagId]/route.ts
@@ -1,0 +1,33 @@
+/** US-2022 — Suppression d'un tag du cabinet (DOCTOR+ membre). */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { requireRole, AuthError } from "@/lib/auth"
+import { patientTagService } from "@/lib/services/patient-tag.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+
+type RouteParams = { params: Promise<{ id: string; tagId: string }> }
+
+export async function DELETE(req: NextRequest, { params }: RouteParams) {
+  try {
+    const user = requireRole(req, "DOCTOR")
+    const { tagId } = await params
+    if (!/^\d+$/.test(tagId)) return NextResponse.json({ error: "invalidTagId" }, { status: 400 })
+
+    const ctx = extractRequestContext(req)
+    await patientTagService.delete(parseInt(tagId, 10), user.id, ctx)
+    return NextResponse.json({ deleted: true })
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    if (msg === "tagNotFound") {
+      return NextResponse.json({ error: "tagNotFound" }, { status: 404 })
+    }
+    if (msg === "forbidden") {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+    console.error("[healthcare/services/:id/tags/:tagId DELETE]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/app/api/healthcare/services/[id]/tags/[tagId]/route.ts
+++ b/src/app/api/healthcare/services/[id]/tags/[tagId]/route.ts
@@ -3,6 +3,10 @@
 import { NextResponse, type NextRequest } from "next/server"
 import { requireRole, AuthError } from "@/lib/auth"
 import { patientTagService } from "@/lib/services/patient-tag.service"
+import {
+  TagForbiddenError,
+  TagNotFoundError,
+} from "@/lib/services/patient-tag.errors"
 import { extractRequestContext } from "@/lib/services/audit.service"
 
 type RouteParams = { params: Promise<{ id: string; tagId: string }> }
@@ -20,13 +24,13 @@ export async function DELETE(req: NextRequest, { params }: RouteParams) {
     if (error instanceof AuthError) {
       return NextResponse.json({ error: error.message }, { status: error.status })
     }
-    const msg = error instanceof Error ? error.message : "Unknown error"
-    if (msg === "tagNotFound") {
+    if (error instanceof TagNotFoundError) {
       return NextResponse.json({ error: "tagNotFound" }, { status: 404 })
     }
-    if (msg === "forbidden") {
+    if (error instanceof TagForbiddenError) {
       return NextResponse.json({ error: "forbidden" }, { status: 403 })
     }
+    const msg = error instanceof Error ? error.message : "Unknown error"
     console.error("[healthcare/services/:id/tags/:tagId DELETE]", msg)
     return NextResponse.json({ error: "serverError" }, { status: 500 })
   }

--- a/src/app/api/healthcare/services/[id]/tags/route.ts
+++ b/src/app/api/healthcare/services/[id]/tags/route.ts
@@ -1,0 +1,85 @@
+/**
+ * US-2022 — CRUD tags du cabinet.
+ *
+ * - `GET /api/healthcare/services/:id/tags` — liste les tags du cabinet (NURSE+).
+ * - `POST /api/healthcare/services/:id/tags` — crée un tag (DOCTOR+).
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireRole, AuthError } from "@/lib/auth"
+import { patientTagService, TagValidationError } from "@/lib/services/patient-tag.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+const createSchema = z.object({
+  label: z.string().trim().min(1).max(50),
+  color: z.string().regex(/^#[0-9A-Fa-f]{6}$/),
+})
+
+async function readServiceId(params: RouteParams["params"]) {
+  const { id } = await params
+  if (!/^\d+$/.test(id)) return null
+  return parseInt(id, 10)
+}
+
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  try {
+    const user = requireRole(req, "NURSE")
+    const serviceId = await readServiceId(params)
+    if (serviceId === null) return NextResponse.json({ error: "invalidServiceId" }, { status: 400 })
+
+    const ctx = extractRequestContext(req)
+    const tags = await patientTagService.listForService(serviceId, user.id, ctx)
+    return NextResponse.json({ items: tags })
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    console.error("[healthcare/services/:id/tags GET]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}
+
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  try {
+    const user = requireRole(req, "DOCTOR")
+    const serviceId = await readServiceId(params)
+    if (serviceId === null) return NextResponse.json({ error: "invalidServiceId" }, { status: 400 })
+
+    const ctx = extractRequestContext(req)
+    const body = await req.json()
+    const parsed = createSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+
+    const tag = await patientTagService.create(
+      { serviceId, label: parsed.data.label, color: parsed.data.color },
+      user.id, ctx,
+    )
+    return NextResponse.json(tag, { status: 201 })
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    if (error instanceof TagValidationError) {
+      return NextResponse.json({ error: error.message, field: error.field }, { status: 422 })
+    }
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    if (msg === "forbidden") {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+    // Unique violation (label already exists in service)
+    if (msg.includes("Unique constraint")) {
+      return NextResponse.json({ error: "labelAlreadyExists" }, { status: 409 })
+    }
+    console.error("[healthcare/services/:id/tags POST]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/app/api/healthcare/services/[id]/tags/route.ts
+++ b/src/app/api/healthcare/services/[id]/tags/route.ts
@@ -1,14 +1,26 @@
 /**
  * US-2022 — CRUD tags du cabinet.
  *
- * - `GET /api/healthcare/services/:id/tags` — liste les tags du cabinet (NURSE+).
- * - `POST /api/healthcare/services/:id/tags` — crée un tag (DOCTOR+).
+ * Sécurité (post-review PR #389):
+ *  - C1 : membership check délégué au service (`listForService` rejette
+ *    un caller non-membre du cabinet ciblé).
+ *  - H8 : `TagForbiddenError`, `TagValidationError`, `TagLabelPiiError` typés.
+ *  - H9 : conflit unique détecté via `Prisma.PrismaClientKnownRequestError`
+ *    code `P2002` (pas de match sur message string).
  */
 
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
+import { Prisma } from "@prisma/client"
 import { requireRole, AuthError } from "@/lib/auth"
-import { patientTagService, TagValidationError } from "@/lib/services/patient-tag.service"
+import {
+  patientTagService,
+  TagValidationError,
+} from "@/lib/services/patient-tag.service"
+import {
+  TagForbiddenError,
+  TagLabelPiiError,
+} from "@/lib/services/patient-tag.errors"
 import { extractRequestContext } from "@/lib/services/audit.service"
 
 type RouteParams = { params: Promise<{ id: string }> }
@@ -31,11 +43,14 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
     if (serviceId === null) return NextResponse.json({ error: "invalidServiceId" }, { status: 400 })
 
     const ctx = extractRequestContext(req)
-    const tags = await patientTagService.listForService(serviceId, user.id, ctx)
-    return NextResponse.json({ items: tags })
+    const result = await patientTagService.listForService(serviceId, user.id, ctx)
+    return NextResponse.json({ items: result.tags })
   } catch (error) {
     if (error instanceof AuthError) {
       return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    if (error instanceof TagForbiddenError) {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
     }
     const msg = error instanceof Error ? error.message : "Unknown error"
     console.error("[healthcare/services/:id/tags GET]", msg)
@@ -71,14 +86,20 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     if (error instanceof TagValidationError) {
       return NextResponse.json({ error: error.message, field: error.field }, { status: 422 })
     }
-    const msg = error instanceof Error ? error.message : "Unknown error"
-    if (msg === "forbidden") {
+    if (error instanceof TagLabelPiiError) {
+      return NextResponse.json({ error: "labelLooksLikePii", reason: error.reason }, { status: 422 })
+    }
+    if (error instanceof TagForbiddenError) {
       return NextResponse.json({ error: "forbidden" }, { status: 403 })
     }
-    // Unique violation (label already exists in service)
-    if (msg.includes("Unique constraint")) {
+    // H9 — Prisma P2002 (unique constraint violation), stable across versions.
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
       return NextResponse.json({ error: "labelAlreadyExists" }, { status: 409 })
     }
+    const msg = error instanceof Error ? error.message : "Unknown error"
     console.error("[healthcare/services/:id/tags POST]", msg)
     return NextResponse.json({ error: "serverError" }, { status: 500 })
   }

--- a/src/app/api/patients/[id]/audit-history/route.ts
+++ b/src/app/api/patients/[id]/audit-history/route.ts
@@ -1,0 +1,109 @@
+/**
+ * US-2024 — Historique des modifications (UI consumption).
+ *
+ * Renvoie les entrées AuditLog liées au patient (via `metadata.patientId`,
+ * convention US-2268). Les valeurs sensibles `oldValue`/`newValue` ne sont
+ * JAMAIS renvoyées en clair — uniquement les clés modifiées (fields list).
+ * Le caller doit pouvoir accéder au patient (RBAC `canAccessPatient`).
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireAuth, AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { auditService, extractRequestContext } from "@/lib/services/audit.service"
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+const querySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+})
+
+type RedactedRow = {
+  id: string
+  userId: number | null
+  action: string
+  resource: string
+  resourceId: string | null
+  createdAt: Date
+  ipAddress: string | null
+  userAgent: string | null
+  /** Names of fields that changed (no values). */
+  changedFields: string[]
+}
+
+function extractChangedFields(oldValue: unknown, newValue: unknown): string[] {
+  const keys = new Set<string>()
+  if (oldValue && typeof oldValue === "object") {
+    for (const k of Object.keys(oldValue as Record<string, unknown>)) keys.add(k)
+  }
+  if (newValue && typeof newValue === "object") {
+    for (const k of Object.keys(newValue as Record<string, unknown>)) keys.add(k)
+  }
+  return Array.from(keys).sort()
+}
+
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  try {
+    const user = requireAuth(req)
+    const { id } = await params
+    if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidPatientId" }, { status: 400 })
+    const patientId = parseInt(id, 10)
+    const ctx = extractRequestContext(req)
+
+    const allowed = await canAccessPatient(user.id, user.role, patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id,
+        resource: "AUDIT_LOG",
+        resourceId: String(patientId),
+        ipAddress: ctx.ipAddress,
+        userAgent: ctx.userAgent,
+        requestId: ctx.requestId,
+        metadata: { patientId, endpoint: "history" },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+
+    const parsed = querySchema.safeParse(
+      Object.fromEntries(req.nextUrl.searchParams.entries()),
+    )
+    if (!parsed.success) {
+      return NextResponse.json({ error: "validationFailed" }, { status: 400 })
+    }
+
+    const rows = await auditService.getByPatient(patientId, parsed.data.limit ?? 50)
+    // Redaction — never return oldValue/newValue plaintext; only field names.
+    const redacted: RedactedRow[] = rows.map((r) => ({
+      id: r.id,
+      userId: r.userId,
+      action: r.action,
+      resource: r.resource,
+      resourceId: r.resourceId,
+      createdAt: r.createdAt,
+      ipAddress: r.ipAddress,
+      userAgent: r.userAgent,
+      changedFields: extractChangedFields(r.oldValue, r.newValue),
+    }))
+
+    await auditService.log({
+      userId: user.id,
+      action: "READ",
+      resource: "AUDIT_LOG",
+      resourceId: String(patientId),
+      ipAddress: ctx.ipAddress,
+      userAgent: ctx.userAgent,
+      requestId: ctx.requestId,
+      metadata: { patientId, kind: "history", count: redacted.length },
+    })
+
+    return NextResponse.json({ items: redacted })
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    console.error("[patients/:id/audit-history]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/app/api/patients/[id]/audit-history/route.ts
+++ b/src/app/api/patients/[id]/audit-history/route.ts
@@ -1,16 +1,25 @@
 /**
  * US-2024 — Historique des modifications (UI consumption).
  *
- * Renvoie les entrées AuditLog liées au patient (via `metadata.patientId`,
- * convention US-2268). Les valeurs sensibles `oldValue`/`newValue` ne sont
- * JAMAIS renvoyées en clair — uniquement les clés modifiées (fields list).
- * Le caller doit pouvoir accéder au patient (RBAC `canAccessPatient`).
+ * Sécurité (post-review PR #389):
+ *  - H2/H3 : route restreinte à DOCTOR+ (NURSE/VIEWER ne voient pas les
+ *    IP/UA du personnel, ni les actions privilégiées comme BOLUS_CALCULATED,
+ *    PROPOSAL_*, MFA_*, etc.).
+ *  - H6 : pré-vérification de l'existence du patient AVANT `accessDenied()`
+ *    pour éviter l'oracle d'existence et la pollution du burst detector
+ *    sur les IDs scannés.
+ *  - H1 : `patientShareConsent` (RGPD Art. 7.3).
+ *  - M4/M5 : `changedFields` lit aussi `metadata.updatedFields` (convention
+ *    repo) et filtre les noms via une allowlist.
+ *  - L (typescript-pro #4) : guard `Array.isArray` ajouté.
  */
 
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
-import { requireAuth, AuthError } from "@/lib/auth"
+import { requireRole, AuthError } from "@/lib/auth"
 import { canAccessPatient } from "@/lib/access-control"
+import { patientShareConsent } from "@/lib/consent"
+import { prisma } from "@/lib/db/client"
 import { auditService, extractRequestContext } from "@/lib/services/audit.service"
 
 type RouteParams = { params: Promise<{ id: string }> }
@@ -19,6 +28,25 @@ const querySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).optional(),
 })
 
+/** Fields a DOCTOR may see surfaced as "changed" in the patient history. */
+const SAFE_FIELD_NAMES = new Set<string>([
+  "pathology", "pregnancyMode", "createdAt", "deletedAt",
+  // Medical-data history (already pro-readable on the detail page):
+  "dt1", "size", "yearDiag", "insulin", "insulinPump",
+  "tabac", "alcool", "riskWeight",
+  // Objectives + treatments + insulin therapy:
+  "veryLow", "low", "ok", "high", "targetGlucose", "targetMin", "targetMax",
+  "sensitivityFactorGl", "sensitivityFactorMgdl", "gramsPerUnit", "basalRate",
+  // Visit/appointment metadata:
+  "scheduledAt", "title", "status",
+])
+
+/** Audit log actions whose names alone reveal protected workflows. */
+const ACTION_HIDE_FOR_NURSE = new Set<string>([
+  "MFA_SETUP_INITIATED", "MFA_ENABLED", "MFA_DISABLED", "MFA_CHALLENGE_FAILED",
+  "RBAC_BREACH_BURST",
+])
+
 type RedactedRow = {
   id: string
   userId: number | null
@@ -26,30 +54,58 @@ type RedactedRow = {
   resource: string
   resourceId: string | null
   createdAt: Date
-  ipAddress: string | null
-  userAgent: string | null
-  /** Names of fields that changed (no values). */
   changedFields: string[]
 }
 
-function extractChangedFields(oldValue: unknown, newValue: unknown): string[] {
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v)
+}
+
+function extractChangedFields(
+  oldValue: unknown,
+  newValue: unknown,
+  metadata: unknown,
+): string[] {
   const keys = new Set<string>()
-  if (oldValue && typeof oldValue === "object") {
-    for (const k of Object.keys(oldValue as Record<string, unknown>)) keys.add(k)
+  if (isPlainObject(oldValue)) Object.keys(oldValue).forEach((k) => keys.add(k))
+  if (isPlainObject(newValue)) Object.keys(newValue).forEach((k) => keys.add(k))
+  // M4 — services often write the change set in `metadata.updatedFields`.
+  if (isPlainObject(metadata)) {
+    const uf = (metadata as { updatedFields?: unknown }).updatedFields
+    if (Array.isArray(uf)) {
+      uf.forEach((k) => { if (typeof k === "string") keys.add(k) })
+    }
   }
-  if (newValue && typeof newValue === "object") {
-    for (const k of Object.keys(newValue as Record<string, unknown>)) keys.add(k)
+  // M5 — allowlist filter (collapse non-allowlisted names into "other").
+  const filtered: string[] = []
+  let hasUnknown = false
+  for (const k of keys) {
+    if (SAFE_FIELD_NAMES.has(k)) filtered.push(k)
+    else hasUnknown = true
   }
-  return Array.from(keys).sort()
+  if (hasUnknown) filtered.push("other")
+  return filtered.sort()
 }
 
 export async function GET(req: NextRequest, { params }: RouteParams) {
   try {
-    const user = requireAuth(req)
+    // H2/H3 — DOCTOR+ only (no patient-facing history yet — would be a
+    // separate `/me/access-history` endpoint with stricter redaction).
+    const user = requireRole(req, "DOCTOR")
     const { id } = await params
     if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidPatientId" }, { status: 400 })
     const patientId = parseInt(id, 10)
     const ctx = extractRequestContext(req)
+
+    // H6 — pre-check patient existence BEFORE calling accessDenied() to
+    // avoid the existence oracle and audit-log pollution.
+    const patient = await prisma.patient.findFirst({
+      where: { id: patientId, deletedAt: null },
+      select: { id: true },
+    })
+    if (!patient) {
+      return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    }
 
     const allowed = await canAccessPatient(user.id, user.role, patientId)
     if (!allowed) {
@@ -65,6 +121,12 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: "forbidden" }, { status: 403 })
     }
 
+    // H1 — patient consent gate.
+    const consent = await patientShareConsent(patientId)
+    if (!consent.ok) {
+      return NextResponse.json({ error: consent.error }, { status: consent.status })
+    }
+
     const parsed = querySchema.safeParse(
       Object.fromEntries(req.nextUrl.searchParams.entries()),
     )
@@ -73,18 +135,22 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
     }
 
     const rows = await auditService.getByPatient(patientId, parsed.data.limit ?? 50)
-    // Redaction — never return oldValue/newValue plaintext; only field names.
-    const redacted: RedactedRow[] = rows.map((r) => ({
-      id: r.id,
-      userId: r.userId,
-      action: r.action,
-      resource: r.resource,
-      resourceId: r.resourceId,
-      createdAt: r.createdAt,
-      ipAddress: r.ipAddress,
-      userAgent: r.userAgent,
-      changedFields: extractChangedFields(r.oldValue, r.newValue),
-    }))
+
+    // H3 — drop rows that surface internal workflows (MFA, RBAC bursts).
+    // Also drop ipAddress/userAgent from the redacted shape: they identify
+    // the staff member's network. Caller is DOCTOR+ so seeing colleague
+    // userId is acceptable.
+    const redacted: RedactedRow[] = rows
+      .filter((r) => !ACTION_HIDE_FOR_NURSE.has(r.action))
+      .map((r) => ({
+        id: r.id,
+        userId: r.userId,
+        action: r.action,
+        resource: r.resource,
+        resourceId: r.resourceId,
+        createdAt: r.createdAt,
+        changedFields: extractChangedFields(r.oldValue, r.newValue, r.metadata),
+      }))
 
     await auditService.log({
       userId: user.id,

--- a/src/app/api/patients/[id]/referent/route.ts
+++ b/src/app/api/patients/[id]/referent/route.ts
@@ -1,0 +1,101 @@
+/**
+ * US-2021 — Transfert du médecin référent d'un patient.
+ * US-2028 — Vue multi-praticiens (membres des services rattachés).
+ *
+ * - `GET  /api/patients/:id/referent` — vue d'équipe (référent principal +
+ *   tous les membres des services rattachés). Lecture NURSE+ avec accès.
+ * - `PUT  /api/patients/:id/referent` — bascule du référent principal vers
+ *   un autre `HealthcareMember`. DOCTOR+ uniquement. Le nouveau référent
+ *   doit être membre d'un des services du patient.
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireAuth, requireRole, AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { patientReferentService } from "@/lib/services/patient-referent.service"
+import { auditService, extractRequestContext } from "@/lib/services/audit.service"
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+const transferSchema = z.object({
+  newProMemberId: z.number().int().positive(),
+})
+
+async function readPatientId(params: RouteParams["params"]) {
+  const { id } = await params
+  if (!/^\d+$/.test(id)) return null
+  return parseInt(id, 10)
+}
+
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  try {
+    const user = requireAuth(req)
+    const patientId = await readPatientId(params)
+    if (patientId === null) return NextResponse.json({ error: "invalidPatientId" }, { status: 400 })
+
+    const ctx = extractRequestContext(req)
+    const allowed = await canAccessPatient(user.id, user.role, patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id, resource: "REFERENT", resourceId: String(patientId),
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: { patientId, endpoint: "list" },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+
+    const entries = await patientReferentService.getReferentsView(patientId, user.id, ctx)
+    return NextResponse.json({ items: entries })
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    console.error("[patients/:id/referent GET]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}
+
+export async function PUT(req: NextRequest, { params }: RouteParams) {
+  try {
+    const user = requireRole(req, "DOCTOR")
+    const patientId = await readPatientId(params)
+    if (patientId === null) return NextResponse.json({ error: "invalidPatientId" }, { status: 400 })
+
+    const ctx = extractRequestContext(req)
+    const allowed = await canAccessPatient(user.id, user.role, patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id, resource: "REFERENT", resourceId: String(patientId),
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: { patientId, endpoint: "transfer" },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+
+    const body = await req.json()
+    const parsed = transferSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+
+    const result = await patientReferentService.transferReferent(
+      patientId, parsed.data.newProMemberId, user.id, ctx,
+    )
+    return NextResponse.json({ id: result.id, proId: result.proId, serviceId: result.serviceId })
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    if (msg === "memberNotEligible") {
+      return NextResponse.json({ error: "memberNotEligible" }, { status: 422 })
+    }
+    console.error("[patients/:id/referent PUT]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/app/api/patients/[id]/referent/route.ts
+++ b/src/app/api/patients/[id]/referent/route.ts
@@ -2,18 +2,27 @@
  * US-2021 — Transfert du médecin référent d'un patient.
  * US-2028 — Vue multi-praticiens (membres des services rattachés).
  *
- * - `GET  /api/patients/:id/referent` — vue d'équipe (référent principal +
- *   tous les membres des services rattachés). Lecture NURSE+ avec accès.
- * - `PUT  /api/patients/:id/referent` — bascule du référent principal vers
- *   un autre `HealthcareMember`. DOCTOR+ uniquement. Le nouveau référent
- *   doit être membre d'un des services du patient.
+ * Sécurité (post-review PR #389):
+ *  - M6 : GET sous `requireRole("NURSE")` (n'expose pas l'équipe au VIEWER).
+ *  - C3 : PUT n'autorise que ADMIN, référent courant, ou self-claim.
+ *    Filtre passé en argument au service (`isAdmin`) qui applique la règle
+ *    intra-transaction.
+ *  - H1 : `patientShareConsent` (RGPD Art. 7.3).
+ *  - H6 : pré-check existence patient avant `accessDenied`.
+ *  - H8 : `MemberNotEligibleError` / `ReferentTransferForbiddenError` typés.
  */
 
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
-import { requireAuth, requireRole, AuthError } from "@/lib/auth"
+import { requireRole, AuthError } from "@/lib/auth"
 import { canAccessPatient } from "@/lib/access-control"
+import { patientShareConsent } from "@/lib/consent"
 import { patientReferentService } from "@/lib/services/patient-referent.service"
+import {
+  MemberNotEligibleError,
+  ReferentTransferForbiddenError,
+} from "@/lib/services/patient-tag.errors"
+import { prisma } from "@/lib/db/client"
 import { auditService, extractRequestContext } from "@/lib/services/audit.service"
 
 type RouteParams = { params: Promise<{ id: string }> }
@@ -28,13 +37,25 @@ async function readPatientId(params: RouteParams["params"]) {
   return parseInt(id, 10)
 }
 
+async function ensurePatientAlive(patientId: number): Promise<boolean> {
+  const p = await prisma.patient.findFirst({
+    where: { id: patientId, deletedAt: null }, select: { id: true },
+  })
+  return !!p
+}
+
 export async function GET(req: NextRequest, { params }: RouteParams) {
   try {
-    const user = requireAuth(req)
+    const user = requireRole(req, "NURSE")
     const patientId = await readPatientId(params)
     if (patientId === null) return NextResponse.json({ error: "invalidPatientId" }, { status: 400 })
 
     const ctx = extractRequestContext(req)
+
+    if (!(await ensurePatientAlive(patientId))) {
+      return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    }
+
     const allowed = await canAccessPatient(user.id, user.role, patientId)
     if (!allowed) {
       await auditService.accessDenied({
@@ -43,6 +64,11 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
         metadata: { patientId, endpoint: "list" },
       })
       return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+
+    const consent = await patientShareConsent(patientId)
+    if (!consent.ok) {
+      return NextResponse.json({ error: consent.error }, { status: consent.status })
     }
 
     const entries = await patientReferentService.getReferentsView(patientId, user.id, ctx)
@@ -64,6 +90,11 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
     if (patientId === null) return NextResponse.json({ error: "invalidPatientId" }, { status: 400 })
 
     const ctx = extractRequestContext(req)
+
+    if (!(await ensurePatientAlive(patientId))) {
+      return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    }
+
     const allowed = await canAccessPatient(user.id, user.role, patientId)
     if (!allowed) {
       await auditService.accessDenied({
@@ -72,6 +103,11 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
         metadata: { patientId, endpoint: "transfer" },
       })
       return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+
+    const consent = await patientShareConsent(patientId)
+    if (!consent.ok) {
+      return NextResponse.json({ error: consent.error }, { status: consent.status })
     }
 
     const body = await req.json()
@@ -84,17 +120,20 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
     }
 
     const result = await patientReferentService.transferReferent(
-      patientId, parsed.data.newProMemberId, user.id, ctx,
+      patientId, parsed.data.newProMemberId, user.id, user.role === "ADMIN", ctx,
     )
-    return NextResponse.json({ id: result.id, proId: result.proId, serviceId: result.serviceId })
+    return NextResponse.json(result)
   } catch (error) {
     if (error instanceof AuthError) {
       return NextResponse.json({ error: error.message }, { status: error.status })
     }
-    const msg = error instanceof Error ? error.message : "Unknown error"
-    if (msg === "memberNotEligible") {
-      return NextResponse.json({ error: "memberNotEligible" }, { status: 422 })
+    if (error instanceof MemberNotEligibleError) {
+      return NextResponse.json({ error: error.message }, { status: 422 })
     }
+    if (error instanceof ReferentTransferForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: 403 })
+    }
+    const msg = error instanceof Error ? error.message : "Unknown error"
     console.error("[patients/:id/referent PUT]", msg)
     return NextResponse.json({ error: "serverError" }, { status: 500 })
   }

--- a/src/app/api/patients/[id]/tags/route.ts
+++ b/src/app/api/patients/[id]/tags/route.ts
@@ -1,17 +1,23 @@
 /**
  * US-2022 — Tags affectés à un patient.
  *
- * - `GET /api/patients/:id/tags` — liste les tags posés (NURSE+ avec accès).
- * - `PUT /api/patients/:id/tags` — remplace l'ensemble par `{ tagIds: [..] }`
- *   (NURSE+). Tous les tags doivent appartenir à un cabinet dont le caller
- *   est membre (vérifié au service layer).
+ * Sécurité (post-review PR #389):
+ *  - H1 : `patientShareConsent` gate.
+ *  - H6 : pré-check existence patient avant `accessDenied`.
+ *  - H8 : `TagForbiddenError` typé (403 uniforme, pas d'oracle d'énumération).
  */
 
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
 import { requireRole, AuthError } from "@/lib/auth"
 import { canAccessPatient } from "@/lib/access-control"
+import { patientShareConsent } from "@/lib/consent"
 import { patientTagService } from "@/lib/services/patient-tag.service"
+import {
+  TagForbiddenError,
+  TagNotFoundError,
+} from "@/lib/services/patient-tag.errors"
+import { prisma } from "@/lib/db/client"
 import { auditService, extractRequestContext } from "@/lib/services/audit.service"
 
 type RouteParams = { params: Promise<{ id: string }> }
@@ -20,6 +26,13 @@ const setSchema = z.object({
   tagIds: z.array(z.number().int().positive()).max(20),
 })
 
+async function ensurePatientAlive(patientId: number): Promise<boolean> {
+  const p = await prisma.patient.findFirst({
+    where: { id: patientId, deletedAt: null }, select: { id: true },
+  })
+  return !!p
+}
+
 export async function GET(req: NextRequest, { params }: RouteParams) {
   try {
     const user = requireRole(req, "NURSE")
@@ -27,6 +40,10 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
     if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidPatientId" }, { status: 400 })
     const patientId = parseInt(id, 10)
     const ctx = extractRequestContext(req)
+
+    if (!(await ensurePatientAlive(patientId))) {
+      return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    }
 
     const allowed = await canAccessPatient(user.id, user.role, patientId)
     if (!allowed) {
@@ -38,7 +55,12 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: "forbidden" }, { status: 403 })
     }
 
-    const tags = await patientTagService.listForPatient(patientId)
+    const consent = await patientShareConsent(patientId)
+    if (!consent.ok) {
+      return NextResponse.json({ error: consent.error }, { status: consent.status })
+    }
+
+    const tags = await patientTagService.listForPatient(patientId, user.id, ctx)
     return NextResponse.json({ items: tags })
   } catch (error) {
     if (error instanceof AuthError) {
@@ -58,6 +80,10 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
     const patientId = parseInt(id, 10)
     const ctx = extractRequestContext(req)
 
+    if (!(await ensurePatientAlive(patientId))) {
+      return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    }
+
     const allowed = await canAccessPatient(user.id, user.role, patientId)
     if (!allowed) {
       await auditService.accessDenied({
@@ -66,6 +92,11 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
         metadata: { patientId, endpoint: "set" },
       })
       return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+
+    const consent = await patientShareConsent(patientId)
+    if (!consent.ok) {
+      return NextResponse.json({ error: consent.error }, { status: consent.status })
     }
 
     const body = await req.json()
@@ -85,10 +116,11 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
     if (error instanceof AuthError) {
       return NextResponse.json({ error: error.message }, { status: error.status })
     }
-    const msg = error instanceof Error ? error.message : "Unknown error"
-    if (msg === "tagNotFound" || msg === "forbidden") {
-      return NextResponse.json({ error: msg }, { status: msg === "forbidden" ? 403 : 404 })
+    if (error instanceof TagForbiddenError || error instanceof TagNotFoundError) {
+      // Both fold to 403 uniformly to prevent enumeration (C2).
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
     }
+    const msg = error instanceof Error ? error.message : "Unknown error"
     console.error("[patients/:id/tags PUT]", msg)
     return NextResponse.json({ error: "serverError" }, { status: 500 })
   }

--- a/src/app/api/patients/[id]/tags/route.ts
+++ b/src/app/api/patients/[id]/tags/route.ts
@@ -1,0 +1,95 @@
+/**
+ * US-2022 — Tags affectés à un patient.
+ *
+ * - `GET /api/patients/:id/tags` — liste les tags posés (NURSE+ avec accès).
+ * - `PUT /api/patients/:id/tags` — remplace l'ensemble par `{ tagIds: [..] }`
+ *   (NURSE+). Tous les tags doivent appartenir à un cabinet dont le caller
+ *   est membre (vérifié au service layer).
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireRole, AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { patientTagService } from "@/lib/services/patient-tag.service"
+import { auditService, extractRequestContext } from "@/lib/services/audit.service"
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+const setSchema = z.object({
+  tagIds: z.array(z.number().int().positive()).max(20),
+})
+
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  try {
+    const user = requireRole(req, "NURSE")
+    const { id } = await params
+    if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidPatientId" }, { status: 400 })
+    const patientId = parseInt(id, 10)
+    const ctx = extractRequestContext(req)
+
+    const allowed = await canAccessPatient(user.id, user.role, patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id, resource: "PATIENT_TAG_ASSIGNMENT", resourceId: String(patientId),
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: { patientId, endpoint: "list" },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+
+    const tags = await patientTagService.listForPatient(patientId)
+    return NextResponse.json({ items: tags })
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    console.error("[patients/:id/tags GET]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}
+
+export async function PUT(req: NextRequest, { params }: RouteParams) {
+  try {
+    const user = requireRole(req, "NURSE")
+    const { id } = await params
+    if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidPatientId" }, { status: 400 })
+    const patientId = parseInt(id, 10)
+    const ctx = extractRequestContext(req)
+
+    const allowed = await canAccessPatient(user.id, user.role, patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id, resource: "PATIENT_TAG_ASSIGNMENT", resourceId: String(patientId),
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: { patientId, endpoint: "set" },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+
+    const body = await req.json()
+    const parsed = setSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+
+    const result = await patientTagService.setForPatient(
+      patientId, parsed.data.tagIds, user.id, ctx,
+    )
+    return NextResponse.json(result)
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    if (msg === "tagNotFound" || msg === "forbidden") {
+      return NextResponse.json({ error: msg }, { status: msg === "forbidden" ? 403 : 404 })
+    }
+    console.error("[patients/:id/tags PUT]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/app/api/patients/search/route.ts
+++ b/src/app/api/patients/search/route.ts
@@ -1,0 +1,68 @@
+/**
+ * US-2019 — Recherche patient (full-text exact match sur HMAC + filtres).
+ *
+ * Query params:
+ *  - `search`     — nom OU prénom EXACT (case-insensitive). HMAC déterministe
+ *                   sur User.firstnameHmac / User.lastnameHmac.
+ *  - `pathology`  — DT1 / DT2 / GD (exact match).
+ *  - `cursor`     — id patient (pagination).
+ *  - `limit`      — page size (1..50, défaut 25).
+ *
+ * Scoping RBAC : ADMIN voit tout, DOCTOR/NURSE limités aux patients de leurs
+ * services, VIEWER → own patient. Le `search` ne contourne JAMAIS la scope.
+ *
+ * Audit : `READ` sur `PATIENT` (`resourceId="search"`) avec le count + flags.
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { Pathology } from "@prisma/client"
+import { requireRole, AuthError } from "@/lib/auth"
+import { getAccessiblePatientIds } from "@/lib/access-control"
+import { patientService } from "@/lib/services/patient.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+
+const querySchema = z.object({
+  search: z.string().trim().min(1).max(100).optional(),
+  pathology: z.enum(Pathology).optional(),
+  cursor: z.coerce.number().int().positive().optional(),
+  limit: z.coerce.number().int().min(1).max(50).optional(),
+})
+
+export async function GET(req: NextRequest) {
+  try {
+    const user = requireRole(req, "NURSE")
+    const ctx = extractRequestContext(req)
+
+    const parsed = querySchema.safeParse(
+      Object.fromEntries(req.nextUrl.searchParams.entries()),
+    )
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+
+    const accessibleIds = await getAccessiblePatientIds(user.id, user.role)
+    const result = await patientService.search(
+      {
+        search: parsed.data.search,
+        pathology: parsed.data.pathology,
+        cursor: parsed.data.cursor,
+        limit: parsed.data.limit,
+        accessibleIds,
+      },
+      user.id,
+      ctx,
+    )
+    return NextResponse.json(result)
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    console.error("[patients/search]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/lib/services/audit.service.ts
+++ b/src/lib/services/audit.service.ts
@@ -113,6 +113,10 @@ export type AuditResource =
   | "PATIENT_SERVICE_LINK"
   | "DEVICE_SYNC"
   | "RETENTION"
+  /** US-2022 — Patient tag entity (cabinet-scoped). */
+  | "PATIENT_TAG"
+  /** US-2022 — Tag <-> patient assignment. */
+  | "PATIENT_TAG_ASSIGNMENT"
 
 /**
  * Audit log entry — parameters for logging an action.

--- a/src/lib/services/patient-referent.service.ts
+++ b/src/lib/services/patient-referent.service.ts
@@ -1,0 +1,129 @@
+/**
+ * @module patient-referent.service
+ * @description US-2021 (transfert référent) + US-2028 (multi-praticiens vue).
+ *
+ * Le `PatientReferent` est 1:1 — un patient n'a qu'un médecin référent
+ * principal à la fois. Le partage inter-PS passe par `PatientService`
+ * (M:N service↔patient ; tout membre du service voit le patient).
+ *
+ * - `getReferentsView(patientId)` agrège le référent principal + tous les
+ *   membres des services auxquels le patient est rattaché → vue "qui peut
+ *   accéder à ce dossier".
+ * - `transferReferent(patientId, newProMemberId)` change `PatientReferent.proId`.
+ *   Le nouveau référent doit être membre d'un des services du patient.
+ */
+
+import { prisma } from "@/lib/db/client"
+import { auditService } from "./audit.service"
+import type { AuditContext } from "./audit.service"
+
+export type ReferentRole = "primary" | "service-member"
+
+export type ReferentEntry = {
+  memberId: number
+  userId: number | null
+  serviceId: number
+  serviceName: string
+  role: ReferentRole
+}
+
+export const patientReferentService = {
+  async getReferentsView(
+    patientId: number,
+    auditUserId: number,
+    ctx?: AuditContext,
+  ): Promise<ReferentEntry[]> {
+    // All members of every service the patient is linked to.
+    const links = await prisma.patientService.findMany({
+      where: { patientId, patient: { deletedAt: null } },
+      include: {
+        service: {
+          select: {
+            id: true,
+            name: true,
+            members: { select: { id: true, userId: true } },
+          },
+        },
+      },
+    })
+    const primary = await prisma.patientReferent.findUnique({
+      where: { patientId },
+      select: { proId: true },
+    })
+
+    const entries: ReferentEntry[] = []
+    const seen = new Set<string>()
+    for (const link of links) {
+      for (const m of link.service.members) {
+        const key = `${m.id}:${link.service.id}`
+        if (seen.has(key)) continue
+        seen.add(key)
+        entries.push({
+          memberId: m.id,
+          userId: m.userId,
+          serviceId: link.service.id,
+          serviceName: link.service.name,
+          role: primary?.proId === m.id ? "primary" : "service-member",
+        })
+      }
+    }
+
+    await auditService.log({
+      userId: auditUserId,
+      action: "READ",
+      resource: "REFERENT",
+      resourceId: String(patientId),
+      ipAddress: ctx?.ipAddress,
+      userAgent: ctx?.userAgent,
+      requestId: ctx?.requestId,
+      metadata: { patientId, count: entries.length },
+    })
+    return entries
+  },
+
+  async transferReferent(
+    patientId: number,
+    newProMemberId: number,
+    auditUserId: number,
+    ctx?: AuditContext,
+  ) {
+    // Verify the new pro is a member of one of the patient's services.
+    const member = await prisma.healthcareMember.findFirst({
+      where: {
+        id: newProMemberId,
+        service: { patientServices: { some: { patientId } } },
+      },
+      select: { id: true, serviceId: true },
+    })
+    if (!member) throw new Error("memberNotEligible")
+
+    return prisma.$transaction(async (tx) => {
+      const existing = await tx.patientReferent.findUnique({
+        where: { patientId },
+        select: { proId: true, serviceId: true },
+      })
+
+      const updated = await tx.patientReferent.upsert({
+        where: { patientId },
+        create: { patientId, proId: newProMemberId, serviceId: member.serviceId },
+        update: { proId: newProMemberId, serviceId: member.serviceId },
+      })
+
+      await auditService.logWithTx(tx, {
+        userId: auditUserId,
+        action: "UPDATE",
+        resource: "REFERENT",
+        resourceId: String(updated.id),
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+        requestId: ctx?.requestId,
+        metadata: {
+          patientId,
+          previousProId: existing?.proId ?? null,
+          newProId: newProMemberId,
+        },
+      })
+      return updated
+    })
+  },
+}

--- a/src/lib/services/patient-referent.service.ts
+++ b/src/lib/services/patient-referent.service.ts
@@ -2,29 +2,42 @@
  * @module patient-referent.service
  * @description US-2021 (transfert référent) + US-2028 (multi-praticiens vue).
  *
- * Le `PatientReferent` est 1:1 — un patient n'a qu'un médecin référent
- * principal à la fois. Le partage inter-PS passe par `PatientService`
- * (M:N service↔patient ; tout membre du service voit le patient).
- *
- * - `getReferentsView(patientId)` agrège le référent principal + tous les
- *   membres des services auxquels le patient est rattaché → vue "qui peut
- *   accéder à ce dossier".
- * - `transferReferent(patientId, newProMemberId)` change `PatientReferent.proId`.
- *   Le nouveau référent doit être membre d'un des services du patient.
+ * Sécurité (post-review PR #389):
+ *  - C3 : le transfert n'est autorisé qu'à l'ADMIN, au référent courant, ou
+ *    au médecin cible (auto-acceptation). Empêche le "vol de patient" :
+ *    aucun DOCTOR tiers du même cabinet ne peut hijack le slot.
+ *  - H7 : tous les services gardent `patient.deletedAt: null` au layer DB.
+ *  - M3 : la vérification d'éligibilité tourne dans la même transaction
+ *    `Serializable` que l'upsert (élimine le TOCTOU sur PatientService).
+ *  - M11 : type de retour explicite (proId/serviceId non-null par construction).
+ *  - Low : `getReferentsView` n'expose `userId` que pour le référent primaire
+ *    (data-minimization vis-à-vis des autres membres).
  */
 
+import { Prisma } from "@prisma/client"
 import { prisma } from "@/lib/db/client"
 import { auditService } from "./audit.service"
 import type { AuditContext } from "./audit.service"
+import {
+  MemberNotEligibleError,
+  ReferentTransferForbiddenError,
+} from "./patient-tag.errors"
 
 export type ReferentRole = "primary" | "service-member"
 
 export type ReferentEntry = {
   memberId: number
+  /** Only populated for `role: "primary"` (data-minimization for peers). */
   userId: number | null
   serviceId: number
   serviceName: string
   role: ReferentRole
+}
+
+export type TransferReferentResult = {
+  id: number
+  proId: number
+  serviceId: number
 }
 
 export const patientReferentService = {
@@ -33,7 +46,6 @@ export const patientReferentService = {
     auditUserId: number,
     ctx?: AuditContext,
   ): Promise<ReferentEntry[]> {
-    // All members of every service the patient is linked to.
     const links = await prisma.patientService.findMany({
       where: { patientId, patient: { deletedAt: null } },
       include: {
@@ -46,8 +58,8 @@ export const patientReferentService = {
         },
       },
     })
-    const primary = await prisma.patientReferent.findUnique({
-      where: { patientId },
+    const primary = await prisma.patientReferent.findFirst({
+      where: { patientId, patient: { deletedAt: null } },
       select: { proId: true },
     })
 
@@ -58,12 +70,13 @@ export const patientReferentService = {
         const key = `${m.id}:${link.service.id}`
         if (seen.has(key)) continue
         seen.add(key)
+        const isPrimary = primary?.proId === m.id
         entries.push({
           memberId: m.id,
-          userId: m.userId,
+          userId: isPrimary ? m.userId : null,
           serviceId: link.service.id,
           serviceName: link.service.name,
-          role: primary?.proId === m.id ? "primary" : "service-member",
+          role: isPrimary ? "primary" : "service-member",
         })
       }
     }
@@ -81,49 +94,97 @@ export const patientReferentService = {
     return entries
   },
 
+  /**
+   * Transfer the primary referent. Authorization rules (C3 fix):
+   *  - ADMIN: always allowed.
+   *  - Current referent (auditUserId === current primary's user): allowed.
+   *  - Target pro (auditUserId === newMember.userId): allowed (self-claim).
+   *  - Any other DOCTOR member of the patient's services: REJECTED.
+   */
   async transferReferent(
     patientId: number,
     newProMemberId: number,
-    auditUserId: number,
+    actingUserId: number,
+    isAdmin: boolean,
     ctx?: AuditContext,
-  ) {
-    // Verify the new pro is a member of one of the patient's services.
-    const member = await prisma.healthcareMember.findFirst({
-      where: {
-        id: newProMemberId,
-        service: { patientServices: { some: { patientId } } },
+  ): Promise<TransferReferentResult> {
+    return prisma.$transaction(
+      async (tx) => {
+        // Patient must exist + be alive.
+        const patient = await tx.patient.findFirst({
+          where: { id: patientId, deletedAt: null },
+          select: { id: true },
+        })
+        if (!patient) throw new MemberNotEligibleError()
+
+        // Eligibility: the new member is linked to the patient via a service
+        // membership (any service the patient belongs to).
+        const newMember = await tx.healthcareMember.findFirst({
+          where: {
+            id: newProMemberId,
+            service: { patientServices: { some: { patientId } } },
+          },
+          select: { id: true, userId: true, serviceId: true },
+        })
+        if (!newMember) throw new MemberNotEligibleError()
+
+        // Existing referent (may be null).
+        const existing = await tx.patientReferent.findUnique({
+          where: { patientId },
+          select: { proId: true, serviceId: true, pro: { select: { userId: true } } },
+        })
+
+        // Authorization (C3 fix).
+        const callerIsCurrentReferent =
+          existing?.pro?.userId === actingUserId && actingUserId !== null
+        const callerIsTarget = newMember.userId === actingUserId
+        if (!isAdmin && !callerIsCurrentReferent && !callerIsTarget) {
+          throw new ReferentTransferForbiddenError()
+        }
+
+        if (newMember.serviceId === null) {
+          // Shouldn't happen — HealthcareMember.serviceId is non-null in
+          // practice — but the schema lets it through. Defensive.
+          throw new MemberNotEligibleError()
+        }
+        const newServiceId: number = newMember.serviceId
+
+        const updated = await tx.patientReferent.upsert({
+          where: { patientId },
+          create: { patientId, proId: newProMemberId, serviceId: newServiceId },
+          update: { proId: newProMemberId, serviceId: newServiceId },
+        })
+
+        await auditService.logWithTx(tx, {
+          userId: actingUserId,
+          action: "UPDATE",
+          resource: "REFERENT",
+          resourceId: String(updated.id),
+          ipAddress: ctx?.ipAddress,
+          userAgent: ctx?.userAgent,
+          requestId: ctx?.requestId,
+          metadata: {
+            patientId,
+            previousProId: existing?.proId ?? null,
+            previousReferentUserId: existing?.pro?.userId ?? null,
+            newProId: newProMemberId,
+            newReferentUserId: newMember.userId,
+            authorizedBy: isAdmin
+              ? "admin"
+              : callerIsCurrentReferent
+                ? "currentReferent"
+                : "selfClaim",
+          },
+        })
+
+        // proId/serviceId are guaranteed non-null by the upsert payload.
+        return {
+          id: updated.id,
+          proId: newProMemberId,
+          serviceId: newServiceId,
+        }
       },
-      select: { id: true, serviceId: true },
-    })
-    if (!member) throw new Error("memberNotEligible")
-
-    return prisma.$transaction(async (tx) => {
-      const existing = await tx.patientReferent.findUnique({
-        where: { patientId },
-        select: { proId: true, serviceId: true },
-      })
-
-      const updated = await tx.patientReferent.upsert({
-        where: { patientId },
-        create: { patientId, proId: newProMemberId, serviceId: member.serviceId },
-        update: { proId: newProMemberId, serviceId: member.serviceId },
-      })
-
-      await auditService.logWithTx(tx, {
-        userId: auditUserId,
-        action: "UPDATE",
-        resource: "REFERENT",
-        resourceId: String(updated.id),
-        ipAddress: ctx?.ipAddress,
-        userAgent: ctx?.userAgent,
-        requestId: ctx?.requestId,
-        metadata: {
-          patientId,
-          previousProId: existing?.proId ?? null,
-          newProId: newProMemberId,
-        },
-      })
-      return updated
-    })
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    )
   },
 }

--- a/src/lib/services/patient-tag.errors.ts
+++ b/src/lib/services/patient-tag.errors.ts
@@ -1,0 +1,49 @@
+/**
+ * @module patient-tag.errors
+ * @description Typed error classes for the patient-tag domain. Routes catch
+ * via `instanceof` rather than `error.message === "..."` — the latter
+ * silently breaks when Prisma wraps an error or a refactor renames the
+ * string. Cf. PR #388 review: same anti-pattern fixed with
+ * `PopulationTooLargeError`.
+ */
+
+export class TagNotFoundError extends Error {
+  constructor(public readonly tagId?: number) {
+    super("tagNotFound")
+    this.name = "TagNotFoundError"
+  }
+}
+
+/**
+ * Either the caller is not a member of the target service, or one of the tag
+ * IDs in the input belongs to a service the caller doesn't belong to. We
+ * collapse "tag does not exist" and "cross-cabinet tag" into the same
+ * error to prevent cross-cabinet ID enumeration.
+ */
+export class TagForbiddenError extends Error {
+  constructor() {
+    super("forbidden")
+    this.name = "TagForbiddenError"
+  }
+}
+
+export class TagLabelPiiError extends Error {
+  constructor(public readonly reason: string) {
+    super("labelLooksLikePii")
+    this.name = "TagLabelPiiError"
+  }
+}
+
+export class MemberNotEligibleError extends Error {
+  constructor() {
+    super("memberNotEligible")
+    this.name = "MemberNotEligibleError"
+  }
+}
+
+export class ReferentTransferForbiddenError extends Error {
+  constructor() {
+    super("referentTransferForbidden")
+    this.name = "ReferentTransferForbiddenError"
+  }
+}

--- a/src/lib/services/patient-tag.service.ts
+++ b/src/lib/services/patient-tag.service.ts
@@ -1,0 +1,186 @@
+/**
+ * @module patient-tag.service
+ * @description US-2022 — Tags & catégorisation patient.
+ *
+ * Chaque `HealthcareService` (cabinet) maintient son propre vocabulaire de
+ * tags. Un tag est posé sur un patient via `PatientTagAssignment`. La
+ * sémantique est libre — étiquettes type "à appeler", "VIP", "ALD",
+ * "non observant", etc. Pas de PII clinique : couleur + label uniquement.
+ *
+ * RBAC:
+ *  - Lister / créer / supprimer un tag du cabinet : DOCTOR+ membre du service.
+ *  - Affecter / désaffecter un tag à un patient : NURSE+ avec accès patient.
+ *
+ * Audit : CREATE/DELETE sur `PATIENT_TAG` (resourceId = tag.id) et
+ * `PATIENT_TAG_ASSIGNMENT` (resourceId = assignment.id, metadata.patientId).
+ */
+
+import { prisma } from "@/lib/db/client"
+import { auditService } from "./audit.service"
+import type { AuditContext } from "./audit.service"
+
+const LABEL_MIN = 1
+const LABEL_MAX = 50
+const COLOR_RE = /^#[0-9A-Fa-f]{6}$/
+
+export class TagValidationError extends Error {
+  readonly field: "label" | "color"
+  constructor(field: "label" | "color", message: string) {
+    super(message)
+    this.name = "TagValidationError"
+    this.field = field
+  }
+}
+
+function validateLabel(label: string): string {
+  const trimmed = label.trim()
+  if (trimmed.length < LABEL_MIN || trimmed.length > LABEL_MAX) {
+    throw new TagValidationError("label", "labelLength")
+  }
+  return trimmed
+}
+function validateColor(color: string): string {
+  if (!COLOR_RE.test(color)) {
+    throw new TagValidationError("color", "colorFormat")
+  }
+  return color.toUpperCase()
+}
+
+async function isServiceMember(userId: number, serviceId: number): Promise<boolean> {
+  const link = await prisma.healthcareMember.findFirst({
+    where: { userId, serviceId },
+    select: { id: true },
+  })
+  return !!link
+}
+
+export const patientTagService = {
+  /** List tags defined by a cabinet (sorted by label). */
+  async listForService(serviceId: number, auditUserId: number, ctx?: AuditContext) {
+    const tags = await prisma.patientTag.findMany({
+      where: { serviceId },
+      orderBy: { label: "asc" },
+    })
+    await auditService.log({
+      userId: auditUserId,
+      action: "READ",
+      resource: "PATIENT_TAG",
+      resourceId: `service:${serviceId}`,
+      ipAddress: ctx?.ipAddress,
+      userAgent: ctx?.userAgent,
+      requestId: ctx?.requestId,
+      metadata: { kind: "tag-list", serviceId, count: tags.length },
+    })
+    return tags
+  },
+
+  /** Create a new tag for a cabinet. Caller must be member of the service. */
+  async create(
+    input: { serviceId: number; label: string; color: string },
+    auditUserId: number,
+    ctx?: AuditContext,
+  ) {
+    if (!(await isServiceMember(auditUserId, input.serviceId))) {
+      throw new Error("forbidden")
+    }
+    const label = validateLabel(input.label)
+    const color = validateColor(input.color)
+
+    return prisma.$transaction(async (tx) => {
+      const tag = await tx.patientTag.create({
+        data: { serviceId: input.serviceId, label, color, createdBy: auditUserId },
+      })
+      await auditService.logWithTx(tx, {
+        userId: auditUserId,
+        action: "CREATE",
+        resource: "PATIENT_TAG",
+        resourceId: String(tag.id),
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+        requestId: ctx?.requestId,
+        metadata: { serviceId: input.serviceId, label, color },
+      })
+      return tag
+    })
+  },
+
+  async delete(tagId: number, auditUserId: number, ctx?: AuditContext) {
+    const tag = await prisma.patientTag.findUnique({
+      where: { id: tagId },
+      select: { id: true, serviceId: true, label: true },
+    })
+    if (!tag) throw new Error("tagNotFound")
+    if (!(await isServiceMember(auditUserId, tag.serviceId))) {
+      throw new Error("forbidden")
+    }
+    return prisma.$transaction(async (tx) => {
+      await tx.patientTag.delete({ where: { id: tagId } })
+      await auditService.logWithTx(tx, {
+        userId: auditUserId,
+        action: "DELETE",
+        resource: "PATIENT_TAG",
+        resourceId: String(tagId),
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+        requestId: ctx?.requestId,
+        metadata: { serviceId: tag.serviceId, label: tag.label },
+      })
+      return { deleted: true }
+    })
+  },
+
+  /** Replace the patient's tag assignments with the given set (atomic). */
+  async setForPatient(
+    patientId: number,
+    tagIds: number[],
+    auditUserId: number,
+    ctx?: AuditContext,
+  ) {
+    // Reject duplicates + ensure all tags exist in some service the caller
+    // is a member of (prevents cross-cabinet contamination).
+    const unique = Array.from(new Set(tagIds))
+    if (unique.length > 0) {
+      const tags = await prisma.patientTag.findMany({
+        where: { id: { in: unique } },
+        select: { id: true, serviceId: true },
+      })
+      if (tags.length !== unique.length) throw new Error("tagNotFound")
+      const memberServices = await prisma.healthcareMember.findMany({
+        where: { userId: auditUserId, serviceId: { in: tags.map((t) => t.serviceId) } },
+        select: { serviceId: true },
+      })
+      const memberSet = new Set(memberServices.map((m) => m.serviceId))
+      if (tags.some((t) => !memberSet.has(t.serviceId))) throw new Error("forbidden")
+    }
+
+    return prisma.$transaction(async (tx) => {
+      await tx.patientTagAssignment.deleteMany({ where: { patientId } })
+      if (unique.length > 0) {
+        await tx.patientTagAssignment.createMany({
+          data: unique.map((tagId) => ({ patientId, tagId, assignedBy: auditUserId })),
+        })
+      }
+      await auditService.logWithTx(tx, {
+        userId: auditUserId,
+        action: "UPDATE",
+        resource: "PATIENT_TAG_ASSIGNMENT",
+        resourceId: String(patientId),
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+        requestId: ctx?.requestId,
+        metadata: { patientId, tagIds: unique },
+      })
+      return { count: unique.length }
+    })
+  },
+
+  /** Get tags currently assigned to a patient. */
+  async listForPatient(patientId: number) {
+    const assignments = await prisma.patientTagAssignment.findMany({
+      where: { patientId },
+      include: { tag: true },
+      orderBy: { tag: { label: "asc" } },
+    })
+    return assignments.map((a) => a.tag)
+  },
+}

--- a/src/lib/services/patient-tag.service.ts
+++ b/src/lib/services/patient-tag.service.ts
@@ -2,26 +2,49 @@
  * @module patient-tag.service
  * @description US-2022 — Tags & catégorisation patient.
  *
- * Chaque `HealthcareService` (cabinet) maintient son propre vocabulaire de
- * tags. Un tag est posé sur un patient via `PatientTagAssignment`. La
- * sémantique est libre — étiquettes type "à appeler", "VIP", "ALD",
- * "non observant", etc. Pas de PII clinique : couleur + label uniquement.
+ * Sécurité (post-review PR #389):
+ *  - Toute opération (lecture incluse) requiert que le caller soit membre du
+ *    cabinet propriétaire (`isServiceMember`). Empêche l'énumération cross-
+ *    cabinet du vocabulaire de tags (C1).
+ *  - Les IDs inconnus et les IDs cross-cabinet sont uniformément renvoyés en
+ *    `TagForbiddenError` (403) — pas d'oracle d'existence (C2).
+ *  - Vérifications transactionnelles : la check membership + tag existence
+ *    s'effectue à l'intérieur du `prisma.$transaction` avec isolation
+ *    `Serializable` pour éliminer le TOCTOU et la course concurrente sur
+ *    `(deleteMany + createMany)` (H5, M1).
+ *  - `label` validé anti-PII (refus si contient chiffres ≥7, email, NIR-like)
+ *    et JAMAIS dupliqué dans audit metadata (H4 + low PII risk).
+ *  - Patient guard `deletedAt: null` au service layer (H7).
+ *  - `setForPatient` émet un audit row par patient avec resourceId = patientId
+ *    et `resource: "PATIENT_TAG_ASSIGNMENT"` (H10 — corrigé vs review).
+ *  - `listForPatient` émet un audit READ (H11).
  *
- * RBAC:
- *  - Lister / créer / supprimer un tag du cabinet : DOCTOR+ membre du service.
- *  - Affecter / désaffecter un tag à un patient : NURSE+ avec accès patient.
- *
- * Audit : CREATE/DELETE sur `PATIENT_TAG` (resourceId = tag.id) et
- * `PATIENT_TAG_ASSIGNMENT` (resourceId = assignment.id, metadata.patientId).
+ * Audit : CREATE/DELETE sur `PATIENT_TAG` (resourceId = tag.id) et UPDATE
+ * sur `PATIENT_TAG_ASSIGNMENT` (resourceId = patientId, metadata.tagIds).
  */
 
+import { Prisma, type PrismaClient } from "@prisma/client"
 import { prisma } from "@/lib/db/client"
+
+/** Either the global Prisma client or a transactional one. */
+type Tx = Parameters<Parameters<PrismaClient["$transaction"]>[0]>[0] | typeof prisma
 import { auditService } from "./audit.service"
 import type { AuditContext } from "./audit.service"
+import {
+  TagForbiddenError,
+  TagLabelPiiError,
+  TagNotFoundError,
+} from "./patient-tag.errors"
 
 const LABEL_MIN = 1
 const LABEL_MAX = 50
 const COLOR_RE = /^#[0-9A-Fa-f]{6}$/
+/** Reject labels containing patterns that look like patient PII. */
+const PII_PATTERNS: Array<{ re: RegExp; reason: string }> = [
+  { re: /\d{7,}/, reason: "digits>=7" },         // long numeric sequences (NIR, phone, IBAN)
+  { re: /@/, reason: "emailAt" },                // email '@'
+  { re: /\b(0[1-9])\s*[\s.-]?(\d{2}\s*[\s.-]?){4}\b/, reason: "frPhone" },
+]
 
 export class TagValidationError extends Error {
   readonly field: "label" | "color"
@@ -32,10 +55,30 @@ export class TagValidationError extends Error {
   }
 }
 
+export type PatientTagDTO = {
+  id: number
+  serviceId: number
+  label: string
+  color: string
+}
+
+export type PatientTagListResult = {
+  tags: PatientTagDTO[]
+}
+
+function toDTO(t: { id: number; serviceId: number; label: string; color: string }): PatientTagDTO {
+  return { id: t.id, serviceId: t.serviceId, label: t.label, color: t.color }
+}
+
 function validateLabel(label: string): string {
   const trimmed = label.trim()
   if (trimmed.length < LABEL_MIN || trimmed.length > LABEL_MAX) {
     throw new TagValidationError("label", "labelLength")
+  }
+  for (const { re, reason } of PII_PATTERNS) {
+    if (re.test(trimmed)) {
+      throw new TagLabelPiiError(reason)
+    }
   }
   return trimmed
 }
@@ -46,141 +89,208 @@ function validateColor(color: string): string {
   return color.toUpperCase()
 }
 
-async function isServiceMember(userId: number, serviceId: number): Promise<boolean> {
-  const link = await prisma.healthcareMember.findFirst({
+async function assertServiceMember(
+  userId: number,
+  serviceId: number,
+  tx: Tx = prisma,
+): Promise<void> {
+  const link = await tx.healthcareMember.findFirst({
     where: { userId, serviceId },
     select: { id: true },
   })
-  return !!link
+  if (!link) throw new TagForbiddenError()
+}
+
+async function assertPatientAlive(patientId: number, tx: Tx = prisma): Promise<void> {
+  const p = await tx.patient.findFirst({
+    where: { id: patientId, deletedAt: null },
+    select: { id: true },
+  })
+  if (!p) throw new TagForbiddenError()
 }
 
 export const patientTagService = {
-  /** List tags defined by a cabinet (sorted by label). */
-  async listForService(serviceId: number, auditUserId: number, ctx?: AuditContext) {
+  /**
+   * List tags defined by a cabinet (sorted by label).
+   * Caller MUST be a member of the service (C1 fix).
+   */
+  async listForService(
+    serviceId: number,
+    auditUserId: number,
+    ctx?: AuditContext,
+  ): Promise<PatientTagListResult> {
+    await assertServiceMember(auditUserId, serviceId)
     const tags = await prisma.patientTag.findMany({
       where: { serviceId },
       orderBy: { label: "asc" },
+      select: { id: true, serviceId: true, label: true, color: true },
     })
     await auditService.log({
       userId: auditUserId,
       action: "READ",
       resource: "PATIENT_TAG",
-      resourceId: `service:${serviceId}`,
+      // US-2268: resourceId = native serviceId (the listed entity's parent).
+      resourceId: String(serviceId),
       ipAddress: ctx?.ipAddress,
       userAgent: ctx?.userAgent,
       requestId: ctx?.requestId,
       metadata: { kind: "tag-list", serviceId, count: tags.length },
     })
-    return tags
+    return { tags: tags.map(toDTO) }
   },
 
-  /** Create a new tag for a cabinet. Caller must be member of the service. */
+  /** Create a new tag for a cabinet. */
   async create(
     input: { serviceId: number; label: string; color: string },
     auditUserId: number,
     ctx?: AuditContext,
-  ) {
-    if (!(await isServiceMember(auditUserId, input.serviceId))) {
-      throw new Error("forbidden")
-    }
+  ): Promise<PatientTagDTO> {
     const label = validateLabel(input.label)
     const color = validateColor(input.color)
 
-    return prisma.$transaction(async (tx) => {
-      const tag = await tx.patientTag.create({
-        data: { serviceId: input.serviceId, label, color, createdBy: auditUserId },
-      })
-      await auditService.logWithTx(tx, {
-        userId: auditUserId,
-        action: "CREATE",
-        resource: "PATIENT_TAG",
-        resourceId: String(tag.id),
-        ipAddress: ctx?.ipAddress,
-        userAgent: ctx?.userAgent,
-        requestId: ctx?.requestId,
-        metadata: { serviceId: input.serviceId, label, color },
-      })
-      return tag
-    })
+    return prisma.$transaction(
+      async (tx) => {
+        await assertServiceMember(auditUserId, input.serviceId, tx)
+        const tag = await tx.patientTag.create({
+          data: { serviceId: input.serviceId, label, color, createdBy: auditUserId },
+        })
+        await auditService.logWithTx(tx, {
+          userId: auditUserId,
+          action: "CREATE",
+          resource: "PATIENT_TAG",
+          resourceId: String(tag.id),
+          ipAddress: ctx?.ipAddress,
+          userAgent: ctx?.userAgent,
+          requestId: ctx?.requestId,
+          // NB: do NOT include `label` plaintext (HDS — label may carry PII
+          // even after validation), only the structural metadata.
+          metadata: { serviceId: input.serviceId, color },
+        })
+        return toDTO(tag)
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    )
   },
 
   async delete(tagId: number, auditUserId: number, ctx?: AuditContext) {
-    const tag = await prisma.patientTag.findUnique({
-      where: { id: tagId },
-      select: { id: true, serviceId: true, label: true },
-    })
-    if (!tag) throw new Error("tagNotFound")
-    if (!(await isServiceMember(auditUserId, tag.serviceId))) {
-      throw new Error("forbidden")
-    }
-    return prisma.$transaction(async (tx) => {
-      await tx.patientTag.delete({ where: { id: tagId } })
-      await auditService.logWithTx(tx, {
-        userId: auditUserId,
-        action: "DELETE",
-        resource: "PATIENT_TAG",
-        resourceId: String(tagId),
-        ipAddress: ctx?.ipAddress,
-        userAgent: ctx?.userAgent,
-        requestId: ctx?.requestId,
-        metadata: { serviceId: tag.serviceId, label: tag.label },
-      })
-      return { deleted: true }
-    })
+    return prisma.$transaction(
+      async (tx) => {
+        const tag = await tx.patientTag.findUnique({
+          where: { id: tagId },
+          select: { id: true, serviceId: true },
+        })
+        if (!tag) throw new TagNotFoundError(tagId)
+        await assertServiceMember(auditUserId, tag.serviceId, tx)
+        await tx.patientTag.delete({ where: { id: tagId } })
+        await auditService.logWithTx(tx, {
+          userId: auditUserId,
+          action: "DELETE",
+          resource: "PATIENT_TAG",
+          resourceId: String(tagId),
+          ipAddress: ctx?.ipAddress,
+          userAgent: ctx?.userAgent,
+          requestId: ctx?.requestId,
+          metadata: { serviceId: tag.serviceId },
+        })
+        return { deleted: true }
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    )
   },
 
-  /** Replace the patient's tag assignments with the given set (atomic). */
+  /**
+   * Replace the patient's tag assignments with the given set. All checks
+   * run inside the serializable transaction to eliminate TOCTOU + race:
+   * the membership check + tag existence check + write happen atomically.
+   *
+   * Any unknown or cross-cabinet tag ID is rejected as `TagForbiddenError`
+   * (uniform 403) to prevent ID enumeration (C2).
+   */
   async setForPatient(
     patientId: number,
     tagIds: number[],
     auditUserId: number,
     ctx?: AuditContext,
   ) {
-    // Reject duplicates + ensure all tags exist in some service the caller
-    // is a member of (prevents cross-cabinet contamination).
     const unique = Array.from(new Set(tagIds))
-    if (unique.length > 0) {
-      const tags = await prisma.patientTag.findMany({
-        where: { id: { in: unique } },
-        select: { id: true, serviceId: true },
-      })
-      if (tags.length !== unique.length) throw new Error("tagNotFound")
-      const memberServices = await prisma.healthcareMember.findMany({
-        where: { userId: auditUserId, serviceId: { in: tags.map((t) => t.serviceId) } },
-        select: { serviceId: true },
-      })
-      const memberSet = new Set(memberServices.map((m) => m.serviceId))
-      if (tags.some((t) => !memberSet.has(t.serviceId))) throw new Error("forbidden")
-    }
 
-    return prisma.$transaction(async (tx) => {
-      await tx.patientTagAssignment.deleteMany({ where: { patientId } })
-      if (unique.length > 0) {
-        await tx.patientTagAssignment.createMany({
-          data: unique.map((tagId) => ({ patientId, tagId, assignedBy: auditUserId })),
+    return prisma.$transaction(
+      async (tx) => {
+        await assertPatientAlive(patientId, tx)
+
+        if (unique.length > 0) {
+          // Caller must be a member of every service holding one of the tags.
+          // Single query: fetch caller's services AND verify each tagId.
+          const memberServices = await tx.healthcareMember.findMany({
+            where: { userId: auditUserId, serviceId: { not: null } },
+            select: { serviceId: true },
+          })
+          const memberSet = new Set(
+            memberServices.map((m) => m.serviceId).filter((s): s is number => s !== null),
+          )
+
+          const tags = await tx.patientTag.findMany({
+            where: { id: { in: unique }, serviceId: { in: Array.from(memberSet) } },
+            select: { id: true },
+          })
+          // Both "tag does not exist" and "tag belongs to a non-member service"
+          // collapse to the same error (no enumeration oracle).
+          if (tags.length !== unique.length) throw new TagForbiddenError()
+        }
+
+        await tx.patientTagAssignment.deleteMany({ where: { patientId } })
+        if (unique.length > 0) {
+          await tx.patientTagAssignment.createMany({
+            data: unique.map((tagId) => ({
+              patientId, tagId, assignedBy: auditUserId,
+            })),
+            skipDuplicates: true,
+          })
+        }
+
+        await auditService.logWithTx(tx, {
+          userId: auditUserId,
+          action: "UPDATE",
+          // US-2268: resourceId = patientId (the entity acted upon at the
+          // patient scope), `metadata.patientId` reinforces the pivot.
+          resource: "PATIENT_TAG_ASSIGNMENT",
+          resourceId: String(patientId),
+          ipAddress: ctx?.ipAddress,
+          userAgent: ctx?.userAgent,
+          requestId: ctx?.requestId,
+          metadata: { patientId, tagIds: unique, kind: "tag-assignment-set" },
         })
-      }
-      await auditService.logWithTx(tx, {
-        userId: auditUserId,
-        action: "UPDATE",
-        resource: "PATIENT_TAG_ASSIGNMENT",
-        resourceId: String(patientId),
-        ipAddress: ctx?.ipAddress,
-        userAgent: ctx?.userAgent,
-        requestId: ctx?.requestId,
-        metadata: { patientId, tagIds: unique },
-      })
-      return { count: unique.length }
-    })
+        return { count: unique.length }
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    )
   },
 
-  /** Get tags currently assigned to a patient. */
-  async listForPatient(patientId: number) {
+  /** Get tags currently assigned to a patient. Audits the READ (H11). */
+  async listForPatient(
+    patientId: number,
+    auditUserId: number,
+    ctx?: AuditContext,
+  ): Promise<PatientTagDTO[]> {
     const assignments = await prisma.patientTagAssignment.findMany({
-      where: { patientId },
-      include: { tag: true },
+      where: { patientId, patient: { deletedAt: null } },
+      include: {
+        tag: { select: { id: true, serviceId: true, label: true, color: true } },
+      },
       orderBy: { tag: { label: "asc" } },
     })
-    return assignments.map((a) => a.tag)
+
+    await auditService.log({
+      userId: auditUserId,
+      action: "READ",
+      resource: "PATIENT_TAG_ASSIGNMENT",
+      resourceId: String(patientId),
+      ipAddress: ctx?.ipAddress,
+      userAgent: ctx?.userAgent,
+      requestId: ctx?.requestId,
+      metadata: { patientId, kind: "tag-list", count: assignments.length },
+    })
+
+    return assignments.map((a) => toDTO(a.tag))
   },
 }

--- a/src/lib/services/patient.service.ts
+++ b/src/lib/services/patient.service.ts
@@ -12,6 +12,7 @@
 import { prisma } from "@/lib/db/client"
 import { encrypt, decrypt } from "@/lib/crypto/health-data"
 import { encryptField } from "@/lib/crypto/fields"
+import { hmacField } from "@/lib/crypto/hmac"
 import { auditService, extractRequestContext } from "./audit.service"
 import type { Pathology, Prisma, PatientMedicalData } from "@prisma/client"
 
@@ -422,6 +423,111 @@ export const patientService = {
    * @param {number} auditUserId - User ID performing the list (audit trail)
    * @returns {Promise<Array<Object>>} Array of patients with decrypted user data
    */
+  /**
+   * US-2019 — Search patients accessible to the caller.
+   *
+   * Search is implemented with the user-side HMAC pattern (`firstnameHmac` /
+   * `lastnameHmac`): the caller types an EXACT firstname or lastname (case-
+   * insensitive). No fuzzy match — by design, since the plaintext is AES-256-GCM
+   * encrypted. Pathology filter is exact-match on the Patient.pathology enum.
+   *
+   * Scoping:
+   *  - `accessibleIds=null` → ADMIN (no IN-clause).
+   *  - `accessibleIds=[]`   → no accessible patients → empty result.
+   *  - otherwise → restricted to the given list.
+   *
+   * Pagination: cursor on `id DESC`. Page size capped server-side.
+   */
+  async search(
+    input: {
+      search?: string
+      pathology?: Pathology
+      accessibleIds: number[] | null
+      cursor?: number
+      limit?: number
+    },
+    auditUserId: number,
+    ctx?: AuditContext,
+  ) {
+    const limit = Math.min(Math.max(input.limit ?? 25, 1), 50)
+
+    if (input.accessibleIds !== null && input.accessibleIds.length === 0) {
+      await auditService.log({
+        userId: auditUserId,
+        action: "READ",
+        resource: "PATIENT",
+        resourceId: "search",
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+        requestId: ctx?.requestId,
+        metadata: { count: 0, scoped: true },
+      })
+      return { items: [], nextCursor: null as number | null }
+    }
+
+    const userFilter: Prisma.UserWhereInput | undefined = input.search?.trim()
+      ? (() => {
+          const hmac = hmacField(input.search!.trim().toLowerCase())
+          return { OR: [{ firstnameHmac: hmac }, { lastnameHmac: hmac }] }
+        })()
+      : undefined
+
+    const where: Prisma.PatientWhereInput = {
+      deletedAt: null,
+      ...(input.accessibleIds !== null && { id: { in: input.accessibleIds } }),
+      ...(input.pathology && { pathology: input.pathology }),
+      ...(userFilter && { user: userFilter }),
+    }
+
+    const items = await prisma.patient.findMany({
+      where,
+      include: {
+        user: {
+          select: {
+            id: true, firstname: true, lastname: true, email: true,
+            birthday: true,
+          },
+        },
+      },
+      orderBy: { id: "desc" },
+      take: limit + 1,
+      ...(input.cursor && { cursor: { id: input.cursor }, skip: 1 }),
+    })
+
+    const hasMore = items.length > limit
+    const page = hasMore ? items.slice(0, limit) : items
+    const nextCursor = hasMore ? (page[page.length - 1]?.id ?? null) : null
+
+    await auditService.log({
+      userId: auditUserId,
+      action: "READ",
+      resource: "PATIENT",
+      resourceId: "search",
+      ipAddress: ctx?.ipAddress,
+      userAgent: ctx?.userAgent,
+      requestId: ctx?.requestId,
+      metadata: {
+        count: page.length,
+        scoped: input.accessibleIds !== null,
+        hasSearch: !!input.search,
+        pathology: input.pathology ?? null,
+      },
+    })
+
+    return {
+      items: page.map((p) => ({
+        ...p,
+        user: {
+          ...p.user,
+          firstname: safeDecrypt(p.user.firstname),
+          lastname: safeDecrypt(p.user.lastname),
+          email: safeDecrypt(p.user.email),
+        },
+      })),
+      nextCursor,
+    }
+  },
+
   async listByDoctor(doctorUserId: number, auditUserId: number) {
     const referents = await prisma.patientReferent.findMany({
       where: {

--- a/src/lib/services/patient.service.ts
+++ b/src/lib/services/patient.service.ts
@@ -460,33 +460,44 @@ export const patientService = {
         ipAddress: ctx?.ipAddress,
         userAgent: ctx?.userAgent,
         requestId: ctx?.requestId,
-        metadata: { count: 0, scoped: true },
+        metadata: {
+          count: 0,
+          scoped: true,
+          // M14 — distinguish "no permissions" from "no matches".
+          reason: "noServiceMembership",
+        },
       })
       return { items: [], nextCursor: null as number | null }
     }
 
     const userFilter: Prisma.UserWhereInput | undefined = input.search?.trim()
+      // hmacField internally normalizes (lowercase + trim).
       ? (() => {
-          const hmac = hmacField(input.search!.trim().toLowerCase())
+          const hmac = hmacField(input.search!)
           return { OR: [{ firstnameHmac: hmac }, { lastnameHmac: hmac }] }
         })()
       : undefined
 
     const where: Prisma.PatientWhereInput = {
       deletedAt: null,
+      // H1 — exclude patients who revoked sharing or never accepted GDPR.
+      // Matches the same filter applied in `population-analytics.service`
+      // (RGPD Art. 7.3 — revocation effective on all aggregations).
+      user: {
+        privacySettings: { gdprConsent: true, shareWithProviders: true },
+        ...(userFilter ?? {}),
+      },
       ...(input.accessibleIds !== null && { id: { in: input.accessibleIds } }),
       ...(input.pathology && { pathology: input.pathology }),
-      ...(userFilter && { user: userFilter }),
     }
 
     const items = await prisma.patient.findMany({
       where,
       include: {
         user: {
-          select: {
-            id: true, firstname: true, lastname: true, email: true,
-            birthday: true,
-          },
+          // Low — data minimization: search list trims to identification
+          // fields only. Email / birthday only on the detail endpoint.
+          select: { id: true, firstname: true, lastname: true },
         },
       },
       orderBy: { id: "desc" },
@@ -516,12 +527,13 @@ export const patientService = {
 
     return {
       items: page.map((p) => ({
-        ...p,
+        id: p.id,
+        pathology: p.pathology,
+        createdAt: p.createdAt,
         user: {
-          ...p.user,
+          id: p.user.id,
           firstname: safeDecrypt(p.user.firstname),
           lastname: safeDecrypt(p.user.lastname),
-          email: safeDecrypt(p.user.email),
         },
       })),
       nextCursor,

--- a/tests/unit/patient-referent.service.test.ts
+++ b/tests/unit/patient-referent.service.test.ts
@@ -2,15 +2,25 @@
  * Test suite: patientReferentService (US-2021 + US-2028)
  *
  * Behaviour tested:
- * - `getReferentsView` flags the primary referent vs other members.
- * - Duplicate members across services are deduped.
- * - `transferReferent` rejects a member who isn't part of any of the
- *   patient's services (`memberNotEligible`).
- * - The new referent is upserted (creates or updates).
+ * - `getReferentsView` flags the primary referent vs other members and only
+ *   exposes `userId` for the primary entry (data-minimization Low).
+ * - `transferReferent` rejects a member not part of any of the patient's
+ *   services (`MemberNotEligibleError`).
+ * - C3 — transfer authorization rules:
+ *    * ADMIN: always allowed
+ *    * current primary referent's user: allowed
+ *    * target member's user: allowed (self-claim)
+ *    * any other DOCTOR: `ReferentTransferForbiddenError`
+ * - Audit metadata records the authorization path (admin / currentReferent / selfClaim).
+ * - Patient `deletedAt: null` guard at the service layer (H7).
  */
 import { describe, it, expect, beforeEach } from "vitest"
 import { prismaMock } from "../helpers/prisma-mock"
 import { patientReferentService } from "@/lib/services/patient-referent.service"
+import {
+  MemberNotEligibleError,
+  ReferentTransferForbiddenError,
+} from "@/lib/services/patient-tag.errors"
 
 beforeEach(() => {
   prismaMock.auditLog.create.mockResolvedValue({} as any)
@@ -18,7 +28,7 @@ beforeEach(() => {
 })
 
 describe("getReferentsView", () => {
-  it("marks the primary referent and lists every service member", async () => {
+  it("marks the primary referent and exposes userId ONLY for primary", async () => {
     prismaMock.patientService.findMany.mockResolvedValue([
       {
         service: {
@@ -29,51 +39,74 @@ describe("getReferentsView", () => {
           ],
         },
       },
-      {
-        service: {
-          id: 20, name: "Cabinet B",
-          members: [
-            { id: 200, userId: 3 },
-          ],
-        },
-      },
     ] as any)
-    prismaMock.patientReferent.findUnique.mockResolvedValue({ proId: 101 } as any)
+    prismaMock.patientReferent.findFirst.mockResolvedValue({ proId: 101 } as any)
 
     const entries = await patientReferentService.getReferentsView(42, 9)
-    expect(entries).toHaveLength(3)
-    const primary = entries.find((e) => e.memberId === 101)!
-    expect(primary.role).toBe("primary")
-    expect(entries.filter((e) => e.role === "service-member")).toHaveLength(2)
+    expect(entries).toHaveLength(2)
+    const primary = entries.find((e) => e.role === "primary")!
+    expect(primary.memberId).toBe(101)
+    expect(primary.userId).toBe(2)
+    const other = entries.find((e) => e.role === "service-member")!
+    expect(other.userId).toBeNull()
   })
 })
 
-describe("transferReferent", () => {
-  it("rejects a member not linked to any service of the patient", async () => {
-    prismaMock.healthcareMember.findFirst.mockResolvedValue(null)
+describe("transferReferent — eligibility (M3)", () => {
+  it("rejects when patient is soft-deleted", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue(null)
     await expect(
-      patientReferentService.transferReferent(42, 999, 7),
-    ).rejects.toThrow(/memberNotEligible/)
+      patientReferentService.transferReferent(42, 500, 7, false),
+    ).rejects.toBeInstanceOf(MemberNotEligibleError)
   })
 
-  it("upserts the referent and audits the change", async () => {
+  it("rejects a member not linked to any service of the patient", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 42 } as any)
+    prismaMock.healthcareMember.findFirst.mockResolvedValue(null)
+    await expect(
+      patientReferentService.transferReferent(42, 999, 7, false),
+    ).rejects.toBeInstanceOf(MemberNotEligibleError)
+  })
+})
+
+describe("transferReferent — authorization (C3)", () => {
+  beforeEach(() => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 42 } as any)
     prismaMock.healthcareMember.findFirst.mockResolvedValue({
-      id: 500, serviceId: 10,
+      id: 500, userId: 999, serviceId: 10,
     } as any)
     prismaMock.patientReferent.findUnique.mockResolvedValue({
-      proId: 100, serviceId: 10,
+      proId: 100, serviceId: 10, pro: { userId: 50 },
     } as any)
     prismaMock.patientReferent.upsert.mockResolvedValue({
       id: 1, patientId: 42, proId: 500, serviceId: 10,
     } as any)
+  })
 
-    const out = await patientReferentService.transferReferent(42, 500, 7)
+  it("rejects a DOCTOR who is neither current referent nor target", async () => {
+    await expect(
+      patientReferentService.transferReferent(42, 500, 77 /* random doctor */, false),
+    ).rejects.toBeInstanceOf(ReferentTransferForbiddenError)
+  })
+
+  it("allows ADMIN regardless", async () => {
+    const out = await patientReferentService.transferReferent(42, 500, 77, true /* isAdmin */)
     expect(out.proId).toBe(500)
-    const audit = prismaMock.auditLog.create.mock.calls[0][0].data as any
-    expect(audit.action).toBe("UPDATE")
-    expect(audit.resource).toBe("REFERENT")
-    expect(audit.metadata).toMatchObject({
-      patientId: 42, previousProId: 100, newProId: 500,
-    })
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.metadata.authorizedBy).toBe("admin")
+  })
+
+  it("allows the current referent (current pro's user)", async () => {
+    const out = await patientReferentService.transferReferent(42, 500, 50 /* current pro userId */, false)
+    expect(out.proId).toBe(500)
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.metadata.authorizedBy).toBe("currentReferent")
+  })
+
+  it("allows the target pro themselves (self-claim)", async () => {
+    const out = await patientReferentService.transferReferent(42, 500, 999 /* target pro userId */, false)
+    expect(out.proId).toBe(500)
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.metadata.authorizedBy).toBe("selfClaim")
   })
 })

--- a/tests/unit/patient-referent.service.test.ts
+++ b/tests/unit/patient-referent.service.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Test suite: patientReferentService (US-2021 + US-2028)
+ *
+ * Behaviour tested:
+ * - `getReferentsView` flags the primary referent vs other members.
+ * - Duplicate members across services are deduped.
+ * - `transferReferent` rejects a member who isn't part of any of the
+ *   patient's services (`memberNotEligible`).
+ * - The new referent is upserted (creates or updates).
+ */
+import { describe, it, expect, beforeEach } from "vitest"
+import { prismaMock } from "../helpers/prisma-mock"
+import { patientReferentService } from "@/lib/services/patient-referent.service"
+
+beforeEach(() => {
+  prismaMock.auditLog.create.mockResolvedValue({} as any)
+  prismaMock.$transaction.mockImplementation(async (fn: any) => fn(prismaMock))
+})
+
+describe("getReferentsView", () => {
+  it("marks the primary referent and lists every service member", async () => {
+    prismaMock.patientService.findMany.mockResolvedValue([
+      {
+        service: {
+          id: 10, name: "Cabinet A",
+          members: [
+            { id: 100, userId: 1 },
+            { id: 101, userId: 2 },
+          ],
+        },
+      },
+      {
+        service: {
+          id: 20, name: "Cabinet B",
+          members: [
+            { id: 200, userId: 3 },
+          ],
+        },
+      },
+    ] as any)
+    prismaMock.patientReferent.findUnique.mockResolvedValue({ proId: 101 } as any)
+
+    const entries = await patientReferentService.getReferentsView(42, 9)
+    expect(entries).toHaveLength(3)
+    const primary = entries.find((e) => e.memberId === 101)!
+    expect(primary.role).toBe("primary")
+    expect(entries.filter((e) => e.role === "service-member")).toHaveLength(2)
+  })
+})
+
+describe("transferReferent", () => {
+  it("rejects a member not linked to any service of the patient", async () => {
+    prismaMock.healthcareMember.findFirst.mockResolvedValue(null)
+    await expect(
+      patientReferentService.transferReferent(42, 999, 7),
+    ).rejects.toThrow(/memberNotEligible/)
+  })
+
+  it("upserts the referent and audits the change", async () => {
+    prismaMock.healthcareMember.findFirst.mockResolvedValue({
+      id: 500, serviceId: 10,
+    } as any)
+    prismaMock.patientReferent.findUnique.mockResolvedValue({
+      proId: 100, serviceId: 10,
+    } as any)
+    prismaMock.patientReferent.upsert.mockResolvedValue({
+      id: 1, patientId: 42, proId: 500, serviceId: 10,
+    } as any)
+
+    const out = await patientReferentService.transferReferent(42, 500, 7)
+    expect(out.proId).toBe(500)
+    const audit = prismaMock.auditLog.create.mock.calls[0][0].data as any
+    expect(audit.action).toBe("UPDATE")
+    expect(audit.resource).toBe("REFERENT")
+    expect(audit.metadata).toMatchObject({
+      patientId: 42, previousProId: 100, newProId: 500,
+    })
+  })
+})

--- a/tests/unit/patient-search.service.test.ts
+++ b/tests/unit/patient-search.service.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Test suite: patientService.search (US-2019)
+ *
+ * Behaviour tested:
+ * - HMAC search emits an OR on `firstnameHmac` / `lastnameHmac`.
+ * - `pathology` filter is added as an enum exact-match.
+ * - `accessibleIds=null` (ADMIN) → no IN-clause; `accessibleIds=[]` →
+ *   short-circuits to empty result without DB call.
+ * - Cursor pagination uses `cursor: { id }` + `skip: 1`.
+ * - Audit row written with `resourceId="search"` + flags in metadata.
+ */
+import { describe, it, expect, beforeEach } from "vitest"
+import { prismaMock } from "../helpers/prisma-mock"
+import { patientService } from "@/lib/services/patient.service"
+import { Pathology } from "@prisma/client"
+
+beforeEach(() => {
+  prismaMock.auditLog.create.mockResolvedValue({} as any)
+  prismaMock.patient.findMany.mockResolvedValue([])
+})
+
+describe("patientService.search", () => {
+  it("short-circuits when accessibleIds is an empty array", async () => {
+    const res = await patientService.search(
+      { accessibleIds: [] },
+      9,
+    )
+    expect(res.items).toEqual([])
+    expect(res.nextCursor).toBeNull()
+    expect(prismaMock.patient.findMany).not.toHaveBeenCalled()
+  })
+
+  it("uses OR on firstnameHmac/lastnameHmac when search is provided", async () => {
+    await patientService.search(
+      { search: "Dupont", accessibleIds: null },
+      9,
+    )
+    const call = prismaMock.patient.findMany.mock.calls[0][0] as any
+    expect(call.where.user.OR).toHaveLength(2)
+    expect(call.where.user.OR[0]).toHaveProperty("firstnameHmac")
+    expect(call.where.user.OR[1]).toHaveProperty("lastnameHmac")
+  })
+
+  it("adds pathology filter as exact match", async () => {
+    await patientService.search(
+      { pathology: Pathology.DT1, accessibleIds: null },
+      9,
+    )
+    const call = prismaMock.patient.findMany.mock.calls[0][0] as any
+    expect(call.where.pathology).toBe(Pathology.DT1)
+  })
+
+  it("scopes via id-in when accessibleIds is a non-empty array", async () => {
+    await patientService.search(
+      { accessibleIds: [1, 2, 3] },
+      9,
+    )
+    const call = prismaMock.patient.findMany.mock.calls[0][0] as any
+    expect(call.where.id).toEqual({ in: [1, 2, 3] })
+  })
+
+  it("paginates via cursor + skip=1", async () => {
+    await patientService.search(
+      { cursor: 100, limit: 10, accessibleIds: null },
+      9,
+    )
+    const call = prismaMock.patient.findMany.mock.calls[0][0] as any
+    expect(call.cursor).toEqual({ id: 100 })
+    expect(call.skip).toBe(1)
+    expect(call.take).toBe(11)
+  })
+
+  it("emits an audit row with flags", async () => {
+    await patientService.search(
+      { search: "Curie", pathology: Pathology.DT2, accessibleIds: [1] },
+      9,
+    )
+    const audit = prismaMock.auditLog.create.mock.calls[0][0].data as any
+    expect(audit.resource).toBe("PATIENT")
+    expect(audit.resourceId).toBe("search")
+    expect(audit.metadata).toMatchObject({
+      hasSearch: true,
+      pathology: Pathology.DT2,
+      scoped: true,
+    })
+  })
+})

--- a/tests/unit/patient-search.service.test.ts
+++ b/tests/unit/patient-search.service.test.ts
@@ -41,6 +41,29 @@ describe("patientService.search", () => {
     expect(call.where.user.OR[1]).toHaveProperty("lastnameHmac")
   })
 
+  it("filters out patients without gdprConsent + shareWithProviders (H1)", async () => {
+    await patientService.search(
+      { accessibleIds: [1] },
+      9,
+    )
+    const call = prismaMock.patient.findMany.mock.calls[0][0] as any
+    expect(call.where.user.privacySettings).toEqual({
+      gdprConsent: true, shareWithProviders: true,
+    })
+  })
+
+  it("response trims to id/firstname/lastname (data-minimization)", async () => {
+    prismaMock.patient.findMany.mockResolvedValueOnce([
+      {
+        id: 1, pathology: "DT1", createdAt: new Date(),
+        user: { id: 9, firstname: "encrypted", lastname: "encrypted" },
+      },
+    ] as any)
+    const r = await patientService.search({ accessibleIds: [1] }, 9)
+    expect(r.items[0].user).not.toHaveProperty("email")
+    expect(r.items[0].user).not.toHaveProperty("birthday")
+  })
+
   it("adds pathology filter as exact match", async () => {
     await patientService.search(
       { pathology: Pathology.DT1, accessibleIds: null },

--- a/tests/unit/patient-tag.service.test.ts
+++ b/tests/unit/patient-tag.service.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Test suite: patientTagService (US-2022)
+ *
+ * Behaviour tested:
+ * - Cabinet membership enforced on create/delete (`forbidden` if not member).
+ * - Cross-cabinet contamination blocked: setForPatient rejects any tagId
+ *   whose service the caller doesn't belong to.
+ * - Label/color validation surfaces `TagValidationError` with the offending
+ *   field name.
+ * - Audit row written on every mutation (CREATE/UPDATE/DELETE) with the
+ *   appropriate resource.
+ */
+import { describe, it, expect, beforeEach } from "vitest"
+import { prismaMock } from "../helpers/prisma-mock"
+import { patientTagService, TagValidationError } from "@/lib/services/patient-tag.service"
+
+beforeEach(() => {
+  prismaMock.auditLog.create.mockResolvedValue({} as any)
+  prismaMock.$transaction.mockImplementation(async (fn: any) => fn(prismaMock))
+})
+
+describe("patientTagService.create", () => {
+  it("rejects callers who are not members of the service", async () => {
+    prismaMock.healthcareMember.findFirst.mockResolvedValue(null)
+    await expect(
+      patientTagService.create({ serviceId: 1, label: "VIP", color: "#FF0000" }, 99),
+    ).rejects.toThrow(/forbidden/)
+  })
+
+  it("rejects an empty label", async () => {
+    prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 1 } as any)
+    await expect(
+      patientTagService.create({ serviceId: 1, label: "  ", color: "#FF0000" }, 7),
+    ).rejects.toBeInstanceOf(TagValidationError)
+  })
+
+  it("rejects an invalid color format", async () => {
+    prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 1 } as any)
+    await expect(
+      patientTagService.create({ serviceId: 1, label: "VIP", color: "red" }, 7),
+    ).rejects.toBeInstanceOf(TagValidationError)
+  })
+
+  it("creates the tag and audits it", async () => {
+    prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.patientTag.create.mockResolvedValue({
+      id: 42, serviceId: 1, label: "VIP", color: "#FF0000",
+    } as any)
+    const tag = await patientTagService.create(
+      { serviceId: 1, label: "VIP ", color: "#ff0000" },
+      7,
+    )
+    expect(tag.id).toBe(42)
+    // Color is normalized to uppercase, label trimmed.
+    const createCall = prismaMock.patientTag.create.mock.calls[0][0] as any
+    expect(createCall.data.label).toBe("VIP")
+    expect(createCall.data.color).toBe("#FF0000")
+    const audit = prismaMock.auditLog.create.mock.calls[0][0].data as any
+    expect(audit.resource).toBe("PATIENT_TAG")
+    expect(audit.action).toBe("CREATE")
+  })
+})
+
+describe("patientTagService.setForPatient", () => {
+  it("rejects assignments mixing tags from non-member services", async () => {
+    prismaMock.patientTag.findMany.mockResolvedValue([
+      { id: 1, serviceId: 10 },
+      { id: 2, serviceId: 99 }, // foreign service
+    ] as any)
+    prismaMock.healthcareMember.findMany.mockResolvedValue([
+      { serviceId: 10 },
+    ] as any)
+    await expect(
+      patientTagService.setForPatient(7, [1, 2], 99),
+    ).rejects.toThrow(/forbidden/)
+  })
+
+  it("dedupes and applies the new set atomically", async () => {
+    prismaMock.patientTag.findMany.mockResolvedValue([
+      { id: 1, serviceId: 10 },
+      { id: 2, serviceId: 10 },
+    ] as any)
+    prismaMock.healthcareMember.findMany.mockResolvedValue([{ serviceId: 10 }] as any)
+    prismaMock.patientTagAssignment.deleteMany.mockResolvedValue({ count: 0 } as any)
+    prismaMock.patientTagAssignment.createMany.mockResolvedValue({ count: 2 } as any)
+
+    const res = await patientTagService.setForPatient(42, [1, 2, 2, 1], 7)
+    expect(res.count).toBe(2)
+    const createArgs = prismaMock.patientTagAssignment.createMany.mock.calls[0][0] as any
+    expect(createArgs.data).toHaveLength(2)
+  })
+
+  it("handles empty list (clears all)", async () => {
+    prismaMock.patientTagAssignment.deleteMany.mockResolvedValue({ count: 3 } as any)
+    const res = await patientTagService.setForPatient(42, [], 7)
+    expect(res.count).toBe(0)
+    expect(prismaMock.patientTagAssignment.createMany).not.toHaveBeenCalled()
+  })
+})
+
+describe("patientTagService.delete", () => {
+  it("returns tagNotFound when the tag does not exist", async () => {
+    prismaMock.patientTag.findUnique.mockResolvedValue(null)
+    await expect(patientTagService.delete(999, 7)).rejects.toThrow(/tagNotFound/)
+  })
+
+  it("rejects non-member callers", async () => {
+    prismaMock.patientTag.findUnique.mockResolvedValue({
+      id: 1, serviceId: 10, label: "VIP",
+    } as any)
+    prismaMock.healthcareMember.findFirst.mockResolvedValue(null)
+    await expect(patientTagService.delete(1, 99)).rejects.toThrow(/forbidden/)
+  })
+})

--- a/tests/unit/patient-tag.service.test.ts
+++ b/tests/unit/patient-tag.service.test.ts
@@ -1,32 +1,57 @@
 /**
- * Test suite: patientTagService (US-2022)
+ * Test suite: patientTagService (US-2022, post-review hardening)
  *
- * Behaviour tested:
- * - Cabinet membership enforced on create/delete (`forbidden` if not member).
- * - Cross-cabinet contamination blocked: setForPatient rejects any tagId
- *   whose service the caller doesn't belong to.
- * - Label/color validation surfaces `TagValidationError` with the offending
- *   field name.
- * - Audit row written on every mutation (CREATE/UPDATE/DELETE) with the
- *   appropriate resource.
+ * Behaviour tested (post PR #389 review):
+ * - C1 — `listForService` rejects callers who aren't members of the target service.
+ * - C2 — `setForPatient` collapses "unknown tag" and "cross-cabinet tag"
+ *   into the SAME `TagForbiddenError` (no enumeration oracle).
+ * - H4 — Label validation rejects PII patterns (long digits, '@', FR phone).
+ * - H4 — Audit metadata for create/delete does NOT contain `label` plaintext.
+ * - H5 — `setForPatient` runs membership + tag-exists check INSIDE the
+ *   transaction with `Serializable` isolation.
+ * - H10 — `setForPatient` audit row has `resourceId = patientId` and
+ *   `metadata.patientId` for US-2268 forensics.
+ * - H11 — `listForPatient` emits an audit READ row.
+ * - M1 — `createMany` uses `skipDuplicates: true`.
+ * - Patient soft-delete (`deletedAt`) blocks tag operations.
  */
 import { describe, it, expect, beforeEach } from "vitest"
 import { prismaMock } from "../helpers/prisma-mock"
-import { patientTagService, TagValidationError } from "@/lib/services/patient-tag.service"
+import {
+  patientTagService,
+  TagValidationError,
+} from "@/lib/services/patient-tag.service"
+import {
+  TagForbiddenError,
+  TagLabelPiiError,
+  TagNotFoundError,
+} from "@/lib/services/patient-tag.errors"
 
 beforeEach(() => {
   prismaMock.auditLog.create.mockResolvedValue({} as any)
   prismaMock.$transaction.mockImplementation(async (fn: any) => fn(prismaMock))
 })
 
-describe("patientTagService.create", () => {
-  it("rejects callers who are not members of the service", async () => {
+describe("listForService (C1 — membership check)", () => {
+  it("rejects callers not member of the service", async () => {
     prismaMock.healthcareMember.findFirst.mockResolvedValue(null)
     await expect(
-      patientTagService.create({ serviceId: 1, label: "VIP", color: "#FF0000" }, 99),
-    ).rejects.toThrow(/forbidden/)
+      patientTagService.listForService(1, 99),
+    ).rejects.toBeInstanceOf(TagForbiddenError)
   })
 
+  it("returns tags when caller is a member", async () => {
+    prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.patientTag.findMany.mockResolvedValue([
+      { id: 1, serviceId: 10, label: "VIP", color: "#FF0000" },
+    ] as any)
+    const r = await patientTagService.listForService(10, 7)
+    expect(r.tags).toHaveLength(1)
+    expect(r.tags[0]).toMatchObject({ id: 1, label: "VIP" })
+  })
+})
+
+describe("create — label validation + PII rejection (H4)", () => {
   it("rejects an empty label", async () => {
     prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 1 } as any)
     await expect(
@@ -41,46 +66,74 @@ describe("patientTagService.create", () => {
     ).rejects.toBeInstanceOf(TagValidationError)
   })
 
-  it("creates the tag and audits it", async () => {
+  it.each([
+    ["NIR 1800175123456", "long digits"],
+    ["jean@dupont.fr", "email"],
+    ["06 12 34 56 78", "FR phone"],
+  ])("rejects PII-shaped label %j (%s)", async (label) => {
+    prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 1 } as any)
+    await expect(
+      patientTagService.create({ serviceId: 1, label, color: "#FF0000" }, 7),
+    ).rejects.toBeInstanceOf(TagLabelPiiError)
+  })
+
+  it("does NOT include `label` plaintext in audit metadata", async () => {
     prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 1 } as any)
     prismaMock.patientTag.create.mockResolvedValue({
       id: 42, serviceId: 1, label: "VIP", color: "#FF0000",
     } as any)
-    const tag = await patientTagService.create(
-      { serviceId: 1, label: "VIP ", color: "#ff0000" },
+    await patientTagService.create(
+      { serviceId: 1, label: "VIP", color: "#ff0000" },
       7,
     )
-    expect(tag.id).toBe(42)
-    // Color is normalized to uppercase, label trimmed.
-    const createCall = prismaMock.patientTag.create.mock.calls[0][0] as any
-    expect(createCall.data.label).toBe("VIP")
-    expect(createCall.data.color).toBe("#FF0000")
     const audit = prismaMock.auditLog.create.mock.calls[0][0].data as any
     expect(audit.resource).toBe("PATIENT_TAG")
-    expect(audit.action).toBe("CREATE")
+    expect(audit.metadata).not.toHaveProperty("label")
   })
 })
 
-describe("patientTagService.setForPatient", () => {
-  it("rejects assignments mixing tags from non-member services", async () => {
-    prismaMock.patientTag.findMany.mockResolvedValue([
-      { id: 1, serviceId: 10 },
-      { id: 2, serviceId: 99 }, // foreign service
-    ] as any)
+describe("setForPatient (C2 + H5 + H10)", () => {
+  it("collapses unknown tag IDs into TagForbiddenError (no oracle)", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
     prismaMock.healthcareMember.findMany.mockResolvedValue([
       { serviceId: 10 },
     ] as any)
+    // Caller asks for tag 1 & 2, but only tag 1 (serviceId=10) found in
+    // caller's services. Tag 2 either does not exist OR is foreign — both
+    // collapse to forbidden.
+    prismaMock.patientTag.findMany.mockResolvedValue([{ id: 1 }] as any)
     await expect(
       patientTagService.setForPatient(7, [1, 2], 99),
-    ).rejects.toThrow(/forbidden/)
+    ).rejects.toBeInstanceOf(TagForbiddenError)
   })
 
-  it("dedupes and applies the new set atomically", async () => {
-    prismaMock.patientTag.findMany.mockResolvedValue([
-      { id: 1, serviceId: 10 },
-      { id: 2, serviceId: 10 },
-    ] as any)
+  it("blocks soft-deleted patients (H7)", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue(null)
+    await expect(
+      patientTagService.setForPatient(7, [1], 99),
+    ).rejects.toBeInstanceOf(TagForbiddenError)
+  })
+
+  it("audit row has resourceId=patientId + metadata.patientId (US-2268)", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 42 } as any)
     prismaMock.healthcareMember.findMany.mockResolvedValue([{ serviceId: 10 }] as any)
+    prismaMock.patientTag.findMany.mockResolvedValue([{ id: 1 }, { id: 2 }] as any)
+    prismaMock.patientTagAssignment.deleteMany.mockResolvedValue({ count: 0 } as any)
+    prismaMock.patientTagAssignment.createMany.mockResolvedValue({ count: 2 } as any)
+
+    await patientTagService.setForPatient(42, [1, 2, 2], 7)
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.resource).toBe("PATIENT_TAG_ASSIGNMENT")
+    expect(audit.resourceId).toBe("42")
+    expect(audit.metadata.patientId).toBe(42)
+  })
+
+  it("dedupes and uses skipDuplicates (M1)", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 42 } as any)
+    prismaMock.healthcareMember.findMany.mockResolvedValue([{ serviceId: 10 }] as any)
+    prismaMock.patientTag.findMany.mockResolvedValue([
+      { id: 1 }, { id: 2 },
+    ] as any)
     prismaMock.patientTagAssignment.deleteMany.mockResolvedValue({ count: 0 } as any)
     prismaMock.patientTagAssignment.createMany.mockResolvedValue({ count: 2 } as any)
 
@@ -88,9 +141,11 @@ describe("patientTagService.setForPatient", () => {
     expect(res.count).toBe(2)
     const createArgs = prismaMock.patientTagAssignment.createMany.mock.calls[0][0] as any
     expect(createArgs.data).toHaveLength(2)
+    expect(createArgs.skipDuplicates).toBe(true)
   })
 
   it("handles empty list (clears all)", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 42 } as any)
     prismaMock.patientTagAssignment.deleteMany.mockResolvedValue({ count: 3 } as any)
     const res = await patientTagService.setForPatient(42, [], 7)
     expect(res.count).toBe(0)
@@ -98,17 +153,29 @@ describe("patientTagService.setForPatient", () => {
   })
 })
 
-describe("patientTagService.delete", () => {
-  it("returns tagNotFound when the tag does not exist", async () => {
+describe("delete", () => {
+  it("returns TagNotFoundError when the tag does not exist", async () => {
     prismaMock.patientTag.findUnique.mockResolvedValue(null)
-    await expect(patientTagService.delete(999, 7)).rejects.toThrow(/tagNotFound/)
+    await expect(patientTagService.delete(999, 7)).rejects.toBeInstanceOf(TagNotFoundError)
   })
 
   it("rejects non-member callers", async () => {
     prismaMock.patientTag.findUnique.mockResolvedValue({
-      id: 1, serviceId: 10, label: "VIP",
+      id: 1, serviceId: 10,
     } as any)
     prismaMock.healthcareMember.findFirst.mockResolvedValue(null)
-    await expect(patientTagService.delete(1, 99)).rejects.toThrow(/forbidden/)
+    await expect(patientTagService.delete(1, 99)).rejects.toBeInstanceOf(TagForbiddenError)
+  })
+})
+
+describe("listForPatient (H11 — audit READ)", () => {
+  it("emits an audit row", async () => {
+    prismaMock.patientTagAssignment.findMany.mockResolvedValue([] as any)
+    await patientTagService.listForPatient(42, 7)
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.action).toBe("READ")
+    expect(audit.resource).toBe("PATIENT_TAG_ASSIGNMENT")
+    expect(audit.resourceId).toBe("42")
+    expect(audit.metadata.patientId).toBe(42)
   })
 })


### PR DESCRIPTION
## Summary
ROADMAP **Groupe 2 — Patients avancés**, Batches 1 + 2 (5 US, ~5 SP).

### Batch 1 — UI/API patient (4 US × 1 SP)
- **US-2021** Transfert référent : `GET/PUT /api/patients/:id/referent`
- **US-2022** Tags & catégorisation : 2 nouveaux modèles Prisma (`PatientTag` cabinet-scoped + `PatientTagAssignment` M:N) + 4 routes
- **US-2024** Historique modifications (PARTIAL → DONE) : `GET /api/patients/:id/audit-history` avec PHI redaction (`changedFields` seulement)
- **US-2028** Multi-praticiens (PARTIAL → DONE) : vue agrégée via la même route `GET /referent`

### Batch 2 — Recherche (1 US, 1 SP)
- **US-2019** Recherche : `GET /api/patients/search?search=&pathology=&cursor=&limit=`
  - HMAC exact-match sur `User.firstnameHmac/lastnameHmac` (déjà en schema)
  - RBAC scoping via `getAccessiblePatientIds`
  - Pagination cursor

## Architecture
- 2 nouveaux services : `patientTagService`, `patientReferentService`
- Méthode `search` ajoutée à `patientService`
- Migration Prisma `20260513150000_patient_tags`
- Audit : 2 nouveaux resources `PATIENT_TAG` + `PATIENT_TAG_ASSIGNMENT`
- US-2268 pattern : `resourceId` plat + `metadata.patientId` pivot

## Sécurité
- `accessDenied()` (helper burst US-2265) sur 403 RBAC, pas `log()`
- Mutations auditées avec `requestId` + métadonnées (CREATE/UPDATE/DELETE)
- Cross-cabinet contamination bloquée sur `setForPatient` (vérif HealthcareMember)
- Validation Zod sur tous les inputs + `TagValidationError` typée
- `oldValue`/`newValue` JAMAIS renvoyés en clair par `/audit-history`

## Test plan
- [x] 18 nouveaux tests (`patient-tag` × 9, `patient-referent` × 3, `patient-search` × 6)
- [x] Suite complète **1269 tests verts**
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm lint` 0 erreur
- [ ] CI verte (post-push)

## Hors scope
- US-2026 INS Identité Nationale Santé (Batch 3, 8 SP — chantier seul)
- UI front (Phase 8, séparé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)