### PR TITLE
feat(team): Groupe 3 Batch 1 — 10 US workflow équipe & communication

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,11 +10,11 @@
 | Priorité | Total | DONE | PARTIAL | NOT STARTED | % Done |
 |----------|-------|------|---------|-------------|--------|
 | **MVP**  | 68    | 65   | 0       | 3           | **96%** |
-| **V1**   | 141   | 15   | 12      | 114         | **11%** |
+| **V1**   | 141   | 25   | 2       | 114         | **18%** |
 | **V2**   | 58    | 0    | 0       | 58          | **0%**  |
 | **V3**   | 9     | 0    | 0       | 9           | **0%**  |
 | **V4**   | 16    | 0    | 0       | 16          | **0%**  |
-| **TOTAL**| **292** | **80** | **13**  | **199**     | **27%** |
+| **TOTAL**| **292** | **90** | **3**   | **199**     | **31%** |
 > Note (2026-05-13 session Samir) : Q6 US-2414 supprimée (V1 −1), Q7 module
 > RDV ajouté V1 (+7 US US-2500-2506 = +49 SP), Q8 US-2800 ajoutée V4 (+1).
 > Total : 286 → 294 (+8).
@@ -258,23 +258,24 @@
 |----|-------|--------|
 | US-2076 | Messagerie sécurisée patient↔PS | NOT STARTED (V1, 13 SP — Batch 3, chantier multi-PR) |
 | US-2077 | MSSanté intégration | NOT STARTED (V1, 3 SP — Batch 2 standalone FR PKI) |
-| US-2078 | Templates de messages | IN REVIEW (PR #390 — 5 critical à fix) |
-| US-2080 | Accusés de lecture | IN REVIEW (PR #390) |
-| US-2083 | Délégation médecin → IDE | IN REVIEW (PR #390) |
-| US-2084 | Remplacement / congés | IN REVIEW (PR #390) |
-| US-2086 | Handoff entre soignants | IN REVIEW (PR #390) |
-| US-2088 | Groupes patients par équipe | IN REVIEW (PR #390) |
-| US-2065 | Accusé réception patient | IN REVIEW (PR #390) |
-| US-2066 | Suivi application réelle | IN REVIEW (PR #390) |
-| US-2068 | Notes consultation | IN REVIEW (PR #390) |
-| US-2072 | Facturation acte téléconsult | IN REVIEW (PR #390) |
+| US-2078 | Templates de messages | DONE (PR #390) |
+| US-2080 | Accusés de lecture | DONE (PR #390 — ReadReceipt générique + H9 access check) |
+| US-2083 | Délégation médecin → IDE | DONE (PR #390 — IDE→DOCTOR workflow + colleague enforcement) |
+| US-2084 | Remplacement / congés | DONE (PR #390 — cabinet-scoped + audit READ) |
+| US-2086 | Handoff entre soignants | DONE (PR #390 — chiffré + consent filter) |
+| US-2088 | Groupes patients par équipe | DONE (PR #390 — cohortes cabinet + M:N) |
+| US-2065 | Accusé réception patient | DONE (PR #390 — patient ack avec auditUserId) |
+| US-2066 | Suivi application réelle | DONE (PR #390 — verifiedVia + overwrite guard) |
+| US-2068 | Notes consultation | DONE (PR #390 — chiffré + appointment-patient guard) |
+| US-2072 | Facturation acte téléconsult | DONE (PR #390 — billing acte + double-invoice guard) |
 | ~~US-2070~~ | ~~Planification suivi~~ | **DÉDOUBLONNÉ → US-2500** (Groupe 8 RDV, PR #388 DONE) |
 | ~~US-2071~~ | ~~Templates consultation~~ | **DÉDOUBLONNÉ → US-2501** (Groupe 8 RDV, PR #388 DONE) |
 
-**Batch 1 (10 US) en review** — PR #390 ouverte le 2026-05-13. Review multi-agent
-(code-reviewer + healthcare-security-auditor + typescript-pro + prisma-specialist) a
-identifié **5 Critical + ~12 High + ~15 Medium + ~12 Low** (≈44 findings). Fixes en cours
-avant merge. Total V1 effectif Groupe 3 : 12 US (vs 15 affiché).
+**Batch 1 livré** — PR #390 mergée. Review multi-agent (4 agents) a identifié 44 findings
+(5 Critical BOLA/fraude/forensic + 12 High RGPD/HDS + 15 Medium + 12 Low) → tous corrigés
+avant merge. Suite 1345 tests verts, branches 76.64%, migration `groupe3_refinements`
+ajoutée (FK adjustment_proposal_acks.patient_id + 2 indexes performance).
+Total V1 effectif Groupe 3 : 12 US (vs 15 affiché initialement).
 
 ### Groupe 4 — Devices & Sync (3 US)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,11 +10,11 @@
 | Priorité | Total | DONE | PARTIAL | NOT STARTED | % Done |
 |----------|-------|------|---------|-------------|--------|
 | **MVP**  | 68    | 65   | 0       | 3           | **96%** |
-| **V1**   | 143   | 15   | 4       | 124         | **10%** |
+| **V1**   | 141   | 15   | 12      | 114         | **11%** |
 | **V2**   | 58    | 0    | 0       | 58          | **0%**  |
 | **V3**   | 9     | 0    | 0       | 9           | **0%**  |
 | **V4**   | 16    | 0    | 0       | 16          | **0%**  |
-| **TOTAL**| **294** | **80** | **4**   | **210**     | **27%** |
+| **TOTAL**| **292** | **80** | **13**  | **199**     | **27%** |
 > Note (2026-05-13 session Samir) : Q6 US-2414 supprimée (V1 −1), Q7 module
 > RDV ajouté V1 (+7 US US-2500-2506 = +49 SP), Q8 US-2800 ajoutée V4 (+1).
 > Total : 286 → 294 (+8).
@@ -252,24 +252,29 @@
 **Batches 1+2 livrés** : 5 US (US-2019, 2021, 2022, 2024, 2028) — PR #389, ~5 SP,
 1282 tests verts, 35 findings de review traités (3 Critical + 11 High + 15 Medium + 8 Low).
 
-### Groupe 3 — Équipe & Communication (15 US)
+### Groupe 3 — Équipe & Communication (12 US — US-2070/2071 dédoublonnés vers Groupe 8 RDV)
 
 | US | Titre | Statut |
 |----|-------|--------|
-| US-2076 | Messagerie sécurisée patient↔PS | NOT STARTED |
-| US-2077 | MSSanté intégration | NOT STARTED |
-| US-2078 | Templates de messages | PARTIAL |
-| US-2080 | Accusés de lecture | NOT STARTED |
-| US-2083 | Délégation médecin → IDE | NOT STARTED |
-| US-2084 | Remplacement / congés | NOT STARTED |
-| US-2086 | Handoff entre soignants | NOT STARTED |
-| US-2088 | Groupes patients par équipe | NOT STARTED |
-| US-2065 | Accusé réception patient | NOT STARTED |
-| US-2066 | Suivi application réelle | NOT STARTED |
-| US-2068 | Notes consultation | NOT STARTED |
-| US-2070 | Planification suivi | PARTIAL |
-| US-2071 | Templates consultation | NOT STARTED |
-| US-2072 | Facturation acte téléconsult | NOT STARTED |
+| US-2076 | Messagerie sécurisée patient↔PS | NOT STARTED (V1, 13 SP — Batch 3, chantier multi-PR) |
+| US-2077 | MSSanté intégration | NOT STARTED (V1, 3 SP — Batch 2 standalone FR PKI) |
+| US-2078 | Templates de messages | IN REVIEW (PR #390 — 5 critical à fix) |
+| US-2080 | Accusés de lecture | IN REVIEW (PR #390) |
+| US-2083 | Délégation médecin → IDE | IN REVIEW (PR #390) |
+| US-2084 | Remplacement / congés | IN REVIEW (PR #390) |
+| US-2086 | Handoff entre soignants | IN REVIEW (PR #390) |
+| US-2088 | Groupes patients par équipe | IN REVIEW (PR #390) |
+| US-2065 | Accusé réception patient | IN REVIEW (PR #390) |
+| US-2066 | Suivi application réelle | IN REVIEW (PR #390) |
+| US-2068 | Notes consultation | IN REVIEW (PR #390) |
+| US-2072 | Facturation acte téléconsult | IN REVIEW (PR #390) |
+| ~~US-2070~~ | ~~Planification suivi~~ | **DÉDOUBLONNÉ → US-2500** (Groupe 8 RDV, PR #388 DONE) |
+| ~~US-2071~~ | ~~Templates consultation~~ | **DÉDOUBLONNÉ → US-2501** (Groupe 8 RDV, PR #388 DONE) |
+
+**Batch 1 (10 US) en review** — PR #390 ouverte le 2026-05-13. Review multi-agent
+(code-reviewer + healthcare-security-auditor + typescript-pro + prisma-specialist) a
+identifié **5 Critical + ~12 High + ~15 Medium + ~12 Low** (≈44 findings). Fixes en cours
+avant merge. Total V1 effectif Groupe 3 : 12 US (vs 15 affiché).
 
 ### Groupe 4 — Devices & Sync (3 US)
 

--- a/prisma/migrations/20260513200000_groupe3_workflow/migration.sql
+++ b/prisma/migrations/20260513200000_groupe3_workflow/migration.sql
@@ -1,0 +1,251 @@
+-- Groupe 3 — Équipe & Communication (10 US workflow équipe)
+
+-- CreateEnum
+CREATE TYPE "delegation_request_status" AS ENUM ('pending', 'approved', 'rejected', 'expired');
+
+-- ─────────────────────────────────────────────────────────────
+-- US-2078 — Templates de messages cabinet
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE "message_templates" (
+    "id" SERIAL NOT NULL,
+    "service_id" INTEGER NOT NULL,
+    "title" VARCHAR(120) NOT NULL,
+    "body" TEXT NOT NULL,
+    "variables" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "created_by" INTEGER,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL,
+
+    CONSTRAINT "message_templates_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "message_templates_service_id_title_key" ON "message_templates"("service_id", "title");
+CREATE INDEX "message_templates_service_id_idx" ON "message_templates"("service_id");
+
+-- ─────────────────────────────────────────────────────────────
+-- US-2080 — Read receipts (Announcement, etc.)
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE "read_receipts" (
+    "id" SERIAL NOT NULL,
+    "resource" VARCHAR(40) NOT NULL,
+    "resource_id" INTEGER NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "read_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "read_receipts_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "read_receipts_resource_resource_id_user_id_key" ON "read_receipts"("resource", "resource_id", "user_id");
+CREATE INDEX "read_receipts_resource_resource_id_idx" ON "read_receipts"("resource", "resource_id");
+
+-- ─────────────────────────────────────────────────────────────
+-- US-2065 — Patient acknowledgment of an adjustment proposal
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE "adjustment_proposal_acks" (
+    "id" SERIAL NOT NULL,
+    "proposal_id" TEXT NOT NULL,
+    "patient_id" INTEGER NOT NULL,
+    "acknowledged" BOOLEAN NOT NULL DEFAULT false,
+    "accepted" BOOLEAN,
+    "read_at" TIMESTAMPTZ,
+    "responded_at" TIMESTAMPTZ,
+    "comment" TEXT,
+
+    CONSTRAINT "adjustment_proposal_acks_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "adjustment_proposal_acks_proposal_id_key" ON "adjustment_proposal_acks"("proposal_id");
+CREATE INDEX "adjustment_proposal_acks_patient_id_idx" ON "adjustment_proposal_acks"("patient_id");
+
+-- ─────────────────────────────────────────────────────────────
+-- US-2066 — Adjustment proposal actualization (real-world apply)
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE "adjustment_proposal_actualizations" (
+    "id" SERIAL NOT NULL,
+    "proposal_id" TEXT NOT NULL,
+    "effective_at" TIMESTAMPTZ,
+    "verified_via" VARCHAR(40) NOT NULL,
+    "verified_by" INTEGER,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "adjustment_proposal_actualizations_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "adjustment_proposal_actualizations_proposal_id_key" ON "adjustment_proposal_actualizations"("proposal_id");
+
+-- ─────────────────────────────────────────────────────────────
+-- US-2068 — Consultation notes (encrypted content)
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE "consultation_notes" (
+    "id" SERIAL NOT NULL,
+    "patient_id" INTEGER NOT NULL,
+    "author_id" INTEGER NOT NULL,
+    "appointment_id" INTEGER,
+    "content" TEXT NOT NULL,
+    "category" VARCHAR(40),
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL,
+
+    CONSTRAINT "consultation_notes_pkey" PRIMARY KEY ("id")
+);
+CREATE INDEX "consultation_notes_patient_id_created_at_idx" ON "consultation_notes"("patient_id", "created_at");
+
+-- ─────────────────────────────────────────────────────────────
+-- US-2083 — Delegation requests (IDE → DOCTOR approval workflow)
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE "delegation_requests" (
+    "id" SERIAL NOT NULL,
+    "patient_id" INTEGER NOT NULL,
+    "from_user_id" INTEGER NOT NULL,
+    "to_user_id" INTEGER NOT NULL,
+    "action" VARCHAR(80) NOT NULL,
+    "payload" JSONB,
+    "status" "delegation_request_status" NOT NULL DEFAULT 'pending',
+    "reviewed_at" TIMESTAMPTZ,
+    "reviewed_by" INTEGER,
+    "reason" VARCHAR(500),
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "delegation_requests_pkey" PRIMARY KEY ("id")
+);
+CREATE INDEX "delegation_requests_to_user_id_status_idx" ON "delegation_requests"("to_user_id", "status");
+CREATE INDEX "delegation_requests_patient_id_idx" ON "delegation_requests"("patient_id");
+
+-- ─────────────────────────────────────────────────────────────
+-- US-2084 — Member absences + cover
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE "member_absences" (
+    "id" SERIAL NOT NULL,
+    "member_id" INTEGER NOT NULL,
+    "start_date" DATE NOT NULL,
+    "end_date" DATE NOT NULL,
+    "cover_member_id" INTEGER,
+    "reason" VARCHAR(120),
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "member_absences_pkey" PRIMARY KEY ("id")
+);
+CREATE INDEX "member_absences_member_id_start_date_idx" ON "member_absences"("member_id", "start_date");
+CREATE INDEX "member_absences_cover_member_id_idx" ON "member_absences"("cover_member_id");
+
+-- ─────────────────────────────────────────────────────────────
+-- US-2086 — Handoff notes (encrypted note + ack)
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE "handoff_notes" (
+    "id" SERIAL NOT NULL,
+    "patient_id" INTEGER NOT NULL,
+    "from_user_id" INTEGER NOT NULL,
+    "to_user_id" INTEGER NOT NULL,
+    "note" TEXT NOT NULL,
+    "acknowledged_at" TIMESTAMPTZ,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "handoff_notes_pkey" PRIMARY KEY ("id")
+);
+CREATE INDEX "handoff_notes_to_user_id_acknowledged_at_idx" ON "handoff_notes"("to_user_id", "acknowledged_at");
+CREATE INDEX "handoff_notes_patient_id_idx" ON "handoff_notes"("patient_id");
+
+-- ─────────────────────────────────────────────────────────────
+-- US-2088 — Patient groups (cohorts) + assignment
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE "patient_groups" (
+    "id" SERIAL NOT NULL,
+    "service_id" INTEGER NOT NULL,
+    "label" VARCHAR(80) NOT NULL,
+    "created_by" INTEGER,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "patient_groups_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "patient_groups_service_id_label_key" ON "patient_groups"("service_id", "label");
+CREATE INDEX "patient_groups_service_id_idx" ON "patient_groups"("service_id");
+
+CREATE TABLE "patient_group_assignments" (
+    "id" SERIAL NOT NULL,
+    "patient_id" INTEGER NOT NULL,
+    "group_id" INTEGER NOT NULL,
+    "assigned_by" INTEGER,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "patient_group_assignments_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "patient_group_assignments_patient_id_group_id_key" ON "patient_group_assignments"("patient_id", "group_id");
+CREATE INDEX "patient_group_assignments_group_id_idx" ON "patient_group_assignments"("group_id");
+CREATE INDEX "patient_group_assignments_patient_id_created_at_idx" ON "patient_group_assignments"("patient_id", "created_at");
+
+-- ─────────────────────────────────────────────────────────────
+-- US-2072 — Teleconsultation acte (billing link)
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE "teleconsultation_actes" (
+    "id" SERIAL NOT NULL,
+    "appointment_id" INTEGER NOT NULL,
+    "billing_code" VARCHAR(20) NOT NULL,
+    "amount_cents" INTEGER,
+    "invoiced_at" TIMESTAMPTZ,
+    "invoiced_by" INTEGER,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "teleconsultation_actes_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "teleconsultation_actes_appointment_id_key" ON "teleconsultation_actes"("appointment_id");
+CREATE INDEX "teleconsultation_actes_invoiced_at_idx" ON "teleconsultation_actes"("invoiced_at");
+
+-- ─────────────────────────────────────────────────────────────
+-- Foreign keys
+-- ─────────────────────────────────────────────────────────────
+ALTER TABLE "message_templates" ADD CONSTRAINT "message_templates_service_id_fkey"
+    FOREIGN KEY ("service_id") REFERENCES "healthcare_services"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "message_templates" ADD CONSTRAINT "message_templates_created_by_fkey"
+    FOREIGN KEY ("created_by") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "read_receipts" ADD CONSTRAINT "read_receipts_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "adjustment_proposal_acks" ADD CONSTRAINT "adjustment_proposal_acks_proposal_id_fkey"
+    FOREIGN KEY ("proposal_id") REFERENCES "adjustment_proposals"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "adjustment_proposal_actualizations" ADD CONSTRAINT "adjustment_proposal_actualizations_proposal_id_fkey"
+    FOREIGN KEY ("proposal_id") REFERENCES "adjustment_proposals"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "adjustment_proposal_actualizations" ADD CONSTRAINT "adjustment_proposal_actualizations_verified_by_fkey"
+    FOREIGN KEY ("verified_by") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "consultation_notes" ADD CONSTRAINT "consultation_notes_patient_id_fkey"
+    FOREIGN KEY ("patient_id") REFERENCES "patients"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "consultation_notes" ADD CONSTRAINT "consultation_notes_author_id_fkey"
+    FOREIGN KEY ("author_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "consultation_notes" ADD CONSTRAINT "consultation_notes_appointment_id_fkey"
+    FOREIGN KEY ("appointment_id") REFERENCES "appointments"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "delegation_requests" ADD CONSTRAINT "delegation_requests_patient_id_fkey"
+    FOREIGN KEY ("patient_id") REFERENCES "patients"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "delegation_requests" ADD CONSTRAINT "delegation_requests_from_user_id_fkey"
+    FOREIGN KEY ("from_user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "delegation_requests" ADD CONSTRAINT "delegation_requests_to_user_id_fkey"
+    FOREIGN KEY ("to_user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "delegation_requests" ADD CONSTRAINT "delegation_requests_reviewed_by_fkey"
+    FOREIGN KEY ("reviewed_by") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "member_absences" ADD CONSTRAINT "member_absences_member_id_fkey"
+    FOREIGN KEY ("member_id") REFERENCES "healthcare_members"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "member_absences" ADD CONSTRAINT "member_absences_cover_member_id_fkey"
+    FOREIGN KEY ("cover_member_id") REFERENCES "healthcare_members"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "handoff_notes" ADD CONSTRAINT "handoff_notes_patient_id_fkey"
+    FOREIGN KEY ("patient_id") REFERENCES "patients"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "handoff_notes" ADD CONSTRAINT "handoff_notes_from_user_id_fkey"
+    FOREIGN KEY ("from_user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "handoff_notes" ADD CONSTRAINT "handoff_notes_to_user_id_fkey"
+    FOREIGN KEY ("to_user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "patient_groups" ADD CONSTRAINT "patient_groups_service_id_fkey"
+    FOREIGN KEY ("service_id") REFERENCES "healthcare_services"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "patient_groups" ADD CONSTRAINT "patient_groups_created_by_fkey"
+    FOREIGN KEY ("created_by") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "patient_group_assignments" ADD CONSTRAINT "patient_group_assignments_patient_id_fkey"
+    FOREIGN KEY ("patient_id") REFERENCES "patients"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "patient_group_assignments" ADD CONSTRAINT "patient_group_assignments_group_id_fkey"
+    FOREIGN KEY ("group_id") REFERENCES "patient_groups"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "patient_group_assignments" ADD CONSTRAINT "patient_group_assignments_assigned_by_fkey"
+    FOREIGN KEY ("assigned_by") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "teleconsultation_actes" ADD CONSTRAINT "teleconsultation_actes_appointment_id_fkey"
+    FOREIGN KEY ("appointment_id") REFERENCES "appointments"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "teleconsultation_actes" ADD CONSTRAINT "teleconsultation_actes_invoiced_by_fkey"
+    FOREIGN KEY ("invoiced_by") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260513210000_groupe3_refinements/migration.sql
+++ b/prisma/migrations/20260513210000_groupe3_refinements/migration.sql
@@ -1,0 +1,18 @@
+-- Review PR #390 refinements:
+--  * H10: AdjustmentProposalAck.patient_id → patients(id) FK (cascade)
+--  * L6:  index on patient_group_assignments.assigned_by
+--  * L7:  index on adjustment_proposal_actualizations.verified_by
+
+-- AddForeignKey (H10)
+ALTER TABLE "adjustment_proposal_acks"
+    ADD CONSTRAINT "adjustment_proposal_acks_patient_id_fkey"
+        FOREIGN KEY ("patient_id") REFERENCES "patients"("id")
+        ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateIndex (L6)
+CREATE INDEX "patient_group_assignments_assigned_by_idx"
+    ON "patient_group_assignments"("assigned_by");
+
+-- CreateIndex (L7)
+CREATE INDEX "adjustment_proposal_actualizations_verified_by_idx"
+    ON "adjustment_proposal_actualizations"("verified_by");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1950,7 +1950,7 @@ model AdjustmentProposalActualization {
   proposalId  String    @unique @map("proposal_id")
   effectiveAt DateTime? @map("effective_at") @db.Timestamptz()
   /// Source de vérification : "device-sync" / "manual-ps" / "patient-confirmed".
-  verifiedVia String    @db.VarChar(40)
+  verifiedVia String    @map("verified_via") @db.VarChar(40)
   /// PS ayant confirmé (NULL si vérification auto via sync device).
   verifiedBy  Int?      @map("verified_by")
   createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz()

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -529,6 +529,8 @@ model Patient {
   handoffNotes          HandoffNote[]
   /// US-2088 — Groupes-cohortes équipe.
   groupAssignments      PatientGroupAssignment[]
+  /// US-2065 — Accusés patient sur AdjustmentProposal (review PR #390 H10).
+  proposalAcks          AdjustmentProposalAck[]
 
   @@index([deletedAt])
   @@map("patients")
@@ -1937,6 +1939,9 @@ model AdjustmentProposalAck {
   comment      String?
 
   proposal AdjustmentProposal @relation(fields: [proposalId], references: [id], onDelete: Cascade)
+  /// FK explicite vers Patient (review PR #390 H10) : empêche le drift
+  /// `patient_id` ↔ proposal.patient_id et cascade le soft-delete RGPD.
+  patient  Patient            @relation(fields: [patientId], references: [id], onDelete: Cascade)
 
   @@index([patientId])
   @@map("adjustment_proposal_acks")
@@ -1958,6 +1963,9 @@ model AdjustmentProposalActualization {
   proposal AdjustmentProposal @relation(fields: [proposalId], references: [id], onDelete: Cascade)
   verifier User?              @relation("ProposalActualizationVerifier", fields: [verifiedBy], references: [id], onDelete: SetNull)
 
+  /// review PR #390 L7 — index sur la FK SetNull pour éviter le seq-scan
+  /// quand un User est anonymisé.
+  @@index([verifiedBy])
   @@map("adjustment_proposal_actualizations")
 }
 
@@ -2088,6 +2096,8 @@ model PatientGroupAssignment {
   @@unique([patientId, groupId])
   @@index([groupId])
   @@index([patientId, createdAt])
+  /// review PR #390 L6 — index sur la FK SetNull (anonymisation user RGPD).
+  @@index([assignedBy])
   @@map("patient_group_assignments")
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -335,6 +335,19 @@ model User {
   managedServices      HealthcareService[]   @relation("HealthcareServiceManager")
   createdPatientTags   PatientTag[]          @relation("PatientTagCreator")
   assignedPatientTags  PatientTagAssignment[] @relation("PatientTagAssigner")
+  // Groupe 3 — Équipe & Communication
+  createdMessageTemplates        MessageTemplate[]                 @relation("MessageTemplateCreator")
+  readReceipts                   ReadReceipt[]                     @relation("ReadReceiptUser")
+  verifiedProposalActualizations AdjustmentProposalActualization[] @relation("ProposalActualizationVerifier")
+  consultationNotes              ConsultationNote[]                @relation("ConsultationNoteAuthor")
+  delegationsRequested           DelegationRequest[]               @relation("DelegationFrom")
+  delegationsToReview            DelegationRequest[]               @relation("DelegationTo")
+  reviewedDelegations            DelegationRequest[]               @relation("DelegationReviewer")
+  handoffsSent                   HandoffNote[]                     @relation("HandoffFrom")
+  handoffsReceived               HandoffNote[]                     @relation("HandoffTo")
+  createdPatientGroups           PatientGroup[]                    @relation("PatientGroupCreator")
+  assignedPatientGroups          PatientGroupAssignment[]          @relation("PatientGroupAssigner")
+  invoicedTeleconsultActes       TeleconsultationActe[]            @relation("TeleconsultInvoicer")
 
   @@index([createdAt])
   @@index([firstnameHmac, lastnameHmac])
@@ -508,6 +521,14 @@ model Patient {
   patientInsulins       PatientInsulin[]
   /// US-2022 — Tags posés sur ce patient au sein de son/ses cabinet(s).
   tagAssignments        PatientTagAssignment[]
+  /// US-2068 — Notes de consultation structurées.
+  consultationNotes     ConsultationNote[]
+  /// US-2083 — Demandes de délégation clinique (IDE → DOCTOR).
+  delegationRequests    DelegationRequest[]
+  /// US-2086 — Handoff entre soignants.
+  handoffNotes          HandoffNote[]
+  /// US-2088 — Groupes-cohortes équipe.
+  groupAssignments      PatientGroupAssignment[]
 
   @@index([deletedAt])
   @@map("patients")
@@ -1059,6 +1080,10 @@ model AdjustmentProposal {
   patient       Patient        @relation(fields: [patientId], references: [id], onDelete: Cascade)
   reviewer      User?          @relation("ReviewedBy", fields: [reviewedBy], references: [id])
   pumpBasalSlot PumpBasalSlot? @relation(fields: [pumpBasalSlotId], references: [id])
+  /// US-2065 — accusé patient (1:1).
+  ack           AdjustmentProposalAck?
+  /// US-2066 — actualisation effective (1:1).
+  actualization AdjustmentProposalActualization?
 
   @@index([patientId, status, createdAt])
   @@map("adjustment_proposals")
@@ -1303,6 +1328,10 @@ model HealthcareService {
   referents       PatientReferent[]
   /// US-2022 — Tags (catégorisation libre) appartenant à ce cabinet.
   patientTags     PatientTag[]
+  /// US-2078 — Templates de messages partagés au sein du cabinet.
+  messageTemplates MessageTemplate[]
+  /// US-2088 — Groupes patients (cohortes).
+  patientGroups   PatientGroup[]
 
   @@unique([name, establishment])
   @@index([type])
@@ -1325,6 +1354,9 @@ model HealthcareMember {
   patientServices PatientService[]
   referents       PatientReferent[]
   documents       MedicalDocument[]
+  /// US-2084 — Absences du membre + couvertures qu'il assure pour autrui
+  absencesAsOwner    MemberAbsence[]  @relation("MemberAbsenceOwner")
+  absencesAsCover    MemberAbsence[]  @relation("MemberAbsenceCover")
 
   @@unique([name, serviceId])
   @@map("healthcare_members")
@@ -1446,6 +1478,10 @@ model Appointment {
   updatedAt DateTime  @updatedAt @map("updated_at") @db.Timestamptz()
 
   patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  /// US-2068 — Notes consultation rattachées
+  consultationNotes ConsultationNote[]
+  /// US-2072 — Acte facturable si téléconsult
+  teleconsultActe   TeleconsultationActe?
 
   @@map("appointments")
 }
@@ -1840,4 +1876,236 @@ model BackupLog {
 
   @@index([status, startedAt])
   @@map("backup_logs")
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 13. DOMAINE ÉQUIPE & COMMUNICATION — Groupe 3 (10 tables)
+// ═══════════════════════════════════════════════════════════════
+// Workflow équipe soignante : templates de messages, accusés de lecture
+// patient/PS, délégation IDE→DOCTOR, remplacement, handoff, groupes
+// patients, notes de consultation, lien facturation téléconsult.
+
+/// US-2078 — Templates de messages réutilisables, scope cabinet.
+/// `variables` est la liste des placeholders supportés (ex: ["firstname",
+/// "appointmentDate"]) ; le rendu côté UI fait l'interpolation.
+model MessageTemplate {
+  id        Int      @id @default(autoincrement())
+  serviceId Int      @map("service_id")
+  title     String   @db.VarChar(120)
+  body      String   // free-text, max 4096 char validé service-side
+  variables String[] @default([])
+  createdBy Int?     @map("created_by")
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz()
+
+  service HealthcareService @relation(fields: [serviceId], references: [id], onDelete: Restrict)
+  creator User?             @relation("MessageTemplateCreator", fields: [createdBy], references: [id], onDelete: SetNull)
+
+  @@unique([serviceId, title])
+  @@index([serviceId])
+  @@map("message_templates")
+}
+
+/// US-2080 — Accusé de lecture sur Announcement (ou autres broadcast objets
+/// dans le futur). Modèle générique : `resource` + `resourceId` polymorphe.
+/// Index unique (resource, resourceId, userId) empêche les doublons.
+model ReadReceipt {
+  id         Int      @id @default(autoincrement())
+  resource   String   @db.VarChar(40) // "ANNOUNCEMENT", "DELEGATION_REQUEST", etc.
+  resourceId Int      @map("resource_id")
+  userId     Int      @map("user_id")
+  readAt     DateTime @default(now()) @map("read_at") @db.Timestamptz()
+
+  user User @relation("ReadReceiptUser", fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([resource, resourceId, userId])
+  @@index([resource, resourceId])
+  @@map("read_receipts")
+}
+
+/// US-2065 — Accusé patient sur une AdjustmentProposal : tracking
+/// lecture / acceptation / rejet côté patient (mobile app).
+model AdjustmentProposalAck {
+  id           Int      @id @default(autoincrement())
+  proposalId   String   @unique @map("proposal_id")
+  patientId    Int      @map("patient_id")
+  acknowledged Boolean  @default(false)
+  accepted     Boolean?
+  readAt       DateTime? @map("read_at") @db.Timestamptz()
+  respondedAt  DateTime? @map("responded_at") @db.Timestamptz()
+  /// Commentaire libre patient (max 500 char). Chiffré AES-256-GCM si non-null.
+  comment      String?
+
+  proposal AdjustmentProposal @relation(fields: [proposalId], references: [id], onDelete: Cascade)
+
+  @@index([patientId])
+  @@map("adjustment_proposal_acks")
+}
+
+/// US-2066 — Vérification que l'ajustement proposé a été appliqué dans le
+/// monde réel (sur le device). `effectiveAt` = quand le réglage a pris
+/// effet (peut différer du `respondedAt` patient).
+model AdjustmentProposalActualization {
+  id          Int       @id @default(autoincrement())
+  proposalId  String    @unique @map("proposal_id")
+  effectiveAt DateTime? @map("effective_at") @db.Timestamptz()
+  /// Source de vérification : "device-sync" / "manual-ps" / "patient-confirmed".
+  verifiedVia String    @db.VarChar(40)
+  /// PS ayant confirmé (NULL si vérification auto via sync device).
+  verifiedBy  Int?      @map("verified_by")
+  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz()
+
+  proposal AdjustmentProposal @relation(fields: [proposalId], references: [id], onDelete: Cascade)
+  verifier User?              @relation("ProposalActualizationVerifier", fields: [verifiedBy], references: [id], onDelete: SetNull)
+
+  @@map("adjustment_proposal_actualizations")
+}
+
+/// US-2068 — Note de consultation structurée. `content` chiffré AES-256-GCM
+/// (texte libre, peut contenir PII clinique).
+model ConsultationNote {
+  id            Int       @id @default(autoincrement())
+  patientId     Int       @map("patient_id")
+  authorId      Int       @map("author_id")
+  appointmentId Int?      @map("appointment_id")
+  content       String    // chiffré base64
+  /// Catégorie structurelle (anamnèse, examen, conclusion, plan…).
+  category      String?   @db.VarChar(40)
+  createdAt     DateTime  @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt     DateTime  @updatedAt @map("updated_at") @db.Timestamptz()
+
+  patient     Patient      @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  author      User         @relation("ConsultationNoteAuthor", fields: [authorId], references: [id], onDelete: Restrict)
+  appointment Appointment? @relation(fields: [appointmentId], references: [id], onDelete: SetNull)
+
+  @@index([patientId, createdAt])
+  @@map("consultation_notes")
+}
+
+/// US-2083 — Demande de délégation IDE → DOCTOR pour une action clinique
+/// nécessitant validation (ex: nouvelle proposition d'ajustement).
+model DelegationRequest {
+  id          Int                       @id @default(autoincrement())
+  patientId   Int                       @map("patient_id")
+  fromUserId  Int                       @map("from_user_id") // IDE qui demande
+  toUserId    Int                       @map("to_user_id")   // DOCTOR sollicité
+  action      String                    @db.VarChar(80)      // ex: "PROPOSE_ADJUSTMENT"
+  payload     Json?
+  status      DelegationRequestStatus   @default(pending)
+  reviewedAt  DateTime?                 @map("reviewed_at") @db.Timestamptz()
+  reviewedBy  Int?                      @map("reviewed_by")
+  reason      String?                   @db.VarChar(500)
+  createdAt   DateTime                  @default(now()) @map("created_at") @db.Timestamptz()
+
+  patient    Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  fromUser   User    @relation("DelegationFrom", fields: [fromUserId], references: [id], onDelete: Restrict)
+  toUser     User    @relation("DelegationTo", fields: [toUserId], references: [id], onDelete: Restrict)
+  reviewer   User?   @relation("DelegationReviewer", fields: [reviewedBy], references: [id], onDelete: SetNull)
+
+  @@index([toUserId, status])
+  @@index([patientId])
+  @@map("delegation_requests")
+}
+
+enum DelegationRequestStatus {
+  pending
+  approved
+  rejected
+  expired
+
+  @@map("delegation_request_status")
+}
+
+/// US-2084 — Période d'absence d'un membre, avec couverture éventuelle
+/// par un autre membre du même cabinet.
+model MemberAbsence {
+  id              Int      @id @default(autoincrement())
+  memberId        Int      @map("member_id")
+  startDate       DateTime @map("start_date") @db.Date
+  endDate         DateTime @map("end_date") @db.Date
+  coverMemberId   Int?     @map("cover_member_id")
+  reason          String?  @db.VarChar(120)
+  createdAt       DateTime @default(now()) @map("created_at") @db.Timestamptz()
+
+  member      HealthcareMember  @relation("MemberAbsenceOwner", fields: [memberId], references: [id], onDelete: Cascade)
+  coverMember HealthcareMember? @relation("MemberAbsenceCover", fields: [coverMemberId], references: [id], onDelete: SetNull)
+
+  @@index([memberId, startDate])
+  @@index([coverMemberId])
+  @@map("member_absences")
+}
+
+/// US-2086 — Note de handoff (transfert dossier annoté) entre soignants.
+/// `note` chiffré AES-256-GCM. `acknowledgedAt` marqué quand le destinataire
+/// a lu et accepté la prise en charge.
+model HandoffNote {
+  id             Int       @id @default(autoincrement())
+  patientId      Int       @map("patient_id")
+  fromUserId     Int       @map("from_user_id")
+  toUserId       Int       @map("to_user_id")
+  note           String    // chiffré base64
+  acknowledgedAt DateTime? @map("acknowledged_at") @db.Timestamptz()
+  createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamptz()
+
+  patient  Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  fromUser User    @relation("HandoffFrom", fields: [fromUserId], references: [id], onDelete: Restrict)
+  toUser   User    @relation("HandoffTo", fields: [toUserId], references: [id], onDelete: Restrict)
+
+  @@index([toUserId, acknowledgedAt])
+  @@index([patientId])
+  @@map("handoff_notes")
+}
+
+/// US-2088 — Groupe-cohorte de patients au sein d'un cabinet (ex: "Service
+/// diabéto endocrino HDJ"). Scope `serviceId`, M:N via PatientGroupAssignment.
+model PatientGroup {
+  id        Int      @id @default(autoincrement())
+  serviceId Int      @map("service_id")
+  label     String   @db.VarChar(80)
+  createdBy Int?     @map("created_by")
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz()
+
+  service     HealthcareService        @relation(fields: [serviceId], references: [id], onDelete: Restrict)
+  creator     User?                    @relation("PatientGroupCreator", fields: [createdBy], references: [id], onDelete: SetNull)
+  assignments PatientGroupAssignment[]
+
+  @@unique([serviceId, label])
+  @@index([serviceId])
+  @@map("patient_groups")
+}
+
+model PatientGroupAssignment {
+  id         Int      @id @default(autoincrement())
+  patientId  Int      @map("patient_id")
+  groupId    Int      @map("group_id")
+  assignedBy Int?     @map("assigned_by")
+  createdAt  DateTime @default(now()) @map("created_at") @db.Timestamptz()
+
+  patient  Patient      @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  group    PatientGroup @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  assigner User?        @relation("PatientGroupAssigner", fields: [assignedBy], references: [id], onDelete: SetNull)
+
+  @@unique([patientId, groupId])
+  @@index([groupId])
+  @@index([patientId, createdAt])
+  @@map("patient_group_assignments")
+}
+
+/// US-2072 — Lien facturation pour un Appointment marqué téléconsultation.
+/// Un Appointment peut avoir un seul Acte (1:1). `billingCode` libre côté
+/// MVP — un futur référentiel `CCAM`/`NABM` pourra contraindre.
+model TeleconsultationActe {
+  id             Int       @id @default(autoincrement())
+  appointmentId  Int       @unique @map("appointment_id")
+  billingCode    String    @map("billing_code") @db.VarChar(20)
+  amountCents    Int?      @map("amount_cents")
+  invoicedAt     DateTime? @map("invoiced_at") @db.Timestamptz()
+  invoicedBy     Int?      @map("invoiced_by")
+  createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamptz()
+
+  appointment Appointment @relation(fields: [appointmentId], references: [id], onDelete: Cascade)
+  invoicer    User?       @relation("TeleconsultInvoicer", fields: [invoicedBy], references: [id], onDelete: SetNull)
+
+  @@index([invoicedAt])
+  @@map("teleconsultation_actes")
 }

--- a/src/app/api/patients/[id]/consultation-notes/route.ts
+++ b/src/app/api/patients/[id]/consultation-notes/route.ts
@@ -1,14 +1,14 @@
-/** US-2068 — Consultation notes (encrypted, per patient). */
+/** US-2068 — Consultation notes par patient (review PR #390 H1, M2). */
 
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
-import { requireRole, AuthError } from "@/lib/auth"
+import { AuthError } from "@/lib/auth"
 import { canAccessPatient } from "@/lib/access-control"
 import { patientShareConsent } from "@/lib/consent"
 import { consultationNoteService } from "@/lib/services/team-workflow.service"
 import { auditService, extractRequestContext } from "@/lib/services/audit.service"
 import { prisma } from "@/lib/db/client"
-import { mapErrorToResponse } from "@/lib/team-route-helpers"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
 
 type RouteParams = { params: Promise<{ id: string }> }
 
@@ -26,12 +26,12 @@ async function ensurePatientAlive(id: number): Promise<boolean> {
 }
 
 export async function GET(req: NextRequest, { params }: RouteParams) {
+  const ctx = extractRequestContext(req)
   try {
-    const user = requireRole(req, "NURSE")
     const { id } = await params
     if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidPatientId" }, { status: 400 })
     const patientId = parseInt(id, 10)
-    const ctx = extractRequestContext(req)
+    const user = await auditedRequireRole(req, "NURSE", ctx, "CONSULTATION_NOTE", String(patientId))
 
     if (!(await ensurePatientAlive(patientId))) {
       return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
@@ -52,17 +52,17 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
     return NextResponse.json({ items })
   } catch (e) {
     if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
-    return mapErrorToResponse(e, "patients/:id/consultation-notes GET")
+    return mapErrorToResponse(e, "patients/:id/consultation-notes GET", ctx.requestId)
   }
 }
 
 export async function POST(req: NextRequest, { params }: RouteParams) {
+  const ctx = extractRequestContext(req)
   try {
-    const user = requireRole(req, "DOCTOR")
     const { id } = await params
     if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidPatientId" }, { status: 400 })
     const patientId = parseInt(id, 10)
-    const ctx = extractRequestContext(req)
+    const user = await auditedRequireRole(req, "DOCTOR", ctx, "CONSULTATION_NOTE", String(patientId))
 
     if (!(await ensurePatientAlive(patientId))) {
       return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
@@ -93,6 +93,6 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     return NextResponse.json(out, { status: 201 })
   } catch (e) {
     if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
-    return mapErrorToResponse(e, "patients/:id/consultation-notes POST")
+    return mapErrorToResponse(e, "patients/:id/consultation-notes POST", ctx.requestId)
   }
 }

--- a/src/app/api/patients/[id]/consultation-notes/route.ts
+++ b/src/app/api/patients/[id]/consultation-notes/route.ts
@@ -1,0 +1,98 @@
+/** US-2068 — Consultation notes (encrypted, per patient). */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireRole, AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { patientShareConsent } from "@/lib/consent"
+import { consultationNoteService } from "@/lib/services/team-workflow.service"
+import { auditService, extractRequestContext } from "@/lib/services/audit.service"
+import { prisma } from "@/lib/db/client"
+import { mapErrorToResponse } from "@/lib/team-route-helpers"
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+const createSchema = z.object({
+  content: z.string().min(1).max(8192),
+  category: z.string().max(40).optional(),
+  appointmentId: z.number().int().positive().optional(),
+})
+
+async function ensurePatientAlive(id: number): Promise<boolean> {
+  const p = await prisma.patient.findFirst({
+    where: { id, deletedAt: null }, select: { id: true },
+  })
+  return !!p
+}
+
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  try {
+    const user = requireRole(req, "NURSE")
+    const { id } = await params
+    if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidPatientId" }, { status: 400 })
+    const patientId = parseInt(id, 10)
+    const ctx = extractRequestContext(req)
+
+    if (!(await ensurePatientAlive(patientId))) {
+      return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    }
+    const allowed = await canAccessPatient(user.id, user.role, patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id, resource: "CONSULTATION_NOTE", resourceId: String(patientId),
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: { patientId, endpoint: "list" },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+    const consent = await patientShareConsent(patientId)
+    if (!consent.ok) return NextResponse.json({ error: consent.error }, { status: consent.status })
+
+    const items = await consultationNoteService.listForPatient(patientId, user.id, ctx)
+    return NextResponse.json({ items })
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "patients/:id/consultation-notes GET")
+  }
+}
+
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  try {
+    const user = requireRole(req, "DOCTOR")
+    const { id } = await params
+    if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidPatientId" }, { status: 400 })
+    const patientId = parseInt(id, 10)
+    const ctx = extractRequestContext(req)
+
+    if (!(await ensurePatientAlive(patientId))) {
+      return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    }
+    const allowed = await canAccessPatient(user.id, user.role, patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id, resource: "CONSULTATION_NOTE", resourceId: String(patientId),
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: { patientId, endpoint: "create" },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+    const consent = await patientShareConsent(patientId)
+    if (!consent.ok) return NextResponse.json({ error: consent.error }, { status: consent.status })
+
+    const body = await req.json()
+    const parsed = createSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+    const out = await consultationNoteService.create(
+      { ...parsed.data, patientId, authorId: user.id }, ctx,
+    )
+    return NextResponse.json(out, { status: 201 })
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "patients/:id/consultation-notes POST")
+  }
+}

--- a/src/app/api/patients/[id]/groups/route.ts
+++ b/src/app/api/patients/[id]/groups/route.ts
@@ -1,0 +1,96 @@
+/** US-2088 — Affectation de groupes-cohortes à un patient. */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireRole, AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { patientShareConsent } from "@/lib/consent"
+import { patientGroupService } from "@/lib/services/team-workflow.service"
+import { prisma } from "@/lib/db/client"
+import { auditService, extractRequestContext } from "@/lib/services/audit.service"
+import { mapErrorToResponse } from "@/lib/team-route-helpers"
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+const setSchema = z.object({
+  groupIds: z.array(z.number().int().positive()).max(20),
+})
+
+async function ensurePatientAlive(id: number): Promise<boolean> {
+  const p = await prisma.patient.findFirst({
+    where: { id, deletedAt: null }, select: { id: true },
+  })
+  return !!p
+}
+
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  try {
+    const user = requireRole(req, "NURSE")
+    const { id } = await params
+    if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidPatientId" }, { status: 400 })
+    const patientId = parseInt(id, 10)
+    const ctx = extractRequestContext(req)
+
+    if (!(await ensurePatientAlive(patientId))) {
+      return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    }
+    const allowed = await canAccessPatient(user.id, user.role, patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id, resource: "PATIENT_GROUP_ASSIGNMENT", resourceId: String(patientId),
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: { patientId, endpoint: "list" },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+    const consent = await patientShareConsent(patientId)
+    if (!consent.ok) return NextResponse.json({ error: consent.error }, { status: consent.status })
+
+    const items = await patientGroupService.listForPatient(patientId)
+    return NextResponse.json({ items })
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "patients/:id/groups GET")
+  }
+}
+
+export async function PUT(req: NextRequest, { params }: RouteParams) {
+  try {
+    const user = requireRole(req, "NURSE")
+    const { id } = await params
+    if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidPatientId" }, { status: 400 })
+    const patientId = parseInt(id, 10)
+    const ctx = extractRequestContext(req)
+
+    if (!(await ensurePatientAlive(patientId))) {
+      return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    }
+    const allowed = await canAccessPatient(user.id, user.role, patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id, resource: "PATIENT_GROUP_ASSIGNMENT", resourceId: String(patientId),
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: { patientId, endpoint: "set" },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+    const consent = await patientShareConsent(patientId)
+    if (!consent.ok) return NextResponse.json({ error: consent.error }, { status: consent.status })
+
+    const body = await req.json()
+    const parsed = setSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+    const out = await patientGroupService.setForPatient(
+      patientId, parsed.data.groupIds, user.id, ctx,
+    )
+    return NextResponse.json(out)
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "patients/:id/groups PUT")
+  }
+}

--- a/src/app/api/patients/[id]/groups/route.ts
+++ b/src/app/api/patients/[id]/groups/route.ts
@@ -1,14 +1,14 @@
-/** US-2088 — Affectation de groupes-cohortes à un patient. */
+/** US-2088 — Groupes patient (review PR #390 H1 + L2). */
 
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
-import { requireRole, AuthError } from "@/lib/auth"
+import { AuthError } from "@/lib/auth"
 import { canAccessPatient } from "@/lib/access-control"
 import { patientShareConsent } from "@/lib/consent"
 import { patientGroupService } from "@/lib/services/team-workflow.service"
 import { prisma } from "@/lib/db/client"
 import { auditService, extractRequestContext } from "@/lib/services/audit.service"
-import { mapErrorToResponse } from "@/lib/team-route-helpers"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
 
 type RouteParams = { params: Promise<{ id: string }> }
 
@@ -24,12 +24,12 @@ async function ensurePatientAlive(id: number): Promise<boolean> {
 }
 
 export async function GET(req: NextRequest, { params }: RouteParams) {
+  const ctx = extractRequestContext(req)
   try {
-    const user = requireRole(req, "NURSE")
     const { id } = await params
     if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidPatientId" }, { status: 400 })
     const patientId = parseInt(id, 10)
-    const ctx = extractRequestContext(req)
+    const user = await auditedRequireRole(req, "NURSE", ctx, "PATIENT_GROUP_ASSIGNMENT", String(patientId))
 
     if (!(await ensurePatientAlive(patientId))) {
       return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
@@ -46,21 +46,21 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
     const consent = await patientShareConsent(patientId)
     if (!consent.ok) return NextResponse.json({ error: consent.error }, { status: consent.status })
 
-    const items = await patientGroupService.listForPatient(patientId)
+    const items = await patientGroupService.listForPatient(patientId, user.id, ctx)
     return NextResponse.json({ items })
   } catch (e) {
     if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
-    return mapErrorToResponse(e, "patients/:id/groups GET")
+    return mapErrorToResponse(e, "patients/:id/groups GET", ctx.requestId)
   }
 }
 
 export async function PUT(req: NextRequest, { params }: RouteParams) {
+  const ctx = extractRequestContext(req)
   try {
-    const user = requireRole(req, "NURSE")
     const { id } = await params
     if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidPatientId" }, { status: 400 })
     const patientId = parseInt(id, 10)
-    const ctx = extractRequestContext(req)
+    const user = await auditedRequireRole(req, "NURSE", ctx, "PATIENT_GROUP_ASSIGNMENT", String(patientId))
 
     if (!(await ensurePatientAlive(patientId))) {
       return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
@@ -91,6 +91,6 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
     return NextResponse.json(out)
   } catch (e) {
     if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
-    return mapErrorToResponse(e, "patients/:id/groups PUT")
+    return mapErrorToResponse(e, "patients/:id/groups PUT", ctx.requestId)
   }
 }

--- a/src/app/api/team/absences/route.ts
+++ b/src/app/api/team/absences/route.ts
@@ -1,11 +1,11 @@
-/** US-2084 — Absence d'un membre du cabinet + couverture. */
+/** US-2084 — Absence membre cabinet (review PR #390 H1, H7, L3). */
 
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
-import { requireRole } from "@/lib/auth"
+import { AuthError } from "@/lib/auth"
 import { memberAbsenceService } from "@/lib/services/team-workflow.service"
 import { extractRequestContext } from "@/lib/services/audit.service"
-import { mapErrorToResponse } from "@/lib/team-route-helpers"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
 
 const createSchema = z.object({
   memberId: z.number().int().positive(),
@@ -18,25 +18,25 @@ const createSchema = z.object({
 const querySchema = z.object({ memberId: z.coerce.number().int().positive() })
 
 export async function GET(req: NextRequest) {
+  const ctx = extractRequestContext(req)
   try {
-    requireRole(req, "NURSE")
     const parsed = querySchema.safeParse(
       Object.fromEntries(req.nextUrl.searchParams.entries()),
     )
-    if (!parsed.success) {
-      return NextResponse.json({ error: "validationFailed" }, { status: 400 })
-    }
-    const items = await memberAbsenceService.listForMember(parsed.data.memberId)
+    if (!parsed.success) return NextResponse.json({ error: "validationFailed" }, { status: 400 })
+    const user = await auditedRequireRole(req, "NURSE", ctx, "MEMBER_ABSENCE", String(parsed.data.memberId))
+    // H7 — service-side membership check + audit happens inside listForMember.
+    const items = await memberAbsenceService.listForMember(parsed.data.memberId, user.id, ctx)
     return NextResponse.json({ items })
   } catch (e) {
-    return mapErrorToResponse(e, "team/absences GET")
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/absences GET", ctx.requestId)
   }
 }
 
 export async function POST(req: NextRequest) {
+  const ctx = extractRequestContext(req)
   try {
-    const user = requireRole(req, "ADMIN")
-    const ctx = extractRequestContext(req)
     const body = await req.json()
     const parsed = createSchema.safeParse(body)
     if (!parsed.success) {
@@ -45,9 +45,11 @@ export async function POST(req: NextRequest) {
         { status: 400 },
       )
     }
+    const user = await auditedRequireRole(req, "ADMIN", ctx, "MEMBER_ABSENCE", String(parsed.data.memberId))
     const row = await memberAbsenceService.create(parsed.data, user.id, ctx)
     return NextResponse.json(row, { status: 201 })
   } catch (e) {
-    return mapErrorToResponse(e, "team/absences POST")
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/absences POST", ctx.requestId)
   }
 }

--- a/src/app/api/team/absences/route.ts
+++ b/src/app/api/team/absences/route.ts
@@ -1,0 +1,53 @@
+/** US-2084 — Absence d'un membre du cabinet + couverture. */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireRole } from "@/lib/auth"
+import { memberAbsenceService } from "@/lib/services/team-workflow.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { mapErrorToResponse } from "@/lib/team-route-helpers"
+
+const createSchema = z.object({
+  memberId: z.number().int().positive(),
+  startDate: z.coerce.date(),
+  endDate: z.coerce.date(),
+  coverMemberId: z.number().int().positive().optional(),
+  reason: z.string().max(120).optional(),
+})
+
+const querySchema = z.object({ memberId: z.coerce.number().int().positive() })
+
+export async function GET(req: NextRequest) {
+  try {
+    requireRole(req, "NURSE")
+    const parsed = querySchema.safeParse(
+      Object.fromEntries(req.nextUrl.searchParams.entries()),
+    )
+    if (!parsed.success) {
+      return NextResponse.json({ error: "validationFailed" }, { status: 400 })
+    }
+    const items = await memberAbsenceService.listForMember(parsed.data.memberId)
+    return NextResponse.json({ items })
+  } catch (e) {
+    return mapErrorToResponse(e, "team/absences GET")
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = requireRole(req, "ADMIN")
+    const ctx = extractRequestContext(req)
+    const body = await req.json()
+    const parsed = createSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+    const row = await memberAbsenceService.create(parsed.data, user.id, ctx)
+    return NextResponse.json(row, { status: 201 })
+  } catch (e) {
+    return mapErrorToResponse(e, "team/absences POST")
+  }
+}

--- a/src/app/api/team/delegations/[id]/respond/route.ts
+++ b/src/app/api/team/delegations/[id]/respond/route.ts
@@ -1,0 +1,35 @@
+/** US-2083 — Approve / reject a delegation request (target DOCTOR only). */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireRole } from "@/lib/auth"
+import { delegationRequestService } from "@/lib/services/team-workflow.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { mapErrorToResponse } from "@/lib/team-route-helpers"
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+const schema = z.object({
+  status: z.enum(["approved", "rejected"]),
+  reason: z.string().max(500).optional(),
+})
+
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  try {
+    const user = requireRole(req, "DOCTOR")
+    const { id } = await params
+    if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidId" }, { status: 400 })
+    const ctx = extractRequestContext(req)
+    const body = await req.json()
+    const parsed = schema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: "validationFailed" }, { status: 400 })
+    }
+    const out = await delegationRequestService.respond(
+      parseInt(id, 10), user.id, parsed.data, ctx,
+    )
+    return NextResponse.json(out)
+  } catch (e) {
+    return mapErrorToResponse(e, "team/delegations/:id/respond POST")
+  }
+}

--- a/src/app/api/team/delegations/[id]/respond/route.ts
+++ b/src/app/api/team/delegations/[id]/respond/route.ts
@@ -1,11 +1,11 @@
-/** US-2083 — Approve / reject a delegation request (target DOCTOR only). */
+/** US-2083 — Approve / reject (review PR #390 C5 + H1). */
 
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
-import { requireRole } from "@/lib/auth"
+import { AuthError } from "@/lib/auth"
 import { delegationRequestService } from "@/lib/services/team-workflow.service"
 import { extractRequestContext } from "@/lib/services/audit.service"
-import { mapErrorToResponse } from "@/lib/team-route-helpers"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
 
 type RouteParams = { params: Promise<{ id: string }> }
 
@@ -15,11 +15,11 @@ const schema = z.object({
 })
 
 export async function POST(req: NextRequest, { params }: RouteParams) {
+  const ctx = extractRequestContext(req)
   try {
-    const user = requireRole(req, "DOCTOR")
     const { id } = await params
     if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidId" }, { status: 400 })
-    const ctx = extractRequestContext(req)
+    const user = await auditedRequireRole(req, "DOCTOR", ctx, "DELEGATION_REQUEST", id)
     const body = await req.json()
     const parsed = schema.safeParse(body)
     if (!parsed.success) {
@@ -30,6 +30,7 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     )
     return NextResponse.json(out)
   } catch (e) {
-    return mapErrorToResponse(e, "team/delegations/:id/respond POST")
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/delegations/:id/respond POST", ctx.requestId)
   }
 }

--- a/src/app/api/team/delegations/route.ts
+++ b/src/app/api/team/delegations/route.ts
@@ -1,0 +1,55 @@
+/** US-2083 — Délégation IDE → DOCTOR (création + inbox du reviewer). */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireRole } from "@/lib/auth"
+import { delegationRequestService } from "@/lib/services/team-workflow.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { mapErrorToResponse } from "@/lib/team-route-helpers"
+
+const createSchema = z.object({
+  patientId: z.number().int().positive(),
+  toUserId: z.number().int().positive(),
+  action: z.string().min(1).max(80),
+  payload: z.unknown().optional(),
+})
+
+export async function GET(req: NextRequest) {
+  try {
+    const user = requireRole(req, "DOCTOR")
+    const ctx = extractRequestContext(req)
+    const items = await delegationRequestService.listInbox(user.id, ctx)
+    return NextResponse.json({ items })
+  } catch (e) {
+    return mapErrorToResponse(e, "team/delegations GET")
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = requireRole(req, "NURSE")
+    const ctx = extractRequestContext(req)
+    const body = await req.json()
+    const parsed = createSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+    const row = await delegationRequestService.create(
+      {
+        patientId: parsed.data.patientId,
+        fromUserId: user.id,
+        toUserId: parsed.data.toUserId,
+        action: parsed.data.action,
+        // z.unknown() is loose by design; the service treats it as InputJsonValue.
+        payload: parsed.data.payload as never,
+      },
+      ctx,
+    )
+    return NextResponse.json(row, { status: 201 })
+  } catch (e) {
+    return mapErrorToResponse(e, "team/delegations POST")
+  }
+}

--- a/src/app/api/team/delegations/route.ts
+++ b/src/app/api/team/delegations/route.ts
@@ -1,34 +1,46 @@
-/** US-2083 — Délégation IDE → DOCTOR (création + inbox du reviewer). */
+/**
+ * US-2083 — Délégation IDE → DOCTOR.
+ *
+ * Review PR #390 :
+ *  - C1 : `canAccessPatient` + `patientShareConsent` avant tout write.
+ *  - H1 : `auditedRequireRole` émet `accessDenied()` sur RBAC fail.
+ *  - H5 : payload Zod strict + reject côté service via `validateDelegationPayload`.
+ *  - H8 : `toUserId` membership-validation côté service.
+ */
 
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
-import { requireRole } from "@/lib/auth"
+import { AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { patientShareConsent } from "@/lib/consent"
 import { delegationRequestService } from "@/lib/services/team-workflow.service"
-import { extractRequestContext } from "@/lib/services/audit.service"
-import { mapErrorToResponse } from "@/lib/team-route-helpers"
+import { auditService, extractRequestContext } from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
 
 const createSchema = z.object({
   patientId: z.number().int().positive(),
   toUserId: z.number().int().positive(),
   action: z.string().min(1).max(80),
-  payload: z.unknown().optional(),
+  // H5 — accept JSON object only (no scalar / array / nested-array PHI dump).
+  payload: z.record(z.string(), z.unknown()).optional(),
 })
 
 export async function GET(req: NextRequest) {
+  const ctx = extractRequestContext(req)
   try {
-    const user = requireRole(req, "DOCTOR")
-    const ctx = extractRequestContext(req)
+    const user = await auditedRequireRole(req, "DOCTOR", ctx, "DELEGATION_REQUEST", "inbox")
     const items = await delegationRequestService.listInbox(user.id, ctx)
     return NextResponse.json({ items })
   } catch (e) {
-    return mapErrorToResponse(e, "team/delegations GET")
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/delegations GET", ctx.requestId)
   }
 }
 
 export async function POST(req: NextRequest) {
+  const ctx = extractRequestContext(req)
   try {
-    const user = requireRole(req, "NURSE")
-    const ctx = extractRequestContext(req)
+    const user = await auditedRequireRole(req, "NURSE", ctx, "DELEGATION_REQUEST", "create")
     const body = await req.json()
     const parsed = createSchema.safeParse(body)
     if (!parsed.success) {
@@ -37,19 +49,34 @@ export async function POST(req: NextRequest) {
         { status: 400 },
       )
     }
+
+    // C1 — caller must have access to the target patient.
+    const allowed = await canAccessPatient(user.id, user.role, parsed.data.patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id, resource: "DELEGATION_REQUEST",
+        resourceId: String(parsed.data.patientId),
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: { patientId: parsed.data.patientId, endpoint: "create" },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+    const consent = await patientShareConsent(parsed.data.patientId)
+    if (!consent.ok) return NextResponse.json({ error: consent.error }, { status: consent.status })
+
     const row = await delegationRequestService.create(
       {
         patientId: parsed.data.patientId,
         fromUserId: user.id,
         toUserId: parsed.data.toUserId,
         action: parsed.data.action,
-        // z.unknown() is loose by design; the service treats it as InputJsonValue.
-        payload: parsed.data.payload as never,
+        payload: parsed.data.payload,
       },
       ctx,
     )
     return NextResponse.json(row, { status: 201 })
   } catch (e) {
-    return mapErrorToResponse(e, "team/delegations POST")
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/delegations POST", ctx.requestId)
   }
 }

--- a/src/app/api/team/groups/route.ts
+++ b/src/app/api/team/groups/route.ts
@@ -1,11 +1,11 @@
-/** US-2088 — Groupes patients (cohortes cabinet). */
+/** US-2088 — Groupes patients (review PR #390 H1). */
 
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
-import { requireRole } from "@/lib/auth"
+import { AuthError } from "@/lib/auth"
 import { patientGroupService } from "@/lib/services/team-workflow.service"
 import { extractRequestContext } from "@/lib/services/audit.service"
-import { mapErrorToResponse } from "@/lib/team-route-helpers"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
 
 const querySchema = z.object({ serviceId: z.coerce.number().int().positive() })
 const createSchema = z.object({
@@ -14,24 +14,24 @@ const createSchema = z.object({
 })
 
 export async function GET(req: NextRequest) {
+  const ctx = extractRequestContext(req)
   try {
-    const user = requireRole(req, "NURSE")
-    const ctx = extractRequestContext(req)
     const parsed = querySchema.safeParse(
       Object.fromEntries(req.nextUrl.searchParams.entries()),
     )
     if (!parsed.success) return NextResponse.json({ error: "validationFailed" }, { status: 400 })
+    const user = await auditedRequireRole(req, "NURSE", ctx, "PATIENT_GROUP", String(parsed.data.serviceId))
     const items = await patientGroupService.listForService(parsed.data.serviceId, user.id, ctx)
     return NextResponse.json({ items })
   } catch (e) {
-    return mapErrorToResponse(e, "team/groups GET")
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/groups GET", ctx.requestId)
   }
 }
 
 export async function POST(req: NextRequest) {
+  const ctx = extractRequestContext(req)
   try {
-    const user = requireRole(req, "DOCTOR")
-    const ctx = extractRequestContext(req)
     const body = await req.json()
     const parsed = createSchema.safeParse(body)
     if (!parsed.success) {
@@ -40,9 +40,11 @@ export async function POST(req: NextRequest) {
         { status: 400 },
       )
     }
+    const user = await auditedRequireRole(req, "DOCTOR", ctx, "PATIENT_GROUP", String(parsed.data.serviceId))
     const g = await patientGroupService.create(parsed.data, user.id, ctx)
     return NextResponse.json(g, { status: 201 })
   } catch (e) {
-    return mapErrorToResponse(e, "team/groups POST")
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/groups POST", ctx.requestId)
   }
 }

--- a/src/app/api/team/groups/route.ts
+++ b/src/app/api/team/groups/route.ts
@@ -1,0 +1,48 @@
+/** US-2088 — Groupes patients (cohortes cabinet). */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireRole } from "@/lib/auth"
+import { patientGroupService } from "@/lib/services/team-workflow.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { mapErrorToResponse } from "@/lib/team-route-helpers"
+
+const querySchema = z.object({ serviceId: z.coerce.number().int().positive() })
+const createSchema = z.object({
+  serviceId: z.number().int().positive(),
+  label: z.string().trim().min(1).max(80),
+})
+
+export async function GET(req: NextRequest) {
+  try {
+    const user = requireRole(req, "NURSE")
+    const ctx = extractRequestContext(req)
+    const parsed = querySchema.safeParse(
+      Object.fromEntries(req.nextUrl.searchParams.entries()),
+    )
+    if (!parsed.success) return NextResponse.json({ error: "validationFailed" }, { status: 400 })
+    const items = await patientGroupService.listForService(parsed.data.serviceId, user.id, ctx)
+    return NextResponse.json({ items })
+  } catch (e) {
+    return mapErrorToResponse(e, "team/groups GET")
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = requireRole(req, "DOCTOR")
+    const ctx = extractRequestContext(req)
+    const body = await req.json()
+    const parsed = createSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+    const g = await patientGroupService.create(parsed.data, user.id, ctx)
+    return NextResponse.json(g, { status: 201 })
+  } catch (e) {
+    return mapErrorToResponse(e, "team/groups POST")
+  }
+}

--- a/src/app/api/team/handoffs/[id]/acknowledge/route.ts
+++ b/src/app/api/team/handoffs/[id]/acknowledge/route.ts
@@ -1,0 +1,22 @@
+/** US-2086 — Le destinataire accuse réception d'un handoff. */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { requireRole } from "@/lib/auth"
+import { handoffNoteService } from "@/lib/services/team-workflow.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { mapErrorToResponse } from "@/lib/team-route-helpers"
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  try {
+    const user = requireRole(req, "NURSE")
+    const { id } = await params
+    if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidId" }, { status: 400 })
+    const ctx = extractRequestContext(req)
+    const out = await handoffNoteService.acknowledge(parseInt(id, 10), user.id, ctx)
+    return NextResponse.json(out)
+  } catch (e) {
+    return mapErrorToResponse(e, "team/handoffs/:id/acknowledge POST")
+  }
+}

--- a/src/app/api/team/handoffs/[id]/acknowledge/route.ts
+++ b/src/app/api/team/handoffs/[id]/acknowledge/route.ts
@@ -1,22 +1,23 @@
-/** US-2086 — Le destinataire accuse réception d'un handoff. */
+/** US-2086 — Handoff acknowledge (review PR #390 H1). */
 
 import { NextResponse, type NextRequest } from "next/server"
-import { requireRole } from "@/lib/auth"
+import { AuthError } from "@/lib/auth"
 import { handoffNoteService } from "@/lib/services/team-workflow.service"
 import { extractRequestContext } from "@/lib/services/audit.service"
-import { mapErrorToResponse } from "@/lib/team-route-helpers"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
 
 type RouteParams = { params: Promise<{ id: string }> }
 
 export async function POST(req: NextRequest, { params }: RouteParams) {
+  const ctx = extractRequestContext(req)
   try {
-    const user = requireRole(req, "NURSE")
     const { id } = await params
     if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidId" }, { status: 400 })
-    const ctx = extractRequestContext(req)
+    const user = await auditedRequireRole(req, "NURSE", ctx, "HANDOFF_NOTE", id)
     const out = await handoffNoteService.acknowledge(parseInt(id, 10), user.id, ctx)
     return NextResponse.json(out)
   } catch (e) {
-    return mapErrorToResponse(e, "team/handoffs/:id/acknowledge POST")
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/handoffs/:id/acknowledge POST", ctx.requestId)
   }
 }

--- a/src/app/api/team/handoffs/route.ts
+++ b/src/app/api/team/handoffs/route.ts
@@ -1,0 +1,45 @@
+/** US-2086 — Handoff notes (inbox du destinataire + création). */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireRole } from "@/lib/auth"
+import { handoffNoteService } from "@/lib/services/team-workflow.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { mapErrorToResponse } from "@/lib/team-route-helpers"
+
+const createSchema = z.object({
+  patientId: z.number().int().positive(),
+  toUserId: z.number().int().positive(),
+  note: z.string().min(1).max(4096),
+})
+
+export async function GET(req: NextRequest) {
+  try {
+    const user = requireRole(req, "NURSE")
+    const items = await handoffNoteService.listInbox(user.id)
+    return NextResponse.json({ items })
+  } catch (e) {
+    return mapErrorToResponse(e, "team/handoffs GET")
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = requireRole(req, "NURSE")
+    const ctx = extractRequestContext(req)
+    const body = await req.json()
+    const parsed = createSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+    const out = await handoffNoteService.create(
+      { ...parsed.data, fromUserId: user.id }, ctx,
+    )
+    return NextResponse.json(out, { status: 201 })
+  } catch (e) {
+    return mapErrorToResponse(e, "team/handoffs POST")
+  }
+}

--- a/src/app/api/team/handoffs/route.ts
+++ b/src/app/api/team/handoffs/route.ts
@@ -1,11 +1,21 @@
-/** US-2086 — Handoff notes (inbox du destinataire + création). */
+/**
+ * US-2086 — Handoff notes.
+ *
+ * Review PR #390 :
+ *  - C2 : `canAccessPatient` + `patientShareConsent` avant write.
+ *  - H1 : `auditedRequireRole` (accessDenied sur 403 RBAC).
+ *  - H6 : `listInbox` filtre RGPD côté service.
+ *  - H8 : `toUserId` colleague-validation côté service.
+ */
 
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
-import { requireRole } from "@/lib/auth"
+import { AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { patientShareConsent } from "@/lib/consent"
 import { handoffNoteService } from "@/lib/services/team-workflow.service"
-import { extractRequestContext } from "@/lib/services/audit.service"
-import { mapErrorToResponse } from "@/lib/team-route-helpers"
+import { auditService, extractRequestContext } from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
 
 const createSchema = z.object({
   patientId: z.number().int().positive(),
@@ -14,19 +24,21 @@ const createSchema = z.object({
 })
 
 export async function GET(req: NextRequest) {
+  const ctx = extractRequestContext(req)
   try {
-    const user = requireRole(req, "NURSE")
-    const items = await handoffNoteService.listInbox(user.id)
+    const user = await auditedRequireRole(req, "NURSE", ctx, "HANDOFF_NOTE", "inbox")
+    const items = await handoffNoteService.listInbox(user.id, ctx)
     return NextResponse.json({ items })
   } catch (e) {
-    return mapErrorToResponse(e, "team/handoffs GET")
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/handoffs GET", ctx.requestId)
   }
 }
 
 export async function POST(req: NextRequest) {
+  const ctx = extractRequestContext(req)
   try {
-    const user = requireRole(req, "NURSE")
-    const ctx = extractRequestContext(req)
+    const user = await auditedRequireRole(req, "NURSE", ctx, "HANDOFF_NOTE", "create")
     const body = await req.json()
     const parsed = createSchema.safeParse(body)
     if (!parsed.success) {
@@ -35,11 +47,33 @@ export async function POST(req: NextRequest) {
         { status: 400 },
       )
     }
+
+    // C2 — caller must have access to the target patient.
+    const allowed = await canAccessPatient(user.id, user.role, parsed.data.patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id, resource: "HANDOFF_NOTE",
+        resourceId: String(parsed.data.patientId),
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: { patientId: parsed.data.patientId, endpoint: "create" },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+    const consent = await patientShareConsent(parsed.data.patientId)
+    if (!consent.ok) return NextResponse.json({ error: consent.error }, { status: consent.status })
+
     const out = await handoffNoteService.create(
-      { ...parsed.data, fromUserId: user.id }, ctx,
+      {
+        patientId: parsed.data.patientId,
+        fromUserId: user.id,
+        toUserId: parsed.data.toUserId,
+        note: parsed.data.note,
+      },
+      ctx,
     )
     return NextResponse.json(out, { status: 201 })
   } catch (e) {
-    return mapErrorToResponse(e, "team/handoffs POST")
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/handoffs POST", ctx.requestId)
   }
 }

--- a/src/app/api/team/proposal-ack/[proposalId]/route.ts
+++ b/src/app/api/team/proposal-ack/[proposalId]/route.ts
@@ -1,0 +1,68 @@
+/**
+ * US-2065 — Patient acknowledgement / response on an AdjustmentProposal.
+ *
+ * `POST` marks read; `PUT` records accept/reject decision with optional
+ * comment (encrypted). Caller must be the patient (VIEWER) — RBAC + audit
+ * trail enforced.
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireAuth } from "@/lib/auth"
+import { getOwnPatientId } from "@/lib/access-control"
+import { prisma } from "@/lib/db/client"
+import { proposalAckService } from "@/lib/services/team-workflow.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { mapErrorToResponse } from "@/lib/team-route-helpers"
+
+type RouteParams = { params: Promise<{ proposalId: string }> }
+
+const respondSchema = z.object({
+  accepted: z.boolean(),
+  comment: z.string().max(500).optional(),
+})
+
+async function ensureProposalOwnership(proposalId: string, userId: number) {
+  const ownPatientId = await getOwnPatientId(userId)
+  if (ownPatientId === null) return null
+  const proposal = await prisma.adjustmentProposal.findFirst({
+    where: { id: proposalId, patientId: ownPatientId },
+    select: { id: true, patientId: true },
+  })
+  return proposal
+}
+
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  try {
+    const user = requireAuth(req)
+    const { proposalId } = await params
+    const ctx = extractRequestContext(req)
+    const owned = await ensureProposalOwnership(proposalId, user.id)
+    if (!owned) return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    const ack = await proposalAckService.markRead(proposalId, owned.patientId, ctx)
+    return NextResponse.json({ id: ack.id, readAt: ack.readAt })
+  } catch (e) {
+    return mapErrorToResponse(e, "team/proposal-ack POST")
+  }
+}
+
+export async function PUT(req: NextRequest, { params }: RouteParams) {
+  try {
+    const user = requireAuth(req)
+    const { proposalId } = await params
+    const ctx = extractRequestContext(req)
+    const owned = await ensureProposalOwnership(proposalId, user.id)
+    if (!owned) return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    const body = await req.json()
+    const parsed = respondSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: "validationFailed" }, { status: 400 })
+    }
+    const ack = await proposalAckService.respond(
+      proposalId, owned.patientId, parsed.data, ctx,
+    )
+    return NextResponse.json({ id: ack.id, accepted: ack.accepted, respondedAt: ack.respondedAt })
+  } catch (e) {
+    return mapErrorToResponse(e, "team/proposal-ack PUT")
+  }
+}

--- a/src/app/api/team/proposal-ack/[proposalId]/route.ts
+++ b/src/app/api/team/proposal-ack/[proposalId]/route.ts
@@ -1,14 +1,12 @@
 /**
- * US-2065 — Patient acknowledgement / response on an AdjustmentProposal.
- *
- * `POST` marks read; `PUT` records accept/reject decision with optional
- * comment (encrypted). Caller must be the patient (VIEWER) — RBAC + audit
- * trail enforced.
+ * US-2065 — Patient acknowledgement / response on AdjustmentProposal.
+ * Review PR #390 :
+ *  - H2 : propagate `user.id` to the service (audit traceability).
  */
 
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
-import { requireAuth } from "@/lib/auth"
+import { requireAuth, AuthError } from "@/lib/auth"
 import { getOwnPatientId } from "@/lib/access-control"
 import { prisma } from "@/lib/db/client"
 import { proposalAckService } from "@/lib/services/team-workflow.service"
@@ -33,24 +31,25 @@ async function ensureProposalOwnership(proposalId: string, userId: number) {
 }
 
 export async function POST(req: NextRequest, { params }: RouteParams) {
+  const ctx = extractRequestContext(req)
   try {
     const user = requireAuth(req)
     const { proposalId } = await params
-    const ctx = extractRequestContext(req)
     const owned = await ensureProposalOwnership(proposalId, user.id)
     if (!owned) return NextResponse.json({ error: "forbidden" }, { status: 403 })
-    const ack = await proposalAckService.markRead(proposalId, owned.patientId, ctx)
+    const ack = await proposalAckService.markRead(proposalId, owned.patientId, user.id, ctx)
     return NextResponse.json({ id: ack.id, readAt: ack.readAt })
   } catch (e) {
-    return mapErrorToResponse(e, "team/proposal-ack POST")
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/proposal-ack POST", ctx.requestId)
   }
 }
 
 export async function PUT(req: NextRequest, { params }: RouteParams) {
+  const ctx = extractRequestContext(req)
   try {
     const user = requireAuth(req)
     const { proposalId } = await params
-    const ctx = extractRequestContext(req)
     const owned = await ensureProposalOwnership(proposalId, user.id)
     if (!owned) return NextResponse.json({ error: "forbidden" }, { status: 403 })
     const body = await req.json()
@@ -59,10 +58,11 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: "validationFailed" }, { status: 400 })
     }
     const ack = await proposalAckService.respond(
-      proposalId, owned.patientId, parsed.data, ctx,
+      proposalId, owned.patientId, parsed.data, user.id, ctx,
     )
     return NextResponse.json({ id: ack.id, accepted: ack.accepted, respondedAt: ack.respondedAt })
   } catch (e) {
-    return mapErrorToResponse(e, "team/proposal-ack PUT")
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/proposal-ack PUT", ctx.requestId)
   }
 }

--- a/src/app/api/team/proposal-actualization/[proposalId]/route.ts
+++ b/src/app/api/team/proposal-actualization/[proposalId]/route.ts
@@ -1,11 +1,13 @@
-/** US-2066 — Record real-world actualization of an AdjustmentProposal. */
+/** US-2066 — Real-world actualization (review PR #390 C4 + H4). */
 
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
-import { requireRole } from "@/lib/auth"
+import { AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { patientShareConsent } from "@/lib/consent"
 import { proposalActualizationService } from "@/lib/services/team-workflow.service"
-import { extractRequestContext } from "@/lib/services/audit.service"
-import { mapErrorToResponse } from "@/lib/team-route-helpers"
+import { auditService, extractRequestContext } from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
 
 type RouteParams = { params: Promise<{ proposalId: string }> }
 
@@ -14,11 +16,35 @@ const schema = z.object({
   effectiveAt: z.coerce.date().optional(),
 })
 
+const PROPOSAL_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 export async function POST(req: NextRequest, { params }: RouteParams) {
+  const ctx = extractRequestContext(req)
   try {
-    const user = requireRole(req, "NURSE")
     const { proposalId } = await params
-    const ctx = extractRequestContext(req)
+    if (!PROPOSAL_ID_RE.test(proposalId)) {
+      return NextResponse.json({ error: "invalidProposalId" }, { status: 400 })
+    }
+    const user = await auditedRequireRole(req, "NURSE", ctx, "PROPOSAL_ACTUALIZATION", proposalId)
+
+    // C4 — verify access to the patient owning the proposal.
+    const patientId = await proposalActualizationService.getProposalPatientId(proposalId)
+    if (patientId === null) {
+      return NextResponse.json({ error: "proposalNotFound" }, { status: 404 })
+    }
+    const allowed = await canAccessPatient(user.id, user.role, patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id, resource: "PROPOSAL_ACTUALIZATION",
+        resourceId: proposalId,
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: { patientId, proposalId, endpoint: "record" },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+    const consent = await patientShareConsent(patientId)
+    if (!consent.ok) return NextResponse.json({ error: consent.error }, { status: consent.status })
+
     const body = await req.json()
     const parsed = schema.safeParse(body)
     if (!parsed.success) {
@@ -29,6 +55,7 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     )
     return NextResponse.json(row, { status: 201 })
   } catch (e) {
-    return mapErrorToResponse(e, "team/proposal-actualization POST")
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/proposal-actualization POST", ctx.requestId)
   }
 }

--- a/src/app/api/team/proposal-actualization/[proposalId]/route.ts
+++ b/src/app/api/team/proposal-actualization/[proposalId]/route.ts
@@ -1,0 +1,34 @@
+/** US-2066 — Record real-world actualization of an AdjustmentProposal. */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireRole } from "@/lib/auth"
+import { proposalActualizationService } from "@/lib/services/team-workflow.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { mapErrorToResponse } from "@/lib/team-route-helpers"
+
+type RouteParams = { params: Promise<{ proposalId: string }> }
+
+const schema = z.object({
+  verifiedVia: z.enum(["device-sync", "manual-ps", "patient-confirmed"]),
+  effectiveAt: z.coerce.date().optional(),
+})
+
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  try {
+    const user = requireRole(req, "NURSE")
+    const { proposalId } = await params
+    const ctx = extractRequestContext(req)
+    const body = await req.json()
+    const parsed = schema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: "validationFailed" }, { status: 400 })
+    }
+    const row = await proposalActualizationService.record(
+      proposalId, parsed.data, user.id, ctx,
+    )
+    return NextResponse.json(row, { status: 201 })
+  } catch (e) {
+    return mapErrorToResponse(e, "team/proposal-actualization POST")
+  }
+}

--- a/src/app/api/team/read-receipts/route.ts
+++ b/src/app/api/team/read-receipts/route.ts
@@ -1,0 +1,31 @@
+/** US-2080 — Mark a resource as read by the caller (idempotent). */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireRole } from "@/lib/auth"
+import { readReceiptService } from "@/lib/services/team-workflow.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { mapErrorToResponse } from "@/lib/team-route-helpers"
+
+const schema = z.object({
+  resource: z.string().min(1).max(40),
+  resourceId: z.number().int().positive(),
+})
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = requireRole(req, "NURSE")
+    const ctx = extractRequestContext(req)
+    const body = await req.json()
+    const parsed = schema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: "validationFailed" }, { status: 400 })
+    }
+    const r = await readReceiptService.markRead(
+      parsed.data.resource, parsed.data.resourceId, user.id, ctx,
+    )
+    return NextResponse.json(r)
+  } catch (e) {
+    return mapErrorToResponse(e, "team/read-receipts POST")
+  }
+}

--- a/src/app/api/team/read-receipts/route.ts
+++ b/src/app/api/team/read-receipts/route.ts
@@ -1,31 +1,35 @@
-/** US-2080 — Mark a resource as read by the caller (idempotent). */
+/** US-2080 — Mark a resource as read (review PR #390 H1 + H9). */
 
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
-import { requireRole } from "@/lib/auth"
+import { AuthError } from "@/lib/auth"
 import { readReceiptService } from "@/lib/services/team-workflow.service"
 import { extractRequestContext } from "@/lib/services/audit.service"
-import { mapErrorToResponse } from "@/lib/team-route-helpers"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
 
 const schema = z.object({
-  resource: z.string().min(1).max(40),
+  resource: z.enum(["ANNOUNCEMENT", "DELEGATION_REQUEST", "HANDOFF_NOTE"]),
   resourceId: z.number().int().positive(),
 })
 
 export async function POST(req: NextRequest) {
+  const ctx = extractRequestContext(req)
   try {
-    const user = requireRole(req, "NURSE")
-    const ctx = extractRequestContext(req)
     const body = await req.json()
     const parsed = schema.safeParse(body)
     if (!parsed.success) {
       return NextResponse.json({ error: "validationFailed" }, { status: 400 })
     }
+    const user = await auditedRequireRole(
+      req, "NURSE", ctx, "READ_RECEIPT",
+      `${parsed.data.resource}:${parsed.data.resourceId}`,
+    )
     const r = await readReceiptService.markRead(
       parsed.data.resource, parsed.data.resourceId, user.id, ctx,
     )
     return NextResponse.json(r)
   } catch (e) {
-    return mapErrorToResponse(e, "team/read-receipts POST")
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/read-receipts POST", ctx.requestId)
   }
 }

--- a/src/app/api/team/teleconsult-actes/[id]/invoice/route.ts
+++ b/src/app/api/team/teleconsult-actes/[id]/invoice/route.ts
@@ -1,22 +1,23 @@
-/** US-2072 — Marquer un acte téléconsult comme facturé. */
+/** US-2072 — Marquer un acte téléconsult comme facturé (review PR #390 H1 + L11). */
 
 import { NextResponse, type NextRequest } from "next/server"
-import { requireRole } from "@/lib/auth"
+import { AuthError } from "@/lib/auth"
 import { teleconsultActeService } from "@/lib/services/team-workflow.service"
 import { extractRequestContext } from "@/lib/services/audit.service"
-import { mapErrorToResponse } from "@/lib/team-route-helpers"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
 
 type RouteParams = { params: Promise<{ id: string }> }
 
 export async function POST(req: NextRequest, { params }: RouteParams) {
+  const ctx = extractRequestContext(req)
   try {
-    const user = requireRole(req, "ADMIN")
     const { id } = await params
     if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidId" }, { status: 400 })
-    const ctx = extractRequestContext(req)
+    const user = await auditedRequireRole(req, "ADMIN", ctx, "TELECONSULT_ACTE", id)
     const updated = await teleconsultActeService.markInvoiced(parseInt(id, 10), user.id, ctx)
     return NextResponse.json(updated)
   } catch (e) {
-    return mapErrorToResponse(e, "team/teleconsult-actes/:id/invoice POST")
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/teleconsult-actes/:id/invoice POST", ctx.requestId)
   }
 }

--- a/src/app/api/team/teleconsult-actes/[id]/invoice/route.ts
+++ b/src/app/api/team/teleconsult-actes/[id]/invoice/route.ts
@@ -1,0 +1,22 @@
+/** US-2072 — Marquer un acte téléconsult comme facturé. */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { requireRole } from "@/lib/auth"
+import { teleconsultActeService } from "@/lib/services/team-workflow.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { mapErrorToResponse } from "@/lib/team-route-helpers"
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  try {
+    const user = requireRole(req, "ADMIN")
+    const { id } = await params
+    if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidId" }, { status: 400 })
+    const ctx = extractRequestContext(req)
+    const updated = await teleconsultActeService.markInvoiced(parseInt(id, 10), user.id, ctx)
+    return NextResponse.json(updated)
+  } catch (e) {
+    return mapErrorToResponse(e, "team/teleconsult-actes/:id/invoice POST")
+  }
+}

--- a/src/app/api/team/teleconsult-actes/route.ts
+++ b/src/app/api/team/teleconsult-actes/route.ts
@@ -1,0 +1,33 @@
+/** US-2072 — Acte de téléconsultation (lien facturation appointment). */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireRole } from "@/lib/auth"
+import { teleconsultActeService } from "@/lib/services/team-workflow.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { mapErrorToResponse } from "@/lib/team-route-helpers"
+
+const schema = z.object({
+  appointmentId: z.number().int().positive(),
+  billingCode: z.string().regex(/^[A-Z0-9]{2,20}$/),
+  amountCents: z.number().int().min(0).max(1_000_000).optional(),
+})
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = requireRole(req, "DOCTOR")
+    const ctx = extractRequestContext(req)
+    const body = await req.json()
+    const parsed = schema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+    const row = await teleconsultActeService.create(parsed.data, user.id, ctx)
+    return NextResponse.json(row, { status: 201 })
+  } catch (e) {
+    return mapErrorToResponse(e, "team/teleconsult-actes POST")
+  }
+}

--- a/src/app/api/team/teleconsult-actes/route.ts
+++ b/src/app/api/team/teleconsult-actes/route.ts
@@ -1,11 +1,14 @@
-/** US-2072 — Acte de téléconsultation (lien facturation appointment). */
+/**
+ * US-2072 — Acte téléconsult (review PR #390 C3 + H1).
+ */
 
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
-import { requireRole } from "@/lib/auth"
+import { AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
 import { teleconsultActeService } from "@/lib/services/team-workflow.service"
-import { extractRequestContext } from "@/lib/services/audit.service"
-import { mapErrorToResponse } from "@/lib/team-route-helpers"
+import { auditService, extractRequestContext } from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
 
 const schema = z.object({
   appointmentId: z.number().int().positive(),
@@ -14,9 +17,9 @@ const schema = z.object({
 })
 
 export async function POST(req: NextRequest) {
+  const ctx = extractRequestContext(req)
   try {
-    const user = requireRole(req, "DOCTOR")
-    const ctx = extractRequestContext(req)
+    const user = await auditedRequireRole(req, "DOCTOR", ctx, "TELECONSULT_ACTE", "create")
     const body = await req.json()
     const parsed = schema.safeParse(body)
     if (!parsed.success) {
@@ -25,9 +28,27 @@ export async function POST(req: NextRequest) {
         { status: 400 },
       )
     }
+
+    // C3 — verify caller has access to the patient owning the appointment
+    // BEFORE the service writes the billable acte (CCAM fraud guard).
+    const patientId = await teleconsultActeService.getAppointmentPatientId(parsed.data.appointmentId)
+    if (patientId === null) {
+      return NextResponse.json({ error: "appointmentNotFound" }, { status: 404 })
+    }
+    const allowed = await canAccessPatient(user.id, user.role, patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id, resource: "TELECONSULT_ACTE", resourceId: String(parsed.data.appointmentId),
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: { patientId, appointmentId: parsed.data.appointmentId, endpoint: "create" },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+
     const row = await teleconsultActeService.create(parsed.data, user.id, ctx)
     return NextResponse.json(row, { status: 201 })
   } catch (e) {
-    return mapErrorToResponse(e, "team/teleconsult-actes POST")
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/teleconsult-actes POST", ctx.requestId)
   }
 }

--- a/src/app/api/team/templates/[id]/route.ts
+++ b/src/app/api/team/templates/[id]/route.ts
@@ -1,22 +1,23 @@
-/** US-2078 — Suppression d'un template de message. */
+/** US-2078 — Delete template (review PR #390 H1). */
 
 import { NextResponse, type NextRequest } from "next/server"
-import { requireRole } from "@/lib/auth"
+import { AuthError } from "@/lib/auth"
 import { messageTemplateService } from "@/lib/services/team-workflow.service"
 import { extractRequestContext } from "@/lib/services/audit.service"
-import { mapErrorToResponse } from "@/lib/team-route-helpers"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
 
 type RouteParams = { params: Promise<{ id: string }> }
 
 export async function DELETE(req: NextRequest, { params }: RouteParams) {
+  const ctx = extractRequestContext(req)
   try {
-    const user = requireRole(req, "DOCTOR")
     const { id } = await params
     if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidId" }, { status: 400 })
-    const ctx = extractRequestContext(req)
+    const user = await auditedRequireRole(req, "DOCTOR", ctx, "MESSAGE_TEMPLATE", id)
     await messageTemplateService.delete(parseInt(id, 10), user.id, ctx)
     return NextResponse.json({ deleted: true })
   } catch (e) {
-    return mapErrorToResponse(e, "team/templates DELETE")
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/templates DELETE", ctx.requestId)
   }
 }

--- a/src/app/api/team/templates/[id]/route.ts
+++ b/src/app/api/team/templates/[id]/route.ts
@@ -1,0 +1,22 @@
+/** US-2078 — Suppression d'un template de message. */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { requireRole } from "@/lib/auth"
+import { messageTemplateService } from "@/lib/services/team-workflow.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { mapErrorToResponse } from "@/lib/team-route-helpers"
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+export async function DELETE(req: NextRequest, { params }: RouteParams) {
+  try {
+    const user = requireRole(req, "DOCTOR")
+    const { id } = await params
+    if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidId" }, { status: 400 })
+    const ctx = extractRequestContext(req)
+    await messageTemplateService.delete(parseInt(id, 10), user.id, ctx)
+    return NextResponse.json({ deleted: true })
+  } catch (e) {
+    return mapErrorToResponse(e, "team/templates DELETE")
+  }
+}

--- a/src/app/api/team/templates/route.ts
+++ b/src/app/api/team/templates/route.ts
@@ -1,0 +1,52 @@
+/** US-2078 — Templates de messages (cabinet-scoped). */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireRole } from "@/lib/auth"
+import { messageTemplateService } from "@/lib/services/team-workflow.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { mapErrorToResponse } from "@/lib/team-route-helpers"
+
+const querySchema = z.object({ serviceId: z.coerce.number().int().positive() })
+const createSchema = z.object({
+  serviceId: z.number().int().positive(),
+  title: z.string().trim().min(1).max(120),
+  body: z.string().min(1).max(4096),
+  variables: z.array(z.string().min(1).max(40)).max(20).optional(),
+})
+
+export async function GET(req: NextRequest) {
+  try {
+    const user = requireRole(req, "NURSE")
+    const ctx = extractRequestContext(req)
+    const parsed = querySchema.safeParse(
+      Object.fromEntries(req.nextUrl.searchParams.entries()),
+    )
+    if (!parsed.success) {
+      return NextResponse.json({ error: "validationFailed" }, { status: 400 })
+    }
+    const items = await messageTemplateService.list(parsed.data.serviceId, user.id, ctx)
+    return NextResponse.json({ items })
+  } catch (e) {
+    return mapErrorToResponse(e, "team/templates GET")
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = requireRole(req, "DOCTOR")
+    const ctx = extractRequestContext(req)
+    const body = await req.json()
+    const parsed = createSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+    const tpl = await messageTemplateService.create(parsed.data, user.id, ctx)
+    return NextResponse.json(tpl, { status: 201 })
+  } catch (e) {
+    return mapErrorToResponse(e, "team/templates POST")
+  }
+}

--- a/src/app/api/team/templates/route.ts
+++ b/src/app/api/team/templates/route.ts
@@ -1,11 +1,11 @@
-/** US-2078 — Templates de messages (cabinet-scoped). */
+/** US-2078 — Templates de messages (review PR #390 H1). */
 
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
-import { requireRole } from "@/lib/auth"
+import { AuthError } from "@/lib/auth"
 import { messageTemplateService } from "@/lib/services/team-workflow.service"
 import { extractRequestContext } from "@/lib/services/audit.service"
-import { mapErrorToResponse } from "@/lib/team-route-helpers"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
 
 const querySchema = z.object({ serviceId: z.coerce.number().int().positive() })
 const createSchema = z.object({
@@ -16,26 +16,26 @@ const createSchema = z.object({
 })
 
 export async function GET(req: NextRequest) {
+  const ctx = extractRequestContext(req)
   try {
-    const user = requireRole(req, "NURSE")
-    const ctx = extractRequestContext(req)
     const parsed = querySchema.safeParse(
       Object.fromEntries(req.nextUrl.searchParams.entries()),
     )
     if (!parsed.success) {
       return NextResponse.json({ error: "validationFailed" }, { status: 400 })
     }
+    const user = await auditedRequireRole(req, "NURSE", ctx, "MESSAGE_TEMPLATE", String(parsed.data.serviceId))
     const items = await messageTemplateService.list(parsed.data.serviceId, user.id, ctx)
     return NextResponse.json({ items })
   } catch (e) {
-    return mapErrorToResponse(e, "team/templates GET")
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/templates GET", ctx.requestId)
   }
 }
 
 export async function POST(req: NextRequest) {
+  const ctx = extractRequestContext(req)
   try {
-    const user = requireRole(req, "DOCTOR")
-    const ctx = extractRequestContext(req)
     const body = await req.json()
     const parsed = createSchema.safeParse(body)
     if (!parsed.success) {
@@ -44,9 +44,11 @@ export async function POST(req: NextRequest) {
         { status: 400 },
       )
     }
+    const user = await auditedRequireRole(req, "DOCTOR", ctx, "MESSAGE_TEMPLATE", String(parsed.data.serviceId))
     const tpl = await messageTemplateService.create(parsed.data, user.id, ctx)
     return NextResponse.json(tpl, { status: 201 })
   } catch (e) {
-    return mapErrorToResponse(e, "team/templates POST")
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/templates POST", ctx.requestId)
   }
 }

--- a/src/lib/db/client.ts
+++ b/src/lib/db/client.ts
@@ -50,6 +50,17 @@ export const prisma = globalForPrisma.prisma ?? createPrismaClient()
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma
 
+/**
+ * Either the global Prisma client or a transactional one (returned from the
+ * `$transaction` callback). Centralised here so service helpers can accept
+ * "tx or prisma" without re-deriving the type signature in each file.
+ *
+ * Single source of truth — review PR #390 M7.
+ */
+export type PrismaClientOrTx =
+  | Parameters<Parameters<PrismaClient["$transaction"]>[0]>[0]
+  | typeof prisma
+
 // NOTE: Prisma 7 removed $use() middleware.
 // AuditLog immutability is enforced via:
 // 1. Database-level trigger (prisma/sql/audit_immutability.sql)

--- a/src/lib/services/audit.service.ts
+++ b/src/lib/services/audit.service.ts
@@ -53,6 +53,10 @@ export type AuditAction =
   | "BOLUS_CALCULATED"
   | "PROPOSAL_ACCEPTED"
   | "PROPOSAL_REJECTED"
+  /** US-2083 — Decision on a delegation request (distinct from PROPOSAL_* on
+   *  AdjustmentProposal to keep forensic queries clean — review PR #390 C5). */
+  | "DELEGATION_APPROVED"
+  | "DELEGATION_REJECTED"
   | "IMPORT"
   | "ANONYMIZE"
   /** US-2265 — RBAC-breach burst signal (50+ UNAUTHORIZED in 60s by same userId). */

--- a/src/lib/services/audit.service.ts
+++ b/src/lib/services/audit.service.ts
@@ -117,6 +117,26 @@ export type AuditResource =
   | "PATIENT_TAG"
   /** US-2022 — Tag <-> patient assignment. */
   | "PATIENT_TAG_ASSIGNMENT"
+  /** US-2078 — Reusable message templates (cabinet-scoped). */
+  | "MESSAGE_TEMPLATE"
+  /** US-2080 / US-2065 — Generic read receipt / patient acknowledgement. */
+  | "READ_RECEIPT"
+  | "PROPOSAL_ACK"
+  /** US-2066 — Adjustment proposal real-world actualization. */
+  | "PROPOSAL_ACTUALIZATION"
+  /** US-2068 — Structured consultation note. */
+  | "CONSULTATION_NOTE"
+  /** US-2083 — IDE→DOCTOR delegation workflow. */
+  | "DELEGATION_REQUEST"
+  /** US-2084 — Member absence + cover. */
+  | "MEMBER_ABSENCE"
+  /** US-2086 — Handoff note between staff. */
+  | "HANDOFF_NOTE"
+  /** US-2088 — Patient group (cohort). */
+  | "PATIENT_GROUP"
+  | "PATIENT_GROUP_ASSIGNMENT"
+  /** US-2072 — Teleconsultation billing acte. */
+  | "TELECONSULT_ACTE"
 
 /**
  * Audit log entry — parameters for logging an action.

--- a/src/lib/services/team-workflow.errors.ts
+++ b/src/lib/services/team-workflow.errors.ts
@@ -1,0 +1,27 @@
+/**
+ * @module team-workflow.errors
+ * @description Typed errors for the Groupe 3 team-workflow domain (10 US).
+ * Same pattern as `patient-tag.errors.ts` — routes use `instanceof` to map
+ * to HTTP status instead of fragile `error.message === "..."` strings.
+ */
+
+export class ValidationError extends Error {
+  constructor(public readonly field: string) {
+    super("validationFailed")
+    this.name = "ValidationError"
+  }
+}
+
+export class NotFoundError extends Error {
+  constructor() {
+    super("notFound")
+    this.name = "NotFoundError"
+  }
+}
+
+export class ForbiddenError extends Error {
+  constructor() {
+    super("forbidden")
+    this.name = "ForbiddenError"
+  }
+}

--- a/src/lib/services/team-workflow.service.ts
+++ b/src/lib/services/team-workflow.service.ts
@@ -3,33 +3,49 @@
  * @description Groupe 3 — Équipe & Communication (workflow équipe soignante).
  *
  * Domaine couvert (10 US, ~10 SP) :
- *  - US-2078 MessageTemplate : bibliothèque de templates cabinet
- *  - US-2080 ReadReceipt     : tracking lecture (Announcement, etc.)
- *  - US-2065 ProposalAck     : accusé patient sur AdjustmentProposal
- *  - US-2066 ProposalActualization : vérif effective application
- *  - US-2068 ConsultationNote     : note structurée (chiffrée)
- *  - US-2072 TeleconsultActe      : lien facturation appointment
- *  - US-2083 DelegationRequest    : workflow IDE→DOCTOR
- *  - US-2084 MemberAbsence        : congé + couverture
- *  - US-2086 HandoffNote          : transfert annoté (chiffré)
- *  - US-2088 PatientGroup / PatientGroupAssignment : cohortes cabinet
+ *  - US-2078 MessageTemplate
+ *  - US-2080 ReadReceipt (générique)
+ *  - US-2065 ProposalAck (patient)
+ *  - US-2066 ProposalActualization
+ *  - US-2068 ConsultationNote (chiffré)
+ *  - US-2072 TeleconsultActe
+ *  - US-2083 DelegationRequest
+ *  - US-2084 MemberAbsence
+ *  - US-2086 HandoffNote (chiffré)
+ *  - US-2088 PatientGroup
  *
- * Conventions (post-reviews PR #388/389) :
- *  - Typed errors via `team-workflow.errors.ts` (pas de `Error("...")`).
- *  - US-2268 audit pattern : resourceId plat + metadata.patientId pivot.
- *  - Toutes les mutations passent par `prisma.$transaction` avec
- *    isolation `Serializable` quand il y a check+write.
- *  - Encryption AES-256-GCM (base64) pour les champs `content`/`note`
- *    susceptibles de contenir des PII cliniques.
- *  - Soft-delete patient (`deletedAt: null`) garanti au layer DB.
+ * Conventions (post-reviews PR #388/389/390) :
+ *  - Typed errors via `team-workflow.errors.ts`.
+ *  - US-2268 audit pivot : `resourceId` plat + `metadata.patientId`.
+ *  - C5 : actions `DELEGATION_APPROVED`/`REJECTED` distinctes de `PROPOSAL_*`.
+ *  - H2 : `proposalAck.markRead/respond` propagent `auditUserId`.
+ *  - H3 : `markInvoiced` rejette si déjà facturé.
+ *  - H4 : `proposalActualization.record` rejette doublon `(proposalId)`.
+ *  - H6 : `handoffNote.listInbox` audite + filtre `patientShareConsent`.
+ *  - H7 : `memberAbsence.listForMember` check cabinet + audit.
+ *  - H8 : `toUserId` (delegations + handoffs) vérifié membre du même cabinet.
+ *  - H9 : `readReceipt.markRead` vérifie l'accès à la resource ciblée.
+ *  - H11/H12 : typed `Prisma.InputJsonValue` + DTO returns sur respond.
+ *  - M2 : `consultationNote.create` vérifie `appointment.patientId === patientId`.
+ *  - M3 : `memberAbsence` → `ValidationError("memberHasNoService")` si serviceId null.
+ *  - M4 : `setForPatient` n'utilise plus `skipDuplicates` après deleteMany.
+ *  - M8 : `verifiedVia` typed literal union (pas `string`).
+ *  - M9 : DTO returns pour `messageTemplate`, `patientGroup`, `teleconsultActe`, etc.
+ *  - M11 : `delegationRequest.create` rejette self-delegation.
+ *  - M14 : audit READ sur tous les listings PHI.
+ *  - L1 : `ALLOWED_READ_RESOURCES` typed literal union.
+ *  - L4 : `DelegationDecision` alias nommé.
+ *  - L8 : `proposalAck.respond` length-check côté service.
+ *
+ *  Encryption AES-256-GCM (base64) sur `ConsultationNote.content`,
+ *  `HandoffNote.note`, `ProposalAck.comment`.
  */
 
 import {
   Prisma,
   type DelegationRequestStatus,
-  type PrismaClient,
 } from "@prisma/client"
-import { prisma } from "@/lib/db/client"
+import { prisma, type PrismaClientOrTx as Tx } from "@/lib/db/client"
 import { auditService } from "./audit.service"
 import type { AuditContext } from "./audit.service"
 import { encryptField, safeDecryptField } from "@/lib/crypto/fields"
@@ -38,8 +54,6 @@ import {
   NotFoundError,
   ValidationError,
 } from "./team-workflow.errors"
-
-type Tx = Parameters<Parameters<PrismaClient["$transaction"]>[0]>[0] | typeof prisma
 
 async function assertServiceMember(
   userId: number,
@@ -59,6 +73,31 @@ async function assertPatientAlive(patientId: number, tx: Tx = prisma): Promise<v
   if (!p) throw new NotFoundError()
 }
 
+/**
+ * H8 — Verify the target user belongs to a service that ALSO covers the patient
+ * AND that the caller is a member of. Used by `delegations` and `handoffs` to
+ * prevent sending workflow rows to arbitrary users.
+ */
+async function assertColleagueWithPatientAccess(
+  fromUserId: number,
+  toUserId: number,
+  patientId: number,
+  tx: Tx = prisma,
+): Promise<void> {
+  if (fromUserId === toUserId) throw new ValidationError("selfTarget") // M11
+  const link = await tx.patientService.findFirst({
+    where: {
+      patientId,
+      service: {
+        members: { some: { userId: fromUserId } },
+        AND: { members: { some: { userId: toUserId } } },
+      },
+    },
+    select: { id: true },
+  })
+  if (!link) throw new ForbiddenError()
+}
+
 // ─────────────────────────────────────────────────────────────
 // US-2078 — Message templates (cabinet-scoped)
 // ─────────────────────────────────────────────────────────────
@@ -66,11 +105,25 @@ async function assertPatientAlive(patientId: number, tx: Tx = prisma): Promise<v
 const TEMPLATE_TITLE_MAX = 120
 const TEMPLATE_BODY_MAX = 4096
 
+export type MessageTemplateDTO = {
+  id: number
+  serviceId: number
+  title: string
+  body: string
+  variables: string[]
+}
+function toMessageTemplateDTO(t: {
+  id: number; serviceId: number; title: string; body: string; variables: string[]
+}): MessageTemplateDTO {
+  return { id: t.id, serviceId: t.serviceId, title: t.title, body: t.body, variables: t.variables }
+}
+
 export const messageTemplateService = {
-  async list(serviceId: number, auditUserId: number, ctx?: AuditContext) {
+  async list(serviceId: number, auditUserId: number, ctx?: AuditContext): Promise<MessageTemplateDTO[]> {
     await assertServiceMember(auditUserId, serviceId)
     const items = await prisma.messageTemplate.findMany({
       where: { serviceId }, orderBy: { title: "asc" },
+      select: { id: true, serviceId: true, title: true, body: true, variables: true },
     })
     await auditService.log({
       userId: auditUserId, action: "READ", resource: "MESSAGE_TEMPLATE",
@@ -78,13 +131,13 @@ export const messageTemplateService = {
       ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
       metadata: { kind: "list", serviceId, count: items.length },
     })
-    return items
+    return items.map(toMessageTemplateDTO)
   },
 
   async create(
     input: { serviceId: number; title: string; body: string; variables?: string[] },
     auditUserId: number, ctx?: AuditContext,
-  ) {
+  ): Promise<MessageTemplateDTO> {
     if (!input.title.trim() || input.title.length > TEMPLATE_TITLE_MAX) {
       throw new ValidationError("title")
     }
@@ -101,6 +154,7 @@ export const messageTemplateService = {
           variables: input.variables ?? [],
           createdBy: auditUserId,
         },
+        select: { id: true, serviceId: true, title: true, body: true, variables: true },
       })
       await auditService.logWithTx(tx, {
         userId: auditUserId, action: "CREATE", resource: "MESSAGE_TEMPLATE",
@@ -108,7 +162,7 @@ export const messageTemplateService = {
         ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
         metadata: { serviceId: input.serviceId },
       })
-      return tpl
+      return toMessageTemplateDTO(tpl)
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
   },
 
@@ -132,40 +186,68 @@ export const messageTemplateService = {
 }
 
 // ─────────────────────────────────────────────────────────────
-// US-2080 — Read receipts (generic over `resource` + `resourceId`)
+// US-2080 — Read receipts (typed literal resource set, L1)
 // ─────────────────────────────────────────────────────────────
 
-const ALLOWED_READ_RESOURCES = new Set(["ANNOUNCEMENT", "DELEGATION_REQUEST", "HANDOFF_NOTE"])
+const ALLOWED_READ_RESOURCES = ["ANNOUNCEMENT", "DELEGATION_REQUEST", "HANDOFF_NOTE"] as const
+type ReadReceiptResource = typeof ALLOWED_READ_RESOURCES[number]
+
+function isAllowedReadResource(s: string): s is ReadReceiptResource {
+  return (ALLOWED_READ_RESOURCES as readonly string[]).includes(s)
+}
+
+/**
+ * H9 — verify the caller is the legitimate audience for the resource being
+ * marked as read. Prevents cross-cabinet tampering on workflow rows.
+ */
+async function assertReadAccess(
+  resource: ReadReceiptResource,
+  resourceId: number,
+  userId: number,
+): Promise<void> {
+  if (resource === "DELEGATION_REQUEST") {
+    const row = await prisma.delegationRequest.findFirst({
+      where: { id: resourceId, toUserId: userId }, select: { id: true },
+    })
+    if (!row) throw new ForbiddenError()
+    return
+  }
+  if (resource === "HANDOFF_NOTE") {
+    const row = await prisma.handoffNote.findFirst({
+      where: { id: resourceId, toUserId: userId }, select: { id: true },
+    })
+    if (!row) throw new ForbiddenError()
+    return
+  }
+  if (resource === "ANNOUNCEMENT") {
+    const row = await prisma.announcement.findFirst({
+      where: { id: resourceId }, select: { id: true },
+    })
+    if (!row) throw new NotFoundError()
+    return
+  }
+}
 
 export const readReceiptService = {
   async markRead(
     resource: string, resourceId: number, auditUserId: number, ctx?: AuditContext,
   ) {
-    if (!ALLOWED_READ_RESOURCES.has(resource)) throw new ValidationError("resource")
-    // Idempotent upsert : `(resource, resourceId, userId)` unique.
+    if (!isAllowedReadResource(resource)) throw new ValidationError("resource")
+    await assertReadAccess(resource, resourceId, auditUserId)
     const r = await prisma.readReceipt.upsert({
       where: {
         resource_resourceId_userId: { resource, resourceId, userId: auditUserId },
       },
       create: { resource, resourceId, userId: auditUserId },
-      update: {}, // no-op : already read
+      update: {},
     })
     await auditService.log({
       userId: auditUserId, action: "READ", resource: "READ_RECEIPT",
-      resourceId: `${resource}:${resourceId}`,
+      resourceId: String(r.id),
       ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
-      metadata: { resource, resourceId, receiptId: r.id },
+      metadata: { resource, parentResourceId: resourceId },
     })
     return { readAt: r.readAt }
-  },
-
-  async listReadersFor(resource: string, resourceId: number) {
-    if (!ALLOWED_READ_RESOURCES.has(resource)) throw new ValidationError("resource")
-    return prisma.readReceipt.findMany({
-      where: { resource, resourceId },
-      orderBy: { readAt: "asc" },
-      select: { userId: true, readAt: true },
-    })
   },
 }
 
@@ -173,15 +255,23 @@ export const readReceiptService = {
 // US-2065 — Patient acknowledgement of an AdjustmentProposal
 // ─────────────────────────────────────────────────────────────
 
+const ACK_COMMENT_MAX = 500
+
 export const proposalAckService = {
-  async markRead(proposalId: string, patientId: number, ctx?: AuditContext) {
+  async markRead(
+    proposalId: string,
+    patientId: number,
+    auditUserId: number,         // H2 — propagated from route
+    ctx?: AuditContext,
+  ) {
     const ack = await prisma.adjustmentProposalAck.upsert({
       where: { proposalId },
       create: { proposalId, patientId, acknowledged: true, readAt: new Date() },
       update: { acknowledged: true, readAt: new Date() },
+      select: { id: true, readAt: true },
     })
     await auditService.log({
-      userId: null, // côté patient app (VIEWER); l'API route renseignera si dispo.
+      userId: auditUserId,
       action: "READ", resource: "PROPOSAL_ACK", resourceId: proposalId,
       ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
       metadata: { patientId, proposalId, kind: "read" },
@@ -192,8 +282,13 @@ export const proposalAckService = {
   async respond(
     proposalId: string, patientId: number,
     decision: { accepted: boolean; comment?: string },
+    auditUserId: number,         // H2
     ctx?: AuditContext,
   ) {
+    // L8 — defensive length check at the service layer too.
+    if (decision.comment && decision.comment.length > ACK_COMMENT_MAX) {
+      throw new ValidationError("comment")
+    }
     const encrypted = decision.comment ? encryptField(decision.comment) : null
     const ack = await prisma.adjustmentProposalAck.upsert({
       where: { proposalId },
@@ -207,47 +302,47 @@ export const proposalAckService = {
         accepted: decision.accepted, respondedAt: new Date(),
         comment: encrypted,
       },
+      select: { id: true, accepted: true, respondedAt: true },
     })
     await auditService.log({
-      userId: null, action: "UPDATE", resource: "PROPOSAL_ACK",
-      resourceId: proposalId,
+      userId: auditUserId,
+      action: "UPDATE", resource: "PROPOSAL_ACK", resourceId: proposalId,
       ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
       metadata: { patientId, proposalId, accepted: decision.accepted, kind: "respond" },
     })
     return ack
   },
-
-  async getForProposal(proposalId: string) {
-    const ack = await prisma.adjustmentProposalAck.findUnique({ where: { proposalId } })
-    if (!ack) return null
-    return {
-      ...ack,
-      comment: ack.comment ? safeDecryptField(ack.comment) : null,
-    }
-  },
 }
 
 // ─────────────────────────────────────────────────────────────
-// US-2066 — Real-world actualization of an adjustment proposal
+// US-2066 — Real-world actualization (H4 guard against overwrite, M8 literal)
 // ─────────────────────────────────────────────────────────────
 
-const ALLOWED_VERIFY_VIA = new Set(["device-sync", "manual-ps", "patient-confirmed"])
+const VERIFY_VIA_VALUES = ["device-sync", "manual-ps", "patient-confirmed"] as const
+export type VerifyVia = typeof VERIFY_VIA_VALUES[number]
 
 export const proposalActualizationService = {
   async record(
     proposalId: string,
-    input: { verifiedVia: string; effectiveAt?: Date },
+    input: { verifiedVia: VerifyVia; effectiveAt?: Date },
     auditUserId: number,
     ctx?: AuditContext,
   ) {
-    if (!ALLOWED_VERIFY_VIA.has(input.verifiedVia)) {
-      throw new ValidationError("verifiedVia")
-    }
     return prisma.$transaction(async (tx) => {
       const proposal = await tx.adjustmentProposal.findUnique({
         where: { id: proposalId }, select: { patientId: true },
       })
       if (!proposal) throw new NotFoundError()
+
+      // H4 — refuse to silently overwrite a prior actualization. Allow re-record
+      // only if same source (`device-sync` re-sync is idempotent and OK).
+      const existing = await tx.adjustmentProposalActualization.findUnique({
+        where: { proposalId }, select: { verifiedVia: true },
+      })
+      if (existing && existing.verifiedVia !== input.verifiedVia) {
+        throw new ValidationError("alreadyActualized")
+      }
+
       const row = await tx.adjustmentProposalActualization.upsert({
         where: { proposalId },
         create: {
@@ -257,13 +352,13 @@ export const proposalActualizationService = {
           verifiedBy: input.verifiedVia === "device-sync" ? null : auditUserId,
         },
         update: {
-          verifiedVia: input.verifiedVia,
           effectiveAt: input.effectiveAt ?? new Date(),
-          verifiedBy: input.verifiedVia === "device-sync" ? null : auditUserId,
         },
       })
       await auditService.logWithTx(tx, {
-        userId: auditUserId, action: "CREATE", resource: "PROPOSAL_ACTUALIZATION",
+        userId: auditUserId,
+        action: existing ? "UPDATE" : "CREATE",
+        resource: "PROPOSAL_ACTUALIZATION",
         resourceId: proposalId,
         ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
         metadata: {
@@ -274,10 +369,21 @@ export const proposalActualizationService = {
       return row
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
   },
+
+  /**
+   * Convenience for routes: returns the patient that owns a proposal (used by
+   * the route to RBAC-check `canAccessPatient` before calling `record`).
+   */
+  async getProposalPatientId(proposalId: string): Promise<number | null> {
+    const p = await prisma.adjustmentProposal.findUnique({
+      where: { id: proposalId }, select: { patientId: true },
+    })
+    return p?.patientId ?? null
+  },
 }
 
 // ─────────────────────────────────────────────────────────────
-// US-2068 — Consultation notes (encrypted)
+// US-2068 — Consultation notes (M2 verify appointment ownership)
 // ─────────────────────────────────────────────────────────────
 
 const NOTE_MAX_LEN = 8192
@@ -298,6 +404,14 @@ export const consultationNoteService = {
     }
     return prisma.$transaction(async (tx) => {
       await assertPatientAlive(input.patientId, tx)
+      // M2 — verify the linked appointment actually belongs to the patient.
+      if (input.appointmentId !== undefined) {
+        const appt = await tx.appointment.findFirst({
+          where: { id: input.appointmentId, patientId: input.patientId },
+          select: { id: true },
+        })
+        if (!appt) throw new ValidationError("appointmentMismatch")
+      }
       const row = await tx.consultationNote.create({
         data: {
           patientId: input.patientId,
@@ -306,6 +420,7 @@ export const consultationNoteService = {
           content: encryptField(input.content),
           category: input.category,
         },
+        select: { id: true, createdAt: true },
       })
       await auditService.logWithTx(tx, {
         userId: input.authorId, action: "CREATE", resource: "CONSULTATION_NOTE",
@@ -313,7 +428,7 @@ export const consultationNoteService = {
         ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
         metadata: { patientId: input.patientId, hasAppointment: !!input.appointmentId },
       })
-      return { id: row.id, createdAt: row.createdAt }
+      return row
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
   },
 
@@ -339,16 +454,41 @@ export const consultationNoteService = {
 }
 
 // ─────────────────────────────────────────────────────────────
-// US-2072 — Teleconsultation billing acte
+// US-2072 — Teleconsultation billing (H3 guard against double-invoicing)
 // ─────────────────────────────────────────────────────────────
 
 const BILLING_CODE_RE = /^[A-Z0-9]{2,20}$/
 
+export type TeleconsultActeDTO = {
+  id: number
+  appointmentId: number
+  billingCode: string
+  amountCents: number | null
+  invoicedAt: Date | null
+}
+function toTeleconsultDTO(t: {
+  id: number; appointmentId: number; billingCode: string;
+  amountCents: number | null; invoicedAt: Date | null;
+}): TeleconsultActeDTO {
+  return {
+    id: t.id, appointmentId: t.appointmentId, billingCode: t.billingCode,
+    amountCents: t.amountCents, invoicedAt: t.invoicedAt,
+  }
+}
+
 export const teleconsultActeService = {
+  /** Helper for routes — fetch the patient owning the appointment. */
+  async getAppointmentPatientId(appointmentId: number): Promise<number | null> {
+    const a = await prisma.appointment.findUnique({
+      where: { id: appointmentId }, select: { patientId: true },
+    })
+    return a?.patientId ?? null
+  },
+
   async create(
     input: { appointmentId: number; billingCode: string; amountCents?: number },
     auditUserId: number, ctx?: AuditContext,
-  ) {
+  ): Promise<TeleconsultActeDTO> {
     if (!BILLING_CODE_RE.test(input.billingCode)) {
       throw new ValidationError("billingCode")
     }
@@ -367,6 +507,10 @@ export const teleconsultActeService = {
           billingCode: input.billingCode,
           amountCents: input.amountCents,
         },
+        select: {
+          id: true, appointmentId: true, billingCode: true,
+          amountCents: true, invoicedAt: true,
+        },
       })
       await auditService.logWithTx(tx, {
         userId: auditUserId, action: "CREATE", resource: "TELECONSULT_ACTE",
@@ -377,19 +521,26 @@ export const teleconsultActeService = {
           appointmentId: input.appointmentId, billingCode: input.billingCode,
         },
       })
-      return row
+      return toTeleconsultDTO(row)
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
   },
 
-  async markInvoiced(id: number, auditUserId: number, ctx?: AuditContext) {
+  async markInvoiced(id: number, auditUserId: number, ctx?: AuditContext): Promise<TeleconsultActeDTO> {
     return prisma.$transaction(async (tx) => {
       const acte = await tx.teleconsultationActe.findUnique({
         where: { id }, include: { appointment: { select: { patientId: true } } },
       })
       if (!acte) throw new NotFoundError()
+      // H3 — refuse double-invoicing.
+      if (acte.invoicedAt) throw new ValidationError("alreadyInvoiced")
+
       const updated = await tx.teleconsultationActe.update({
         where: { id },
         data: { invoicedAt: new Date(), invoicedBy: auditUserId },
+        select: {
+          id: true, appointmentId: true, billingCode: true,
+          amountCents: true, invoicedAt: true,
+        },
       })
       await auditService.logWithTx(tx, {
         userId: auditUserId, action: "UPDATE", resource: "TELECONSULT_ACTE",
@@ -400,35 +551,66 @@ export const teleconsultActeService = {
           billingCode: acte.billingCode, kind: "invoiced",
         },
       })
-      return updated
+      return toTeleconsultDTO(updated)
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
   },
 }
 
 // ─────────────────────────────────────────────────────────────
-// US-2083 — Delegation requests (IDE → DOCTOR)
+// US-2083 — Delegation requests (H5 payload schema, H8 cabinet, M11 self)
 // ─────────────────────────────────────────────────────────────
+
+export type DelegationDecision = Extract<DelegationRequestStatus, "approved" | "rejected">
+
+const DELEGATION_PAYLOAD_MAX_BYTES = 2048
+const DELEGATION_PAYLOAD_PII_RE = /\b(0[1-9])(\s*[\s.-]?\d{2}){4}\b|\d{7,}|@|\bnir\b|\bins\b/i
+
+function validateDelegationPayload(payload: unknown): Prisma.InputJsonValue | undefined {
+  if (payload === undefined || payload === null) return undefined
+  if (typeof payload !== "object" || Array.isArray(payload)) {
+    throw new ValidationError("payloadShape")
+  }
+  const serialized = JSON.stringify(payload)
+  if (serialized.length > DELEGATION_PAYLOAD_MAX_BYTES) {
+    throw new ValidationError("payloadSize")
+  }
+  // H5 — refuse free-form clinical PHI (digits, phone, email, NIR/INS mention).
+  if (DELEGATION_PAYLOAD_PII_RE.test(serialized)) {
+    throw new ValidationError("payloadLooksLikePii")
+  }
+  return payload as Prisma.InputJsonValue
+}
 
 export const delegationRequestService = {
   async create(
     input: {
       patientId: number; fromUserId: number; toUserId: number;
-      action: string; payload?: Prisma.InputJsonValue;
+      action: string; payload?: unknown;
     },
     ctx?: AuditContext,
   ) {
     if (!input.action.trim() || input.action.length > 80) {
       throw new ValidationError("action")
     }
+    const safePayload = validateDelegationPayload(input.payload)
+
     return prisma.$transaction(async (tx) => {
       await assertPatientAlive(input.patientId, tx)
+      // H8 + M11 — caller and target must share a service with patient access.
+      await assertColleagueWithPatientAccess(
+        input.fromUserId, input.toUserId, input.patientId, tx,
+      )
       const row = await tx.delegationRequest.create({
         data: {
           patientId: input.patientId,
           fromUserId: input.fromUserId,
           toUserId: input.toUserId,
           action: input.action.trim(),
-          payload: input.payload ?? Prisma.JsonNull,
+          payload: safePayload ?? Prisma.JsonNull,
+        },
+        select: {
+          id: true, patientId: true, fromUserId: true, toUserId: true,
+          action: true, status: true, createdAt: true,
         },
       })
       await auditService.logWithTx(tx, {
@@ -437,13 +619,13 @@ export const delegationRequestService = {
         ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
         metadata: { patientId: input.patientId, toUserId: input.toUserId, action: input.action },
       })
-      return row
+      return row // H12 — narrowed select (no payload returned)
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
   },
 
   async respond(
     id: number, reviewerId: number,
-    decision: { status: Extract<DelegationRequestStatus, "approved" | "rejected">; reason?: string },
+    decision: { status: DelegationDecision; reason?: string },
     ctx?: AuditContext,
   ) {
     return prisma.$transaction(async (tx) => {
@@ -462,13 +644,17 @@ export const delegationRequestService = {
           reviewedAt: new Date(),
           reason: decision.reason?.slice(0, 500),
         },
+        select: {
+          id: true, patientId: true, status: true, reviewedAt: true,
+        },
       })
       await auditService.logWithTx(tx, {
         userId: reviewerId,
-        action: decision.status === "approved" ? "PROPOSAL_ACCEPTED" : "PROPOSAL_REJECTED",
+        // C5 — actions dédiées (plus de PROPOSAL_ACCEPTED/REJECTED ici).
+        action: decision.status === "approved" ? "DELEGATION_APPROVED" : "DELEGATION_REJECTED",
         resource: "DELEGATION_REQUEST", resourceId: String(id),
         ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
-        metadata: { patientId: req.patientId, status: decision.status },
+        metadata: { patientId: req.patientId, status: decision.status }, // pivot US-2268
       })
       return updated
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
@@ -479,6 +665,10 @@ export const delegationRequestService = {
       where: { toUserId, status: "pending" },
       orderBy: { createdAt: "desc" },
       take: 100,
+      select: {
+        id: true, patientId: true, fromUserId: true,
+        action: true, status: true, createdAt: true,
+      },
     })
     await auditService.log({
       userId: toUserId, action: "READ", resource: "DELEGATION_REQUEST",
@@ -491,7 +681,7 @@ export const delegationRequestService = {
 }
 
 // ─────────────────────────────────────────────────────────────
-// US-2084 — Member absences + cover
+// US-2084 — Member absences (M3, H7 — listForMember check)
 // ─────────────────────────────────────────────────────────────
 
 export const memberAbsenceService = {
@@ -507,7 +697,8 @@ export const memberAbsenceService = {
       const member = await tx.healthcareMember.findUnique({
         where: { id: input.memberId }, select: { id: true, serviceId: true },
       })
-      if (!member || member.serviceId === null) throw new NotFoundError()
+      if (!member) throw new NotFoundError()
+      if (member.serviceId === null) throw new ValidationError("memberHasNoService") // M3
       await assertServiceMember(auditUserId, member.serviceId, tx)
       const row = await tx.memberAbsence.create({
         data: {
@@ -531,17 +722,35 @@ export const memberAbsenceService = {
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
   },
 
-  async listForMember(memberId: number) {
-    return prisma.memberAbsence.findMany({
+  /**
+   * H7 — caller must be a member of the absent member's service. Audit READ
+   * row emitted with `metadata.memberId`.
+   */
+  async listForMember(memberId: number, auditUserId: number, ctx?: AuditContext) {
+    const member = await prisma.healthcareMember.findUnique({
+      where: { id: memberId }, select: { id: true, serviceId: true },
+    })
+    if (!member) throw new NotFoundError()
+    if (member.serviceId === null) throw new ValidationError("memberHasNoService")
+    await assertServiceMember(auditUserId, member.serviceId)
+
+    const items = await prisma.memberAbsence.findMany({
       where: { memberId },
       orderBy: { startDate: "desc" },
       take: 50,
     })
+    await auditService.log({
+      userId: auditUserId, action: "READ", resource: "MEMBER_ABSENCE",
+      resourceId: String(memberId),
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { memberId, serviceId: member.serviceId, count: items.length },
+    })
+    return items
   },
 }
 
 // ─────────────────────────────────────────────────────────────
-// US-2086 — Handoff notes (encrypted)
+// US-2086 — Handoff notes (H6 audit + consent, H8 colleague check)
 // ─────────────────────────────────────────────────────────────
 
 const HANDOFF_MAX_LEN = 4096
@@ -556,6 +765,9 @@ export const handoffNoteService = {
     }
     return prisma.$transaction(async (tx) => {
       await assertPatientAlive(input.patientId, tx)
+      await assertColleagueWithPatientAccess(
+        input.fromUserId, input.toUserId, input.patientId, tx,
+      )
       const row = await tx.handoffNote.create({
         data: {
           patientId: input.patientId,
@@ -563,6 +775,7 @@ export const handoffNoteService = {
           toUserId: input.toUserId,
           note: encryptField(input.note),
         },
+        select: { id: true, createdAt: true },
       })
       await auditService.logWithTx(tx, {
         userId: input.fromUserId, action: "CREATE", resource: "HANDOFF_NOTE",
@@ -570,7 +783,7 @@ export const handoffNoteService = {
         ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
         metadata: { patientId: input.patientId, toUserId: input.toUserId },
       })
-      return { id: row.id, createdAt: row.createdAt }
+      return row
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
   },
 
@@ -584,6 +797,7 @@ export const handoffNoteService = {
       if (h.acknowledgedAt) return { acknowledgedAt: h.acknowledgedAt }
       const updated = await tx.handoffNote.update({
         where: { id }, data: { acknowledgedAt: new Date() },
+        select: { acknowledgedAt: true },
       })
       await auditService.logWithTx(tx, {
         userId, action: "UPDATE", resource: "HANDOFF_NOTE",
@@ -591,31 +805,54 @@ export const handoffNoteService = {
         ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
         metadata: { patientId: h.patientId, kind: "ack" },
       })
-      return { acknowledgedAt: updated.acknowledgedAt }
+      return updated
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
   },
 
-  async listInbox(toUserId: number) {
+  /**
+   * H6 — audit READ + filter to consenting patients (RGPD Art. 7.3).
+   * `note` is decrypted on the way out. The filter goes via the privacy
+   * settings of the patient's user.
+   */
+  async listInbox(toUserId: number, ctx?: AuditContext) {
     const items = await prisma.handoffNote.findMany({
-      where: { toUserId, acknowledgedAt: null, patient: { deletedAt: null } },
+      where: {
+        toUserId, acknowledgedAt: null,
+        patient: {
+          deletedAt: null,
+          user: { privacySettings: { gdprConsent: true, shareWithProviders: true } },
+        },
+      },
       orderBy: { createdAt: "desc" },
       take: 50,
+    })
+    await auditService.log({
+      userId: toUserId, action: "READ", resource: "HANDOFF_NOTE",
+      resourceId: "inbox",
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { toUserId, count: items.length },
     })
     return items.map((h) => ({ ...h, note: safeDecryptField(h.note) }))
   },
 }
 
 // ─────────────────────────────────────────────────────────────
-// US-2088 — Patient groups (cohorts) + assignment
+// US-2088 — Patient groups (cohorts)
 // ─────────────────────────────────────────────────────────────
 
 const GROUP_LABEL_MAX = 80
 
+export type PatientGroupDTO = { id: number; serviceId: number; label: string }
+function toPatientGroupDTO(g: { id: number; serviceId: number; label: string }): PatientGroupDTO {
+  return { id: g.id, serviceId: g.serviceId, label: g.label }
+}
+
 export const patientGroupService = {
-  async listForService(serviceId: number, auditUserId: number, ctx?: AuditContext) {
+  async listForService(serviceId: number, auditUserId: number, ctx?: AuditContext): Promise<PatientGroupDTO[]> {
     await assertServiceMember(auditUserId, serviceId)
     const items = await prisma.patientGroup.findMany({
       where: { serviceId }, orderBy: { label: "asc" },
+      select: { id: true, serviceId: true, label: true },
     })
     await auditService.log({
       userId: auditUserId, action: "READ", resource: "PATIENT_GROUP",
@@ -623,19 +860,20 @@ export const patientGroupService = {
       ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
       metadata: { kind: "list", serviceId, count: items.length },
     })
-    return items
+    return items.map(toPatientGroupDTO)
   },
 
   async create(
     input: { serviceId: number; label: string },
     auditUserId: number, ctx?: AuditContext,
-  ) {
+  ): Promise<PatientGroupDTO> {
     const label = input.label.trim()
     if (!label || label.length > GROUP_LABEL_MAX) throw new ValidationError("label")
     return prisma.$transaction(async (tx) => {
       await assertServiceMember(auditUserId, input.serviceId, tx)
       const g = await tx.patientGroup.create({
         data: { serviceId: input.serviceId, label, createdBy: auditUserId },
+        select: { id: true, serviceId: true, label: true },
       })
       await auditService.logWithTx(tx, {
         userId: auditUserId, action: "CREATE", resource: "PATIENT_GROUP",
@@ -643,7 +881,7 @@ export const patientGroupService = {
         ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
         metadata: { serviceId: input.serviceId },
       })
-      return g
+      return toPatientGroupDTO(g)
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
   },
 
@@ -669,9 +907,10 @@ export const patientGroupService = {
       }
       await tx.patientGroupAssignment.deleteMany({ where: { patientId } })
       if (unique.length > 0) {
+        // M4 — `skipDuplicates` retiré : on vient de tout supprimer, plus de
+        // doublon possible. Simplifie le mock + clarifie l'intention.
         await tx.patientGroupAssignment.createMany({
           data: unique.map((groupId) => ({ patientId, groupId, assignedBy: auditUserId })),
-          skipDuplicates: true,
         })
       }
       await auditService.logWithTx(tx, {
@@ -684,12 +923,18 @@ export const patientGroupService = {
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
   },
 
-  async listForPatient(patientId: number) {
+  async listForPatient(patientId: number, auditUserId: number, ctx?: AuditContext) {
     const assignments = await prisma.patientGroupAssignment.findMany({
       where: { patientId, patient: { deletedAt: null } },
-      include: { group: true },
+      include: { group: { select: { id: true, serviceId: true, label: true } } },
       orderBy: { group: { label: "asc" } },
     })
-    return assignments.map((a) => a.group)
+    await auditService.log({
+      userId: auditUserId, action: "READ", resource: "PATIENT_GROUP_ASSIGNMENT",
+      resourceId: String(patientId),
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { patientId, kind: "list", count: assignments.length },
+    })
+    return assignments.map((a) => toPatientGroupDTO(a.group))
   },
 }

--- a/src/lib/services/team-workflow.service.ts
+++ b/src/lib/services/team-workflow.service.ts
@@ -1,0 +1,695 @@
+/**
+ * @module team-workflow.service
+ * @description Groupe 3 — Équipe & Communication (workflow équipe soignante).
+ *
+ * Domaine couvert (10 US, ~10 SP) :
+ *  - US-2078 MessageTemplate : bibliothèque de templates cabinet
+ *  - US-2080 ReadReceipt     : tracking lecture (Announcement, etc.)
+ *  - US-2065 ProposalAck     : accusé patient sur AdjustmentProposal
+ *  - US-2066 ProposalActualization : vérif effective application
+ *  - US-2068 ConsultationNote     : note structurée (chiffrée)
+ *  - US-2072 TeleconsultActe      : lien facturation appointment
+ *  - US-2083 DelegationRequest    : workflow IDE→DOCTOR
+ *  - US-2084 MemberAbsence        : congé + couverture
+ *  - US-2086 HandoffNote          : transfert annoté (chiffré)
+ *  - US-2088 PatientGroup / PatientGroupAssignment : cohortes cabinet
+ *
+ * Conventions (post-reviews PR #388/389) :
+ *  - Typed errors via `team-workflow.errors.ts` (pas de `Error("...")`).
+ *  - US-2268 audit pattern : resourceId plat + metadata.patientId pivot.
+ *  - Toutes les mutations passent par `prisma.$transaction` avec
+ *    isolation `Serializable` quand il y a check+write.
+ *  - Encryption AES-256-GCM (base64) pour les champs `content`/`note`
+ *    susceptibles de contenir des PII cliniques.
+ *  - Soft-delete patient (`deletedAt: null`) garanti au layer DB.
+ */
+
+import {
+  Prisma,
+  type DelegationRequestStatus,
+  type PrismaClient,
+} from "@prisma/client"
+import { prisma } from "@/lib/db/client"
+import { auditService } from "./audit.service"
+import type { AuditContext } from "./audit.service"
+import { encryptField, safeDecryptField } from "@/lib/crypto/fields"
+import {
+  ForbiddenError,
+  NotFoundError,
+  ValidationError,
+} from "./team-workflow.errors"
+
+type Tx = Parameters<Parameters<PrismaClient["$transaction"]>[0]>[0] | typeof prisma
+
+async function assertServiceMember(
+  userId: number,
+  serviceId: number,
+  tx: Tx = prisma,
+): Promise<void> {
+  const link = await tx.healthcareMember.findFirst({
+    where: { userId, serviceId }, select: { id: true },
+  })
+  if (!link) throw new ForbiddenError()
+}
+
+async function assertPatientAlive(patientId: number, tx: Tx = prisma): Promise<void> {
+  const p = await tx.patient.findFirst({
+    where: { id: patientId, deletedAt: null }, select: { id: true },
+  })
+  if (!p) throw new NotFoundError()
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2078 — Message templates (cabinet-scoped)
+// ─────────────────────────────────────────────────────────────
+
+const TEMPLATE_TITLE_MAX = 120
+const TEMPLATE_BODY_MAX = 4096
+
+export const messageTemplateService = {
+  async list(serviceId: number, auditUserId: number, ctx?: AuditContext) {
+    await assertServiceMember(auditUserId, serviceId)
+    const items = await prisma.messageTemplate.findMany({
+      where: { serviceId }, orderBy: { title: "asc" },
+    })
+    await auditService.log({
+      userId: auditUserId, action: "READ", resource: "MESSAGE_TEMPLATE",
+      resourceId: String(serviceId),
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { kind: "list", serviceId, count: items.length },
+    })
+    return items
+  },
+
+  async create(
+    input: { serviceId: number; title: string; body: string; variables?: string[] },
+    auditUserId: number, ctx?: AuditContext,
+  ) {
+    if (!input.title.trim() || input.title.length > TEMPLATE_TITLE_MAX) {
+      throw new ValidationError("title")
+    }
+    if (!input.body.trim() || input.body.length > TEMPLATE_BODY_MAX) {
+      throw new ValidationError("body")
+    }
+    return prisma.$transaction(async (tx) => {
+      await assertServiceMember(auditUserId, input.serviceId, tx)
+      const tpl = await tx.messageTemplate.create({
+        data: {
+          serviceId: input.serviceId,
+          title: input.title.trim(),
+          body: input.body,
+          variables: input.variables ?? [],
+          createdBy: auditUserId,
+        },
+      })
+      await auditService.logWithTx(tx, {
+        userId: auditUserId, action: "CREATE", resource: "MESSAGE_TEMPLATE",
+        resourceId: String(tpl.id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: { serviceId: input.serviceId },
+      })
+      return tpl
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+
+  async delete(id: number, auditUserId: number, ctx?: AuditContext) {
+    return prisma.$transaction(async (tx) => {
+      const tpl = await tx.messageTemplate.findUnique({
+        where: { id }, select: { id: true, serviceId: true },
+      })
+      if (!tpl) throw new NotFoundError()
+      await assertServiceMember(auditUserId, tpl.serviceId, tx)
+      await tx.messageTemplate.delete({ where: { id } })
+      await auditService.logWithTx(tx, {
+        userId: auditUserId, action: "DELETE", resource: "MESSAGE_TEMPLATE",
+        resourceId: String(id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: { serviceId: tpl.serviceId },
+      })
+      return { deleted: true }
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2080 — Read receipts (generic over `resource` + `resourceId`)
+// ─────────────────────────────────────────────────────────────
+
+const ALLOWED_READ_RESOURCES = new Set(["ANNOUNCEMENT", "DELEGATION_REQUEST", "HANDOFF_NOTE"])
+
+export const readReceiptService = {
+  async markRead(
+    resource: string, resourceId: number, auditUserId: number, ctx?: AuditContext,
+  ) {
+    if (!ALLOWED_READ_RESOURCES.has(resource)) throw new ValidationError("resource")
+    // Idempotent upsert : `(resource, resourceId, userId)` unique.
+    const r = await prisma.readReceipt.upsert({
+      where: {
+        resource_resourceId_userId: { resource, resourceId, userId: auditUserId },
+      },
+      create: { resource, resourceId, userId: auditUserId },
+      update: {}, // no-op : already read
+    })
+    await auditService.log({
+      userId: auditUserId, action: "READ", resource: "READ_RECEIPT",
+      resourceId: `${resource}:${resourceId}`,
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { resource, resourceId, receiptId: r.id },
+    })
+    return { readAt: r.readAt }
+  },
+
+  async listReadersFor(resource: string, resourceId: number) {
+    if (!ALLOWED_READ_RESOURCES.has(resource)) throw new ValidationError("resource")
+    return prisma.readReceipt.findMany({
+      where: { resource, resourceId },
+      orderBy: { readAt: "asc" },
+      select: { userId: true, readAt: true },
+    })
+  },
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2065 — Patient acknowledgement of an AdjustmentProposal
+// ─────────────────────────────────────────────────────────────
+
+export const proposalAckService = {
+  async markRead(proposalId: string, patientId: number, ctx?: AuditContext) {
+    const ack = await prisma.adjustmentProposalAck.upsert({
+      where: { proposalId },
+      create: { proposalId, patientId, acknowledged: true, readAt: new Date() },
+      update: { acknowledged: true, readAt: new Date() },
+    })
+    await auditService.log({
+      userId: null, // côté patient app (VIEWER); l'API route renseignera si dispo.
+      action: "READ", resource: "PROPOSAL_ACK", resourceId: proposalId,
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { patientId, proposalId, kind: "read" },
+    })
+    return ack
+  },
+
+  async respond(
+    proposalId: string, patientId: number,
+    decision: { accepted: boolean; comment?: string },
+    ctx?: AuditContext,
+  ) {
+    const encrypted = decision.comment ? encryptField(decision.comment) : null
+    const ack = await prisma.adjustmentProposalAck.upsert({
+      where: { proposalId },
+      create: {
+        proposalId, patientId,
+        acknowledged: true, readAt: new Date(),
+        accepted: decision.accepted, respondedAt: new Date(),
+        comment: encrypted,
+      },
+      update: {
+        accepted: decision.accepted, respondedAt: new Date(),
+        comment: encrypted,
+      },
+    })
+    await auditService.log({
+      userId: null, action: "UPDATE", resource: "PROPOSAL_ACK",
+      resourceId: proposalId,
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { patientId, proposalId, accepted: decision.accepted, kind: "respond" },
+    })
+    return ack
+  },
+
+  async getForProposal(proposalId: string) {
+    const ack = await prisma.adjustmentProposalAck.findUnique({ where: { proposalId } })
+    if (!ack) return null
+    return {
+      ...ack,
+      comment: ack.comment ? safeDecryptField(ack.comment) : null,
+    }
+  },
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2066 — Real-world actualization of an adjustment proposal
+// ─────────────────────────────────────────────────────────────
+
+const ALLOWED_VERIFY_VIA = new Set(["device-sync", "manual-ps", "patient-confirmed"])
+
+export const proposalActualizationService = {
+  async record(
+    proposalId: string,
+    input: { verifiedVia: string; effectiveAt?: Date },
+    auditUserId: number,
+    ctx?: AuditContext,
+  ) {
+    if (!ALLOWED_VERIFY_VIA.has(input.verifiedVia)) {
+      throw new ValidationError("verifiedVia")
+    }
+    return prisma.$transaction(async (tx) => {
+      const proposal = await tx.adjustmentProposal.findUnique({
+        where: { id: proposalId }, select: { patientId: true },
+      })
+      if (!proposal) throw new NotFoundError()
+      const row = await tx.adjustmentProposalActualization.upsert({
+        where: { proposalId },
+        create: {
+          proposalId,
+          verifiedVia: input.verifiedVia,
+          effectiveAt: input.effectiveAt ?? new Date(),
+          verifiedBy: input.verifiedVia === "device-sync" ? null : auditUserId,
+        },
+        update: {
+          verifiedVia: input.verifiedVia,
+          effectiveAt: input.effectiveAt ?? new Date(),
+          verifiedBy: input.verifiedVia === "device-sync" ? null : auditUserId,
+        },
+      })
+      await auditService.logWithTx(tx, {
+        userId: auditUserId, action: "CREATE", resource: "PROPOSAL_ACTUALIZATION",
+        resourceId: proposalId,
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: {
+          patientId: proposal.patientId,
+          proposalId, verifiedVia: input.verifiedVia,
+        },
+      })
+      return row
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2068 — Consultation notes (encrypted)
+// ─────────────────────────────────────────────────────────────
+
+const NOTE_MAX_LEN = 8192
+
+export const consultationNoteService = {
+  async create(
+    input: {
+      patientId: number
+      authorId: number
+      appointmentId?: number
+      content: string
+      category?: string
+    },
+    ctx?: AuditContext,
+  ) {
+    if (!input.content.trim() || input.content.length > NOTE_MAX_LEN) {
+      throw new ValidationError("content")
+    }
+    return prisma.$transaction(async (tx) => {
+      await assertPatientAlive(input.patientId, tx)
+      const row = await tx.consultationNote.create({
+        data: {
+          patientId: input.patientId,
+          authorId: input.authorId,
+          appointmentId: input.appointmentId,
+          content: encryptField(input.content),
+          category: input.category,
+        },
+      })
+      await auditService.logWithTx(tx, {
+        userId: input.authorId, action: "CREATE", resource: "CONSULTATION_NOTE",
+        resourceId: String(row.id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: { patientId: input.patientId, hasAppointment: !!input.appointmentId },
+      })
+      return { id: row.id, createdAt: row.createdAt }
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+
+  async listForPatient(patientId: number, auditUserId: number, ctx?: AuditContext) {
+    const rows = await prisma.consultationNote.findMany({
+      where: { patientId, patient: { deletedAt: null } },
+      orderBy: { createdAt: "desc" },
+      take: 100,
+    })
+    await auditService.log({
+      userId: auditUserId, action: "READ", resource: "CONSULTATION_NOTE",
+      resourceId: String(patientId),
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { patientId, kind: "list", count: rows.length },
+    })
+    return rows.map((r) => ({
+      id: r.id, patientId: r.patientId, authorId: r.authorId,
+      appointmentId: r.appointmentId, category: r.category,
+      content: safeDecryptField(r.content),
+      createdAt: r.createdAt, updatedAt: r.updatedAt,
+    }))
+  },
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2072 — Teleconsultation billing acte
+// ─────────────────────────────────────────────────────────────
+
+const BILLING_CODE_RE = /^[A-Z0-9]{2,20}$/
+
+export const teleconsultActeService = {
+  async create(
+    input: { appointmentId: number; billingCode: string; amountCents?: number },
+    auditUserId: number, ctx?: AuditContext,
+  ) {
+    if (!BILLING_CODE_RE.test(input.billingCode)) {
+      throw new ValidationError("billingCode")
+    }
+    if (input.amountCents !== undefined && (input.amountCents < 0 || input.amountCents > 1_000_000)) {
+      throw new ValidationError("amountCents")
+    }
+    return prisma.$transaction(async (tx) => {
+      const appointment = await tx.appointment.findUnique({
+        where: { id: input.appointmentId },
+        select: { id: true, patientId: true },
+      })
+      if (!appointment) throw new NotFoundError()
+      const row = await tx.teleconsultationActe.create({
+        data: {
+          appointmentId: input.appointmentId,
+          billingCode: input.billingCode,
+          amountCents: input.amountCents,
+        },
+      })
+      await auditService.logWithTx(tx, {
+        userId: auditUserId, action: "CREATE", resource: "TELECONSULT_ACTE",
+        resourceId: String(row.id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: {
+          patientId: appointment.patientId,
+          appointmentId: input.appointmentId, billingCode: input.billingCode,
+        },
+      })
+      return row
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+
+  async markInvoiced(id: number, auditUserId: number, ctx?: AuditContext) {
+    return prisma.$transaction(async (tx) => {
+      const acte = await tx.teleconsultationActe.findUnique({
+        where: { id }, include: { appointment: { select: { patientId: true } } },
+      })
+      if (!acte) throw new NotFoundError()
+      const updated = await tx.teleconsultationActe.update({
+        where: { id },
+        data: { invoicedAt: new Date(), invoicedBy: auditUserId },
+      })
+      await auditService.logWithTx(tx, {
+        userId: auditUserId, action: "UPDATE", resource: "TELECONSULT_ACTE",
+        resourceId: String(id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: {
+          patientId: acte.appointment.patientId,
+          billingCode: acte.billingCode, kind: "invoiced",
+        },
+      })
+      return updated
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2083 — Delegation requests (IDE → DOCTOR)
+// ─────────────────────────────────────────────────────────────
+
+export const delegationRequestService = {
+  async create(
+    input: {
+      patientId: number; fromUserId: number; toUserId: number;
+      action: string; payload?: Prisma.InputJsonValue;
+    },
+    ctx?: AuditContext,
+  ) {
+    if (!input.action.trim() || input.action.length > 80) {
+      throw new ValidationError("action")
+    }
+    return prisma.$transaction(async (tx) => {
+      await assertPatientAlive(input.patientId, tx)
+      const row = await tx.delegationRequest.create({
+        data: {
+          patientId: input.patientId,
+          fromUserId: input.fromUserId,
+          toUserId: input.toUserId,
+          action: input.action.trim(),
+          payload: input.payload ?? Prisma.JsonNull,
+        },
+      })
+      await auditService.logWithTx(tx, {
+        userId: input.fromUserId, action: "CREATE", resource: "DELEGATION_REQUEST",
+        resourceId: String(row.id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: { patientId: input.patientId, toUserId: input.toUserId, action: input.action },
+      })
+      return row
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+
+  async respond(
+    id: number, reviewerId: number,
+    decision: { status: Extract<DelegationRequestStatus, "approved" | "rejected">; reason?: string },
+    ctx?: AuditContext,
+  ) {
+    return prisma.$transaction(async (tx) => {
+      const req = await tx.delegationRequest.findUnique({
+        where: { id }, select: { id: true, toUserId: true, status: true, patientId: true },
+      })
+      if (!req) throw new NotFoundError()
+      if (req.toUserId !== reviewerId) throw new ForbiddenError()
+      if (req.status !== "pending") throw new ValidationError("alreadyReviewed")
+
+      const updated = await tx.delegationRequest.update({
+        where: { id },
+        data: {
+          status: decision.status,
+          reviewedBy: reviewerId,
+          reviewedAt: new Date(),
+          reason: decision.reason?.slice(0, 500),
+        },
+      })
+      await auditService.logWithTx(tx, {
+        userId: reviewerId,
+        action: decision.status === "approved" ? "PROPOSAL_ACCEPTED" : "PROPOSAL_REJECTED",
+        resource: "DELEGATION_REQUEST", resourceId: String(id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: { patientId: req.patientId, status: decision.status },
+      })
+      return updated
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+
+  async listInbox(toUserId: number, ctx?: AuditContext) {
+    const items = await prisma.delegationRequest.findMany({
+      where: { toUserId, status: "pending" },
+      orderBy: { createdAt: "desc" },
+      take: 100,
+    })
+    await auditService.log({
+      userId: toUserId, action: "READ", resource: "DELEGATION_REQUEST",
+      resourceId: "inbox",
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { toUserId, count: items.length },
+    })
+    return items
+  },
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2084 — Member absences + cover
+// ─────────────────────────────────────────────────────────────
+
+export const memberAbsenceService = {
+  async create(
+    input: {
+      memberId: number; startDate: Date; endDate: Date;
+      coverMemberId?: number; reason?: string;
+    },
+    auditUserId: number, ctx?: AuditContext,
+  ) {
+    if (input.endDate < input.startDate) throw new ValidationError("dateRange")
+    return prisma.$transaction(async (tx) => {
+      const member = await tx.healthcareMember.findUnique({
+        where: { id: input.memberId }, select: { id: true, serviceId: true },
+      })
+      if (!member || member.serviceId === null) throw new NotFoundError()
+      await assertServiceMember(auditUserId, member.serviceId, tx)
+      const row = await tx.memberAbsence.create({
+        data: {
+          memberId: input.memberId,
+          startDate: input.startDate,
+          endDate: input.endDate,
+          coverMemberId: input.coverMemberId,
+          reason: input.reason?.slice(0, 120),
+        },
+      })
+      await auditService.logWithTx(tx, {
+        userId: auditUserId, action: "CREATE", resource: "MEMBER_ABSENCE",
+        resourceId: String(row.id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: {
+          memberId: input.memberId, serviceId: member.serviceId,
+          coverMemberId: input.coverMemberId ?? null,
+        },
+      })
+      return row
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+
+  async listForMember(memberId: number) {
+    return prisma.memberAbsence.findMany({
+      where: { memberId },
+      orderBy: { startDate: "desc" },
+      take: 50,
+    })
+  },
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2086 — Handoff notes (encrypted)
+// ─────────────────────────────────────────────────────────────
+
+const HANDOFF_MAX_LEN = 4096
+
+export const handoffNoteService = {
+  async create(
+    input: { patientId: number; fromUserId: number; toUserId: number; note: string },
+    ctx?: AuditContext,
+  ) {
+    if (!input.note.trim() || input.note.length > HANDOFF_MAX_LEN) {
+      throw new ValidationError("note")
+    }
+    return prisma.$transaction(async (tx) => {
+      await assertPatientAlive(input.patientId, tx)
+      const row = await tx.handoffNote.create({
+        data: {
+          patientId: input.patientId,
+          fromUserId: input.fromUserId,
+          toUserId: input.toUserId,
+          note: encryptField(input.note),
+        },
+      })
+      await auditService.logWithTx(tx, {
+        userId: input.fromUserId, action: "CREATE", resource: "HANDOFF_NOTE",
+        resourceId: String(row.id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: { patientId: input.patientId, toUserId: input.toUserId },
+      })
+      return { id: row.id, createdAt: row.createdAt }
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+
+  async acknowledge(id: number, userId: number, ctx?: AuditContext) {
+    return prisma.$transaction(async (tx) => {
+      const h = await tx.handoffNote.findUnique({
+        where: { id }, select: { id: true, toUserId: true, patientId: true, acknowledgedAt: true },
+      })
+      if (!h) throw new NotFoundError()
+      if (h.toUserId !== userId) throw new ForbiddenError()
+      if (h.acknowledgedAt) return { acknowledgedAt: h.acknowledgedAt }
+      const updated = await tx.handoffNote.update({
+        where: { id }, data: { acknowledgedAt: new Date() },
+      })
+      await auditService.logWithTx(tx, {
+        userId, action: "UPDATE", resource: "HANDOFF_NOTE",
+        resourceId: String(id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: { patientId: h.patientId, kind: "ack" },
+      })
+      return { acknowledgedAt: updated.acknowledgedAt }
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+
+  async listInbox(toUserId: number) {
+    const items = await prisma.handoffNote.findMany({
+      where: { toUserId, acknowledgedAt: null, patient: { deletedAt: null } },
+      orderBy: { createdAt: "desc" },
+      take: 50,
+    })
+    return items.map((h) => ({ ...h, note: safeDecryptField(h.note) }))
+  },
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2088 — Patient groups (cohorts) + assignment
+// ─────────────────────────────────────────────────────────────
+
+const GROUP_LABEL_MAX = 80
+
+export const patientGroupService = {
+  async listForService(serviceId: number, auditUserId: number, ctx?: AuditContext) {
+    await assertServiceMember(auditUserId, serviceId)
+    const items = await prisma.patientGroup.findMany({
+      where: { serviceId }, orderBy: { label: "asc" },
+    })
+    await auditService.log({
+      userId: auditUserId, action: "READ", resource: "PATIENT_GROUP",
+      resourceId: String(serviceId),
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { kind: "list", serviceId, count: items.length },
+    })
+    return items
+  },
+
+  async create(
+    input: { serviceId: number; label: string },
+    auditUserId: number, ctx?: AuditContext,
+  ) {
+    const label = input.label.trim()
+    if (!label || label.length > GROUP_LABEL_MAX) throw new ValidationError("label")
+    return prisma.$transaction(async (tx) => {
+      await assertServiceMember(auditUserId, input.serviceId, tx)
+      const g = await tx.patientGroup.create({
+        data: { serviceId: input.serviceId, label, createdBy: auditUserId },
+      })
+      await auditService.logWithTx(tx, {
+        userId: auditUserId, action: "CREATE", resource: "PATIENT_GROUP",
+        resourceId: String(g.id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: { serviceId: input.serviceId },
+      })
+      return g
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+
+  async setForPatient(
+    patientId: number, groupIds: number[], auditUserId: number, ctx?: AuditContext,
+  ) {
+    const unique = Array.from(new Set(groupIds))
+    return prisma.$transaction(async (tx) => {
+      await assertPatientAlive(patientId, tx)
+      if (unique.length > 0) {
+        const memberServices = await tx.healthcareMember.findMany({
+          where: { userId: auditUserId, serviceId: { not: null } },
+          select: { serviceId: true },
+        })
+        const memberSet = new Set(
+          memberServices.map((m) => m.serviceId).filter((s): s is number => s !== null),
+        )
+        const groups = await tx.patientGroup.findMany({
+          where: { id: { in: unique }, serviceId: { in: Array.from(memberSet) } },
+          select: { id: true },
+        })
+        if (groups.length !== unique.length) throw new ForbiddenError()
+      }
+      await tx.patientGroupAssignment.deleteMany({ where: { patientId } })
+      if (unique.length > 0) {
+        await tx.patientGroupAssignment.createMany({
+          data: unique.map((groupId) => ({ patientId, groupId, assignedBy: auditUserId })),
+          skipDuplicates: true,
+        })
+      }
+      await auditService.logWithTx(tx, {
+        userId: auditUserId, action: "UPDATE", resource: "PATIENT_GROUP_ASSIGNMENT",
+        resourceId: String(patientId),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: { patientId, groupIds: unique },
+      })
+      return { count: unique.length }
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+
+  async listForPatient(patientId: number) {
+    const assignments = await prisma.patientGroupAssignment.findMany({
+      where: { patientId, patient: { deletedAt: null } },
+      include: { group: true },
+      orderBy: { group: { label: "asc" } },
+    })
+    return assignments.map((a) => a.group)
+  },
+}

--- a/src/lib/team-route-helpers.ts
+++ b/src/lib/team-route-helpers.ts
@@ -1,0 +1,33 @@
+/**
+ * @module team-route-helpers
+ * @description Shared helpers for Groupe 3 routes — typed-error → HTTP
+ * mapping + Zod validation shortcut. Reduces boilerplate across 10+ routes.
+ */
+
+import { NextResponse } from "next/server"
+import { AuthError } from "@/lib/auth"
+import {
+  ForbiddenError,
+  NotFoundError,
+  ValidationError,
+} from "@/lib/services/team-workflow.errors"
+
+/** Map any error caught at the route layer to a NextResponse. */
+export function mapErrorToResponse(error: unknown, routeTag: string): NextResponse {
+  if (error instanceof AuthError) {
+    return NextResponse.json({ error: error.message }, { status: error.status })
+  }
+  if (error instanceof ValidationError) {
+    return NextResponse.json({ error: error.message, field: error.field }, { status: 422 })
+  }
+  if (error instanceof NotFoundError) {
+    return NextResponse.json({ error: "notFound" }, { status: 404 })
+  }
+  if (error instanceof ForbiddenError) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 })
+  }
+  const msg = error instanceof Error ? error.message : "Unknown error"
+  // eslint-disable-next-line no-console
+  console.error(`[${routeTag}]`, msg)
+  return NextResponse.json({ error: "serverError" }, { status: 500 })
+}

--- a/src/lib/team-route-helpers.ts
+++ b/src/lib/team-route-helpers.ts
@@ -1,19 +1,72 @@
 /**
  * @module team-route-helpers
  * @description Shared helpers for Groupe 3 routes — typed-error → HTTP
- * mapping + Zod validation shortcut. Reduces boilerplate across 10+ routes.
+ * mapping + RBAC role check with `accessDenied` audit emission.
+ *
+ * Review PR #390 :
+ *  - M1 : log includes error.stack + requestId for HDS correlation.
+ *  - H1 : `auditedRequireRole` emits an `accessDenied` audit row on RBAC
+ *         failures so US-2265 burst detector sees them.
+ *  - H6 / H7 / H9 : services raise `ForbiddenError`; here we provide the
+ *    bridge to a 403 + optional audit row before responding.
  */
 
 import { NextResponse } from "next/server"
-import { AuthError } from "@/lib/auth"
+import { AuthError, getAuthUser, requireRole, type AuthUser } from "@/lib/auth"
+import type { Role } from "@prisma/client"
+import {
+  auditService,
+  type AuditContext,
+  type AuditResource,
+} from "@/lib/services/audit.service"
 import {
   ForbiddenError,
   NotFoundError,
   ValidationError,
 } from "@/lib/services/team-workflow.errors"
 
+/**
+ * Wrapper around `requireRole` that emits an `accessDenied()` audit entry
+ * when the caller is authenticated but lacks the required role. Drops the
+ * 401-no-user case (no audit row possible without a userId).
+ *
+ * Re-throws `AuthError` so the route's outer catch (via `mapErrorToResponse`)
+ * still produces the right HTTP status.
+ */
+export async function auditedRequireRole(
+  req: Request,
+  minRole: Role,
+  ctx: AuditContext,
+  resource: AuditResource,
+  resourceId: string,
+): Promise<AuthUser> {
+  try {
+    return requireRole(req, minRole)
+  } catch (e) {
+    if (e instanceof AuthError && e.status === 403) {
+      const u = getAuthUser(req)
+      if (u) {
+        try {
+          await auditService.accessDenied({
+            userId: u.id,
+            resource,
+            resourceId,
+            ipAddress: ctx.ipAddress,
+            userAgent: ctx.userAgent,
+            requestId: ctx.requestId,
+            metadata: { requiredRole: minRole },
+          })
+        } catch {
+          // swallow — never fail the response on audit-write hiccup.
+        }
+      }
+    }
+    throw e
+  }
+}
+
 /** Map any error caught at the route layer to a NextResponse. */
-export function mapErrorToResponse(error: unknown, routeTag: string): NextResponse {
+export function mapErrorToResponse(error: unknown, routeTag: string, requestId?: string): NextResponse {
   if (error instanceof AuthError) {
     return NextResponse.json({ error: error.message }, { status: error.status })
   }
@@ -27,7 +80,8 @@ export function mapErrorToResponse(error: unknown, routeTag: string): NextRespon
     return NextResponse.json({ error: "forbidden" }, { status: 403 })
   }
   const msg = error instanceof Error ? error.message : "Unknown error"
+  const stack = error instanceof Error ? error.stack : undefined
   // eslint-disable-next-line no-console
-  console.error(`[${routeTag}]`, msg)
+  console.error(`[${routeTag}]`, { msg, stack, requestId })
   return NextResponse.json({ error: "serverError" }, { status: 500 })
 }

--- a/tests/unit/team-workflow.service.test.ts
+++ b/tests/unit/team-workflow.service.test.ts
@@ -1,18 +1,21 @@
 /**
- * Test suite: team-workflow services (Groupe 3 Batch 1, 10 US)
+ * Test suite: team-workflow services (Groupe 3 Batch 1, 10 US + review fixes PR #390)
  *
- * Covers:
- *  - US-2078 MessageTemplate : membership check + validation + audit
- *  - US-2080 ReadReceipt     : upsert + restricted resource set
- *  - US-2065 ProposalAck     : patient mark-read + respond (encrypted comment)
- *  - US-2066 ProposalActualization : verifiedVia enum, verifiedBy auto-null
- *      for device-sync
- *  - US-2068 ConsultationNote : encrypts content, audits patient pivot
- *  - US-2072 TeleconsultActe : billing code regex, audit metadata
- *  - US-2083 DelegationRequest : create + respond (only target user)
- *  - US-2084 MemberAbsence : membership check via member's service
- *  - US-2086 HandoffNote : encrypted note + ack restricted to recipient
- *  - US-2088 PatientGroup : cross-cabinet contamination blocked
+ * Covers (selected behaviours from 44 findings):
+ *  - C1/C2/C3/C4 — route-level RBAC checks (covered in route tests, not here)
+ *  - C5 — `delegationRequest.respond` audits `DELEGATION_APPROVED`/`REJECTED`
+ *  - H2 — `proposalAck` propagates auditUserId
+ *  - H3 — `markInvoiced` rejects double-invoicing
+ *  - H4 — `proposalActualization.record` rejects source mismatch
+ *  - H5 — `delegationRequest.create` rejects PHI-shaped payload + over-size
+ *  - H6 — `handoffNote.listInbox` emits audit READ
+ *  - H7 — `memberAbsence.listForMember` requires service membership
+ *  - H8 — `delegationRequest.create` rejects toUserId not colleague
+ *  - H9 — `readReceipt.markRead` requires access to underlying resource
+ *  - M2 — `consultationNote.create` rejects appointment cross-patient mismatch
+ *  - M3 — `memberAbsence.create` rejects member without service
+ *  - M11 — self-delegation rejected
+ *  - L8 — `proposalAck.respond` rejects oversized comment
  */
 import { describe, it, expect, beforeEach } from "vitest"
 import { prismaMock } from "../helpers/prisma-mock"
@@ -50,173 +53,246 @@ describe("messageTemplateService", () => {
       messageTemplateService.create({ serviceId: 1, title: "  ", body: "x" }, 9),
     ).rejects.toBeInstanceOf(ValidationError)
   })
-  it("audits CREATE with serviceId in metadata", async () => {
-    prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 1 } as any)
-    prismaMock.messageTemplate.create.mockResolvedValue({
-      id: 42, serviceId: 1, title: "Welcome", body: "...", variables: [],
-    } as any)
-    await messageTemplateService.create(
-      { serviceId: 1, title: "Welcome", body: "hello" }, 9,
-    )
-    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
-    expect(audit.resource).toBe("MESSAGE_TEMPLATE")
-    expect(audit.metadata.serviceId).toBe(1)
-  })
 })
 
-describe("readReceiptService", () => {
+describe("readReceiptService (H9 — resource access check)", () => {
   it("rejects unknown resource", async () => {
     await expect(readReceiptService.markRead("UNKNOWN", 1, 9))
       .rejects.toBeInstanceOf(ValidationError)
   })
-  it("upserts idempotently and audits", async () => {
-    prismaMock.readReceipt.upsert.mockResolvedValue({ id: 1, readAt: new Date() } as any)
-    const r = await readReceiptService.markRead("ANNOUNCEMENT", 1, 9)
-    expect(r.readAt).toBeInstanceOf(Date)
-    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
-    expect(audit.resource).toBe("READ_RECEIPT")
+  it("rejects DELEGATION_REQUEST not addressed to caller", async () => {
+    prismaMock.delegationRequest.findFirst.mockResolvedValue(null)
+    await expect(readReceiptService.markRead("DELEGATION_REQUEST", 1, 99))
+      .rejects.toBeInstanceOf(ForbiddenError)
+  })
+  it("rejects HANDOFF_NOTE not addressed to caller", async () => {
+    prismaMock.handoffNote.findFirst.mockResolvedValue(null)
+    await expect(readReceiptService.markRead("HANDOFF_NOTE", 1, 99))
+      .rejects.toBeInstanceOf(ForbiddenError)
   })
 })
 
-describe("proposalAckService", () => {
-  it("encrypts comment on respond (no plaintext at-rest)", async () => {
+describe("proposalAckService (H2 — auditUserId propagation, L8 — length)", () => {
+  it("audits markRead with the caller userId, not null", async () => {
     prismaMock.adjustmentProposalAck.upsert.mockResolvedValue({
-      id: 1, proposalId: "abc", patientId: 7, acknowledged: true,
-      accepted: true, comment: null, readAt: new Date(), respondedAt: new Date(),
+      id: 1, readAt: new Date(),
     } as any)
-    await proposalAckService.respond("abc", 7, { accepted: true, comment: "OK pour moi" })
-    const upsertArgs = prismaMock.adjustmentProposalAck.upsert.mock.calls[0][0] as any
-    expect(upsertArgs.create.comment).not.toBe("OK pour moi") // encrypted
-    expect(typeof upsertArgs.create.comment).toBe("string")
+    await proposalAckService.markRead("abc", 7, 999 /* auditUserId */)
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.userId).toBe(999)
   })
-})
-
-describe("proposalActualizationService", () => {
-  it("rejects unknown verifiedVia", async () => {
+  it("rejects oversized comment in respond (L8)", async () => {
     await expect(
-      proposalActualizationService.record("abc", { verifiedVia: "magic" }, 9),
+      proposalAckService.respond("abc", 7, { accepted: true, comment: "x".repeat(501) }, 999),
     ).rejects.toBeInstanceOf(ValidationError)
   })
-  it("sets verifiedBy=null when verifiedVia=device-sync", async () => {
+  it("encrypts comment + audits with caller userId", async () => {
+    prismaMock.adjustmentProposalAck.upsert.mockResolvedValue({
+      id: 1, accepted: true, respondedAt: new Date(),
+    } as any)
+    await proposalAckService.respond("abc", 7, { accepted: true, comment: "OK" }, 999)
+    const upsertArgs = prismaMock.adjustmentProposalAck.upsert.mock.calls[0][0] as any
+    expect(upsertArgs.create.comment).not.toBe("OK")
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.userId).toBe(999)
+  })
+})
+
+describe("proposalActualizationService (H4 — overwrite guard)", () => {
+  it("rejects record() when prior actualization has different verifiedVia", async () => {
     prismaMock.adjustmentProposal.findUnique.mockResolvedValue({ patientId: 7 } as any)
+    prismaMock.adjustmentProposalActualization.findUnique.mockResolvedValue({
+      verifiedVia: "device-sync",
+    } as any)
+    await expect(
+      proposalActualizationService.record("abc", { verifiedVia: "manual-ps" }, 9),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+  it("allows idempotent re-record with same verifiedVia", async () => {
+    prismaMock.adjustmentProposal.findUnique.mockResolvedValue({ patientId: 7 } as any)
+    prismaMock.adjustmentProposalActualization.findUnique.mockResolvedValue({
+      verifiedVia: "device-sync",
+    } as any)
     prismaMock.adjustmentProposalActualization.upsert.mockResolvedValue({} as any)
     await proposalActualizationService.record("abc", { verifiedVia: "device-sync" }, 9)
-    const args = prismaMock.adjustmentProposalActualization.upsert.mock.calls[0][0] as any
-    expect(args.create.verifiedBy).toBeNull()
-  })
-  it("keeps verifiedBy for manual-ps", async () => {
-    prismaMock.adjustmentProposal.findUnique.mockResolvedValue({ patientId: 7 } as any)
-    prismaMock.adjustmentProposalActualization.upsert.mockResolvedValue({} as any)
-    await proposalActualizationService.record("abc", { verifiedVia: "manual-ps" }, 9)
-    const args = prismaMock.adjustmentProposalActualization.upsert.mock.calls[0][0] as any
-    expect(args.create.verifiedBy).toBe(9)
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.action).toBe("UPDATE")
   })
 })
 
-describe("consultationNoteService", () => {
-  it("blocks soft-deleted patient", async () => {
-    prismaMock.patient.findFirst.mockResolvedValue(null)
-    await expect(
-      consultationNoteService.create({ patientId: 7, authorId: 9, content: "ok" }),
-    ).rejects.toBeInstanceOf(NotFoundError)
-  })
-  it("encrypts content before persisting", async () => {
+describe("consultationNoteService (M2 — appointment cross-patient guard)", () => {
+  it("rejects when appointment does not belong to the patient", async () => {
     prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
+    prismaMock.appointment.findFirst.mockResolvedValue(null)
+    await expect(
+      consultationNoteService.create({
+        patientId: 7, authorId: 9, appointmentId: 99, content: "examen",
+      }),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+  it("accepts when appointment matches the patient", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
+    prismaMock.appointment.findFirst.mockResolvedValue({ id: 99 } as any)
     prismaMock.consultationNote.create.mockResolvedValue({ id: 1, createdAt: new Date() } as any)
-    await consultationNoteService.create({
-      patientId: 7, authorId: 9, content: "Examen normal — TA 12/8",
+    const out = await consultationNoteService.create({
+      patientId: 7, authorId: 9, appointmentId: 99, content: "examen",
     })
-    const args = prismaMock.consultationNote.create.mock.calls[0][0] as any
-    expect(args.data.content).not.toContain("Examen")
+    expect(out.id).toBe(1)
   })
 })
 
-describe("teleconsultActeService", () => {
+describe("teleconsultActeService (H3 — double-invoicing guard)", () => {
   it("rejects invalid billing code", async () => {
     await expect(
       teleconsultActeService.create({ appointmentId: 1, billingCode: "bad code" }, 9),
     ).rejects.toBeInstanceOf(ValidationError)
   })
-  it("rejects when appointment is missing", async () => {
-    prismaMock.appointment.findUnique.mockResolvedValue(null)
-    await expect(
-      teleconsultActeService.create({ appointmentId: 999, billingCode: "TCG" }, 9),
-    ).rejects.toBeInstanceOf(NotFoundError)
+  it("rejects markInvoiced when already invoiced (H3)", async () => {
+    prismaMock.teleconsultationActe.findUnique.mockResolvedValue({
+      id: 1, invoicedAt: new Date(), billingCode: "TCG",
+      appointment: { patientId: 7 },
+    } as any)
+    await expect(teleconsultActeService.markInvoiced(1, 9))
+      .rejects.toBeInstanceOf(ValidationError)
   })
-  it("audits with patientId pivot derived from appointment", async () => {
-    prismaMock.appointment.findUnique.mockResolvedValue({ id: 1, patientId: 7 } as any)
-    prismaMock.teleconsultationActe.create.mockResolvedValue({ id: 11 } as any)
-    await teleconsultActeService.create({ appointmentId: 1, billingCode: "TCG" }, 9)
+  it("invoices when not yet invoiced + audits with patientId pivot", async () => {
+    prismaMock.teleconsultationActe.findUnique.mockResolvedValue({
+      id: 1, invoicedAt: null, billingCode: "TCG",
+      appointment: { patientId: 7 },
+    } as any)
+    prismaMock.teleconsultationActe.update.mockResolvedValue({
+      id: 1, appointmentId: 1, billingCode: "TCG", amountCents: null, invoicedAt: new Date(),
+    } as any)
+    await teleconsultActeService.markInvoiced(1, 9)
     const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
     expect(audit.metadata.patientId).toBe(7)
   })
 })
 
 describe("delegationRequestService", () => {
-  it("rejects empty action", async () => {
+  it("rejects self-delegation (M11)", async () => {
     prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
     await expect(
       delegationRequestService.create({
-        patientId: 7, fromUserId: 9, toUserId: 10, action: "  ",
+        patientId: 7, fromUserId: 9, toUserId: 9, action: "PROPOSE",
       }),
     ).rejects.toBeInstanceOf(ValidationError)
   })
-  it("respond forbidden if reviewer ≠ target", async () => {
+
+  it("rejects toUserId not sharing a service+patient (H8)", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
+    prismaMock.patientService.findFirst.mockResolvedValue(null)
+    await expect(
+      delegationRequestService.create({
+        patientId: 7, fromUserId: 9, toUserId: 10, action: "PROPOSE",
+      }),
+    ).rejects.toBeInstanceOf(ForbiddenError)
+  })
+
+  it("rejects payload looking like PHI (H5 — digits/email)", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
+    prismaMock.patientService.findFirst.mockResolvedValue({ id: 1 } as any)
+    await expect(
+      delegationRequestService.create({
+        patientId: 7, fromUserId: 9, toUserId: 10, action: "PROPOSE",
+        payload: { note: "HbA1c 8.2 patient Dupont 1800175123456" },
+      }),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("rejects payload exceeding 2 KB (H5)", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
+    prismaMock.patientService.findFirst.mockResolvedValue({ id: 1 } as any)
+    const oversize = { data: "x".repeat(3000) }
+    await expect(
+      delegationRequestService.create({
+        patientId: 7, fromUserId: 9, toUserId: 10, action: "PROPOSE",
+        payload: oversize,
+      }),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("audits respond with DELEGATION_APPROVED + metadata.patientId (C5)", async () => {
     prismaMock.delegationRequest.findUnique.mockResolvedValue({
       id: 1, toUserId: 10, status: "pending", patientId: 7,
     } as any)
-    await expect(
-      delegationRequestService.respond(1, 99, { status: "approved" }),
-    ).rejects.toBeInstanceOf(ForbiddenError)
-  })
-  it("respond rejects already-reviewed", async () => {
-    prismaMock.delegationRequest.findUnique.mockResolvedValue({
-      id: 1, toUserId: 10, status: "approved", patientId: 7,
+    prismaMock.delegationRequest.update.mockResolvedValue({
+      id: 1, patientId: 7, status: "approved", reviewedAt: new Date(),
     } as any)
-    await expect(
-      delegationRequestService.respond(1, 10, { status: "approved" }),
-    ).rejects.toBeInstanceOf(ValidationError)
+    await delegationRequestService.respond(1, 10, { status: "approved" })
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.action).toBe("DELEGATION_APPROVED")
+    expect(audit.metadata.patientId).toBe(7)
+  })
+
+  it("audits respond with DELEGATION_REJECTED", async () => {
+    prismaMock.delegationRequest.findUnique.mockResolvedValue({
+      id: 1, toUserId: 10, status: "pending", patientId: 7,
+    } as any)
+    prismaMock.delegationRequest.update.mockResolvedValue({
+      id: 1, patientId: 7, status: "rejected", reviewedAt: new Date(),
+    } as any)
+    await delegationRequestService.respond(1, 10, { status: "rejected", reason: "nope" })
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.action).toBe("DELEGATION_REJECTED")
   })
 })
 
 describe("memberAbsenceService", () => {
-  it("rejects endDate < startDate", async () => {
+  it("rejects member without service (M3)", async () => {
+    prismaMock.healthcareMember.findUnique.mockResolvedValue({ id: 1, serviceId: null } as any)
     await expect(
       memberAbsenceService.create(
-        { memberId: 1, startDate: new Date("2026-06-10"), endDate: new Date("2026-06-01") },
-        9,
+        { memberId: 1, startDate: new Date(), endDate: new Date() }, 9,
       ),
     ).rejects.toBeInstanceOf(ValidationError)
   })
-  it("requires caller to be member of the absent member's service", async () => {
+
+  it("listForMember requires service membership (H7)", async () => {
     prismaMock.healthcareMember.findUnique.mockResolvedValue({ id: 1, serviceId: 10 } as any)
     prismaMock.healthcareMember.findFirst.mockResolvedValue(null)
-    await expect(
-      memberAbsenceService.create(
-        { memberId: 1, startDate: new Date(), endDate: new Date() },
-        9,
-      ),
-    ).rejects.toBeInstanceOf(ForbiddenError)
+    await expect(memberAbsenceService.listForMember(1, 99))
+      .rejects.toBeInstanceOf(ForbiddenError)
+  })
+
+  it("listForMember audits READ with metadata.memberId", async () => {
+    prismaMock.healthcareMember.findUnique.mockResolvedValue({ id: 1, serviceId: 10 } as any)
+    prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 99 } as any)
+    prismaMock.memberAbsence.findMany.mockResolvedValue([] as any)
+    await memberAbsenceService.listForMember(1, 9)
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.action).toBe("READ")
+    expect(audit.resource).toBe("MEMBER_ABSENCE")
+    expect(audit.metadata.memberId).toBe(1)
   })
 })
 
 describe("handoffNoteService", () => {
-  it("encrypts note on create", async () => {
+  it("rejects toUserId not colleague with patient access (H8)", async () => {
     prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
-    prismaMock.handoffNote.create.mockResolvedValue({ id: 1, createdAt: new Date() } as any)
-    await handoffNoteService.create({
-      patientId: 7, fromUserId: 9, toUserId: 10, note: "Surveiller hypo nocturne",
-    })
-    const args = prismaMock.handoffNote.create.mock.calls[0][0] as any
-    expect(args.data.note).not.toContain("Surveiller")
+    prismaMock.patientService.findFirst.mockResolvedValue(null)
+    await expect(
+      handoffNoteService.create({
+        patientId: 7, fromUserId: 9, toUserId: 10, note: "x",
+      }),
+    ).rejects.toBeInstanceOf(ForbiddenError)
   })
+
   it("acknowledge rejects non-recipient", async () => {
     prismaMock.handoffNote.findUnique.mockResolvedValue({
       id: 1, toUserId: 10, patientId: 7, acknowledgedAt: null,
     } as any)
-    await expect(
-      handoffNoteService.acknowledge(1, 99),
-    ).rejects.toBeInstanceOf(ForbiddenError)
+    await expect(handoffNoteService.acknowledge(1, 99))
+      .rejects.toBeInstanceOf(ForbiddenError)
+  })
+
+  it("listInbox audits READ (H6)", async () => {
+    prismaMock.handoffNote.findMany.mockResolvedValue([] as any)
+    await handoffNoteService.listInbox(10)
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.action).toBe("READ")
+    expect(audit.resource).toBe("HANDOFF_NOTE")
+    expect(audit.resourceId).toBe("inbox")
   })
 })
 
@@ -229,13 +305,326 @@ describe("patientGroupService", () => {
       patientGroupService.setForPatient(7, [1, 2], 9),
     ).rejects.toBeInstanceOf(ForbiddenError)
   })
-  it("setForPatient passes with all-in-scope groups", async () => {
+
+  it("setForPatient happy path: deletes + creates new assignments", async () => {
     prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
     prismaMock.healthcareMember.findMany.mockResolvedValue([{ serviceId: 10 }] as any)
     prismaMock.patientGroup.findMany.mockResolvedValue([{ id: 1 }, { id: 2 }] as any)
-    prismaMock.patientGroupAssignment.deleteMany.mockResolvedValue({ count: 0 } as any)
+    prismaMock.patientGroupAssignment.deleteMany.mockResolvedValue({ count: 1 } as any)
     prismaMock.patientGroupAssignment.createMany.mockResolvedValue({ count: 2 } as any)
     const out = await patientGroupService.setForPatient(7, [1, 2], 9)
     expect(out.count).toBe(2)
+  })
+
+  it("setForPatient with empty list clears all assignments", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
+    prismaMock.patientGroupAssignment.deleteMany.mockResolvedValue({ count: 3 } as any)
+    const out = await patientGroupService.setForPatient(7, [], 9)
+    expect(out.count).toBe(0)
+    expect(prismaMock.patientGroupAssignment.createMany).not.toHaveBeenCalled()
+  })
+
+  it("listForService rejects non-members", async () => {
+    prismaMock.healthcareMember.findFirst.mockResolvedValue(null)
+    await expect(patientGroupService.listForService(1, 9))
+      .rejects.toBeInstanceOf(ForbiddenError)
+  })
+
+  it("listForService returns DTO list", async () => {
+    prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.patientGroup.findMany.mockResolvedValue([
+      { id: 1, serviceId: 10, label: "HDJ" },
+    ] as any)
+    const out = await patientGroupService.listForService(10, 9)
+    expect(out).toHaveLength(1)
+    expect(out[0]).toEqual({ id: 1, serviceId: 10, label: "HDJ" })
+  })
+
+  it("create rejects oversized label", async () => {
+    await expect(
+      patientGroupService.create({ serviceId: 1, label: "x".repeat(81) }, 9),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("create happy path returns DTO", async () => {
+    prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.patientGroup.create.mockResolvedValue({
+      id: 99, serviceId: 10, label: "HDJ",
+    } as any)
+    const g = await patientGroupService.create({ serviceId: 10, label: " HDJ " }, 9)
+    expect(g.label).toBe("HDJ")
+  })
+
+  it("listForPatient audits READ (L2)", async () => {
+    prismaMock.patientGroupAssignment.findMany.mockResolvedValue([] as any)
+    await patientGroupService.listForPatient(7, 9)
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.action).toBe("READ")
+    expect(audit.resource).toBe("PATIENT_GROUP_ASSIGNMENT")
+  })
+})
+
+describe("messageTemplateService — list + delete happy paths", () => {
+  it("list returns DTO", async () => {
+    prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.messageTemplate.findMany.mockResolvedValue([
+      { id: 1, serviceId: 10, title: "T", body: "B", variables: [] },
+    ] as any)
+    const out = await messageTemplateService.list(10, 9)
+    expect(out).toHaveLength(1)
+    expect(out[0].title).toBe("T")
+  })
+
+  it("create happy path with audit", async () => {
+    prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.messageTemplate.create.mockResolvedValue({
+      id: 42, serviceId: 1, title: "T", body: "B", variables: [],
+    } as any)
+    await messageTemplateService.create(
+      { serviceId: 1, title: "T", body: "Body" }, 9,
+    )
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.action).toBe("CREATE")
+    expect(audit.resource).toBe("MESSAGE_TEMPLATE")
+  })
+
+  it("delete returns notFound when missing", async () => {
+    prismaMock.messageTemplate.findUnique.mockResolvedValue(null)
+    await expect(messageTemplateService.delete(99, 9))
+      .rejects.toBeInstanceOf(NotFoundError)
+  })
+
+  it("delete happy path with audit", async () => {
+    prismaMock.messageTemplate.findUnique.mockResolvedValue({ id: 1, serviceId: 10 } as any)
+    prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.messageTemplate.delete.mockResolvedValue({} as any)
+    const out = await messageTemplateService.delete(1, 9)
+    expect(out.deleted).toBe(true)
+  })
+
+  it("create rejects oversized body", async () => {
+    await expect(
+      messageTemplateService.create({ serviceId: 1, title: "T", body: "x".repeat(4097) }, 9),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+})
+
+describe("teleconsultActeService — create + helpers", () => {
+  it("create happy path returns DTO with patientId in audit", async () => {
+    prismaMock.appointment.findUnique.mockResolvedValue({ id: 1, patientId: 7 } as any)
+    prismaMock.teleconsultationActe.create.mockResolvedValue({
+      id: 10, appointmentId: 1, billingCode: "TCG", amountCents: 2300, invoicedAt: null,
+    } as any)
+    const out = await teleconsultActeService.create(
+      { appointmentId: 1, billingCode: "TCG", amountCents: 2300 }, 9,
+    )
+    expect(out.billingCode).toBe("TCG")
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.metadata.patientId).toBe(7)
+  })
+
+  it("rejects amountCents out of range", async () => {
+    await expect(
+      teleconsultActeService.create({ appointmentId: 1, billingCode: "TCG", amountCents: 9_999_999 }, 9),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("getAppointmentPatientId returns null for missing appointment", async () => {
+    prismaMock.appointment.findUnique.mockResolvedValue(null)
+    const r = await teleconsultActeService.getAppointmentPatientId(999)
+    expect(r).toBeNull()
+  })
+
+  it("getAppointmentPatientId returns patientId on hit", async () => {
+    prismaMock.appointment.findUnique.mockResolvedValue({ patientId: 7 } as any)
+    const r = await teleconsultActeService.getAppointmentPatientId(1)
+    expect(r).toBe(7)
+  })
+})
+
+describe("delegationRequestService — listInbox + create happy path", () => {
+  it("listInbox returns pending items + audits READ", async () => {
+    prismaMock.delegationRequest.findMany.mockResolvedValue([
+      { id: 1, patientId: 7, fromUserId: 9, action: "PROPOSE", status: "pending", createdAt: new Date() },
+    ] as any)
+    const out = await delegationRequestService.listInbox(10)
+    expect(out).toHaveLength(1)
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.action).toBe("READ")
+    expect(audit.resourceId).toBe("inbox")
+  })
+
+  it("create happy path", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
+    prismaMock.patientService.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.delegationRequest.create.mockResolvedValue({
+      id: 1, patientId: 7, fromUserId: 9, toUserId: 10,
+      action: "PROPOSE", status: "pending", createdAt: new Date(),
+    } as any)
+    const out = await delegationRequestService.create({
+      patientId: 7, fromUserId: 9, toUserId: 10, action: "PROPOSE",
+      payload: { adjustment: "basal", value: 1.2 },
+    })
+    expect(out.id).toBe(1)
+  })
+
+  it("respond rejects already-reviewed (status != pending)", async () => {
+    prismaMock.delegationRequest.findUnique.mockResolvedValue({
+      id: 1, toUserId: 10, status: "approved", patientId: 7,
+    } as any)
+    await expect(
+      delegationRequestService.respond(1, 10, { status: "approved" }),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("respond rejects when reviewer is not the target", async () => {
+    prismaMock.delegationRequest.findUnique.mockResolvedValue({
+      id: 1, toUserId: 10, status: "pending", patientId: 7,
+    } as any)
+    await expect(
+      delegationRequestService.respond(1, 99, { status: "approved" }),
+    ).rejects.toBeInstanceOf(ForbiddenError)
+  })
+})
+
+describe("consultationNoteService — list happy path", () => {
+  it("listForPatient decrypts content + audits READ", async () => {
+    prismaMock.consultationNote.findMany.mockResolvedValue([
+      { id: 1, patientId: 7, authorId: 9, appointmentId: null, category: null,
+        content: "cipher", createdAt: new Date(), updatedAt: new Date() },
+    ] as any)
+    const out = await consultationNoteService.listForPatient(7, 9)
+    expect(out).toHaveLength(1)
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.action).toBe("READ")
+    expect(audit.resource).toBe("CONSULTATION_NOTE")
+  })
+
+  it("create rejects oversized content", async () => {
+    await expect(
+      consultationNoteService.create({
+        patientId: 7, authorId: 9, content: "x".repeat(8193),
+      }),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+})
+
+describe("proposalActualizationService — getProposalPatientId helper", () => {
+  it("returns null when proposal missing", async () => {
+    prismaMock.adjustmentProposal.findUnique.mockResolvedValue(null)
+    const r = await proposalActualizationService.getProposalPatientId("abc")
+    expect(r).toBeNull()
+  })
+  it("returns patientId on hit", async () => {
+    prismaMock.adjustmentProposal.findUnique.mockResolvedValue({ patientId: 7 } as any)
+    const r = await proposalActualizationService.getProposalPatientId("abc")
+    expect(r).toBe(7)
+  })
+
+  it("record rejects when proposal missing", async () => {
+    prismaMock.adjustmentProposal.findUnique.mockResolvedValue(null)
+    await expect(
+      proposalActualizationService.record("abc", { verifiedVia: "device-sync" }, 9),
+    ).rejects.toBeInstanceOf(NotFoundError)
+  })
+
+  it("record device-sync sets verifiedBy=null", async () => {
+    prismaMock.adjustmentProposal.findUnique.mockResolvedValue({ patientId: 7 } as any)
+    prismaMock.adjustmentProposalActualization.findUnique.mockResolvedValue(null)
+    prismaMock.adjustmentProposalActualization.upsert.mockResolvedValue({} as any)
+    await proposalActualizationService.record("abc", { verifiedVia: "device-sync" }, 9)
+    const args = prismaMock.adjustmentProposalActualization.upsert.mock.calls[0][0] as any
+    expect(args.create.verifiedBy).toBeNull()
+  })
+
+  it("record manual-ps sets verifiedBy=auditUserId", async () => {
+    prismaMock.adjustmentProposal.findUnique.mockResolvedValue({ patientId: 7 } as any)
+    prismaMock.adjustmentProposalActualization.findUnique.mockResolvedValue(null)
+    prismaMock.adjustmentProposalActualization.upsert.mockResolvedValue({} as any)
+    await proposalActualizationService.record("abc", { verifiedVia: "manual-ps" }, 9)
+    const args = prismaMock.adjustmentProposalActualization.upsert.mock.calls[0][0] as any
+    expect(args.create.verifiedBy).toBe(9)
+  })
+})
+
+describe("memberAbsenceService — date range + create happy path", () => {
+  it("rejects endDate < startDate", async () => {
+    await expect(
+      memberAbsenceService.create(
+        { memberId: 1, startDate: new Date("2026-06-10"), endDate: new Date("2026-06-01") },
+        9,
+      ),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("rejects when member not found", async () => {
+    prismaMock.healthcareMember.findUnique.mockResolvedValue(null)
+    await expect(
+      memberAbsenceService.create(
+        { memberId: 99, startDate: new Date(), endDate: new Date() }, 9,
+      ),
+    ).rejects.toBeInstanceOf(NotFoundError)
+  })
+
+  it("happy path returns row with audit metadata", async () => {
+    prismaMock.healthcareMember.findUnique.mockResolvedValue({ id: 1, serviceId: 10 } as any)
+    prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.memberAbsence.create.mockResolvedValue({ id: 1 } as any)
+    await memberAbsenceService.create(
+      { memberId: 1, startDate: new Date(), endDate: new Date() }, 9,
+    )
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.metadata.serviceId).toBe(10)
+  })
+})
+
+describe("handoffNoteService — create + acknowledge happy paths", () => {
+  it("create happy path encrypts note", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
+    prismaMock.patientService.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.handoffNote.create.mockResolvedValue({ id: 1, createdAt: new Date() } as any)
+    await handoffNoteService.create({
+      patientId: 7, fromUserId: 9, toUserId: 10, note: "Surveiller hypo",
+    })
+    const args = prismaMock.handoffNote.create.mock.calls[0][0] as any
+    expect(args.data.note).not.toContain("Surveiller")
+  })
+
+  it("acknowledge happy path", async () => {
+    prismaMock.handoffNote.findUnique.mockResolvedValue({
+      id: 1, toUserId: 10, patientId: 7, acknowledgedAt: null,
+    } as any)
+    prismaMock.handoffNote.update.mockResolvedValue({
+      acknowledgedAt: new Date(),
+    } as any)
+    const out = await handoffNoteService.acknowledge(1, 10)
+    expect(out.acknowledgedAt).toBeInstanceOf(Date)
+  })
+
+  it("acknowledge idempotent (already acknowledged)", async () => {
+    const prev = new Date()
+    prismaMock.handoffNote.findUnique.mockResolvedValue({
+      id: 1, toUserId: 10, patientId: 7, acknowledgedAt: prev,
+    } as any)
+    const out = await handoffNoteService.acknowledge(1, 10)
+    expect(out.acknowledgedAt).toBe(prev)
+    expect(prismaMock.handoffNote.update).not.toHaveBeenCalled()
+  })
+})
+
+describe("readReceiptService — happy path on ANNOUNCEMENT", () => {
+  it("marks read and audits", async () => {
+    prismaMock.announcement.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.readReceipt.upsert.mockResolvedValue({ id: 1, readAt: new Date() } as any)
+    const r = await readReceiptService.markRead("ANNOUNCEMENT", 1, 9)
+    expect(r.readAt).toBeInstanceOf(Date)
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.resource).toBe("READ_RECEIPT")
+  })
+
+  it("rejects ANNOUNCEMENT that doesn't exist", async () => {
+    prismaMock.announcement.findFirst.mockResolvedValue(null)
+    await expect(readReceiptService.markRead("ANNOUNCEMENT", 999, 9))
+      .rejects.toBeInstanceOf(NotFoundError)
   })
 })

--- a/tests/unit/team-workflow.service.test.ts
+++ b/tests/unit/team-workflow.service.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Test suite: team-workflow services (Groupe 3 Batch 1, 10 US)
+ *
+ * Covers:
+ *  - US-2078 MessageTemplate : membership check + validation + audit
+ *  - US-2080 ReadReceipt     : upsert + restricted resource set
+ *  - US-2065 ProposalAck     : patient mark-read + respond (encrypted comment)
+ *  - US-2066 ProposalActualization : verifiedVia enum, verifiedBy auto-null
+ *      for device-sync
+ *  - US-2068 ConsultationNote : encrypts content, audits patient pivot
+ *  - US-2072 TeleconsultActe : billing code regex, audit metadata
+ *  - US-2083 DelegationRequest : create + respond (only target user)
+ *  - US-2084 MemberAbsence : membership check via member's service
+ *  - US-2086 HandoffNote : encrypted note + ack restricted to recipient
+ *  - US-2088 PatientGroup : cross-cabinet contamination blocked
+ */
+import { describe, it, expect, beforeEach } from "vitest"
+import { prismaMock } from "../helpers/prisma-mock"
+import {
+  messageTemplateService,
+  readReceiptService,
+  proposalAckService,
+  proposalActualizationService,
+  consultationNoteService,
+  teleconsultActeService,
+  delegationRequestService,
+  memberAbsenceService,
+  handoffNoteService,
+  patientGroupService,
+} from "@/lib/services/team-workflow.service"
+import {
+  ForbiddenError,
+  NotFoundError,
+  ValidationError,
+} from "@/lib/services/team-workflow.errors"
+
+beforeEach(() => {
+  prismaMock.auditLog.create.mockResolvedValue({} as any)
+  prismaMock.$transaction.mockImplementation(async (fn: any) => fn(prismaMock))
+})
+
+describe("messageTemplateService", () => {
+  it("rejects non-members on list", async () => {
+    prismaMock.healthcareMember.findFirst.mockResolvedValue(null)
+    await expect(messageTemplateService.list(1, 9)).rejects.toBeInstanceOf(ForbiddenError)
+  })
+  it("rejects empty title on create", async () => {
+    prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 1 } as any)
+    await expect(
+      messageTemplateService.create({ serviceId: 1, title: "  ", body: "x" }, 9),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+  it("audits CREATE with serviceId in metadata", async () => {
+    prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.messageTemplate.create.mockResolvedValue({
+      id: 42, serviceId: 1, title: "Welcome", body: "...", variables: [],
+    } as any)
+    await messageTemplateService.create(
+      { serviceId: 1, title: "Welcome", body: "hello" }, 9,
+    )
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.resource).toBe("MESSAGE_TEMPLATE")
+    expect(audit.metadata.serviceId).toBe(1)
+  })
+})
+
+describe("readReceiptService", () => {
+  it("rejects unknown resource", async () => {
+    await expect(readReceiptService.markRead("UNKNOWN", 1, 9))
+      .rejects.toBeInstanceOf(ValidationError)
+  })
+  it("upserts idempotently and audits", async () => {
+    prismaMock.readReceipt.upsert.mockResolvedValue({ id: 1, readAt: new Date() } as any)
+    const r = await readReceiptService.markRead("ANNOUNCEMENT", 1, 9)
+    expect(r.readAt).toBeInstanceOf(Date)
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.resource).toBe("READ_RECEIPT")
+  })
+})
+
+describe("proposalAckService", () => {
+  it("encrypts comment on respond (no plaintext at-rest)", async () => {
+    prismaMock.adjustmentProposalAck.upsert.mockResolvedValue({
+      id: 1, proposalId: "abc", patientId: 7, acknowledged: true,
+      accepted: true, comment: null, readAt: new Date(), respondedAt: new Date(),
+    } as any)
+    await proposalAckService.respond("abc", 7, { accepted: true, comment: "OK pour moi" })
+    const upsertArgs = prismaMock.adjustmentProposalAck.upsert.mock.calls[0][0] as any
+    expect(upsertArgs.create.comment).not.toBe("OK pour moi") // encrypted
+    expect(typeof upsertArgs.create.comment).toBe("string")
+  })
+})
+
+describe("proposalActualizationService", () => {
+  it("rejects unknown verifiedVia", async () => {
+    await expect(
+      proposalActualizationService.record("abc", { verifiedVia: "magic" }, 9),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+  it("sets verifiedBy=null when verifiedVia=device-sync", async () => {
+    prismaMock.adjustmentProposal.findUnique.mockResolvedValue({ patientId: 7 } as any)
+    prismaMock.adjustmentProposalActualization.upsert.mockResolvedValue({} as any)
+    await proposalActualizationService.record("abc", { verifiedVia: "device-sync" }, 9)
+    const args = prismaMock.adjustmentProposalActualization.upsert.mock.calls[0][0] as any
+    expect(args.create.verifiedBy).toBeNull()
+  })
+  it("keeps verifiedBy for manual-ps", async () => {
+    prismaMock.adjustmentProposal.findUnique.mockResolvedValue({ patientId: 7 } as any)
+    prismaMock.adjustmentProposalActualization.upsert.mockResolvedValue({} as any)
+    await proposalActualizationService.record("abc", { verifiedVia: "manual-ps" }, 9)
+    const args = prismaMock.adjustmentProposalActualization.upsert.mock.calls[0][0] as any
+    expect(args.create.verifiedBy).toBe(9)
+  })
+})
+
+describe("consultationNoteService", () => {
+  it("blocks soft-deleted patient", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue(null)
+    await expect(
+      consultationNoteService.create({ patientId: 7, authorId: 9, content: "ok" }),
+    ).rejects.toBeInstanceOf(NotFoundError)
+  })
+  it("encrypts content before persisting", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
+    prismaMock.consultationNote.create.mockResolvedValue({ id: 1, createdAt: new Date() } as any)
+    await consultationNoteService.create({
+      patientId: 7, authorId: 9, content: "Examen normal — TA 12/8",
+    })
+    const args = prismaMock.consultationNote.create.mock.calls[0][0] as any
+    expect(args.data.content).not.toContain("Examen")
+  })
+})
+
+describe("teleconsultActeService", () => {
+  it("rejects invalid billing code", async () => {
+    await expect(
+      teleconsultActeService.create({ appointmentId: 1, billingCode: "bad code" }, 9),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+  it("rejects when appointment is missing", async () => {
+    prismaMock.appointment.findUnique.mockResolvedValue(null)
+    await expect(
+      teleconsultActeService.create({ appointmentId: 999, billingCode: "TCG" }, 9),
+    ).rejects.toBeInstanceOf(NotFoundError)
+  })
+  it("audits with patientId pivot derived from appointment", async () => {
+    prismaMock.appointment.findUnique.mockResolvedValue({ id: 1, patientId: 7 } as any)
+    prismaMock.teleconsultationActe.create.mockResolvedValue({ id: 11 } as any)
+    await teleconsultActeService.create({ appointmentId: 1, billingCode: "TCG" }, 9)
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.metadata.patientId).toBe(7)
+  })
+})
+
+describe("delegationRequestService", () => {
+  it("rejects empty action", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
+    await expect(
+      delegationRequestService.create({
+        patientId: 7, fromUserId: 9, toUserId: 10, action: "  ",
+      }),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+  it("respond forbidden if reviewer ≠ target", async () => {
+    prismaMock.delegationRequest.findUnique.mockResolvedValue({
+      id: 1, toUserId: 10, status: "pending", patientId: 7,
+    } as any)
+    await expect(
+      delegationRequestService.respond(1, 99, { status: "approved" }),
+    ).rejects.toBeInstanceOf(ForbiddenError)
+  })
+  it("respond rejects already-reviewed", async () => {
+    prismaMock.delegationRequest.findUnique.mockResolvedValue({
+      id: 1, toUserId: 10, status: "approved", patientId: 7,
+    } as any)
+    await expect(
+      delegationRequestService.respond(1, 10, { status: "approved" }),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+})
+
+describe("memberAbsenceService", () => {
+  it("rejects endDate < startDate", async () => {
+    await expect(
+      memberAbsenceService.create(
+        { memberId: 1, startDate: new Date("2026-06-10"), endDate: new Date("2026-06-01") },
+        9,
+      ),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+  it("requires caller to be member of the absent member's service", async () => {
+    prismaMock.healthcareMember.findUnique.mockResolvedValue({ id: 1, serviceId: 10 } as any)
+    prismaMock.healthcareMember.findFirst.mockResolvedValue(null)
+    await expect(
+      memberAbsenceService.create(
+        { memberId: 1, startDate: new Date(), endDate: new Date() },
+        9,
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenError)
+  })
+})
+
+describe("handoffNoteService", () => {
+  it("encrypts note on create", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
+    prismaMock.handoffNote.create.mockResolvedValue({ id: 1, createdAt: new Date() } as any)
+    await handoffNoteService.create({
+      patientId: 7, fromUserId: 9, toUserId: 10, note: "Surveiller hypo nocturne",
+    })
+    const args = prismaMock.handoffNote.create.mock.calls[0][0] as any
+    expect(args.data.note).not.toContain("Surveiller")
+  })
+  it("acknowledge rejects non-recipient", async () => {
+    prismaMock.handoffNote.findUnique.mockResolvedValue({
+      id: 1, toUserId: 10, patientId: 7, acknowledgedAt: null,
+    } as any)
+    await expect(
+      handoffNoteService.acknowledge(1, 99),
+    ).rejects.toBeInstanceOf(ForbiddenError)
+  })
+})
+
+describe("patientGroupService", () => {
+  it("setForPatient blocks cross-cabinet groups", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
+    prismaMock.healthcareMember.findMany.mockResolvedValue([{ serviceId: 10 }] as any)
+    prismaMock.patientGroup.findMany.mockResolvedValue([{ id: 1 }] as any)
+    await expect(
+      patientGroupService.setForPatient(7, [1, 2], 9),
+    ).rejects.toBeInstanceOf(ForbiddenError)
+  })
+  it("setForPatient passes with all-in-scope groups", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
+    prismaMock.healthcareMember.findMany.mockResolvedValue([{ serviceId: 10 }] as any)
+    prismaMock.patientGroup.findMany.mockResolvedValue([{ id: 1 }, { id: 2 }] as any)
+    prismaMock.patientGroupAssignment.deleteMany.mockResolvedValue({ count: 0 } as any)
+    prismaMock.patientGroupAssignment.createMany.mockResolvedValue({ count: 2 } as any)
+    const out = await patientGroupService.setForPatient(7, [1, 2], 9)
+    expect(out.count).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary
ROADMAP **Groupe 3 — Équipe & Communication**, Batch 1 (workflow soignant non-messagerie). **10 US, ~10 SP**.

### US livrées
| US | Titre | Surface |
|----|-------|---------|
| **US-2078** | MessageTemplate | `/api/team/templates` CRUD cabinet |
| **US-2080** | ReadReceipt générique | `/api/team/read-receipts` |
| **US-2065** | Patient ack proposal | `/api/team/proposal-ack/[id]` |
| **US-2066** | Proposal actualization | `/api/team/proposal-actualization/[id]` |
| **US-2068** | ConsultationNote chiffrée | `/api/patients/[id]/consultation-notes` |
| **US-2072** | TeleconsultActe (facturation) | `/api/team/teleconsult-actes` |
| **US-2083** | DelegationRequest IDE→DOCTOR | `/api/team/delegations` + `/respond` |
| **US-2084** | MemberAbsence | `/api/team/absences` |
| **US-2086** | HandoffNote chiffrée | `/api/team/handoffs` + `/acknowledge` |
| **US-2088** | PatientGroup cohortes | `/api/team/groups` + `/api/patients/[id]/groups` |

## Architecture
- **10 nouvelles tables** : migration `20260513200000_groupe3_workflow` (purement additive, ON UPDATE CASCADE, FK Restrict pour service/Cascade pour patient/SetNull pour user audit-trails)
- **Service composite** : `src/lib/services/team-workflow.service.ts` (10 services modulaires)
- **Typed errors** : `team-workflow.errors.ts` (ValidationError/NotFoundError/ForbiddenError)
- **Route helper DRY** : `team-route-helpers.ts:mapErrorToResponse` factorise 15 routes
- **15 nouveaux endpoints** sous `/api/team/*` + 2 sous `/api/patients/[id]/*`

## Conventions appliquées (lessons learned PR #388/389)
- **US-2268** : `resourceId` plat + `metadata.patientId` pivot pour forensic
- **US-2265** : `accessDenied()` (burst detector) sur 403 RBAC sur les routes patient-scoped
- **patientShareConsent** : gate RGPD Art. 7.3 sur `consultation-notes` + `groups`
- **AES-256-GCM** : `ConsultationNote.content`, `HandoffNote.note`, `ProposalAck.comment`
- **Serializable transactions** : toutes les écritures critiques + `skipDuplicates`
- **Cross-cabinet protection** : groupes/templates/absences vérifient membership (résiste à l'énumération)

## Test plan
- [x] **23 tests Vitest** ciblés sur les 10 services
- [x] Suite complète **1305 verts**
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm lint` 0 erreur (18 warnings pré-existants)
- [ ] CI verte (à confirmer post-push)
- [ ] Review multi-agent (code-reviewer + healthcare-security + typescript-pro + prisma-specialist) à enchaîner

## Hors scope (batches suivants)
- **US-2077 MSSanté** (3 SP, FR PKI/SSO) → Batch 2 standalone
- **US-2076 Messagerie HDS** (13 SP, WS + polling + FCM) → Batch 3 multi-PR
- **US-2070/2071** → doublons US-2500/2501 déjà livrés PR #388 (module RDV)

🤖 Generated with [Claude Code](https://claude.com/claude-code)