### PR TITLE
feat(rdv): Groupe 8 Batch 1 — 5 US RDV core CRUD (~36 SP)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -928,4 +928,4 @@ pnpm test:e2e                          # Playwright sur pages et API routes
 
 ---
 
-*Dernière mise à jour : 2026-05-08 — Mirror MVP livré (PR #343), Batch D1 livré (PR #349 : US-2265 + US-2266), US-2267 reclassée V1 + blocker-pre-prod (Diabeo pas en prod). Total 268 US. MVP 49/65 = 75% (78% sur scope original 63).*
+*Dernière mise à jour : 2026-05-14 — Groupe 8 Batch 1 RDV livré (PR #392 : US-2500/2501/2503/2504/2505, 36 SP). Module RDV CRUD complet : calendrier sécurisé (scope obligatoire, soft-delete filter, cross-midnight overlap), note/motif/cancelReason chiffrés AES-256-GCM, state machine annulation/report bilatéral (actor + callerRole audit), plages indisponibles `MemberUnavailability` avec EXCLUDE GiST constraint (btree_gist), mode booking auto/validation. 1412/1412 tests verts. Batch 2 (US-2502 rappels + US-2506 SMS, 13 SP) TODO. Total 268 US.*

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -353,16 +353,19 @@ tous corrigés. Migration `20260513230000_groupe5_review_fixes` (FK + unique + p
 > US-2407 (infirmier). IDs frais US-2500-2506 pour éviter collision avec
 > US-2070 "Planification suivi" PARTIAL et US-2071 "Templates consultation"
 > NOT STARTED qui ont une sémantique différente.
+>
+> **Batch 1 (CRUD core, 36 SP) — DONE PR #392** : US-2500/2501/2503/2504/2505.
+> Batch 2 (notifications, 13 SP) — TODO : US-2502 + US-2506.
 
-| US | Titre | SP | Notes |
-|----|-------|---:|-------|
-| US-2500 | Calendrier RDV (jour/semaine/mois + drag&drop) | 13 | 3 vues commutables, drag&drop pour reprogrammer |
-| US-2501 | Détail RDV (CRUD + note médicale chiffrée AES-256-GCM) | 8 | Champs : date+heure, patient, type, durée, note, motif, lieu (présentiel/visio) |
-| US-2502 | Rappels RDV multi-canal (email J-2 / SMS J-1 / push J-0) | 8 | Patient choisit son canal préféré dans `UserNotifPreferences` |
-| US-2503 | Annulation / report bilatéral | 5 | Patient ou médecin, délai 24h sans pénalité, si annulation médecin → proposition alternative |
-| US-2504 | Plages indisponibles médecin | 5 | Congés, jours fériés FR/DZ, créneaux bloqués manuellement |
-| US-2505 | Config prise de RDV (auto vs validation manuelle) | 5 | Toggle par médecin lors de la config de son calendrier |
-| US-2506 | Option SMS payante cabinet | 5 | Provider SMS (Twilio/OVH/autre) + activation cabinet via admin UI |
+| US | Titre | SP | Status | Notes |
+|----|-------|---:|:------:|-------|
+| US-2500 | Calendrier RDV (list + range query, sécurisé scope) | 13 | ✅ DONE | `listInRange` scope obligatoire (patient/member), soft-delete filter, cross-midnight overlap, truncated flag — PR #392 |
+| US-2501 | Détail RDV (CRUD + note/motif/cancelReason chiffrés AES-256-GCM) | 8 | ✅ DONE | 5 endpoints API (list, detail, create, update, cancel), DTO split list/detail (pas de bulk decrypt) — PR #392 |
+| US-2502 | Rappels RDV multi-canal (email J-2 / SMS J-1 / push J-0) | 8 | ⏳ Batch 2 | Provider SMS dépend US-2506 |
+| US-2503 | Annulation / report bilatéral | 5 | ✅ DONE | State machine cancel/propose/accept, TTL 7j sur alternative, audit `actor`+`callerRole`, EXCLUDE overlap re-check — PR #392 |
+| US-2504 | Plages indisponibles médecin | 5 | ✅ DONE | `MemberUnavailability` table, EXCLUDE GiST constraint (btree_gist), reason chiffrée, audit US-2265 — PR #392 |
+| US-2505 | Config prise de RDV (auto vs validation manuelle) | 5 | ✅ DONE | `HealthcareMember.bookingMode` enum, `confirm` route DOCTOR, default duration 15-240 — PR #392 |
+| US-2506 | Option SMS payante cabinet | 5 | ⏳ Batch 2 | Provider SMS (Twilio/OVH) + activation admin UI |
 
 > **Dépendances** :
 >  - US-2074 (Email Resend, DONE) pour rappels email

--- a/docs/runbook/migrations.md
+++ b/docs/runbook/migrations.md
@@ -212,3 +212,28 @@ Avant le go-live :
 - [ ] Health endpoint `/api/health` répond 200 post-deploy
 - [ ] Tests E2E smoke (login + un READ patient) verts en prod
 - [ ] Rollback testé (sur dump récent staging) : voir §5
+
+---
+
+## Prérequis extensions Postgres (Groupe 8 RDV)
+
+La migration `20260514100000_groupe8_rdv` crée une contrainte `EXCLUDE USING GIST` sur `member_unavailabilities` pour bloquer les chevauchements horaires sans dépendre de Serializable. Elle requiert l'extension `btree_gist`.
+
+### Vérification avant deploy
+
+```sql
+-- Sur le rôle applicatif
+SELECT extname, extversion FROM pg_extension WHERE extname = 'btree_gist';
+-- Si absent, vérifier sa disponibilité
+SELECT * FROM pg_available_extensions WHERE name = 'btree_gist';
+```
+
+### Action si extension manquante
+
+OVH Public Cloud DBaaS pré-installe `btree_gist`. Si le rôle applicatif n'a pas `CREATE EXTENSION`, exécuter en superuser :
+
+```sql
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+```
+
+Puis relancer `pnpm prisma migrate deploy` (idempotent).

--- a/prisma/migrations/20260514100000_groupe8_rdv/migration.sql
+++ b/prisma/migrations/20260514100000_groupe8_rdv/migration.sql
@@ -1,0 +1,74 @@
+-- Groupe 8 Batch 1 — RDV core CRUD (5 US, 36 SP)
+--  * US-2500 Calendrier — indexes pour list par range
+--  * US-2501 Detail RDV — Appointment étendu + note chiffrée
+--  * US-2503 Annulation/report bilatéral — state machine
+--  * US-2504 Plages indisponibles — member_unavailabilities
+--  * US-2505 Config prise RDV — HealthcareMember.bookingMode
+
+-- ─────────────────────────────────────────────────────────────
+-- New enums
+-- ─────────────────────────────────────────────────────────────
+CREATE TYPE "appointment_location" AS ENUM ('in_person', 'video', 'phone');
+CREATE TYPE "appointment_status" AS ENUM (
+    'scheduled', 'pending_validation', 'confirmed',
+    'cancelled', 'completed', 'no_show'
+);
+CREATE TYPE "booking_mode" AS ENUM ('auto', 'validation');
+
+-- ─────────────────────────────────────────────────────────────
+-- US-2501/2503 — Appointment columns
+-- ─────────────────────────────────────────────────────────────
+ALTER TABLE "appointments"
+    ADD COLUMN "member_id" INTEGER,
+    ADD COLUMN "duration_minutes" INTEGER,
+    ADD COLUMN "location" "appointment_location",
+    ADD COLUMN "status" "appointment_status" NOT NULL DEFAULT 'scheduled',
+    ADD COLUMN "motif" VARCHAR(200),
+    ADD COLUMN "note_encrypted" TEXT,
+    ADD COLUMN "proposed_alternative_at" TIMESTAMPTZ,
+    ADD COLUMN "cancelled_by" VARCHAR(20),
+    ADD COLUMN "cancel_reason" VARCHAR(500),
+    ADD COLUMN "cancelled_at" TIMESTAMPTZ;
+
+ALTER TABLE "appointments"
+    ADD CONSTRAINT "appointments_member_id_fkey"
+        FOREIGN KEY ("member_id") REFERENCES "healthcare_members"("id")
+        ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE INDEX "appointments_member_id_date_idx" ON "appointments"("member_id", "date");
+CREATE INDEX "appointments_patient_id_date_idx" ON "appointments"("patient_id", "date");
+CREATE INDEX "appointments_member_id_status_date_idx"
+    ON "appointments"("member_id", "status", "date");
+
+-- ─────────────────────────────────────────────────────────────
+-- US-2505 — HealthcareMember booking config
+-- ─────────────────────────────────────────────────────────────
+ALTER TABLE "healthcare_members"
+    ADD COLUMN "booking_mode" "booking_mode" NOT NULL DEFAULT 'auto',
+    ADD COLUMN "default_appointment_minutes" INTEGER;
+
+-- ─────────────────────────────────────────────────────────────
+-- US-2504 — Member unavailabilities (time-slot blockers)
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE "member_unavailabilities" (
+    "id" SERIAL NOT NULL,
+    "member_id" INTEGER NOT NULL,
+    "start_at" TIMESTAMPTZ NOT NULL,
+    "end_at" TIMESTAMPTZ NOT NULL,
+    "reason" VARCHAR(200),
+    "created_by" INTEGER,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "member_unavailabilities_pkey" PRIMARY KEY ("id")
+);
+CREATE INDEX "member_unavailabilities_member_id_start_at_idx"
+    ON "member_unavailabilities"("member_id", "start_at");
+
+ALTER TABLE "member_unavailabilities"
+    ADD CONSTRAINT "member_unavailabilities_member_id_fkey"
+        FOREIGN KEY ("member_id") REFERENCES "healthcare_members"("id")
+        ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "member_unavailabilities"
+    ADD CONSTRAINT "member_unavailabilities_created_by_fkey"
+        FOREIGN KEY ("created_by") REFERENCES "users"("id")
+        ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260514100000_groupe8_rdv/migration.sql
+++ b/prisma/migrations/20260514100000_groupe8_rdv/migration.sql
@@ -43,6 +43,17 @@ ALTER TABLE "appointments"
     ADD CONSTRAINT "appointments_duration_minutes_check"
         CHECK ("duration_minutes" IS NULL OR ("duration_minutes" BETWEEN 15 AND 240));
 
+-- L2 — Defense-in-depth caps on encrypted PHI columns. Plaintext caps are
+-- 200 (motif), 4096 (note), 500 (reason). Encrypted base64 overhead is ~33% +
+-- 28 bytes (12 IV + 16 TAG) + base64 padding. Allow ~2x headroom.
+ALTER TABLE "appointments"
+    ADD CONSTRAINT "appointments_motif_enc_length_check"
+        CHECK (octet_length("motif_encrypted") IS NULL OR octet_length("motif_encrypted") <= 600),
+    ADD CONSTRAINT "appointments_note_enc_length_check"
+        CHECK (octet_length("note_encrypted") IS NULL OR octet_length("note_encrypted") <= 9000),
+    ADD CONSTRAINT "appointments_cancel_reason_enc_length_check"
+        CHECK (octet_length("cancel_reason_encrypted") IS NULL OR octet_length("cancel_reason_encrypted") <= 1200);
+
 CREATE INDEX "appointments_member_id_date_idx" ON "appointments"("member_id", "date");
 CREATE INDEX "appointments_patient_id_date_idx" ON "appointments"("patient_id", "date");
 CREATE INDEX "appointments_member_id_status_date_idx"
@@ -74,7 +85,10 @@ CREATE TABLE "member_unavailabilities" (
 
     CONSTRAINT "member_unavailabilities_pkey" PRIMARY KEY ("id"),
     -- L8 — Coherence check on temporal interval.
-    CONSTRAINT "member_unavailabilities_range_check" CHECK ("end_at" > "start_at")
+    CONSTRAINT "member_unavailabilities_range_check" CHECK ("end_at" > "start_at"),
+    -- L2 — Defense-in-depth cap on encrypted reason (plaintext 200 chars).
+    CONSTRAINT "member_unavailabilities_reason_enc_length_check"
+        CHECK (octet_length("reason_encrypted") IS NULL OR octet_length("reason_encrypted") <= 600)
 );
 CREATE INDEX "member_unavailabilities_member_id_start_at_idx"
     ON "member_unavailabilities"("member_id", "start_at");
@@ -85,7 +99,16 @@ CREATE INDEX "member_unavailabilities_member_id_end_at_idx"
 -- H3/M12 — Postgres EXCLUDE constraint prevents overlapping unavailabilities
 -- for the same member without relying on Serializable transactions catching
 -- write-write conflicts (which they may not when no rw-conflict exists).
+--
 -- `btree_gist` extension is required for INT GiST ops.
+-- ┌─────────────────────────────────────────────────────────────────────────┐
+-- │ DEPLOYMENT PREREQUISITE (H4) — `btree_gist` must be available on the    │
+-- │ target Postgres instance. OVH-managed DBaaS pre-installs it by default  │
+-- │ (verify via `SELECT * FROM pg_available_extensions WHERE name           │
+-- │ = 'btree_gist'`). If the role lacks `CREATE EXTENSION` privilege, run   │
+-- │ the statement below as a superuser BEFORE `prisma migrate deploy`.      │
+-- │ Documented in `docs/runbook/migrations.md` (US-2267).                   │
+-- └─────────────────────────────────────────────────────────────────────────┘
 CREATE EXTENSION IF NOT EXISTS btree_gist;
 ALTER TABLE "member_unavailabilities"
     ADD CONSTRAINT "member_unavailabilities_no_overlap"

--- a/prisma/migrations/20260514100000_groupe8_rdv/migration.sql
+++ b/prisma/migrations/20260514100000_groupe8_rdv/migration.sql
@@ -14,26 +14,34 @@ CREATE TYPE "appointment_status" AS ENUM (
     'cancelled', 'completed', 'no_show'
 );
 CREATE TYPE "booking_mode" AS ENUM ('auto', 'validation');
+CREATE TYPE "cancellation_actor" AS ENUM ('patient', 'doctor');
 
 -- ─────────────────────────────────────────────────────────────
 -- US-2501/2503 — Appointment columns
+-- PHI free-text fields are stored encrypted (AES-256-GCM base64).
 -- ─────────────────────────────────────────────────────────────
 ALTER TABLE "appointments"
     ADD COLUMN "member_id" INTEGER,
     ADD COLUMN "duration_minutes" INTEGER,
     ADD COLUMN "location" "appointment_location",
     ADD COLUMN "status" "appointment_status" NOT NULL DEFAULT 'scheduled',
-    ADD COLUMN "motif" VARCHAR(200),
+    ADD COLUMN "motif_encrypted" TEXT,
     ADD COLUMN "note_encrypted" TEXT,
     ADD COLUMN "proposed_alternative_at" TIMESTAMPTZ,
-    ADD COLUMN "cancelled_by" VARCHAR(20),
-    ADD COLUMN "cancel_reason" VARCHAR(500),
+    ADD COLUMN "cancelled_by" "cancellation_actor",
+    ADD COLUMN "cancel_reason_encrypted" TEXT,
     ADD COLUMN "cancelled_at" TIMESTAMPTZ;
 
 ALTER TABLE "appointments"
     ADD CONSTRAINT "appointments_member_id_fkey"
         FOREIGN KEY ("member_id") REFERENCES "healthcare_members"("id")
         ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- M8 — Enforce clinical bounds at DB level (15-240 min). NULL allowed for
+-- legacy rows pre-Groupe-8.
+ALTER TABLE "appointments"
+    ADD CONSTRAINT "appointments_duration_minutes_check"
+        CHECK ("duration_minutes" IS NULL OR ("duration_minutes" BETWEEN 15 AND 240));
 
 CREATE INDEX "appointments_member_id_date_idx" ON "appointments"("member_id", "date");
 CREATE INDEX "appointments_patient_id_date_idx" ON "appointments"("patient_id", "date");
@@ -47,6 +55,11 @@ ALTER TABLE "healthcare_members"
     ADD COLUMN "booking_mode" "booking_mode" NOT NULL DEFAULT 'auto',
     ADD COLUMN "default_appointment_minutes" INTEGER;
 
+ALTER TABLE "healthcare_members"
+    ADD CONSTRAINT "healthcare_members_default_appointment_minutes_check"
+        CHECK ("default_appointment_minutes" IS NULL
+            OR ("default_appointment_minutes" BETWEEN 15 AND 240));
+
 -- ─────────────────────────────────────────────────────────────
 -- US-2504 — Member unavailabilities (time-slot blockers)
 -- ─────────────────────────────────────────────────────────────
@@ -55,14 +68,31 @@ CREATE TABLE "member_unavailabilities" (
     "member_id" INTEGER NOT NULL,
     "start_at" TIMESTAMPTZ NOT NULL,
     "end_at" TIMESTAMPTZ NOT NULL,
-    "reason" VARCHAR(200),
+    "reason_encrypted" TEXT,
     "created_by" INTEGER,
     "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-    CONSTRAINT "member_unavailabilities_pkey" PRIMARY KEY ("id")
+    CONSTRAINT "member_unavailabilities_pkey" PRIMARY KEY ("id"),
+    -- L8 — Coherence check on temporal interval.
+    CONSTRAINT "member_unavailabilities_range_check" CHECK ("end_at" > "start_at")
 );
 CREATE INDEX "member_unavailabilities_member_id_start_at_idx"
     ON "member_unavailabilities"("member_id", "start_at");
+-- M15 — Cover end_at lookups (overlap queries filter on both bounds).
+CREATE INDEX "member_unavailabilities_member_id_end_at_idx"
+    ON "member_unavailabilities"("member_id", "end_at");
+
+-- H3/M12 — Postgres EXCLUDE constraint prevents overlapping unavailabilities
+-- for the same member without relying on Serializable transactions catching
+-- write-write conflicts (which they may not when no rw-conflict exists).
+-- `btree_gist` extension is required for INT GiST ops.
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+ALTER TABLE "member_unavailabilities"
+    ADD CONSTRAINT "member_unavailabilities_no_overlap"
+        EXCLUDE USING GIST (
+            "member_id" WITH =,
+            tstzrange("start_at", "end_at", '[)') WITH &&
+        );
 
 ALTER TABLE "member_unavailabilities"
     ADD CONSTRAINT "member_unavailabilities_member_id_fkey"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -352,6 +352,8 @@ model User {
   createdInsulinAdjustmentTemplates InsulinAdjustmentTemplate[]    @relation("InsulinAdjustmentTemplateCreator")
   validatedDiabetesEvents        DiabetesEvent[]                   @relation("DiabetesEventValidator")
   uploadedMealPhotos             MealPhoto[]                       @relation("MealPhotoUploader")
+  // Groupe 8 — RDV
+  createdMemberUnavailabilities  MemberUnavailability[]            @relation("MemberUnavailabilityCreator")
 
   @@index([createdAt])
   @@index([firstnameHmac, lastnameHmac])
@@ -1372,6 +1374,11 @@ model HealthcareMember {
   name      String @db.VarChar(255)
   serviceId Int?   @map("service_id")
 
+  /// US-2505 — Mode de prise de RDV (auto-confirm vs validation manuelle).
+  bookingMode    BookingMode @default(auto) @map("booking_mode")
+  /// US-2505 — Durée par défaut (min) appliquée si l'input ne précise pas.
+  defaultAppointmentMinutes Int? @map("default_appointment_minutes")
+
   service         HealthcareService? @relation(fields: [serviceId], references: [id])
   patientServices PatientService[]
   referents       PatientReferent[]
@@ -1379,9 +1386,37 @@ model HealthcareMember {
   /// US-2084 — Absences du membre + couvertures qu'il assure pour autrui
   absencesAsOwner    MemberAbsence[]  @relation("MemberAbsenceOwner")
   absencesAsCover    MemberAbsence[]  @relation("MemberAbsenceCover")
+  /// US-2500/2501 — RDV portés par ce membre.
+  appointments       Appointment[]
+  /// US-2504 — Plages indisponibles (créneaux bloqués pour la prise de RDV).
+  unavailabilities   MemberUnavailability[]
 
   @@unique([name, serviceId])
   @@map("healthcare_members")
+}
+
+/// US-2504 — Plages d'indisponibilité d'un membre (créneaux bloqués pour la
+/// prise de RDV — congé court, blocage personnel, jour férié manuel). Distinct
+/// de `MemberAbsence` qui modélise un congé multi-jours avec couverture.
+///
+/// Représentation : intervalle (`startAt`, `endAt`) en UTC stocké timestamptz.
+/// Recouvrement avec un RDV existant : prévention au service layer (le service
+/// vérifie qu'aucun `Appointment.status IN scheduled/confirmed/pending_validation`
+/// ne touche l'intervalle avant insertion).
+model MemberUnavailability {
+  id        Int       @id @default(autoincrement())
+  memberId  Int       @map("member_id")
+  startAt   DateTime  @map("start_at") @db.Timestamptz()
+  endAt     DateTime  @map("end_at") @db.Timestamptz()
+  reason    String?   @db.VarChar(200)
+  createdBy Int?      @map("created_by")
+  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz()
+
+  member  HealthcareMember @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  creator User?            @relation("MemberUnavailabilityCreator", fields: [createdBy], references: [id], onDelete: SetNull)
+
+  @@index([memberId, startAt])
+  @@map("member_unavailabilities")
 }
 
 model PatientService {
@@ -1496,16 +1531,78 @@ model Appointment {
   date      DateTime  @db.Date
   hour      DateTime? @db.Time()
   comment   String?
+  /// US-2500/2501 — Praticien titulaire du RDV (NULL si non-affecté).
+  memberId    Int?              @map("member_id")
+  /// US-2501 — Durée en minutes (15-240). NULL = legacy/non-typé.
+  durationMinutes Int?          @map("duration_minutes")
+  /// US-2501 — Lieu/canal du RDV.
+  location    AppointmentLocation?
+  /// US-2501/2503 — État du RDV. Defaults `scheduled`, état terminal `cancelled`/`completed`/`no_show`.
+  ///                Workflow `pending_validation` activé si le médecin est en mode "validation" (US-2505).
+  status      AppointmentStatus @default(scheduled)
+  /// US-2501 — Motif court (libre, max 200 char).
+  motif       String?           @db.VarChar(200)
+  /// US-2501 — Note médicale chiffrée AES-256-GCM (base64). NULL = pas de note.
+  noteEncrypted String?         @map("note_encrypted")
+  /// US-2503 — Date/heure proposée par le médecin lors d'une annulation pour
+  /// re-programmer. Renseignée par `propose-alternative`, validée par le patient
+  /// via `accept-alternative` (qui repasse le RDV en `scheduled` et met à jour
+  /// `date` + `hour`).
+  proposedAlternativeAt DateTime? @map("proposed_alternative_at") @db.Timestamptz()
+  /// US-2503 — Auteur de l'annulation/report. `patient`/`doctor`.
+  cancelledBy   String?         @map("cancelled_by") @db.VarChar(20)
+  cancelReason  String?         @map("cancel_reason") @db.VarChar(500)
+  cancelledAt   DateTime?       @map("cancelled_at") @db.Timestamptz()
   createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz()
   updatedAt DateTime  @updatedAt @map("updated_at") @db.Timestamptz()
 
   patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  member  HealthcareMember? @relation(fields: [memberId], references: [id], onDelete: SetNull)
   /// US-2068 — Notes consultation rattachées
   consultationNotes ConsultationNote[]
   /// US-2072 — Acte facturable si téléconsult
   teleconsultActe   TeleconsultationActe?
 
+  /// Hot path : liste RDV d'un praticien sur une plage temporelle (calendrier).
+  @@index([memberId, date])
+  @@index([patientId, date])
+  /// US-2503 — filtre `WHERE status = 'scheduled'` pour la vue calendrier.
+  @@index([memberId, status, date])
   @@map("appointments")
+}
+
+enum AppointmentLocation {
+  in_person
+  video
+  phone
+
+  @@map("appointment_location")
+}
+
+enum AppointmentStatus {
+  /// État initial après création (mode auto-booking).
+  scheduled
+  /// US-2505 — créé en mode validation manuelle ; le médecin doit accepter.
+  pending_validation
+  /// Confirmé par le médecin (ou auto après création en mode auto).
+  confirmed
+  /// US-2503 — annulé par l'une ou l'autre partie.
+  cancelled
+  /// Le RDV a eu lieu.
+  completed
+  /// Le patient ne s'est pas présenté.
+  no_show
+
+  @@map("appointment_status")
+}
+
+enum BookingMode {
+  /// Tout RDV créé est immédiatement `scheduled`.
+  auto
+  /// Tout RDV créé est `pending_validation` jusqu'à accept du médecin.
+  validation
+
+  @@map("booking_mode")
 }
 
 // ═══════════════════════════════════════════════════════════════

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1408,7 +1408,8 @@ model MemberUnavailability {
   memberId  Int       @map("member_id")
   startAt   DateTime  @map("start_at") @db.Timestamptz()
   endAt     DateTime  @map("end_at") @db.Timestamptz()
-  reason    String?   @db.VarChar(200)
+  /// Raison chiffrée AES-256-GCM (PHI possible : "congé maladie", "examen médical").
+  reasonEncrypted String? @map("reason_encrypted")
   createdBy Int?      @map("created_by")
   createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz()
 
@@ -1416,6 +1417,7 @@ model MemberUnavailability {
   creator User?            @relation("MemberUnavailabilityCreator", fields: [createdBy], references: [id], onDelete: SetNull)
 
   @@index([memberId, startAt])
+  @@index([memberId, endAt])
   @@map("member_unavailabilities")
 }
 
@@ -1540,18 +1542,19 @@ model Appointment {
   /// US-2501/2503 — État du RDV. Defaults `scheduled`, état terminal `cancelled`/`completed`/`no_show`.
   ///                Workflow `pending_validation` activé si le médecin est en mode "validation" (US-2505).
   status      AppointmentStatus @default(scheduled)
-  /// US-2501 — Motif court (libre, max 200 char).
-  motif       String?           @db.VarChar(200)
+  /// US-2501 — Motif chiffré AES-256-GCM (base64). PHI : peut contenir nom/symptômes patient.
+  motifEncrypted String?        @map("motif_encrypted")
   /// US-2501 — Note médicale chiffrée AES-256-GCM (base64). NULL = pas de note.
   noteEncrypted String?         @map("note_encrypted")
   /// US-2503 — Date/heure proposée par le médecin lors d'une annulation pour
   /// re-programmer. Renseignée par `propose-alternative`, validée par le patient
   /// via `accept-alternative` (qui repasse le RDV en `scheduled` et met à jour
-  /// `date` + `hour`).
+  /// `date` + `hour`). TTL applicatif : la proposition expire après 7 jours.
   proposedAlternativeAt DateTime? @map("proposed_alternative_at") @db.Timestamptz()
-  /// US-2503 — Auteur de l'annulation/report. `patient`/`doctor`.
-  cancelledBy   String?         @map("cancelled_by") @db.VarChar(20)
-  cancelReason  String?         @map("cancel_reason") @db.VarChar(500)
+  /// US-2503 — Auteur de l'annulation. Dérivé du rôle au moment du cancel.
+  cancelledBy   CancellationActor? @map("cancelled_by")
+  /// US-2503 — Raison d'annulation chiffrée AES-256-GCM (PHI possible).
+  cancelReasonEncrypted String? @map("cancel_reason_encrypted")
   cancelledAt   DateTime?       @map("cancelled_at") @db.Timestamptz()
   createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz()
   updatedAt DateTime  @updatedAt @map("updated_at") @db.Timestamptz()
@@ -1594,6 +1597,13 @@ enum AppointmentStatus {
   no_show
 
   @@map("appointment_status")
+}
+
+enum CancellationActor {
+  patient
+  doctor
+
+  @@map("cancellation_actor")
 }
 
 enum BookingMode {

--- a/src/app/api/appointments/[id]/accept-alternative/route.ts
+++ b/src/app/api/appointments/[id]/accept-alternative/route.ts
@@ -1,0 +1,37 @@
+/** US-2503 — Patient accepts the alternative proposed by the doctor. */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { rdvAppointmentService } from "@/lib/services/rdv.service"
+import { auditService, extractRequestContext } from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  const ctx = extractRequestContext(req)
+  try {
+    const { id } = await params
+    if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidId" }, { status: 400 })
+    const apptId = parseInt(id, 10)
+    const user = await auditedRequireRole(req, "NURSE", ctx, "APPOINTMENT", id)
+
+    const patientId = await rdvAppointmentService.getPatientIdFor(apptId)
+    if (patientId === null) return NextResponse.json({ error: "notFound" }, { status: 404 })
+    const allowed = await canAccessPatient(user.id, user.role, patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id, resource: "APPOINTMENT", resourceId: id,
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: { patientId, endpoint: "accept-alternative" },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+    const out = await rdvAppointmentService.acceptAlternative(apptId, user.id, ctx)
+    return NextResponse.json(out)
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "appointments/:id/accept-alternative POST", ctx.requestId)
+  }
+}

--- a/src/app/api/appointments/[id]/accept-alternative/route.ts
+++ b/src/app/api/appointments/[id]/accept-alternative/route.ts
@@ -16,7 +16,9 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     const gate = await appointmentRouteGate(req, id, "NURSE", "accept-alternative")
     if (gate.kind === "error") return gate.res
 
-    const out = await rdvAppointmentService.acceptAlternative(gate.apptId, gate.user.id, ctx)
+    const out = await rdvAppointmentService.acceptAlternative(
+      gate.apptId, gate.user.id, ctx, gate.user.role,
+    )
     return NextResponse.json(out)
   } catch (e) {
     if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })

--- a/src/app/api/appointments/[id]/accept-alternative/route.ts
+++ b/src/app/api/appointments/[id]/accept-alternative/route.ts
@@ -2,10 +2,10 @@
 
 import { NextResponse, type NextRequest } from "next/server"
 import { AuthError } from "@/lib/auth"
-import { canAccessPatient } from "@/lib/access-control"
 import { rdvAppointmentService } from "@/lib/services/rdv.service"
-import { auditService, extractRequestContext } from "@/lib/services/audit.service"
-import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { mapErrorToResponse } from "@/lib/team-route-helpers"
+import { appointmentRouteGate } from "@/lib/appointments-route-helpers"
 
 type RouteParams = { params: Promise<{ id: string }> }
 
@@ -13,22 +13,10 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
   const ctx = extractRequestContext(req)
   try {
     const { id } = await params
-    if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidId" }, { status: 400 })
-    const apptId = parseInt(id, 10)
-    const user = await auditedRequireRole(req, "NURSE", ctx, "APPOINTMENT", id)
+    const gate = await appointmentRouteGate(req, id, "NURSE", "accept-alternative")
+    if (gate.kind === "error") return gate.res
 
-    const patientId = await rdvAppointmentService.getPatientIdFor(apptId)
-    if (patientId === null) return NextResponse.json({ error: "notFound" }, { status: 404 })
-    const allowed = await canAccessPatient(user.id, user.role, patientId)
-    if (!allowed) {
-      await auditService.accessDenied({
-        userId: user.id, resource: "APPOINTMENT", resourceId: id,
-        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
-        metadata: { patientId, endpoint: "accept-alternative" },
-      })
-      return NextResponse.json({ error: "forbidden" }, { status: 403 })
-    }
-    const out = await rdvAppointmentService.acceptAlternative(apptId, user.id, ctx)
+    const out = await rdvAppointmentService.acceptAlternative(gate.apptId, gate.user.id, ctx)
     return NextResponse.json(out)
   } catch (e) {
     if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })

--- a/src/app/api/appointments/[id]/cancel/route.ts
+++ b/src/app/api/appointments/[id]/cancel/route.ts
@@ -3,15 +3,14 @@
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
 import { AuthError } from "@/lib/auth"
-import { canAccessPatient } from "@/lib/access-control"
 import { rdvAppointmentService } from "@/lib/services/rdv.service"
-import { auditService, extractRequestContext } from "@/lib/services/audit.service"
-import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { mapErrorToResponse } from "@/lib/team-route-helpers"
+import { appointmentRouteGate } from "@/lib/appointments-route-helpers"
 
 type RouteParams = { params: Promise<{ id: string }> }
 
 const schema = z.object({
-  by: z.enum(["patient", "doctor"]),
   reason: z.string().max(500).optional(),
 })
 
@@ -19,28 +18,22 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
   const ctx = extractRequestContext(req)
   try {
     const { id } = await params
-    if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidId" }, { status: 400 })
-    const apptId = parseInt(id, 10)
-    const user = await auditedRequireRole(req, "NURSE", ctx, "APPOINTMENT", id)
+    const gate = await appointmentRouteGate(req, id, "NURSE", "cancel")
+    if (gate.kind === "error") return gate.res
 
-    const patientId = await rdvAppointmentService.getPatientIdFor(apptId)
-    if (patientId === null) return NextResponse.json({ error: "notFound" }, { status: 404 })
-    const allowed = await canAccessPatient(user.id, user.role, patientId)
-    if (!allowed) {
-      await auditService.accessDenied({
-        userId: user.id, resource: "APPOINTMENT", resourceId: id,
-        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
-        metadata: { patientId, endpoint: "cancel" },
-      })
-      return NextResponse.json({ error: "forbidden" }, { status: 403 })
-    }
-
-    const body = await req.json()
+    const body = await req.json().catch(() => ({}))
     const parsed = schema.safeParse(body)
     if (!parsed.success) {
       return NextResponse.json({ error: "validationFailed" }, { status: 400 })
     }
-    const out = await rdvAppointmentService.cancel(apptId, parsed.data, user.id, ctx)
+    // H4 — actor is derived from the caller's role (never from request body).
+    // VIEWER falls into the patient branch (read-side; cancels via patient flow);
+    // NURSE/DOCTOR/ADMIN cancel on behalf of the doctor.
+    const actor = gate.user.role === "VIEWER" ? "patient" : "doctor"
+
+    const out = await rdvAppointmentService.cancel(
+      gate.apptId, { actor, reason: parsed.data.reason }, gate.user.id, ctx,
+    )
     return NextResponse.json(out)
   } catch (e) {
     if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })

--- a/src/app/api/appointments/[id]/cancel/route.ts
+++ b/src/app/api/appointments/[id]/cancel/route.ts
@@ -1,16 +1,31 @@
-/** US-2503 — Cancel an appointment (patient or doctor). */
+/** US-2503 — Cancel an appointment (staff route).
+ *
+ * The route is staff-only (gate enforces NURSE+). Staff may cancel either
+ * on the doctor's initiative (`actor: "doctor"`) or as a reception desk
+ * recording a patient-initiated cancel (`actor: "patient"`). The immutable
+ * audit log records BOTH the declared `actor` (intent) and the caller's
+ * `callerRole` (forensics), so a misattribution can never silently corrupt
+ * the cancel-by-doctor branch downstream (propose-alternative gate).
+ *
+ * Patient self-cancel (via mobile app) will use a separate `/api/patient`
+ * route in a future story — out of scope here.
+ */
 
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
 import { AuthError } from "@/lib/auth"
 import { rdvAppointmentService } from "@/lib/services/rdv.service"
-import { extractRequestContext } from "@/lib/services/audit.service"
+import {
+  auditService,
+  extractRequestContext,
+} from "@/lib/services/audit.service"
 import { mapErrorToResponse } from "@/lib/team-route-helpers"
 import { appointmentRouteGate } from "@/lib/appointments-route-helpers"
 
 type RouteParams = { params: Promise<{ id: string }> }
 
 const schema = z.object({
+  actor: z.enum(["patient", "doctor"]),
   reason: z.string().max(500).optional(),
 })
 
@@ -26,14 +41,32 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     if (!parsed.success) {
       return NextResponse.json({ error: "validationFailed" }, { status: 400 })
     }
-    // H4 — actor is derived from the caller's role (never from request body).
-    // VIEWER falls into the patient branch (read-side; cancels via patient flow);
-    // NURSE/DOCTOR/ADMIN cancel on behalf of the doctor.
-    const actor = gate.user.role === "VIEWER" ? "patient" : "doctor"
 
     const out = await rdvAppointmentService.cancel(
-      gate.apptId, { actor, reason: parsed.data.reason }, gate.user.id, ctx,
+      gate.apptId,
+      {
+        actor: parsed.data.actor,
+        reason: parsed.data.reason,
+        callerRole: gate.user.role,
+      },
+      gate.user.id, ctx,
     )
+
+    // H5/H8 — record the caller's role distinct from the declared actor so
+    //         forensics can detect impersonation patterns (e.g. NURSE always
+    //         declaring `doctor`).
+    await auditService.log({
+      userId: gate.user.id,
+      action: "UPDATE", resource: "APPOINTMENT", resourceId: String(gate.apptId),
+      ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+      metadata: {
+        patientId: gate.patientId,
+        kind: "cancel-actor-claim",
+        declaredActor: parsed.data.actor,
+        callerRole: gate.user.role,
+      },
+    })
+
     return NextResponse.json(out)
   } catch (e) {
     if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })

--- a/src/app/api/appointments/[id]/cancel/route.ts
+++ b/src/app/api/appointments/[id]/cancel/route.ts
@@ -1,0 +1,49 @@
+/** US-2503 — Cancel an appointment (patient or doctor). */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { rdvAppointmentService } from "@/lib/services/rdv.service"
+import { auditService, extractRequestContext } from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+const schema = z.object({
+  by: z.enum(["patient", "doctor"]),
+  reason: z.string().max(500).optional(),
+})
+
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  const ctx = extractRequestContext(req)
+  try {
+    const { id } = await params
+    if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidId" }, { status: 400 })
+    const apptId = parseInt(id, 10)
+    const user = await auditedRequireRole(req, "NURSE", ctx, "APPOINTMENT", id)
+
+    const patientId = await rdvAppointmentService.getPatientIdFor(apptId)
+    if (patientId === null) return NextResponse.json({ error: "notFound" }, { status: 404 })
+    const allowed = await canAccessPatient(user.id, user.role, patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id, resource: "APPOINTMENT", resourceId: id,
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: { patientId, endpoint: "cancel" },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+
+    const body = await req.json()
+    const parsed = schema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: "validationFailed" }, { status: 400 })
+    }
+    const out = await rdvAppointmentService.cancel(apptId, parsed.data, user.id, ctx)
+    return NextResponse.json(out)
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "appointments/:id/cancel POST", ctx.requestId)
+  }
+}

--- a/src/app/api/appointments/[id]/confirm/route.ts
+++ b/src/app/api/appointments/[id]/confirm/route.ts
@@ -2,10 +2,10 @@
 
 import { NextResponse, type NextRequest } from "next/server"
 import { AuthError } from "@/lib/auth"
-import { canAccessPatient } from "@/lib/access-control"
 import { rdvAppointmentService } from "@/lib/services/rdv.service"
-import { auditService, extractRequestContext } from "@/lib/services/audit.service"
-import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { mapErrorToResponse } from "@/lib/team-route-helpers"
+import { appointmentRouteGate } from "@/lib/appointments-route-helpers"
 
 type RouteParams = { params: Promise<{ id: string }> }
 
@@ -13,22 +13,10 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
   const ctx = extractRequestContext(req)
   try {
     const { id } = await params
-    if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidId" }, { status: 400 })
-    const apptId = parseInt(id, 10)
-    const user = await auditedRequireRole(req, "DOCTOR", ctx, "APPOINTMENT", id)
+    const gate = await appointmentRouteGate(req, id, "DOCTOR", "confirm")
+    if (gate.kind === "error") return gate.res
 
-    const patientId = await rdvAppointmentService.getPatientIdFor(apptId)
-    if (patientId === null) return NextResponse.json({ error: "notFound" }, { status: 404 })
-    const allowed = await canAccessPatient(user.id, user.role, patientId)
-    if (!allowed) {
-      await auditService.accessDenied({
-        userId: user.id, resource: "APPOINTMENT", resourceId: id,
-        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
-        metadata: { patientId, endpoint: "confirm" },
-      })
-      return NextResponse.json({ error: "forbidden" }, { status: 403 })
-    }
-    const out = await rdvAppointmentService.confirm(apptId, user.id, ctx)
+    const out = await rdvAppointmentService.confirm(gate.apptId, gate.user.id, ctx)
     return NextResponse.json(out)
   } catch (e) {
     if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })

--- a/src/app/api/appointments/[id]/confirm/route.ts
+++ b/src/app/api/appointments/[id]/confirm/route.ts
@@ -1,0 +1,37 @@
+/** US-2505 — Doctor confirms a pending_validation appointment. */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { rdvAppointmentService } from "@/lib/services/rdv.service"
+import { auditService, extractRequestContext } from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  const ctx = extractRequestContext(req)
+  try {
+    const { id } = await params
+    if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidId" }, { status: 400 })
+    const apptId = parseInt(id, 10)
+    const user = await auditedRequireRole(req, "DOCTOR", ctx, "APPOINTMENT", id)
+
+    const patientId = await rdvAppointmentService.getPatientIdFor(apptId)
+    if (patientId === null) return NextResponse.json({ error: "notFound" }, { status: 404 })
+    const allowed = await canAccessPatient(user.id, user.role, patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id, resource: "APPOINTMENT", resourceId: id,
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: { patientId, endpoint: "confirm" },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+    const out = await rdvAppointmentService.confirm(apptId, user.id, ctx)
+    return NextResponse.json(out)
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "appointments/:id/confirm POST", ctx.requestId)
+  }
+}

--- a/src/app/api/appointments/[id]/propose-alternative/route.ts
+++ b/src/app/api/appointments/[id]/propose-alternative/route.ts
@@ -3,10 +3,10 @@
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
 import { AuthError } from "@/lib/auth"
-import { canAccessPatient } from "@/lib/access-control"
 import { rdvAppointmentService } from "@/lib/services/rdv.service"
-import { auditService, extractRequestContext } from "@/lib/services/audit.service"
-import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { mapErrorToResponse } from "@/lib/team-route-helpers"
+import { appointmentRouteGate } from "@/lib/appointments-route-helpers"
 
 type RouteParams = { params: Promise<{ id: string }> }
 const schema = z.object({ alternativeAt: z.coerce.date() })
@@ -15,26 +15,15 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
   const ctx = extractRequestContext(req)
   try {
     const { id } = await params
-    if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidId" }, { status: 400 })
-    const apptId = parseInt(id, 10)
-    const user = await auditedRequireRole(req, "DOCTOR", ctx, "APPOINTMENT", id)
-
-    const patientId = await rdvAppointmentService.getPatientIdFor(apptId)
-    if (patientId === null) return NextResponse.json({ error: "notFound" }, { status: 404 })
-    const allowed = await canAccessPatient(user.id, user.role, patientId)
-    if (!allowed) {
-      await auditService.accessDenied({
-        userId: user.id, resource: "APPOINTMENT", resourceId: id,
-        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
-        metadata: { patientId, endpoint: "propose-alternative" },
-      })
-      return NextResponse.json({ error: "forbidden" }, { status: 403 })
-    }
+    const gate = await appointmentRouteGate(req, id, "DOCTOR", "propose-alternative")
+    if (gate.kind === "error") return gate.res
 
     const body = await req.json()
     const parsed = schema.safeParse(body)
     if (!parsed.success) return NextResponse.json({ error: "validationFailed" }, { status: 400 })
-    const out = await rdvAppointmentService.proposeAlternative(apptId, parsed.data.alternativeAt, user.id, ctx)
+    const out = await rdvAppointmentService.proposeAlternative(
+      gate.apptId, parsed.data.alternativeAt, gate.user.id, ctx,
+    )
     return NextResponse.json(out)
   } catch (e) {
     if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })

--- a/src/app/api/appointments/[id]/propose-alternative/route.ts
+++ b/src/app/api/appointments/[id]/propose-alternative/route.ts
@@ -1,0 +1,43 @@
+/** US-2503 — Doctor proposes an alternative date/hour after cancellation. */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { rdvAppointmentService } from "@/lib/services/rdv.service"
+import { auditService, extractRequestContext } from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+
+type RouteParams = { params: Promise<{ id: string }> }
+const schema = z.object({ alternativeAt: z.coerce.date() })
+
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  const ctx = extractRequestContext(req)
+  try {
+    const { id } = await params
+    if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidId" }, { status: 400 })
+    const apptId = parseInt(id, 10)
+    const user = await auditedRequireRole(req, "DOCTOR", ctx, "APPOINTMENT", id)
+
+    const patientId = await rdvAppointmentService.getPatientIdFor(apptId)
+    if (patientId === null) return NextResponse.json({ error: "notFound" }, { status: 404 })
+    const allowed = await canAccessPatient(user.id, user.role, patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id, resource: "APPOINTMENT", resourceId: id,
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: { patientId, endpoint: "propose-alternative" },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+
+    const body = await req.json()
+    const parsed = schema.safeParse(body)
+    if (!parsed.success) return NextResponse.json({ error: "validationFailed" }, { status: 400 })
+    const out = await rdvAppointmentService.proposeAlternative(apptId, parsed.data.alternativeAt, user.id, ctx)
+    return NextResponse.json(out)
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "appointments/:id/propose-alternative POST", ctx.requestId)
+  }
+}

--- a/src/app/api/appointments/[id]/route.ts
+++ b/src/app/api/appointments/[id]/route.ts
@@ -4,7 +4,10 @@ import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
 import { AppointmentLocation } from "@prisma/client"
 import { AuthError } from "@/lib/auth"
-import { rdvAppointmentService } from "@/lib/services/rdv.service"
+import {
+  rdvAppointmentService,
+  type AppointmentUpdatePatch,
+} from "@/lib/services/rdv.service"
 import { extractRequestContext } from "@/lib/services/audit.service"
 import { mapErrorToResponse } from "@/lib/team-route-helpers"
 import { appointmentRouteGate, HOUR_RE } from "@/lib/appointments-route-helpers"
@@ -52,7 +55,7 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
       )
     }
     // H6 — preserve `null` as explicit clear (don't drop it via && short-circuit).
-    const patch: Parameters<typeof rdvAppointmentService.update>[1] = {}
+    const patch: AppointmentUpdatePatch = {}
     if (parsed.data.date) patch.date = new Date(parsed.data.date)
     if (parsed.data.hour) patch.hour = new Date(`1970-01-01T${parsed.data.hour}:00Z`)
     if (parsed.data.durationMinutes !== undefined) patch.durationMinutes = parsed.data.durationMinutes

--- a/src/app/api/appointments/[id]/route.ts
+++ b/src/app/api/appointments/[id]/route.ts
@@ -4,15 +4,12 @@ import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
 import { AppointmentLocation } from "@prisma/client"
 import { AuthError } from "@/lib/auth"
-import { canAccessPatient } from "@/lib/access-control"
-import { patientShareConsent } from "@/lib/consent"
 import { rdvAppointmentService } from "@/lib/services/rdv.service"
-import { auditService, extractRequestContext } from "@/lib/services/audit.service"
-import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { mapErrorToResponse } from "@/lib/team-route-helpers"
+import { appointmentRouteGate, HOUR_RE } from "@/lib/appointments-route-helpers"
 
 type RouteParams = { params: Promise<{ id: string }> }
-
-const HOUR_RE = /^([01]\d|2[0-3]):[0-5]\d$/
 
 const updateSchema = z.object({
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
@@ -20,41 +17,15 @@ const updateSchema = z.object({
   durationMinutes: z.number().int().min(15).max(240).optional(),
   location: z.enum(AppointmentLocation).optional(),
   type: z.string().trim().max(50).optional(),
-  motif: z.string().trim().max(200).optional(),
+  motif: z.string().trim().max(200).nullable().optional(),
   note: z.string().max(4096).nullable().optional(),
 })
-
-async function gateById(req: NextRequest, ctx: ReturnType<typeof extractRequestContext>, id: string) {
-  if (!/^\d+$/.test(id)) {
-    return { kind: "error" as const, res: NextResponse.json({ error: "invalidId" }, { status: 400 }) }
-  }
-  const apptId = parseInt(id, 10)
-  const user = await auditedRequireRole(req, "NURSE", ctx, "APPOINTMENT", id)
-  const patientId = await rdvAppointmentService.getPatientIdFor(apptId)
-  if (patientId === null) {
-    return { kind: "error" as const, res: NextResponse.json({ error: "notFound" }, { status: 404 }) }
-  }
-  const allowed = await canAccessPatient(user.id, user.role, patientId)
-  if (!allowed) {
-    await auditService.accessDenied({
-      userId: user.id, resource: "APPOINTMENT", resourceId: id,
-      ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
-      metadata: { patientId, appointmentId: apptId },
-    })
-    return { kind: "error" as const, res: NextResponse.json({ error: "forbidden" }, { status: 403 }) }
-  }
-  const consent = await patientShareConsent(patientId)
-  if (!consent.ok) {
-    return { kind: "error" as const, res: NextResponse.json({ error: consent.error }, { status: consent.status }) }
-  }
-  return { kind: "ok" as const, user, apptId, patientId }
-}
 
 export async function GET(req: NextRequest, { params }: RouteParams) {
   const ctx = extractRequestContext(req)
   try {
     const { id } = await params
-    const gate = await gateById(req, ctx, id)
+    const gate = await appointmentRouteGate(req, id, "NURSE", "detail")
     if (gate.kind === "error") return gate.res
     const item = await rdvAppointmentService.getById(gate.apptId, gate.user.id, ctx)
     if (!item) return NextResponse.json({ error: "notFound" }, { status: 404 })
@@ -69,7 +40,7 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
   const ctx = extractRequestContext(req)
   try {
     const { id } = await params
-    const gate = await gateById(req, ctx, id)
+    const gate = await appointmentRouteGate(req, id, "NURSE", "update")
     if (gate.kind === "error") return gate.res
 
     const body = await req.json()
@@ -80,15 +51,16 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
         { status: 400 },
       )
     }
-    const patch = {
-      ...(parsed.data.date && { date: new Date(parsed.data.date) }),
-      ...(parsed.data.hour && { hour: new Date(`1970-01-01T${parsed.data.hour}:00Z`) }),
-      ...(parsed.data.durationMinutes !== undefined && { durationMinutes: parsed.data.durationMinutes }),
-      ...(parsed.data.location !== undefined && { location: parsed.data.location }),
-      ...(parsed.data.type !== undefined && { type: parsed.data.type }),
-      ...(parsed.data.motif !== undefined && { motif: parsed.data.motif }),
-      ...(parsed.data.note !== undefined && { note: parsed.data.note }),
-    }
+    // H6 — preserve `null` as explicit clear (don't drop it via && short-circuit).
+    const patch: Parameters<typeof rdvAppointmentService.update>[1] = {}
+    if (parsed.data.date) patch.date = new Date(parsed.data.date)
+    if (parsed.data.hour) patch.hour = new Date(`1970-01-01T${parsed.data.hour}:00Z`)
+    if (parsed.data.durationMinutes !== undefined) patch.durationMinutes = parsed.data.durationMinutes
+    if (parsed.data.location !== undefined) patch.location = parsed.data.location
+    if (parsed.data.type !== undefined) patch.type = parsed.data.type
+    if (parsed.data.motif !== undefined) patch.motif = parsed.data.motif
+    if (parsed.data.note !== undefined) patch.note = parsed.data.note
+
     const out = await rdvAppointmentService.update(gate.apptId, patch, gate.user.id, ctx)
     return NextResponse.json(out)
   } catch (e) {

--- a/src/app/api/appointments/[id]/route.ts
+++ b/src/app/api/appointments/[id]/route.ts
@@ -1,0 +1,98 @@
+/** US-2501 — Appointment detail + update. */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { AppointmentLocation } from "@prisma/client"
+import { AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { patientShareConsent } from "@/lib/consent"
+import { rdvAppointmentService } from "@/lib/services/rdv.service"
+import { auditService, extractRequestContext } from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+const HOUR_RE = /^([01]\d|2[0-3]):[0-5]\d$/
+
+const updateSchema = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  hour: z.string().regex(HOUR_RE).optional(),
+  durationMinutes: z.number().int().min(15).max(240).optional(),
+  location: z.enum(AppointmentLocation).optional(),
+  type: z.string().trim().max(50).optional(),
+  motif: z.string().trim().max(200).optional(),
+  note: z.string().max(4096).nullable().optional(),
+})
+
+async function gateById(req: NextRequest, ctx: ReturnType<typeof extractRequestContext>, id: string) {
+  if (!/^\d+$/.test(id)) {
+    return { kind: "error" as const, res: NextResponse.json({ error: "invalidId" }, { status: 400 }) }
+  }
+  const apptId = parseInt(id, 10)
+  const user = await auditedRequireRole(req, "NURSE", ctx, "APPOINTMENT", id)
+  const patientId = await rdvAppointmentService.getPatientIdFor(apptId)
+  if (patientId === null) {
+    return { kind: "error" as const, res: NextResponse.json({ error: "notFound" }, { status: 404 }) }
+  }
+  const allowed = await canAccessPatient(user.id, user.role, patientId)
+  if (!allowed) {
+    await auditService.accessDenied({
+      userId: user.id, resource: "APPOINTMENT", resourceId: id,
+      ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+      metadata: { patientId, appointmentId: apptId },
+    })
+    return { kind: "error" as const, res: NextResponse.json({ error: "forbidden" }, { status: 403 }) }
+  }
+  const consent = await patientShareConsent(patientId)
+  if (!consent.ok) {
+    return { kind: "error" as const, res: NextResponse.json({ error: consent.error }, { status: consent.status }) }
+  }
+  return { kind: "ok" as const, user, apptId, patientId }
+}
+
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  const ctx = extractRequestContext(req)
+  try {
+    const { id } = await params
+    const gate = await gateById(req, ctx, id)
+    if (gate.kind === "error") return gate.res
+    const item = await rdvAppointmentService.getById(gate.apptId, gate.user.id, ctx)
+    if (!item) return NextResponse.json({ error: "notFound" }, { status: 404 })
+    return NextResponse.json(item)
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "appointments/:id GET", ctx.requestId)
+  }
+}
+
+export async function PUT(req: NextRequest, { params }: RouteParams) {
+  const ctx = extractRequestContext(req)
+  try {
+    const { id } = await params
+    const gate = await gateById(req, ctx, id)
+    if (gate.kind === "error") return gate.res
+
+    const body = await req.json()
+    const parsed = updateSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+    const patch = {
+      ...(parsed.data.date && { date: new Date(parsed.data.date) }),
+      ...(parsed.data.hour && { hour: new Date(`1970-01-01T${parsed.data.hour}:00Z`) }),
+      ...(parsed.data.durationMinutes !== undefined && { durationMinutes: parsed.data.durationMinutes }),
+      ...(parsed.data.location !== undefined && { location: parsed.data.location }),
+      ...(parsed.data.type !== undefined && { type: parsed.data.type }),
+      ...(parsed.data.motif !== undefined && { motif: parsed.data.motif }),
+      ...(parsed.data.note !== undefined && { note: parsed.data.note }),
+    }
+    const out = await rdvAppointmentService.update(gate.apptId, patch, gate.user.id, ctx)
+    return NextResponse.json(out)
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "appointments/:id PUT", ctx.requestId)
+  }
+}

--- a/src/app/api/appointments/route.ts
+++ b/src/app/api/appointments/route.ts
@@ -61,8 +61,11 @@ export async function GET(req: NextRequest) {
         return NextResponse.json({ error: "forbidden" }, { status: 403 })
       }
     }
-    // C1 — when scoped by member only, enforce same-service membership.
-    if (parsed.data.memberId !== undefined && parsed.data.patientId === undefined) {
+    // C1/L1 — when scoped by member (with or without patient), enforce
+    //         same-service membership. Defense-in-depth: even when patientId
+    //         is also provided (and authorised), a cross-tenant memberId must
+    //         not leak via empty results.
+    if (parsed.data.memberId !== undefined) {
       try {
         await assertMemberServiceAccess(user.id, parsed.data.memberId)
       } catch (err) {

--- a/src/app/api/appointments/route.ts
+++ b/src/app/api/appointments/route.ts
@@ -1,64 +1,108 @@
+/** US-2500/2501 — Appointments list (calendar) + create. */
+
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
-import { requireAuth, AuthError } from "@/lib/auth"
-import { resolvePatientId } from "@/lib/access-control"
-import { requireGdprConsent } from "@/lib/gdpr"
-import { appointmentService } from "@/lib/services/appointment.service"
-import { extractRequestContext } from "@/lib/services/audit.service"
+import { AppointmentLocation, AppointmentStatus } from "@prisma/client"
+import { AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { patientShareConsent } from "@/lib/consent"
+import { rdvAppointmentService } from "@/lib/services/rdv.service"
+import { auditService, extractRequestContext } from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
 
-const createSchema = z.object({
-  patientId: z.number().int().positive().optional(),
-  type: z.enum(["ide", "diabeto", "hdj"]),
-  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
-  hour: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/).optional(),
-  comment: z.string().max(500).optional(),
+const HOUR_RE = /^([01]\d|2[0-3]):[0-5]\d$/
+
+const listSchema = z.object({
+  from: z.coerce.date(),
+  to: z.coerce.date(),
+  memberId: z.coerce.number().int().positive().optional(),
+  patientId: z.coerce.number().int().positive().optional(),
+  status: z.enum(AppointmentStatus).optional(),
 })
 
-/** GET /api/appointments — list appointments */
+const createSchema = z.object({
+  patientId: z.number().int().positive(),
+  memberId: z.number().int().positive(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  hour: z.string().regex(HOUR_RE),
+  durationMinutes: z.number().int().min(15).max(240).optional(),
+  location: z.enum(AppointmentLocation).optional(),
+  type: z.string().trim().max(50).optional(),
+  motif: z.string().trim().max(200).optional(),
+  note: z.string().max(4096).optional(),
+})
+
 export async function GET(req: NextRequest) {
+  const ctx = extractRequestContext(req)
   try {
-    const user = requireAuth(req)
-    const hasConsent = await requireGdprConsent(user.id)
-    if (!hasConsent) return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
+    const parsed = listSchema.safeParse(
+      Object.fromEntries(req.nextUrl.searchParams.entries()),
+    )
+    if (!parsed.success) return NextResponse.json({ error: "validationFailed" }, { status: 400 })
+    const user = await auditedRequireRole(req, "NURSE", ctx, "APPOINTMENT", "list")
 
-    const patientIdParam = req.nextUrl.searchParams.get("patientId")
-    const patientId = await resolvePatientId(user.id, user.role, patientIdParam ? parseInt(patientIdParam, 10) : undefined)
-    if (!patientId) return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    if (parsed.data.patientId !== undefined) {
+      const allowed = await canAccessPatient(user.id, user.role, parsed.data.patientId)
+      if (!allowed) {
+        await auditService.accessDenied({
+          userId: user.id, resource: "APPOINTMENT", resourceId: String(parsed.data.patientId),
+          ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+          metadata: { patientId: parsed.data.patientId, endpoint: "list" },
+        })
+        return NextResponse.json({ error: "forbidden" }, { status: 403 })
+      }
+    }
 
-    const ctx = extractRequestContext(req)
-    const appointments = await appointmentService.list(patientId, user.id, ctx)
-    return NextResponse.json(appointments)
-  } catch (error) {
-    if (error instanceof AuthError) return NextResponse.json({ error: error.message }, { status: error.status })
-    const msg = error instanceof Error ? error.message : "Unknown error"
-    console.error("[appointments GET]", msg)
-    return NextResponse.json({ error: "serverError" }, { status: 500 })
+    const items = await rdvAppointmentService.listInRange(parsed.data, user.id, ctx)
+    return NextResponse.json({ items })
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "appointments GET", ctx.requestId)
   }
 }
 
-/** POST /api/appointments — create appointment */
 export async function POST(req: NextRequest) {
+  const ctx = extractRequestContext(req)
   try {
-    const user = requireAuth(req)
-    const hasConsent = await requireGdprConsent(user.id)
-    if (!hasConsent) return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
-
     const body = await req.json()
     const parsed = createSchema.safeParse(body)
     if (!parsed.success) {
-      return NextResponse.json({ error: "validationFailed", details: parsed.error.flatten().fieldErrors }, { status: 400 })
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
     }
+    const user = await auditedRequireRole(req, "NURSE", ctx, "APPOINTMENT", "create")
 
-    const { patientId: pidParam, ...apptInput } = parsed.data
-    const patientId = await resolvePatientId(user.id, user.role, pidParam)
-    if (!patientId) return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    const allowed = await canAccessPatient(user.id, user.role, parsed.data.patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id, resource: "APPOINTMENT", resourceId: String(parsed.data.patientId),
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: { patientId: parsed.data.patientId, endpoint: "create" },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+    const consent = await patientShareConsent(parsed.data.patientId)
+    if (!consent.ok) return NextResponse.json({ error: consent.error }, { status: consent.status })
 
-    const result = await appointmentService.create(patientId, apptInput, user.id)
-    return NextResponse.json(result, { status: 201 })
-  } catch (error) {
-    if (error instanceof AuthError) return NextResponse.json({ error: error.message }, { status: error.status })
-    const msg = error instanceof Error ? error.message : "Unknown error"
-    console.error("[appointments POST]", msg)
-    return NextResponse.json({ error: "serverError" }, { status: 500 })
+    const out = await rdvAppointmentService.create(
+      {
+        patientId: parsed.data.patientId,
+        memberId: parsed.data.memberId,
+        date: new Date(parsed.data.date),
+        hour: new Date(`1970-01-01T${parsed.data.hour}:00Z`),
+        durationMinutes: parsed.data.durationMinutes,
+        location: parsed.data.location,
+        type: parsed.data.type,
+        motif: parsed.data.motif,
+        note: parsed.data.note,
+      },
+      user.id, ctx,
+    )
+    return NextResponse.json(out, { status: 201 })
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "appointments POST", ctx.requestId)
   }
 }

--- a/src/app/api/appointments/route.ts
+++ b/src/app/api/appointments/route.ts
@@ -6,11 +6,13 @@ import { AppointmentLocation, AppointmentStatus } from "@prisma/client"
 import { AuthError } from "@/lib/auth"
 import { canAccessPatient } from "@/lib/access-control"
 import { patientShareConsent } from "@/lib/consent"
-import { rdvAppointmentService } from "@/lib/services/rdv.service"
+import {
+  rdvAppointmentService,
+  assertMemberServiceAccess,
+} from "@/lib/services/rdv.service"
 import { auditService, extractRequestContext } from "@/lib/services/audit.service"
 import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
-
-const HOUR_RE = /^([01]\d|2[0-3]):[0-5]\d$/
+import { HOUR_RE } from "@/lib/appointments-route-helpers"
 
 const listSchema = z.object({
   from: z.coerce.date(),
@@ -39,8 +41,15 @@ export async function GET(req: NextRequest) {
       Object.fromEntries(req.nextUrl.searchParams.entries()),
     )
     if (!parsed.success) return NextResponse.json({ error: "validationFailed" }, { status: 400 })
+
+    // C1 — refuse unscoped listings (cross-tenant PHI leak otherwise).
+    if (parsed.data.memberId === undefined && parsed.data.patientId === undefined) {
+      return NextResponse.json({ error: "scopeRequired" }, { status: 400 })
+    }
+
     const user = await auditedRequireRole(req, "NURSE", ctx, "APPOINTMENT", "list")
 
+    // C1 — when scoped by patient, enforce per-patient access control.
     if (parsed.data.patientId !== undefined) {
       const allowed = await canAccessPatient(user.id, user.role, parsed.data.patientId)
       if (!allowed) {
@@ -52,9 +61,21 @@ export async function GET(req: NextRequest) {
         return NextResponse.json({ error: "forbidden" }, { status: 403 })
       }
     }
+    // C1 — when scoped by member only, enforce same-service membership.
+    if (parsed.data.memberId !== undefined && parsed.data.patientId === undefined) {
+      try {
+        await assertMemberServiceAccess(user.id, parsed.data.memberId)
+      } catch (err) {
+        return mapErrorToResponse(err, "appointments GET", ctx.requestId, {
+          user, ctx, resource: "APPOINTMENT",
+          resourceId: `member:${parsed.data.memberId}`,
+          metadata: { memberId: parsed.data.memberId, endpoint: "list" },
+        })
+      }
+    }
 
-    const items = await rdvAppointmentService.listInRange(parsed.data, user.id, ctx)
-    return NextResponse.json({ items })
+    const out = await rdvAppointmentService.listInRange(parsed.data, user.id, ctx)
+    return NextResponse.json(out)
   } catch (e) {
     if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
     return mapErrorToResponse(e, "appointments GET", ctx.requestId)

--- a/src/app/api/team/availability/[id]/route.ts
+++ b/src/app/api/team/availability/[id]/route.ts
@@ -10,14 +10,27 @@ type RouteParams = { params: Promise<{ id: string }> }
 
 export async function DELETE(req: NextRequest, { params }: RouteParams) {
   const ctx = extractRequestContext(req)
+  const { id } = await params
+  if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidId" }, { status: 400 })
+
+  let user
   try {
-    const { id } = await params
-    if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidId" }, { status: 400 })
-    const user = await auditedRequireRole(req, "DOCTOR", ctx, "MEMBER_UNAVAILABILITY", id)
-    await memberUnavailabilityService.delete(parseInt(id, 10), user.id, ctx)
-    return NextResponse.json({ deleted: true })
+    user = await auditedRequireRole(req, "DOCTOR", ctx, "MEMBER_UNAVAILABILITY", id)
   } catch (e) {
     if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
     return mapErrorToResponse(e, "team/availability/:id DELETE", ctx.requestId)
+  }
+
+  try {
+    await memberUnavailabilityService.delete(parseInt(id, 10), user.id, ctx)
+    return NextResponse.json({ deleted: true })
+  } catch (e) {
+    // L3 — `ForbiddenError` from the service goes through `mapErrorToResponse`
+    //      with `auditTarget` to feed the US-2265 burst detector.
+    return mapErrorToResponse(e, "team/availability/:id DELETE", ctx.requestId, {
+      user, ctx,
+      resource: "MEMBER_UNAVAILABILITY", resourceId: id,
+      metadata: { unavailabilityId: id, endpoint: "delete" },
+    })
   }
 }

--- a/src/app/api/team/availability/[id]/route.ts
+++ b/src/app/api/team/availability/[id]/route.ts
@@ -1,0 +1,23 @@
+/** US-2504 — Delete an unavailability slot. */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { AuthError } from "@/lib/auth"
+import { memberUnavailabilityService } from "@/lib/services/rdv.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+export async function DELETE(req: NextRequest, { params }: RouteParams) {
+  const ctx = extractRequestContext(req)
+  try {
+    const { id } = await params
+    if (!/^\d+$/.test(id)) return NextResponse.json({ error: "invalidId" }, { status: 400 })
+    const user = await auditedRequireRole(req, "DOCTOR", ctx, "MEMBER_UNAVAILABILITY", id)
+    await memberUnavailabilityService.delete(parseInt(id, 10), user.id, ctx)
+    return NextResponse.json({ deleted: true })
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/availability/:id DELETE", ctx.requestId)
+  }
+}

--- a/src/app/api/team/availability/route.ts
+++ b/src/app/api/team/availability/route.ts
@@ -3,7 +3,10 @@
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
 import { AuthError } from "@/lib/auth"
-import { memberUnavailabilityService } from "@/lib/services/rdv.service"
+import {
+  memberUnavailabilityService,
+  assertMemberServiceAccess,
+} from "@/lib/services/rdv.service"
 import { extractRequestContext } from "@/lib/services/audit.service"
 import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
 
@@ -26,7 +29,19 @@ export async function GET(req: NextRequest) {
       Object.fromEntries(req.nextUrl.searchParams.entries()),
     )
     if (!parsed.success) return NextResponse.json({ error: "validationFailed" }, { status: 400 })
-    const user = await auditedRequireRole(req, "NURSE", ctx, "MEMBER_UNAVAILABILITY", String(parsed.data.memberId))
+    const user = await auditedRequireRole(
+      req, "NURSE", ctx, "MEMBER_UNAVAILABILITY", String(parsed.data.memberId),
+    )
+    // H3 — route-level guard with `accessDenied` audit (US-2265 burst feed).
+    try {
+      await assertMemberServiceAccess(user.id, parsed.data.memberId)
+    } catch (err) {
+      return mapErrorToResponse(err, "team/availability GET", ctx.requestId, {
+        user, ctx, resource: "MEMBER_UNAVAILABILITY",
+        resourceId: String(parsed.data.memberId),
+        metadata: { memberId: parsed.data.memberId, endpoint: "list" },
+      })
+    }
     const items = await memberUnavailabilityService.listForMember(
       parsed.data.memberId, { from: parsed.data.from, to: parsed.data.to }, user.id, ctx,
     )
@@ -48,7 +63,18 @@ export async function POST(req: NextRequest) {
         { status: 400 },
       )
     }
-    const user = await auditedRequireRole(req, "DOCTOR", ctx, "MEMBER_UNAVAILABILITY", String(parsed.data.memberId))
+    const user = await auditedRequireRole(
+      req, "DOCTOR", ctx, "MEMBER_UNAVAILABILITY", String(parsed.data.memberId),
+    )
+    try {
+      await assertMemberServiceAccess(user.id, parsed.data.memberId)
+    } catch (err) {
+      return mapErrorToResponse(err, "team/availability POST", ctx.requestId, {
+        user, ctx, resource: "MEMBER_UNAVAILABILITY",
+        resourceId: String(parsed.data.memberId),
+        metadata: { memberId: parsed.data.memberId, endpoint: "create" },
+      })
+    }
     const row = await memberUnavailabilityService.create(parsed.data, user.id, ctx)
     return NextResponse.json(row, { status: 201 })
   } catch (e) {

--- a/src/app/api/team/availability/route.ts
+++ b/src/app/api/team/availability/route.ts
@@ -1,0 +1,58 @@
+/** US-2504 — Member unavailability slots (list + create). */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { AuthError } from "@/lib/auth"
+import { memberUnavailabilityService } from "@/lib/services/rdv.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+
+const listSchema = z.object({
+  memberId: z.coerce.number().int().positive(),
+  from: z.coerce.date(),
+  to: z.coerce.date(),
+})
+const createSchema = z.object({
+  memberId: z.number().int().positive(),
+  startAt: z.coerce.date(),
+  endAt: z.coerce.date(),
+  reason: z.string().max(200).optional(),
+})
+
+export async function GET(req: NextRequest) {
+  const ctx = extractRequestContext(req)
+  try {
+    const parsed = listSchema.safeParse(
+      Object.fromEntries(req.nextUrl.searchParams.entries()),
+    )
+    if (!parsed.success) return NextResponse.json({ error: "validationFailed" }, { status: 400 })
+    const user = await auditedRequireRole(req, "NURSE", ctx, "MEMBER_UNAVAILABILITY", String(parsed.data.memberId))
+    const items = await memberUnavailabilityService.listForMember(
+      parsed.data.memberId, { from: parsed.data.from, to: parsed.data.to }, user.id, ctx,
+    )
+    return NextResponse.json({ items })
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/availability GET", ctx.requestId)
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const ctx = extractRequestContext(req)
+  try {
+    const body = await req.json()
+    const parsed = createSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+    const user = await auditedRequireRole(req, "DOCTOR", ctx, "MEMBER_UNAVAILABILITY", String(parsed.data.memberId))
+    const row = await memberUnavailabilityService.create(parsed.data, user.id, ctx)
+    return NextResponse.json(row, { status: 201 })
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/availability POST", ctx.requestId)
+  }
+}

--- a/src/app/api/team/booking-config/[memberId]/route.ts
+++ b/src/app/api/team/booking-config/[memberId]/route.ts
@@ -7,6 +7,7 @@ import { AuthError } from "@/lib/auth"
 import {
   memberBookingConfigService,
   assertMemberServiceAccess,
+  type MemberBookingConfigUpdateInput,
 } from "@/lib/services/rdv.service"
 import { extractRequestContext } from "@/lib/services/audit.service"
 import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
@@ -58,7 +59,7 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
       )
     }
     // H1 — preserve `null` (clear) vs `undefined` (no-op) through the call chain.
-    const input: Parameters<typeof memberBookingConfigService.update>[1] = {}
+    const input: MemberBookingConfigUpdateInput = {}
     if (parsed.data.bookingMode !== undefined) input.bookingMode = parsed.data.bookingMode
     if (parsed.data.defaultAppointmentMinutes !== undefined) {
       input.defaultAppointmentMinutes = parsed.data.defaultAppointmentMinutes

--- a/src/app/api/team/booking-config/[memberId]/route.ts
+++ b/src/app/api/team/booking-config/[memberId]/route.ts
@@ -4,7 +4,10 @@ import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
 import { BookingMode } from "@prisma/client"
 import { AuthError } from "@/lib/auth"
-import { memberBookingConfigService } from "@/lib/services/rdv.service"
+import {
+  memberBookingConfigService,
+  assertMemberServiceAccess,
+} from "@/lib/services/rdv.service"
 import { extractRequestContext } from "@/lib/services/audit.service"
 import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
 
@@ -20,8 +23,18 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
   try {
     const { memberId } = await params
     if (!/^\d+$/.test(memberId)) return NextResponse.json({ error: "invalidId" }, { status: 400 })
-    await auditedRequireRole(req, "NURSE", ctx, "MEMBER_BOOKING_CONFIG", memberId)
-    const cfg = await memberBookingConfigService.get(parseInt(memberId, 10))
+    const user = await auditedRequireRole(req, "NURSE", ctx, "MEMBER_BOOKING_CONFIG", memberId)
+    const mid = parseInt(memberId, 10)
+    try {
+      // H11 — same-service access required before any read.
+      await assertMemberServiceAccess(user.id, mid)
+    } catch (err) {
+      return mapErrorToResponse(err, "team/booking-config GET", ctx.requestId, {
+        user, ctx, resource: "MEMBER_BOOKING_CONFIG", resourceId: memberId,
+        metadata: { memberId: mid, endpoint: "get" },
+      })
+    }
+    const cfg = await memberBookingConfigService.get(mid)
     if (!cfg) return NextResponse.json({ error: "notFound" }, { status: 404 })
     return NextResponse.json(cfg)
   } catch (e) {
@@ -44,8 +57,14 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
         { status: 400 },
       )
     }
+    // H1 — preserve `null` (clear) vs `undefined` (no-op) through the call chain.
+    const input: Parameters<typeof memberBookingConfigService.update>[1] = {}
+    if (parsed.data.bookingMode !== undefined) input.bookingMode = parsed.data.bookingMode
+    if (parsed.data.defaultAppointmentMinutes !== undefined) {
+      input.defaultAppointmentMinutes = parsed.data.defaultAppointmentMinutes
+    }
     const out = await memberBookingConfigService.update(
-      parseInt(memberId, 10), parsed.data, user.id, ctx,
+      parseInt(memberId, 10), input, user.id, ctx,
     )
     return NextResponse.json(out)
   } catch (e) {

--- a/src/app/api/team/booking-config/[memberId]/route.ts
+++ b/src/app/api/team/booking-config/[memberId]/route.ts
@@ -1,0 +1,55 @@
+/** US-2505 — Member booking config (auto vs validation). */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { BookingMode } from "@prisma/client"
+import { AuthError } from "@/lib/auth"
+import { memberBookingConfigService } from "@/lib/services/rdv.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+
+type RouteParams = { params: Promise<{ memberId: string }> }
+
+const updateSchema = z.object({
+  bookingMode: z.enum(BookingMode).optional(),
+  defaultAppointmentMinutes: z.number().int().min(15).max(240).nullable().optional(),
+})
+
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  const ctx = extractRequestContext(req)
+  try {
+    const { memberId } = await params
+    if (!/^\d+$/.test(memberId)) return NextResponse.json({ error: "invalidId" }, { status: 400 })
+    await auditedRequireRole(req, "NURSE", ctx, "MEMBER_BOOKING_CONFIG", memberId)
+    const cfg = await memberBookingConfigService.get(parseInt(memberId, 10))
+    if (!cfg) return NextResponse.json({ error: "notFound" }, { status: 404 })
+    return NextResponse.json(cfg)
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/booking-config GET", ctx.requestId)
+  }
+}
+
+export async function PUT(req: NextRequest, { params }: RouteParams) {
+  const ctx = extractRequestContext(req)
+  try {
+    const { memberId } = await params
+    if (!/^\d+$/.test(memberId)) return NextResponse.json({ error: "invalidId" }, { status: 400 })
+    const user = await auditedRequireRole(req, "DOCTOR", ctx, "MEMBER_BOOKING_CONFIG", memberId)
+    const body = await req.json()
+    const parsed = updateSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+    const out = await memberBookingConfigService.update(
+      parseInt(memberId, 10), parsed.data, user.id, ctx,
+    )
+    return NextResponse.json(out)
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "team/booking-config PUT", ctx.requestId)
+  }
+}

--- a/src/lib/appointments-route-helpers.ts
+++ b/src/lib/appointments-route-helpers.ts
@@ -1,0 +1,67 @@
+/**
+ * @module appointments-route-helpers
+ * @description Shared gates for `/api/appointments/:id/*` routes. Dedupes the
+ * RBAC + access-control + consent chain that was repeated across
+ * cancel/propose-alternative/accept-alternative/confirm (M5).
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { canAccessPatient } from "@/lib/access-control"
+import { patientShareConsent } from "@/lib/consent"
+import { rdvAppointmentService } from "@/lib/services/rdv.service"
+import {
+  auditService,
+  extractRequestContext,
+  type AuditContext,
+} from "@/lib/services/audit.service"
+import { auditedRequireRole } from "@/lib/team-route-helpers"
+import type { AuthUser } from "@/lib/auth"
+import type { Role } from "@prisma/client"
+
+export const HOUR_RE = /^([01]\d|2[0-3]):[0-5]\d$/
+
+export type GateResult =
+  | { kind: "ok"; user: AuthUser; apptId: number; patientId: number; ctx: AuditContext }
+  | { kind: "error"; res: NextResponse }
+
+/**
+ * Validates `id` is a positive integer, enforces `minRole`, then runs
+ * `canAccessPatient` + `patientShareConsent` for the patient owning the
+ * appointment. Emits `accessDenied()` audit on RBAC/access failure.
+ */
+export async function appointmentRouteGate(
+  req: NextRequest,
+  rawId: string,
+  minRole: Role,
+  endpoint: string,
+): Promise<GateResult> {
+  const ctx = extractRequestContext(req)
+  if (!/^\d+$/.test(rawId)) {
+    return { kind: "error", res: NextResponse.json({ error: "invalidId" }, { status: 400 }) }
+  }
+  const apptId = parseInt(rawId, 10)
+  const user = await auditedRequireRole(req, minRole, ctx, "APPOINTMENT", rawId)
+
+  const patientId = await rdvAppointmentService.getPatientIdFor(apptId)
+  if (patientId === null) {
+    return { kind: "error", res: NextResponse.json({ error: "notFound" }, { status: 404 }) }
+  }
+  const allowed = await canAccessPatient(user.id, user.role, patientId)
+  if (!allowed) {
+    await auditService.accessDenied({
+      userId: user.id, resource: "APPOINTMENT", resourceId: rawId,
+      ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+      metadata: { patientId, endpoint },
+    })
+    return { kind: "error", res: NextResponse.json({ error: "forbidden" }, { status: 403 }) }
+  }
+  // H12 — consent gate on every mutation that touches patient-scoped data.
+  const consent = await patientShareConsent(patientId)
+  if (!consent.ok) {
+    return {
+      kind: "error",
+      res: NextResponse.json({ error: consent.error }, { status: consent.status }),
+    }
+  }
+  return { kind: "ok", user, apptId, patientId, ctx }
+}

--- a/src/lib/appointments-route-helpers.ts
+++ b/src/lib/appointments-route-helpers.ts
@@ -15,7 +15,7 @@ import {
   type AuditContext,
 } from "@/lib/services/audit.service"
 import { auditedRequireRole } from "@/lib/team-route-helpers"
-import type { AuthUser } from "@/lib/auth"
+import { AuthError, type AuthUser } from "@/lib/auth"
 import type { Role } from "@prisma/client"
 
 export const HOUR_RE = /^([01]\d|2[0-3]):[0-5]\d$/
@@ -28,6 +28,10 @@ export type GateResult =
  * Validates `id` is a positive integer, enforces `minRole`, then runs
  * `canAccessPatient` + `patientShareConsent` for the patient owning the
  * appointment. Emits `accessDenied()` audit on RBAC/access failure.
+ *
+ * H6 — `AuthError` from `auditedRequireRole` is caught internally so callers
+ * can rely purely on the `GateResult` discriminated union (no implicit throw
+ * across the type contract).
  */
 export async function appointmentRouteGate(
   req: NextRequest,
@@ -40,7 +44,21 @@ export async function appointmentRouteGate(
     return { kind: "error", res: NextResponse.json({ error: "invalidId" }, { status: 400 }) }
   }
   const apptId = parseInt(rawId, 10)
-  const user = await auditedRequireRole(req, minRole, ctx, "APPOINTMENT", rawId)
+  // L4 — use String(apptId) for resourceId so forensics are consistent with
+  //      the parsed int and not confused by leading-zero strings.
+  const resourceId = String(apptId)
+  let user: AuthUser
+  try {
+    user = await auditedRequireRole(req, minRole, ctx, "APPOINTMENT", resourceId)
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return {
+        kind: "error",
+        res: NextResponse.json({ error: err.message }, { status: err.status }),
+      }
+    }
+    throw err
+  }
 
   const patientId = await rdvAppointmentService.getPatientIdFor(apptId)
   if (patientId === null) {
@@ -49,7 +67,7 @@ export async function appointmentRouteGate(
   const allowed = await canAccessPatient(user.id, user.role, patientId)
   if (!allowed) {
     await auditService.accessDenied({
-      userId: user.id, resource: "APPOINTMENT", resourceId: rawId,
+      userId: user.id, resource: "APPOINTMENT", resourceId,
       ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
       metadata: { patientId, endpoint },
     })

--- a/src/lib/services/audit.service.ts
+++ b/src/lib/services/audit.service.ts
@@ -147,6 +147,10 @@ export type AuditResource =
   | "FOOD_ITEM"
   /** US-2057 — Meal photo (S3 reference, patient-scoped). */
   | "MEAL_PHOTO"
+  /** US-2504 — Member unavailability (RDV slot blocker). */
+  | "MEMBER_UNAVAILABILITY"
+  /** US-2505 — Member booking config (auto vs validation). */
+  | "MEMBER_BOOKING_CONFIG"
 
 /**
  * Audit log entry — parameters for logging an action.

--- a/src/lib/services/export.service.ts
+++ b/src/lib/services/export.service.ts
@@ -127,6 +127,18 @@ export async function generateUserExport(userId: number) {
       prisma.medicalDocument.findMany({ where: { patientId: pid }, orderBy: { createdAt: "desc" } }),
     ])
 
+    // C1 — RGPD Art. 20 portability requires intelligible content. Encrypted
+    // PHI columns must be decrypted before serialising for the data subject.
+    const appointmentsDecrypted = appointments.map((a) => ({
+      ...a,
+      motifEncrypted: undefined,
+      noteEncrypted: undefined,
+      cancelReasonEncrypted: undefined,
+      motif: safeDecrypt(a.motifEncrypted),
+      note: safeDecrypt(a.noteEncrypted),
+      cancelReason: safeDecrypt(a.cancelReasonEncrypted),
+    }))
+
     patientData = {
       pathology: patient.pathology,
       medicalData: decryptMedicalData(medicalData as unknown as Record<string, unknown>),
@@ -139,7 +151,7 @@ export async function generateUserExport(userId: number) {
       bolusLogs,
       adjustmentProposals,
       devices,
-      appointments,
+      appointments: appointmentsDecrypted,
       documents: documents.map((d) => ({
         id: d.id,
         title: d.title,

--- a/src/lib/services/rdv.service.ts
+++ b/src/lib/services/rdv.service.ts
@@ -22,6 +22,7 @@ import {
   type AppointmentLocation,
   type AppointmentStatus,
   type BookingMode,
+  type CancellationActor,
 } from "@prisma/client"
 import { prisma, type PrismaClientOrTx as Tx } from "@/lib/db/client"
 import { auditService } from "./audit.service"
@@ -39,6 +40,7 @@ const MOTIF_MAX = 200
 const NOTE_MAX = 4096
 const RANGE_MAX_DAYS = 62 // ≈ 2 months window
 const CANCEL_GRACE_HOURS = 24 // delay below which "doctor cancel" must propose alt
+const PROPOSAL_TTL_MS = 7 * 86_400_000 // M10 — alternatives expire after 7 days
 
 async function assertServiceMember(
   userId: number,
@@ -51,6 +53,22 @@ async function assertServiceMember(
   if (!link) throw new ForbiddenError()
 }
 
+/**
+ * H11 — guard for routes that scope by `memberId` rather than `patientId`.
+ * Ensures the caller is a member of the same service as the target member,
+ * preventing cross-tenant reconnaissance via member-scoped endpoints.
+ */
+export async function assertMemberServiceAccess(
+  callerUserId: number, memberId: number,
+): Promise<void> {
+  const target = await prisma.healthcareMember.findUnique({
+    where: { id: memberId }, select: { id: true, serviceId: true },
+  })
+  if (!target) throw new NotFoundError()
+  if (target.serviceId === null) throw new ForbiddenError()
+  await assertServiceMember(callerUserId, target.serviceId)
+}
+
 async function assertPatientAlive(patientId: number, tx: Tx = prisma): Promise<void> {
   const p = await tx.patient.findFirst({
     where: { id: patientId, deletedAt: null }, select: { id: true },
@@ -58,8 +76,19 @@ async function assertPatientAlive(patientId: number, tx: Tx = prisma): Promise<v
   if (!p) throw new NotFoundError()
 }
 
-/** Combine date + hour columns into a single UTC instant. `hour` is a `Time`
- *  (no zone) ; we treat it as already-UTC. */
+/**
+ * Combine a `date` (calendar day) + `hour` (time-of-day) into a single UTC
+ * instant.
+ *
+ * **Timezone contract** : both columns are persisted as UTC clock values.
+ * The backoffice contract is "absolute UTC wall-clock" — no DST adjustment is
+ * applied. Clients (web UI, iOS) are responsible for translating user-local
+ * times to UTC before submission, and re-translating UTC back for display.
+ * This avoids ambiguity around the autumn DST fall-back hour and keeps the
+ * service stateless w.r.t. the patient/practitioner's local zone.
+ *
+ * If `hour` is null we assume midnight (00:00 UTC).
+ */
 function combineDateHour(date: Date, hour: Date | null): Date {
   const d = new Date(date)
   if (hour) {
@@ -81,6 +110,9 @@ function computeEnd(start: Date, durationMinutes: number | null): Date {
  *
  * `excludeAppointmentId` lets `update/cancel/reschedule` skip the row being
  * modified.
+ *
+ * Day-bound query expands by 1 day backwards to catch prior-day appointments
+ * whose hour+duration spills past midnight into the requested slot (fix C3).
  */
 async function assertNoOverlap(
   tx: Tx,
@@ -90,10 +122,9 @@ async function assertNoOverlap(
   excludeAppointmentId?: number,
 ): Promise<void> {
   const activeStatuses: AppointmentStatus[] = ["scheduled", "pending_validation", "confirmed"]
-  // Appointments: rough filter on `date` THEN check overlap in JS using hour.
-  // Limit scan to the day(s) the slot touches.
   const dayFloor = new Date(startAt)
   dayFloor.setUTCHours(0, 0, 0, 0)
+  dayFloor.setUTCDate(dayFloor.getUTCDate() - 1) // include yesterday for cross-midnight
   const dayCeil = new Date(endAt)
   dayCeil.setUTCHours(23, 59, 59, 999)
 
@@ -105,6 +136,7 @@ async function assertNoOverlap(
       ...(excludeAppointmentId ? { NOT: { id: excludeAppointmentId } } : {}),
     },
     select: { date: true, hour: true, durationMinutes: true },
+    take: 1000, // M3 safety cap — a single day overlap query should never exceed this
   })
   for (const a of sameDay) {
     const aStart = combineDateHour(a.date, a.hour)
@@ -121,6 +153,7 @@ async function assertNoOverlap(
       endAt: { gt: startAt },
     },
     select: { id: true },
+    take: 100,
   })
   if (unav.length > 0) throw new ValidationError("slotOverlapUnavailability")
 }
@@ -139,35 +172,59 @@ export type AppointmentDTO = {
   durationMinutes: number | null
   location: AppointmentLocation | null
   status: AppointmentStatus
-  motif: string | null
-  note: string | null   // decrypted
+  motif: string | null  // decrypted
+  note: string | null   // decrypted (only on detail)
   proposedAlternativeAt: Date | null
-  cancelledBy: string | null
-  cancelReason: string | null
+  cancelledBy: CancellationActor | null
+  cancelReason: string | null  // decrypted
   cancelledAt: Date | null
   createdAt: Date
   updatedAt: Date
 }
 
-function toAppointmentDTO(a: {
+/** Light DTO for list view — never contains decrypted note or cancelReason. */
+export type AppointmentListItemDTO = Omit<AppointmentDTO, "note" | "cancelReason">
+
+type AppointmentRow = {
   id: number; patientId: number; memberId: number | null;
   type: string | null; date: Date; hour: Date | null;
   durationMinutes: number | null;
   location: AppointmentLocation | null; status: AppointmentStatus;
-  motif: string | null; noteEncrypted: string | null;
+  motifEncrypted: string | null; noteEncrypted: string | null;
   proposedAlternativeAt: Date | null;
-  cancelledBy: string | null; cancelReason: string | null; cancelledAt: Date | null;
+  cancelledBy: CancellationActor | null;
+  cancelReasonEncrypted: string | null;
+  cancelledAt: Date | null;
   createdAt: Date; updatedAt: Date;
-}): AppointmentDTO {
+}
+
+function toAppointmentDTO(a: AppointmentRow): AppointmentDTO {
   return {
     id: a.id, patientId: a.patientId, memberId: a.memberId,
     type: a.type, date: a.date, hour: a.hour,
     durationMinutes: a.durationMinutes,
     location: a.location, status: a.status,
-    motif: a.motif,
+    motif: a.motifEncrypted ? safeDecryptField(a.motifEncrypted) : null,
     note: a.noteEncrypted ? safeDecryptField(a.noteEncrypted) : null,
     proposedAlternativeAt: a.proposedAlternativeAt,
-    cancelledBy: a.cancelledBy, cancelReason: a.cancelReason, cancelledAt: a.cancelledAt,
+    cancelledBy: a.cancelledBy,
+    cancelReason: a.cancelReasonEncrypted ? safeDecryptField(a.cancelReasonEncrypted) : null,
+    cancelledAt: a.cancelledAt,
+    createdAt: a.createdAt, updatedAt: a.updatedAt,
+  }
+}
+
+/** List DTO — strips encrypted/sensitive free-text fields. Avoids bulk decrypt. */
+function toAppointmentListItemDTO(a: Omit<AppointmentRow, "noteEncrypted" | "cancelReasonEncrypted">): AppointmentListItemDTO {
+  return {
+    id: a.id, patientId: a.patientId, memberId: a.memberId,
+    type: a.type, date: a.date, hour: a.hour,
+    durationMinutes: a.durationMinutes,
+    location: a.location, status: a.status,
+    motif: a.motifEncrypted ? safeDecryptField(a.motifEncrypted) : null,
+    proposedAlternativeAt: a.proposedAlternativeAt,
+    cancelledBy: a.cancelledBy,
+    cancelledAt: a.cancelledAt,
     createdAt: a.createdAt, updatedAt: a.updatedAt,
   }
 }
@@ -229,7 +286,7 @@ export const rdvAppointmentService = {
           durationMinutes: duration,
           location: input.location ?? null,
           status: initialStatus,
-          motif: input.motif ?? null,
+          motifEncrypted: input.motif ? encryptField(input.motif) : null,
           noteEncrypted: input.note ? encryptField(input.note) : null,
         },
       })
@@ -264,6 +321,10 @@ export const rdvAppointmentService = {
   /**
    * US-2500 — list appointments in a date range. Filterable by member or patient
    * scope (route enforces RBAC). Hard-cap on range (62 days) to avoid heavy queries.
+   *
+   * Returns lighter `AppointmentListItemDTO` (no decrypted note / cancelReason).
+   * Soft-deleted patients are excluded (M1). Result is paginated/limited at 200
+   * with `truncated` flag so the UI can warn the user (M2).
    */
   async listInRange(
     input: {
@@ -273,20 +334,42 @@ export const rdvAppointmentService = {
     },
     auditUserId: number,
     ctx?: AuditContext,
-  ): Promise<AppointmentDTO[]> {
+  ): Promise<{ items: AppointmentListItemDTO[]; truncated: boolean }> {
     if (input.to < input.from) throw new ValidationError("dateRange")
     const days = (input.to.getTime() - input.from.getTime()) / 86_400_000
     if (days > RANGE_MAX_DAYS) throw new ValidationError("rangeTooLarge")
+    // C1 — refuse unscoped listings ; route enforces RBAC per scope.
+    if (input.memberId === undefined && input.patientId === undefined) {
+      throw new ValidationError("scopeRequired")
+    }
 
+    const LIST_LIMIT = 200
     const where: Prisma.AppointmentWhereInput = {
       date: { gte: input.from, lte: input.to },
+      // M1 — exclude soft-deleted patients.
+      patient: { deletedAt: null },
       ...(input.memberId !== undefined && { memberId: input.memberId }),
       ...(input.patientId !== undefined && { patientId: input.patientId }),
       ...(input.status && { status: input.status }),
     }
     const rows = await prisma.appointment.findMany({
-      where, orderBy: [{ date: "asc" }, { hour: "asc" }], take: 500,
+      where,
+      orderBy: [{ date: "asc" }, { hour: "asc" }],
+      take: LIST_LIMIT + 1,
+      select: {
+        id: true, patientId: true, memberId: true,
+        type: true, date: true, hour: true,
+        durationMinutes: true,
+        location: true, status: true,
+        motifEncrypted: true,
+        proposedAlternativeAt: true,
+        cancelledBy: true,
+        cancelledAt: true,
+        createdAt: true, updatedAt: true,
+      },
     })
+    const truncated = rows.length > LIST_LIMIT
+    const items = (truncated ? rows.slice(0, LIST_LIMIT) : rows).map(toAppointmentListItemDTO)
 
     await auditService.log({
       userId: auditUserId, action: "READ", resource: "APPOINTMENT",
@@ -295,10 +378,10 @@ export const rdvAppointmentService = {
       metadata: {
         from: input.from.toISOString(), to: input.to.toISOString(),
         memberId: input.memberId ?? null, patientId: input.patientId ?? null,
-        count: rows.length,
+        count: items.length, truncated,
       },
     })
-    return rows.map(toAppointmentDTO)
+    return { items, truncated }
   },
 
   async update(
@@ -306,12 +389,12 @@ export const rdvAppointmentService = {
     patch: {
       date?: Date; hour?: Date; durationMinutes?: number;
       location?: AppointmentLocation; type?: string;
-      motif?: string; note?: string | null;
+      motif?: string | null; note?: string | null;
     },
     auditUserId: number,
     ctx?: AuditContext,
   ): Promise<AppointmentDTO> {
-    if (patch.motif !== undefined && patch.motif.length > MOTIF_MAX) {
+    if (patch.motif !== undefined && patch.motif !== null && patch.motif.length > MOTIF_MAX) {
       throw new ValidationError("motif")
     }
     if (patch.note !== undefined && patch.note !== null && patch.note.length > NOTE_MAX) {
@@ -327,7 +410,12 @@ export const rdvAppointmentService = {
     return prisma.$transaction(async (tx) => {
       const existing = await tx.appointment.findUnique({ where: { id } })
       if (!existing) throw new NotFoundError()
-      if (existing.status === "cancelled" || existing.status === "no_show") {
+      // H5 — terminal states (cancelled, completed, no_show) are immutable.
+      if (
+        existing.status === "cancelled" ||
+        existing.status === "completed" ||
+        existing.status === "no_show"
+      ) {
         throw new ValidationError("alreadyClosed")
       }
 
@@ -335,31 +423,34 @@ export const rdvAppointmentService = {
       const newDate = patch.date ?? existing.date
       const newHour = patch.hour ?? existing.hour
       const newDuration = patch.durationMinutes ?? existing.durationMinutes
-      if (existing.memberId !== null && (patch.date || patch.hour || patch.durationMinutes)) {
+      const rescheduled =
+        patch.date !== undefined ||
+        patch.hour !== undefined ||
+        patch.durationMinutes !== undefined
+      if (existing.memberId !== null && rescheduled) {
         const startAt = combineDateHour(newDate, newHour)
         const endAt = computeEnd(startAt, newDuration)
         await assertNoOverlap(tx, existing.memberId, startAt, endAt, id)
       }
 
-      const noteUpdate: { noteEncrypted?: string | null } =
-        patch.note === undefined
-          ? {}
-          : patch.note === null
-            ? { noteEncrypted: null }
-            : { noteEncrypted: encryptField(patch.note) }
+      // H6 — `null` is the explicit clear signal ; build update fields explicitly so
+      //       Prisma writes `null` instead of treating it as "unchanged".
+      const data: Prisma.AppointmentUpdateInput = {}
+      if (patch.date) data.date = patch.date
+      if (patch.hour) data.hour = patch.hour
+      if (patch.durationMinutes !== undefined) data.durationMinutes = patch.durationMinutes
+      if (patch.location !== undefined) data.location = patch.location
+      if (patch.type !== undefined) data.type = patch.type
+      if (patch.motif !== undefined) {
+        data.motifEncrypted = patch.motif === null ? null : encryptField(patch.motif)
+      }
+      if (patch.note !== undefined) {
+        data.noteEncrypted = patch.note === null ? null : encryptField(patch.note)
+      }
+      // M6 — reschedule clears any stale alternative proposal.
+      if (rescheduled) data.proposedAlternativeAt = null
 
-      const updated = await tx.appointment.update({
-        where: { id },
-        data: {
-          date: patch.date,
-          hour: patch.hour,
-          durationMinutes: patch.durationMinutes,
-          location: patch.location,
-          type: patch.type,
-          motif: patch.motif,
-          ...noteUpdate,
-        },
-      })
+      const updated = await tx.appointment.update({ where: { id }, data })
       await auditService.logWithTx(tx, {
         userId: auditUserId, action: "UPDATE", resource: "APPOINTMENT",
         resourceId: String(id),
@@ -376,15 +467,15 @@ export const rdvAppointmentService = {
   },
 
   /**
-   * US-2503 — Cancel an appointment. `cancelledBy` distinguishes
-   * patient/doctor for the audit pivot and triggers different UX flows:
-   * a patient cancel within `CANCEL_GRACE_HOURS` is recorded without
-   * penalty. A doctor cancel typically proposes an alternative via
-   * `proposeAlternative`.
+   * US-2503 — Cancel an appointment. `actor` is derived by the route from the
+   * caller's role (NEVER from request body — H4) and recorded in the immutable
+   * audit log. A patient cancel within `CANCEL_GRACE_HOURS` of the start time
+   * is flagged `lateCancel=true` for downstream UX (penalty / notification).
+   * A doctor cancel typically proposes an alternative via `proposeAlternative`.
    */
   async cancel(
     id: number,
-    input: { by: "patient" | "doctor"; reason?: string },
+    input: { actor: CancellationActor; reason?: string },
     auditUserId: number,
     ctx?: AuditContext,
   ): Promise<AppointmentDTO> {
@@ -399,14 +490,16 @@ export const rdvAppointmentService = {
       const now = new Date()
       const startAt = combineDateHour(existing.date, existing.hour)
       const hoursUntil = (startAt.getTime() - now.getTime()) / 3_600_000
-      const withinGrace = hoursUntil >= CANCEL_GRACE_HOURS
+      // H2 — semantic fix: late = cancel within grace window before start.
+      const lateCancel = hoursUntil >= 0 && hoursUntil < CANCEL_GRACE_HOURS
 
+      const reasonClipped = input.reason?.slice(0, 500)
       const updated = await tx.appointment.update({
         where: { id },
         data: {
           status: "cancelled",
-          cancelledBy: input.by,
-          cancelReason: input.reason?.slice(0, 500) ?? null,
+          cancelledBy: input.actor,
+          cancelReasonEncrypted: reasonClipped ? encryptField(reasonClipped) : null,
           cancelledAt: now,
         },
       })
@@ -416,15 +509,17 @@ export const rdvAppointmentService = {
         ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
         metadata: {
           patientId: existing.patientId,
-          kind: "cancel", by: input.by,
-          withinGrace, hoursUntil: Math.round(hoursUntil),
+          kind: "cancel", actor: input.actor,
+          lateCancel, hoursUntil: Math.round(hoursUntil),
         },
       })
       return toAppointmentDTO(updated)
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
   },
 
-  /** US-2503 — doctor proposes a new date/hour to a cancelled appointment. */
+  /** US-2503 — doctor proposes a new date/hour to a cancelled appointment.
+   *  H10 — overlap-check the proposed slot so the patient doesn't accept a
+   *  slot that has become unavailable since the cancel. */
   async proposeAlternative(
     id: number, alternativeAt: Date, auditUserId: number, ctx?: AuditContext,
   ): Promise<AppointmentDTO> {
@@ -435,6 +530,11 @@ export const rdvAppointmentService = {
         throw new ValidationError("notDoctorCancelled")
       }
       if (alternativeAt <= new Date()) throw new ValidationError("alternativeInPast")
+
+      if (existing.memberId !== null) {
+        const endAt = computeEnd(alternativeAt, existing.durationMinutes)
+        await assertNoOverlap(tx, existing.memberId, alternativeAt, endAt, id)
+      }
 
       const updated = await tx.appointment.update({
         where: { id },
@@ -454,24 +554,47 @@ export const rdvAppointmentService = {
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
   },
 
-  /** US-2503 — patient accepts the alternative → revert cancellation. */
+  /** US-2503 — patient accepts the alternative → revert cancellation.
+   *  M14 — must still be `cancelled`. M10 — TTL applied (proposal expires after 7d).
+   *  L6 — preserve seconds in the new hour. L9 — audit on conflict. */
   async acceptAlternative(
     id: number, auditUserId: number, ctx?: AuditContext,
   ): Promise<AppointmentDTO> {
     return prisma.$transaction(async (tx) => {
       const existing = await tx.appointment.findUnique({ where: { id } })
       if (!existing) throw new NotFoundError()
+      if (existing.status !== "cancelled") throw new ValidationError("notCancelled")
       if (!existing.proposedAlternativeAt) throw new ValidationError("noAlternative")
+      if (Date.now() - existing.proposedAlternativeAt.getTime() > PROPOSAL_TTL_MS) {
+        throw new ValidationError("alternativeExpired")
+      }
 
       const alt = existing.proposedAlternativeAt
       const newDate = new Date(alt)
       newDate.setUTCHours(0, 0, 0, 0)
-      const newHour = new Date(Date.UTC(1970, 0, 1, alt.getUTCHours(), alt.getUTCMinutes()))
+      const newHour = new Date(Date.UTC(
+        1970, 0, 1, alt.getUTCHours(), alt.getUTCMinutes(), alt.getUTCSeconds(),
+      ))
 
       if (existing.memberId !== null) {
         const startAt = combineDateHour(newDate, newHour)
         const endAt = computeEnd(startAt, existing.durationMinutes)
-        await assertNoOverlap(tx, existing.memberId, startAt, endAt, id)
+        try {
+          await assertNoOverlap(tx, existing.memberId, startAt, endAt, id)
+        } catch (err) {
+          // L9 — audit the conflict so forensics can correlate which proposal raced.
+          await auditService.logWithTx(tx, {
+            userId: auditUserId, action: "UPDATE", resource: "APPOINTMENT",
+            resourceId: String(id),
+            ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+            metadata: {
+              patientId: existing.patientId,
+              kind: "accept-alternative-conflict",
+              alternativeAt: alt.toISOString(),
+            },
+          })
+          throw err
+        }
       }
 
       const updated = await tx.appointment.update({
@@ -480,7 +603,7 @@ export const rdvAppointmentService = {
           status: "scheduled",
           date: newDate, hour: newHour,
           proposedAlternativeAt: null,
-          cancelledBy: null, cancelReason: null, cancelledAt: null,
+          cancelledBy: null, cancelReasonEncrypted: null, cancelledAt: null,
         },
       })
       await auditService.logWithTx(tx, {
@@ -508,7 +631,8 @@ export const rdvAppointmentService = {
         throw new ValidationError("notPending")
       }
       const updated = await tx.appointment.update({
-        where: { id }, data: { status: "confirmed" },
+        where: { id },
+        data: { status: "confirmed", proposedAlternativeAt: null },
       })
       await auditService.logWithTx(tx, {
         userId: auditUserId, action: "UPDATE", resource: "APPOINTMENT",
@@ -543,6 +667,18 @@ export type UnavailabilityDTO = {
   reason: string | null
 }
 
+const UNAVAIL_REASON_MAX = 200
+
+function decodeUnavailability(r: {
+  id: number; memberId: number; startAt: Date; endAt: Date;
+  reasonEncrypted: string | null;
+}): UnavailabilityDTO {
+  return {
+    id: r.id, memberId: r.memberId, startAt: r.startAt, endAt: r.endAt,
+    reason: r.reasonEncrypted ? safeDecryptField(r.reasonEncrypted) : null,
+  }
+}
+
 export const memberUnavailabilityService = {
   async create(
     input: { memberId: number; startAt: Date; endAt: Date; reason?: string },
@@ -561,22 +697,34 @@ export const memberUnavailabilityService = {
       if (member.serviceId === null) throw new ValidationError("memberHasNoService")
       await assertServiceMember(auditUserId, member.serviceId, tx)
 
-      const row = await tx.memberUnavailability.create({
-        data: {
-          memberId: input.memberId,
-          startAt: input.startAt,
-          endAt: input.endAt,
-          reason: input.reason?.slice(0, 200),
-          createdBy: auditUserId,
-        },
-      })
-      await auditService.logWithTx(tx, {
-        userId: auditUserId, action: "CREATE", resource: "MEMBER_UNAVAILABILITY",
-        resourceId: String(row.id),
-        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
-        metadata: { memberId: input.memberId, serviceId: member.serviceId },
-      })
-      return { id: row.id, memberId: row.memberId, startAt: row.startAt, endAt: row.endAt, reason: row.reason }
+      const reasonClipped = input.reason?.slice(0, UNAVAIL_REASON_MAX)
+      try {
+        const row = await tx.memberUnavailability.create({
+          data: {
+            memberId: input.memberId,
+            startAt: input.startAt,
+            endAt: input.endAt,
+            reasonEncrypted: reasonClipped ? encryptField(reasonClipped) : null,
+            createdBy: auditUserId,
+          },
+        })
+        await auditService.logWithTx(tx, {
+          userId: auditUserId, action: "CREATE", resource: "MEMBER_UNAVAILABILITY",
+          resourceId: String(row.id),
+          ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+          metadata: { memberId: input.memberId, serviceId: member.serviceId },
+        })
+        return decodeUnavailability(row)
+      } catch (err) {
+        // H3 — Postgres EXCLUDE constraint surfaces as P2002/P2010 ; map to typed error.
+        if (
+          err instanceof Prisma.PrismaClientKnownRequestError &&
+          (err.code === "P2002" || err.code === "P2010")
+        ) {
+          throw new ValidationError("unavailabilityOverlap")
+        }
+        throw err
+      }
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
   },
 
@@ -603,9 +751,7 @@ export const memberUnavailabilityService = {
       ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
       metadata: { memberId, count: rows.length },
     })
-    return rows.map((r) => ({
-      id: r.id, memberId: r.memberId, startAt: r.startAt, endAt: r.endAt, reason: r.reason,
-    }))
+    return rows.map(decodeUnavailability)
   },
 
   async delete(id: number, auditUserId: number, ctx?: AuditContext) {
@@ -676,12 +822,16 @@ export const memberBookingConfigService = {
       if (m.serviceId === null) throw new ValidationError("memberHasNoService")
       await assertServiceMember(auditUserId, m.serviceId, tx)
 
+      // H1 — distinguish "not provided" (undefined → no-op) from
+      // "explicit clear" (null → set to NULL). Coalescing to `undefined`
+      // silently swallowed the null and prevented clears.
+      const data: Prisma.HealthcareMemberUpdateInput = {}
+      if (input.bookingMode !== undefined) data.bookingMode = input.bookingMode
+      if (input.defaultAppointmentMinutes !== undefined) {
+        data.defaultAppointmentMinutes = input.defaultAppointmentMinutes
+      }
       const updated = await tx.healthcareMember.update({
-        where: { id: memberId },
-        data: {
-          bookingMode: input.bookingMode,
-          defaultAppointmentMinutes: input.defaultAppointmentMinutes ?? undefined,
-        },
+        where: { id: memberId }, data,
         select: { id: true, bookingMode: true, defaultAppointmentMinutes: true },
       })
       await auditService.logWithTx(tx, {

--- a/src/lib/services/rdv.service.ts
+++ b/src/lib/services/rdv.service.ts
@@ -1,0 +1,703 @@
+/**
+ * @module rdv.service
+ * @description Groupe 8 Batch 1 — Gestion des RDV (5 US, 36 SP).
+ *
+ *  - US-2500 `appointmentService.listInRange` (calendrier)
+ *  - US-2501 `appointmentService.create/get/update/cancel` (CRUD + note chiffrée)
+ *  - US-2503 cancel/reschedule bilatéral (state machine)
+ *  - US-2504 `memberUnavailabilityService` (plages bloquées)
+ *  - US-2505 `memberBookingConfigService` (auto vs validation)
+ *
+ * Conventions (post-reviews PR #388/389/390/391) :
+ *  - Typed errors (`team-workflow.errors`)
+ *  - US-2268 audit pivot `metadata.patientId`
+ *  - Transactions Serializable sur les écritures (overlap checks intra-tx)
+ *  - AES-256-GCM sur `Appointment.noteEncrypted`
+ *  - `patientShareConsent` côté route (RGPD Art. 7.3)
+ *  - `canAccessPatient` côté route (RBAC)
+ */
+
+import {
+  Prisma,
+  type AppointmentLocation,
+  type AppointmentStatus,
+  type BookingMode,
+} from "@prisma/client"
+import { prisma, type PrismaClientOrTx as Tx } from "@/lib/db/client"
+import { auditService } from "./audit.service"
+import type { AuditContext } from "./audit.service"
+import { encryptField, safeDecryptField } from "@/lib/crypto/fields"
+import {
+  ForbiddenError,
+  NotFoundError,
+  ValidationError,
+} from "./team-workflow.errors"
+
+const DURATION_MIN = 15
+const DURATION_MAX = 240
+const MOTIF_MAX = 200
+const NOTE_MAX = 4096
+const RANGE_MAX_DAYS = 62 // ≈ 2 months window
+const CANCEL_GRACE_HOURS = 24 // delay below which "doctor cancel" must propose alt
+
+async function assertServiceMember(
+  userId: number,
+  serviceId: number,
+  tx: Tx = prisma,
+): Promise<void> {
+  const link = await tx.healthcareMember.findFirst({
+    where: { userId, serviceId }, select: { id: true },
+  })
+  if (!link) throw new ForbiddenError()
+}
+
+async function assertPatientAlive(patientId: number, tx: Tx = prisma): Promise<void> {
+  const p = await tx.patient.findFirst({
+    where: { id: patientId, deletedAt: null }, select: { id: true },
+  })
+  if (!p) throw new NotFoundError()
+}
+
+/** Combine date + hour columns into a single UTC instant. `hour` is a `Time`
+ *  (no zone) ; we treat it as already-UTC. */
+function combineDateHour(date: Date, hour: Date | null): Date {
+  const d = new Date(date)
+  if (hour) {
+    d.setUTCHours(hour.getUTCHours(), hour.getUTCMinutes(), 0, 0)
+  } else {
+    d.setUTCHours(0, 0, 0, 0)
+  }
+  return d
+}
+
+/** Compute the end timestamp from start + duration (minutes). */
+function computeEnd(start: Date, durationMinutes: number | null): Date {
+  return new Date(start.getTime() + (durationMinutes ?? 30) * 60_000)
+}
+
+/**
+ * Reject if the requested slot overlaps an existing active appointment or
+ * unavailability for the member. Active = status NOT IN (cancelled, no_show).
+ *
+ * `excludeAppointmentId` lets `update/cancel/reschedule` skip the row being
+ * modified.
+ */
+async function assertNoOverlap(
+  tx: Tx,
+  memberId: number,
+  startAt: Date,
+  endAt: Date,
+  excludeAppointmentId?: number,
+): Promise<void> {
+  const activeStatuses: AppointmentStatus[] = ["scheduled", "pending_validation", "confirmed"]
+  // Appointments: rough filter on `date` THEN check overlap in JS using hour.
+  // Limit scan to the day(s) the slot touches.
+  const dayFloor = new Date(startAt)
+  dayFloor.setUTCHours(0, 0, 0, 0)
+  const dayCeil = new Date(endAt)
+  dayCeil.setUTCHours(23, 59, 59, 999)
+
+  const sameDay = await tx.appointment.findMany({
+    where: {
+      memberId,
+      status: { in: activeStatuses },
+      date: { gte: dayFloor, lte: dayCeil },
+      ...(excludeAppointmentId ? { NOT: { id: excludeAppointmentId } } : {}),
+    },
+    select: { date: true, hour: true, durationMinutes: true },
+  })
+  for (const a of sameDay) {
+    const aStart = combineDateHour(a.date, a.hour)
+    const aEnd = computeEnd(aStart, a.durationMinutes)
+    if (startAt < aEnd && endAt > aStart) {
+      throw new ValidationError("slotOverlapAppointment")
+    }
+  }
+
+  const unav = await tx.memberUnavailability.findMany({
+    where: {
+      memberId,
+      startAt: { lt: endAt },
+      endAt: { gt: startAt },
+    },
+    select: { id: true },
+  })
+  if (unav.length > 0) throw new ValidationError("slotOverlapUnavailability")
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2501 / US-2500 — Appointment CRUD + list
+// ─────────────────────────────────────────────────────────────
+
+export type AppointmentDTO = {
+  id: number
+  patientId: number
+  memberId: number | null
+  type: string | null
+  date: Date
+  hour: Date | null
+  durationMinutes: number | null
+  location: AppointmentLocation | null
+  status: AppointmentStatus
+  motif: string | null
+  note: string | null   // decrypted
+  proposedAlternativeAt: Date | null
+  cancelledBy: string | null
+  cancelReason: string | null
+  cancelledAt: Date | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+function toAppointmentDTO(a: {
+  id: number; patientId: number; memberId: number | null;
+  type: string | null; date: Date; hour: Date | null;
+  durationMinutes: number | null;
+  location: AppointmentLocation | null; status: AppointmentStatus;
+  motif: string | null; noteEncrypted: string | null;
+  proposedAlternativeAt: Date | null;
+  cancelledBy: string | null; cancelReason: string | null; cancelledAt: Date | null;
+  createdAt: Date; updatedAt: Date;
+}): AppointmentDTO {
+  return {
+    id: a.id, patientId: a.patientId, memberId: a.memberId,
+    type: a.type, date: a.date, hour: a.hour,
+    durationMinutes: a.durationMinutes,
+    location: a.location, status: a.status,
+    motif: a.motif,
+    note: a.noteEncrypted ? safeDecryptField(a.noteEncrypted) : null,
+    proposedAlternativeAt: a.proposedAlternativeAt,
+    cancelledBy: a.cancelledBy, cancelReason: a.cancelReason, cancelledAt: a.cancelledAt,
+    createdAt: a.createdAt, updatedAt: a.updatedAt,
+  }
+}
+
+export type AppointmentCreateInput = {
+  patientId: number
+  memberId: number
+  date: Date           // YYYY-MM-DD
+  hour: Date           // HH:MM:SS UTC
+  durationMinutes?: number
+  location?: AppointmentLocation
+  type?: string
+  motif?: string
+  note?: string
+}
+
+export const rdvAppointmentService = {
+  async create(
+    input: AppointmentCreateInput,
+    auditUserId: number,
+    ctx?: AuditContext,
+  ): Promise<AppointmentDTO> {
+    if (input.motif && input.motif.length > MOTIF_MAX) throw new ValidationError("motif")
+    if (input.note && input.note.length > NOTE_MAX) throw new ValidationError("note")
+    if (
+      input.durationMinutes !== undefined &&
+      (input.durationMinutes < DURATION_MIN || input.durationMinutes > DURATION_MAX)
+    ) {
+      throw new ValidationError("durationMinutes")
+    }
+
+    return prisma.$transaction(async (tx) => {
+      await assertPatientAlive(input.patientId, tx)
+
+      const member = await tx.healthcareMember.findUnique({
+        where: { id: input.memberId },
+        select: { id: true, serviceId: true, bookingMode: true, defaultAppointmentMinutes: true },
+      })
+      if (!member) throw new NotFoundError()
+      if (member.serviceId === null) throw new ValidationError("memberHasNoService")
+
+      // Overlap check (US-2504 unavailability + active appointments).
+      const startAt = combineDateHour(input.date, input.hour)
+      const duration = input.durationMinutes ?? member.defaultAppointmentMinutes ?? 30
+      const endAt = computeEnd(startAt, duration)
+      await assertNoOverlap(tx, input.memberId, startAt, endAt)
+
+      // US-2505 — booking mode drives initial status.
+      const initialStatus: AppointmentStatus =
+        member.bookingMode === "validation" ? "pending_validation" : "scheduled"
+
+      const created = await tx.appointment.create({
+        data: {
+          patientId: input.patientId,
+          memberId: input.memberId,
+          type: input.type ?? null,
+          date: input.date,
+          hour: input.hour,
+          durationMinutes: duration,
+          location: input.location ?? null,
+          status: initialStatus,
+          motif: input.motif ?? null,
+          noteEncrypted: input.note ? encryptField(input.note) : null,
+        },
+      })
+
+      await auditService.logWithTx(tx, {
+        userId: auditUserId, action: "CREATE", resource: "APPOINTMENT",
+        resourceId: String(created.id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: {
+          patientId: input.patientId, memberId: input.memberId,
+          status: initialStatus, location: input.location ?? null,
+        },
+      })
+      return toAppointmentDTO(created)
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+
+  async getById(
+    id: number, auditUserId: number, ctx?: AuditContext,
+  ): Promise<AppointmentDTO | null> {
+    const row = await prisma.appointment.findUnique({ where: { id } })
+    if (!row) return null
+    await auditService.log({
+      userId: auditUserId, action: "READ", resource: "APPOINTMENT",
+      resourceId: String(id),
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { patientId: row.patientId },
+    })
+    return toAppointmentDTO(row)
+  },
+
+  /**
+   * US-2500 — list appointments in a date range. Filterable by member or patient
+   * scope (route enforces RBAC). Hard-cap on range (62 days) to avoid heavy queries.
+   */
+  async listInRange(
+    input: {
+      from: Date; to: Date;
+      memberId?: number; patientId?: number;
+      status?: AppointmentStatus;
+    },
+    auditUserId: number,
+    ctx?: AuditContext,
+  ): Promise<AppointmentDTO[]> {
+    if (input.to < input.from) throw new ValidationError("dateRange")
+    const days = (input.to.getTime() - input.from.getTime()) / 86_400_000
+    if (days > RANGE_MAX_DAYS) throw new ValidationError("rangeTooLarge")
+
+    const where: Prisma.AppointmentWhereInput = {
+      date: { gte: input.from, lte: input.to },
+      ...(input.memberId !== undefined && { memberId: input.memberId }),
+      ...(input.patientId !== undefined && { patientId: input.patientId }),
+      ...(input.status && { status: input.status }),
+    }
+    const rows = await prisma.appointment.findMany({
+      where, orderBy: [{ date: "asc" }, { hour: "asc" }], take: 500,
+    })
+
+    await auditService.log({
+      userId: auditUserId, action: "READ", resource: "APPOINTMENT",
+      resourceId: "list",
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: {
+        from: input.from.toISOString(), to: input.to.toISOString(),
+        memberId: input.memberId ?? null, patientId: input.patientId ?? null,
+        count: rows.length,
+      },
+    })
+    return rows.map(toAppointmentDTO)
+  },
+
+  async update(
+    id: number,
+    patch: {
+      date?: Date; hour?: Date; durationMinutes?: number;
+      location?: AppointmentLocation; type?: string;
+      motif?: string; note?: string | null;
+    },
+    auditUserId: number,
+    ctx?: AuditContext,
+  ): Promise<AppointmentDTO> {
+    if (patch.motif !== undefined && patch.motif.length > MOTIF_MAX) {
+      throw new ValidationError("motif")
+    }
+    if (patch.note !== undefined && patch.note !== null && patch.note.length > NOTE_MAX) {
+      throw new ValidationError("note")
+    }
+    if (
+      patch.durationMinutes !== undefined &&
+      (patch.durationMinutes < DURATION_MIN || patch.durationMinutes > DURATION_MAX)
+    ) {
+      throw new ValidationError("durationMinutes")
+    }
+
+    return prisma.$transaction(async (tx) => {
+      const existing = await tx.appointment.findUnique({ where: { id } })
+      if (!existing) throw new NotFoundError()
+      if (existing.status === "cancelled" || existing.status === "no_show") {
+        throw new ValidationError("alreadyClosed")
+      }
+
+      // If date/hour/duration change AND member is set, re-check overlap.
+      const newDate = patch.date ?? existing.date
+      const newHour = patch.hour ?? existing.hour
+      const newDuration = patch.durationMinutes ?? existing.durationMinutes
+      if (existing.memberId !== null && (patch.date || patch.hour || patch.durationMinutes)) {
+        const startAt = combineDateHour(newDate, newHour)
+        const endAt = computeEnd(startAt, newDuration)
+        await assertNoOverlap(tx, existing.memberId, startAt, endAt, id)
+      }
+
+      const noteUpdate: { noteEncrypted?: string | null } =
+        patch.note === undefined
+          ? {}
+          : patch.note === null
+            ? { noteEncrypted: null }
+            : { noteEncrypted: encryptField(patch.note) }
+
+      const updated = await tx.appointment.update({
+        where: { id },
+        data: {
+          date: patch.date,
+          hour: patch.hour,
+          durationMinutes: patch.durationMinutes,
+          location: patch.location,
+          type: patch.type,
+          motif: patch.motif,
+          ...noteUpdate,
+        },
+      })
+      await auditService.logWithTx(tx, {
+        userId: auditUserId, action: "UPDATE", resource: "APPOINTMENT",
+        resourceId: String(id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: {
+          patientId: existing.patientId,
+          updatedFields: Object.keys(patch).filter((k) =>
+            patch[k as keyof typeof patch] !== undefined,
+          ),
+        },
+      })
+      return toAppointmentDTO(updated)
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+
+  /**
+   * US-2503 — Cancel an appointment. `cancelledBy` distinguishes
+   * patient/doctor for the audit pivot and triggers different UX flows:
+   * a patient cancel within `CANCEL_GRACE_HOURS` is recorded without
+   * penalty. A doctor cancel typically proposes an alternative via
+   * `proposeAlternative`.
+   */
+  async cancel(
+    id: number,
+    input: { by: "patient" | "doctor"; reason?: string },
+    auditUserId: number,
+    ctx?: AuditContext,
+  ): Promise<AppointmentDTO> {
+    return prisma.$transaction(async (tx) => {
+      const existing = await tx.appointment.findUnique({ where: { id } })
+      if (!existing) throw new NotFoundError()
+      if (existing.status === "cancelled") throw new ValidationError("alreadyCancelled")
+      if (existing.status === "completed" || existing.status === "no_show") {
+        throw new ValidationError("alreadyClosed")
+      }
+
+      const now = new Date()
+      const startAt = combineDateHour(existing.date, existing.hour)
+      const hoursUntil = (startAt.getTime() - now.getTime()) / 3_600_000
+      const withinGrace = hoursUntil >= CANCEL_GRACE_HOURS
+
+      const updated = await tx.appointment.update({
+        where: { id },
+        data: {
+          status: "cancelled",
+          cancelledBy: input.by,
+          cancelReason: input.reason?.slice(0, 500) ?? null,
+          cancelledAt: now,
+        },
+      })
+      await auditService.logWithTx(tx, {
+        userId: auditUserId, action: "UPDATE", resource: "APPOINTMENT",
+        resourceId: String(id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: {
+          patientId: existing.patientId,
+          kind: "cancel", by: input.by,
+          withinGrace, hoursUntil: Math.round(hoursUntil),
+        },
+      })
+      return toAppointmentDTO(updated)
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+
+  /** US-2503 — doctor proposes a new date/hour to a cancelled appointment. */
+  async proposeAlternative(
+    id: number, alternativeAt: Date, auditUserId: number, ctx?: AuditContext,
+  ): Promise<AppointmentDTO> {
+    return prisma.$transaction(async (tx) => {
+      const existing = await tx.appointment.findUnique({ where: { id } })
+      if (!existing) throw new NotFoundError()
+      if (existing.status !== "cancelled" || existing.cancelledBy !== "doctor") {
+        throw new ValidationError("notDoctorCancelled")
+      }
+      if (alternativeAt <= new Date()) throw new ValidationError("alternativeInPast")
+
+      const updated = await tx.appointment.update({
+        where: { id },
+        data: { proposedAlternativeAt: alternativeAt },
+      })
+      await auditService.logWithTx(tx, {
+        userId: auditUserId, action: "UPDATE", resource: "APPOINTMENT",
+        resourceId: String(id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: {
+          patientId: existing.patientId,
+          kind: "propose-alternative",
+          alternativeAt: alternativeAt.toISOString(),
+        },
+      })
+      return toAppointmentDTO(updated)
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+
+  /** US-2503 — patient accepts the alternative → revert cancellation. */
+  async acceptAlternative(
+    id: number, auditUserId: number, ctx?: AuditContext,
+  ): Promise<AppointmentDTO> {
+    return prisma.$transaction(async (tx) => {
+      const existing = await tx.appointment.findUnique({ where: { id } })
+      if (!existing) throw new NotFoundError()
+      if (!existing.proposedAlternativeAt) throw new ValidationError("noAlternative")
+
+      const alt = existing.proposedAlternativeAt
+      const newDate = new Date(alt)
+      newDate.setUTCHours(0, 0, 0, 0)
+      const newHour = new Date(Date.UTC(1970, 0, 1, alt.getUTCHours(), alt.getUTCMinutes()))
+
+      if (existing.memberId !== null) {
+        const startAt = combineDateHour(newDate, newHour)
+        const endAt = computeEnd(startAt, existing.durationMinutes)
+        await assertNoOverlap(tx, existing.memberId, startAt, endAt, id)
+      }
+
+      const updated = await tx.appointment.update({
+        where: { id },
+        data: {
+          status: "scheduled",
+          date: newDate, hour: newHour,
+          proposedAlternativeAt: null,
+          cancelledBy: null, cancelReason: null, cancelledAt: null,
+        },
+      })
+      await auditService.logWithTx(tx, {
+        userId: auditUserId, action: "UPDATE", resource: "APPOINTMENT",
+        resourceId: String(id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: {
+          patientId: existing.patientId,
+          kind: "accept-alternative",
+          newAt: alt.toISOString(),
+        },
+      })
+      return toAppointmentDTO(updated)
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+
+  /** US-2505 — member confirms a `pending_validation` appointment. */
+  async confirm(
+    id: number, auditUserId: number, ctx?: AuditContext,
+  ): Promise<AppointmentDTO> {
+    return prisma.$transaction(async (tx) => {
+      const existing = await tx.appointment.findUnique({ where: { id } })
+      if (!existing) throw new NotFoundError()
+      if (existing.status !== "pending_validation") {
+        throw new ValidationError("notPending")
+      }
+      const updated = await tx.appointment.update({
+        where: { id }, data: { status: "confirmed" },
+      })
+      await auditService.logWithTx(tx, {
+        userId: auditUserId, action: "UPDATE", resource: "APPOINTMENT",
+        resourceId: String(id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: { patientId: existing.patientId, kind: "confirm" },
+      })
+      return toAppointmentDTO(updated)
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+
+  /** Helper for routes — fetch the patient owning an appointment. */
+  async getPatientIdFor(id: number): Promise<number | null> {
+    const a = await prisma.appointment.findUnique({
+      where: { id }, select: { patientId: true },
+    })
+    return a?.patientId ?? null
+  },
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2504 — Member unavailability
+// ─────────────────────────────────────────────────────────────
+
+const UNAVAIL_MAX_RANGE_DAYS = 365
+
+export type UnavailabilityDTO = {
+  id: number
+  memberId: number
+  startAt: Date
+  endAt: Date
+  reason: string | null
+}
+
+export const memberUnavailabilityService = {
+  async create(
+    input: { memberId: number; startAt: Date; endAt: Date; reason?: string },
+    auditUserId: number,
+    ctx?: AuditContext,
+  ): Promise<UnavailabilityDTO> {
+    if (input.endAt <= input.startAt) throw new ValidationError("dateRange")
+    if (input.endAt.getTime() - input.startAt.getTime() > UNAVAIL_MAX_RANGE_DAYS * 86_400_000) {
+      throw new ValidationError("rangeTooLong")
+    }
+    return prisma.$transaction(async (tx) => {
+      const member = await tx.healthcareMember.findUnique({
+        where: { id: input.memberId }, select: { id: true, serviceId: true },
+      })
+      if (!member) throw new NotFoundError()
+      if (member.serviceId === null) throw new ValidationError("memberHasNoService")
+      await assertServiceMember(auditUserId, member.serviceId, tx)
+
+      const row = await tx.memberUnavailability.create({
+        data: {
+          memberId: input.memberId,
+          startAt: input.startAt,
+          endAt: input.endAt,
+          reason: input.reason?.slice(0, 200),
+          createdBy: auditUserId,
+        },
+      })
+      await auditService.logWithTx(tx, {
+        userId: auditUserId, action: "CREATE", resource: "MEMBER_UNAVAILABILITY",
+        resourceId: String(row.id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: { memberId: input.memberId, serviceId: member.serviceId },
+      })
+      return { id: row.id, memberId: row.memberId, startAt: row.startAt, endAt: row.endAt, reason: row.reason }
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+
+  async listForMember(
+    memberId: number,
+    range: { from: Date; to: Date },
+    auditUserId: number,
+    ctx?: AuditContext,
+  ): Promise<UnavailabilityDTO[]> {
+    const member = await prisma.healthcareMember.findUnique({
+      where: { id: memberId }, select: { id: true, serviceId: true },
+    })
+    if (!member) throw new NotFoundError()
+    if (member.serviceId === null) throw new ValidationError("memberHasNoService")
+    await assertServiceMember(auditUserId, member.serviceId)
+
+    const rows = await prisma.memberUnavailability.findMany({
+      where: { memberId, startAt: { lt: range.to }, endAt: { gt: range.from } },
+      orderBy: { startAt: "asc" }, take: 200,
+    })
+    await auditService.log({
+      userId: auditUserId, action: "READ", resource: "MEMBER_UNAVAILABILITY",
+      resourceId: String(memberId),
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { memberId, count: rows.length },
+    })
+    return rows.map((r) => ({
+      id: r.id, memberId: r.memberId, startAt: r.startAt, endAt: r.endAt, reason: r.reason,
+    }))
+  },
+
+  async delete(id: number, auditUserId: number, ctx?: AuditContext) {
+    return prisma.$transaction(async (tx) => {
+      const u = await tx.memberUnavailability.findUnique({
+        where: { id },
+        select: { id: true, memberId: true, member: { select: { serviceId: true } } },
+      })
+      if (!u) throw new NotFoundError()
+      if (u.member.serviceId === null) throw new ValidationError("memberHasNoService")
+      await assertServiceMember(auditUserId, u.member.serviceId, tx)
+      await tx.memberUnavailability.delete({ where: { id } })
+      await auditService.logWithTx(tx, {
+        userId: auditUserId, action: "DELETE", resource: "MEMBER_UNAVAILABILITY",
+        resourceId: String(id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: { memberId: u.memberId, serviceId: u.member.serviceId },
+      })
+      return { deleted: true }
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2505 — Member booking config (auto vs validation)
+// ─────────────────────────────────────────────────────────────
+
+export type MemberBookingConfigDTO = {
+  memberId: number
+  bookingMode: BookingMode
+  defaultAppointmentMinutes: number | null
+}
+
+export const memberBookingConfigService = {
+  async get(memberId: number): Promise<MemberBookingConfigDTO | null> {
+    const m = await prisma.healthcareMember.findUnique({
+      where: { id: memberId },
+      select: { id: true, bookingMode: true, defaultAppointmentMinutes: true },
+    })
+    if (!m) return null
+    return {
+      memberId: m.id,
+      bookingMode: m.bookingMode,
+      defaultAppointmentMinutes: m.defaultAppointmentMinutes,
+    }
+  },
+
+  async update(
+    memberId: number,
+    input: { bookingMode?: BookingMode; defaultAppointmentMinutes?: number | null },
+    auditUserId: number,
+    ctx?: AuditContext,
+  ): Promise<MemberBookingConfigDTO> {
+    if (
+      input.defaultAppointmentMinutes !== undefined &&
+      input.defaultAppointmentMinutes !== null &&
+      (input.defaultAppointmentMinutes < DURATION_MIN ||
+        input.defaultAppointmentMinutes > DURATION_MAX)
+    ) {
+      throw new ValidationError("defaultAppointmentMinutes")
+    }
+
+    return prisma.$transaction(async (tx) => {
+      const m = await tx.healthcareMember.findUnique({
+        where: { id: memberId }, select: { id: true, serviceId: true },
+      })
+      if (!m) throw new NotFoundError()
+      if (m.serviceId === null) throw new ValidationError("memberHasNoService")
+      await assertServiceMember(auditUserId, m.serviceId, tx)
+
+      const updated = await tx.healthcareMember.update({
+        where: { id: memberId },
+        data: {
+          bookingMode: input.bookingMode,
+          defaultAppointmentMinutes: input.defaultAppointmentMinutes ?? undefined,
+        },
+        select: { id: true, bookingMode: true, defaultAppointmentMinutes: true },
+      })
+      await auditService.logWithTx(tx, {
+        userId: auditUserId, action: "UPDATE", resource: "MEMBER_BOOKING_CONFIG",
+        resourceId: String(memberId),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: {
+          memberId, serviceId: m.serviceId,
+          bookingMode: input.bookingMode ?? null,
+        },
+      })
+      return {
+        memberId: updated.id,
+        bookingMode: updated.bookingMode,
+        defaultAppointmentMinutes: updated.defaultAppointmentMinutes,
+      }
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+}

--- a/src/lib/services/rdv.service.ts
+++ b/src/lib/services/rdv.service.ts
@@ -23,6 +23,7 @@ import {
   type AppointmentStatus,
   type BookingMode,
   type CancellationActor,
+  type Role,
 } from "@prisma/client"
 import { prisma, type PrismaClientOrTx as Tx } from "@/lib/db/client"
 import { auditService } from "./audit.service"
@@ -54,19 +55,28 @@ async function assertServiceMember(
 }
 
 /**
- * H11 — guard for routes that scope by `memberId` rather than `patientId`.
- * Ensures the caller is a member of the same service as the target member,
- * preventing cross-tenant reconnaissance via member-scoped endpoints.
+ * H11/H2 — guard for routes that scope by `memberId` rather than `patientId`.
+ * Ensures the caller is a member of the same service as the target member.
+ *
+ * **Returns `ForbiddenError` for all failure modes** (member missing, member
+ * has no service, caller is not in the same service) — collapses 404 vs 403
+ * into a single response shape to prevent cross-tenant memberId enumeration.
+ *
+ * H7 — single-query implementation : join the membership check with the
+ * target lookup to avoid two sequential round-trips.
  */
 export async function assertMemberServiceAccess(
   callerUserId: number, memberId: number,
 ): Promise<void> {
-  const target = await prisma.healthcareMember.findUnique({
-    where: { id: memberId }, select: { id: true, serviceId: true },
+  const target = await prisma.healthcareMember.findFirst({
+    where: {
+      id: memberId,
+      serviceId: { not: null },
+      service: { members: { some: { userId: callerUserId } } },
+    },
+    select: { id: true },
   })
-  if (!target) throw new NotFoundError()
-  if (target.serviceId === null) throw new ForbiddenError()
-  await assertServiceMember(callerUserId, target.serviceId)
+  if (!target) throw new ForbiddenError()
 }
 
 async function assertPatientAlive(patientId: number, tx: Tx = prisma): Promise<void> {
@@ -128,6 +138,7 @@ async function assertNoOverlap(
   const dayCeil = new Date(endAt)
   dayCeil.setUTCHours(23, 59, 59, 999)
 
+  const OVERLAP_TAKE = 1000
   const sameDay = await tx.appointment.findMany({
     where: {
       memberId,
@@ -136,8 +147,13 @@ async function assertNoOverlap(
       ...(excludeAppointmentId ? { NOT: { id: excludeAppointmentId } } : {}),
     },
     select: { date: true, hour: true, durationMinutes: true },
-    take: 1000, // M3 safety cap — a single day overlap query should never exceed this
+    take: OVERLAP_TAKE, // M3 safety cap
   })
+  if (sameDay.length === OVERLAP_TAKE) {
+    // M4 — silent truncation would miss conflicts beyond position 1000.
+    //      Refuse the booking conservatively rather than risk a double-book.
+    throw new ValidationError("overlapQueryTruncated")
+  }
   for (const a of sameDay) {
     const aStart = combineDateHour(a.date, a.hour)
     const aEnd = computeEnd(aStart, a.durationMinutes)
@@ -239,6 +255,18 @@ export type AppointmentCreateInput = {
   type?: string
   motif?: string
   note?: string
+}
+
+/** M7 — named patch types so callers don't depend on positional `Parameters<>`
+ *  indexing into private function signatures. */
+export type AppointmentUpdatePatch = {
+  date?: Date; hour?: Date; durationMinutes?: number;
+  location?: AppointmentLocation; type?: string;
+  motif?: string | null; note?: string | null;
+}
+export type MemberBookingConfigUpdateInput = {
+  bookingMode?: BookingMode;
+  defaultAppointmentMinutes?: number | null;
 }
 
 export const rdvAppointmentService = {
@@ -344,15 +372,20 @@ export const rdvAppointmentService = {
     }
 
     const LIST_LIMIT = 200
+    // M2 — widen `from` by 1 day so cross-midnight appointments starting the
+    //      day before the queried range are returned, then re-filter in JS to
+    //      keep only those whose end-time falls inside [input.from, input.to].
+    const widenedFrom = new Date(input.from)
+    widenedFrom.setUTCDate(widenedFrom.getUTCDate() - 1)
     const where: Prisma.AppointmentWhereInput = {
-      date: { gte: input.from, lte: input.to },
+      date: { gte: widenedFrom, lte: input.to },
       // M1 — exclude soft-deleted patients.
       patient: { deletedAt: null },
       ...(input.memberId !== undefined && { memberId: input.memberId }),
       ...(input.patientId !== undefined && { patientId: input.patientId }),
       ...(input.status && { status: input.status }),
     }
-    const rows = await prisma.appointment.findMany({
+    const rowsRaw = await prisma.appointment.findMany({
       where,
       orderBy: [{ date: "asc" }, { hour: "asc" }],
       take: LIST_LIMIT + 1,
@@ -367,6 +400,13 @@ export const rdvAppointmentService = {
         cancelledAt: true,
         createdAt: true, updatedAt: true,
       },
+    })
+    // Filter day-before rows whose end ≤ input.from (they don't spill into the
+    // requested window).
+    const rows = rowsRaw.filter((r) => {
+      const start = combineDateHour(r.date, r.hour)
+      const end = computeEnd(start, r.durationMinutes)
+      return end > input.from && start <= input.to
     })
     const truncated = rows.length > LIST_LIMIT
     const items = (truncated ? rows.slice(0, LIST_LIMIT) : rows).map(toAppointmentListItemDTO)
@@ -386,11 +426,7 @@ export const rdvAppointmentService = {
 
   async update(
     id: number,
-    patch: {
-      date?: Date; hour?: Date; durationMinutes?: number;
-      location?: AppointmentLocation; type?: string;
-      motif?: string | null; note?: string | null;
-    },
+    patch: AppointmentUpdatePatch,
     auditUserId: number,
     ctx?: AuditContext,
   ): Promise<AppointmentDTO> {
@@ -475,7 +511,7 @@ export const rdvAppointmentService = {
    */
   async cancel(
     id: number,
-    input: { actor: CancellationActor; reason?: string },
+    input: { actor: CancellationActor; reason?: string; callerRole?: Role },
     auditUserId: number,
     ctx?: AuditContext,
   ): Promise<AppointmentDTO> {
@@ -510,6 +546,7 @@ export const rdvAppointmentService = {
         metadata: {
           patientId: existing.patientId,
           kind: "cancel", actor: input.actor,
+          callerRole: input.callerRole ?? null,
           lateCancel, hoursUntil: Math.round(hoursUntil),
         },
       })
@@ -519,7 +556,12 @@ export const rdvAppointmentService = {
 
   /** US-2503 — doctor proposes a new date/hour to a cancelled appointment.
    *  H10 — overlap-check the proposed slot so the patient doesn't accept a
-   *  slot that has become unavailable since the cancel. */
+   *  slot that has become unavailable since the cancel.
+   *
+   *  L7 — re-proposal is idempotent (overwrites any stale `proposedAlternativeAt`).
+   *       The TTL (`PROPOSAL_TTL_MS`) is only checked on the accept-side so an
+   *       expired proposal can be refreshed by the doctor without a state transition.
+   */
   async proposeAlternative(
     id: number, alternativeAt: Date, auditUserId: number, ctx?: AuditContext,
   ): Promise<AppointmentDTO> {
@@ -556,9 +598,11 @@ export const rdvAppointmentService = {
 
   /** US-2503 — patient accepts the alternative → revert cancellation.
    *  M14 — must still be `cancelled`. M10 — TTL applied (proposal expires after 7d).
-   *  L6 — preserve seconds in the new hour. L9 — audit on conflict. */
+   *  L6 — preserve seconds in the new hour. L9 — audit on conflict.
+   *  H8 — `callerRole` is logged alongside the accept action so forensics
+   *       can distinguish patient self-accept vs staff accept-on-behalf. */
   async acceptAlternative(
-    id: number, auditUserId: number, ctx?: AuditContext,
+    id: number, auditUserId: number, ctx?: AuditContext, callerRole?: Role,
   ): Promise<AppointmentDTO> {
     return prisma.$transaction(async (tx) => {
       const existing = await tx.appointment.findUnique({ where: { id } })
@@ -613,6 +657,7 @@ export const rdvAppointmentService = {
         metadata: {
           patientId: existing.patientId,
           kind: "accept-alternative",
+          callerRole: callerRole ?? null,
           newAt: alt.toISOString(),
         },
       })
@@ -716,10 +761,19 @@ export const memberUnavailabilityService = {
         })
         return decodeUnavailability(row)
       } catch (err) {
-        // H3 — Postgres EXCLUDE constraint surfaces as P2002/P2010 ; map to typed error.
+        // H3/C2 — Postgres EXCLUDE constraint violations raise sqlstate 23P01.
+        // @prisma/adapter-pg does NOT remap 23P01 to a `PrismaClientKnownRequestError`,
+        // so the error surfaces as `PrismaClientUnknownRequestError` with the raw
+        // driver code embedded in `.message`. We must catch both flavours.
         if (
           err instanceof Prisma.PrismaClientKnownRequestError &&
-          (err.code === "P2002" || err.code === "P2010")
+          err.code === "P2002"
+        ) {
+          throw new ValidationError("unavailabilityOverlap") // UNIQUE fallback
+        }
+        if (
+          err instanceof Prisma.PrismaClientUnknownRequestError &&
+          err.message.includes("23P01")
         ) {
           throw new ValidationError("unavailabilityOverlap")
         }
@@ -734,12 +788,8 @@ export const memberUnavailabilityService = {
     auditUserId: number,
     ctx?: AuditContext,
   ): Promise<UnavailabilityDTO[]> {
-    const member = await prisma.healthcareMember.findUnique({
-      where: { id: memberId }, select: { id: true, serviceId: true },
-    })
-    if (!member) throw new NotFoundError()
-    if (member.serviceId === null) throw new ValidationError("memberHasNoService")
-    await assertServiceMember(auditUserId, member.serviceId)
+    // H2 — uniform `ForbiddenError` (no 404 vs 403 oracle on member enumeration).
+    await assertMemberServiceAccess(auditUserId, memberId)
 
     const rows = await prisma.memberUnavailability.findMany({
       where: { memberId, startAt: { lt: range.to }, endAt: { gt: range.from } },
@@ -756,13 +806,20 @@ export const memberUnavailabilityService = {
 
   async delete(id: number, auditUserId: number, ctx?: AuditContext) {
     return prisma.$transaction(async (tx) => {
-      const u = await tx.memberUnavailability.findUnique({
-        where: { id },
+      // H2 — fold the membership check + existence check into one query so
+      // a cross-tenant caller sees a uniform `ForbiddenError` regardless of
+      // whether the unavailability exists.
+      const u = await tx.memberUnavailability.findFirst({
+        where: {
+          id,
+          member: {
+            serviceId: { not: null },
+            service: { members: { some: { userId: auditUserId } } },
+          },
+        },
         select: { id: true, memberId: true, member: { select: { serviceId: true } } },
       })
-      if (!u) throw new NotFoundError()
-      if (u.member.serviceId === null) throw new ValidationError("memberHasNoService")
-      await assertServiceMember(auditUserId, u.member.serviceId, tx)
+      if (!u) throw new ForbiddenError()
       await tx.memberUnavailability.delete({ where: { id } })
       await auditService.logWithTx(tx, {
         userId: auditUserId, action: "DELETE", resource: "MEMBER_UNAVAILABILITY",
@@ -801,7 +858,7 @@ export const memberBookingConfigService = {
 
   async update(
     memberId: number,
-    input: { bookingMode?: BookingMode; defaultAppointmentMinutes?: number | null },
+    input: MemberBookingConfigUpdateInput,
     auditUserId: number,
     ctx?: AuditContext,
   ): Promise<MemberBookingConfigDTO> {

--- a/src/lib/team-route-helpers.ts
+++ b/src/lib/team-route-helpers.ts
@@ -11,6 +11,7 @@
  */
 
 import { NextResponse } from "next/server"
+import { Prisma } from "@prisma/client"
 import { AuthError, getAuthUser, requireRole, type AuthUser } from "@/lib/auth"
 import type { Role } from "@prisma/client"
 import {
@@ -89,6 +90,13 @@ export function mapErrorToResponse(
   }
   if (error instanceof NotFoundError) {
     return NextResponse.json({ error: "notFound" }, { status: 404 })
+  }
+  // H7 — Postgres serialization conflict ; client should retry the request.
+  if (
+    error instanceof Prisma.PrismaClientKnownRequestError &&
+    error.code === "P2034"
+  ) {
+    return NextResponse.json({ error: "serializationConflict" }, { status: 409 })
   }
   if (error instanceof ForbiddenError) {
     if (auditTarget) {

--- a/tests/unit/rdv.service.test.ts
+++ b/tests/unit/rdv.service.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Test suite: rdv.service (Groupe 8 Batch 1 — 5 US, 36 SP)
+ *
+ * Covers:
+ *  - US-2501 appointment CRUD (validation, encrypted note, status defaults)
+ *  - US-2500 listInRange (range cap, audit count)
+ *  - US-2503 cancel + propose-alternative + accept-alternative workflow
+ *  - US-2504 memberUnavailability (overlap detection)
+ *  - US-2505 memberBookingConfig + auto/validation mode side-effects
+ */
+import { describe, it, expect, beforeEach } from "vitest"
+import { prismaMock } from "../helpers/prisma-mock"
+import {
+  rdvAppointmentService,
+  memberUnavailabilityService,
+  memberBookingConfigService,
+} from "@/lib/services/rdv.service"
+import {
+  ForbiddenError,
+  NotFoundError,
+  ValidationError,
+} from "@/lib/services/team-workflow.errors"
+
+beforeEach(() => {
+  prismaMock.auditLog.create.mockResolvedValue({} as any)
+  prismaMock.$transaction.mockImplementation(async (fn: any) => fn(prismaMock))
+})
+
+const date = new Date("2026-06-10")
+const hour = new Date("1970-01-01T09:00:00Z")
+
+describe("rdvAppointmentService.create", () => {
+  it("rejects invalid duration", async () => {
+    await expect(
+      rdvAppointmentService.create(
+        { patientId: 7, memberId: 1, date, hour, durationMinutes: 5 }, 9,
+      ),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("rejects when patient is missing", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue(null)
+    await expect(
+      rdvAppointmentService.create({ patientId: 7, memberId: 1, date, hour }, 9),
+    ).rejects.toBeInstanceOf(NotFoundError)
+  })
+
+  it("rejects member with no service", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
+    prismaMock.healthcareMember.findUnique.mockResolvedValue({
+      id: 1, serviceId: null, bookingMode: "auto", defaultAppointmentMinutes: null,
+    } as any)
+    await expect(
+      rdvAppointmentService.create({ patientId: 7, memberId: 1, date, hour }, 9),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("rejects slot overlap with existing appointment", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
+    prismaMock.healthcareMember.findUnique.mockResolvedValue({
+      id: 1, serviceId: 10, bookingMode: "auto", defaultAppointmentMinutes: null,
+    } as any)
+    prismaMock.appointment.findMany.mockResolvedValue([
+      { date, hour, durationMinutes: 30 } as any,
+    ])
+    await expect(
+      rdvAppointmentService.create({ patientId: 7, memberId: 1, date, hour }, 9),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("rejects slot overlap with an unavailability", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
+    prismaMock.healthcareMember.findUnique.mockResolvedValue({
+      id: 1, serviceId: 10, bookingMode: "auto", defaultAppointmentMinutes: null,
+    } as any)
+    prismaMock.appointment.findMany.mockResolvedValue([])
+    prismaMock.memberUnavailability.findMany.mockResolvedValue([{ id: 1 } as any])
+    await expect(
+      rdvAppointmentService.create({ patientId: 7, memberId: 1, date, hour }, 9),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("creates `scheduled` when bookingMode=auto", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
+    prismaMock.healthcareMember.findUnique.mockResolvedValue({
+      id: 1, serviceId: 10, bookingMode: "auto", defaultAppointmentMinutes: 30,
+    } as any)
+    prismaMock.appointment.findMany.mockResolvedValue([])
+    prismaMock.memberUnavailability.findMany.mockResolvedValue([])
+    prismaMock.appointment.create.mockResolvedValue({
+      id: 1, patientId: 7, memberId: 1, type: null, date, hour, durationMinutes: 30,
+      location: null, status: "scheduled", motif: null, noteEncrypted: null,
+      proposedAlternativeAt: null, cancelledBy: null, cancelReason: null, cancelledAt: null,
+      createdAt: new Date(), updatedAt: new Date(),
+    } as any)
+    const out = await rdvAppointmentService.create(
+      { patientId: 7, memberId: 1, date, hour }, 9,
+    )
+    expect(out.status).toBe("scheduled")
+  })
+
+  it("creates `pending_validation` when bookingMode=validation (US-2505)", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
+    prismaMock.healthcareMember.findUnique.mockResolvedValue({
+      id: 1, serviceId: 10, bookingMode: "validation", defaultAppointmentMinutes: 30,
+    } as any)
+    prismaMock.appointment.findMany.mockResolvedValue([])
+    prismaMock.memberUnavailability.findMany.mockResolvedValue([])
+    prismaMock.appointment.create.mockResolvedValue({
+      id: 1, patientId: 7, memberId: 1, type: null, date, hour, durationMinutes: 30,
+      location: null, status: "pending_validation", motif: null, noteEncrypted: null,
+      proposedAlternativeAt: null, cancelledBy: null, cancelReason: null, cancelledAt: null,
+      createdAt: new Date(), updatedAt: new Date(),
+    } as any)
+    const out = await rdvAppointmentService.create(
+      { patientId: 7, memberId: 1, date, hour }, 9,
+    )
+    expect(out.status).toBe("pending_validation")
+  })
+
+  it("encrypts note before insertion", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
+    prismaMock.healthcareMember.findUnique.mockResolvedValue({
+      id: 1, serviceId: 10, bookingMode: "auto", defaultAppointmentMinutes: 30,
+    } as any)
+    prismaMock.appointment.findMany.mockResolvedValue([])
+    prismaMock.memberUnavailability.findMany.mockResolvedValue([])
+    prismaMock.appointment.create.mockResolvedValue({
+      id: 1, patientId: 7, memberId: 1, type: null, date, hour, durationMinutes: 30,
+      location: null, status: "scheduled", motif: null, noteEncrypted: "cipher",
+      proposedAlternativeAt: null, cancelledBy: null, cancelReason: null, cancelledAt: null,
+      createdAt: new Date(), updatedAt: new Date(),
+    } as any)
+    await rdvAppointmentService.create(
+      { patientId: 7, memberId: 1, date, hour, note: "Patient sensible aux pénicillines" }, 9,
+    )
+    const args = prismaMock.appointment.create.mock.calls[0][0] as any
+    expect(args.data.noteEncrypted).not.toContain("pénicillines")
+  })
+})
+
+describe("rdvAppointmentService.listInRange (US-2500)", () => {
+  it("rejects range > 62 days", async () => {
+    await expect(
+      rdvAppointmentService.listInRange(
+        { from: new Date("2026-01-01"), to: new Date("2026-04-01") }, 9,
+      ),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+  it("rejects to < from", async () => {
+    await expect(
+      rdvAppointmentService.listInRange(
+        { from: new Date("2026-02-01"), to: new Date("2026-01-01") }, 9,
+      ),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+  it("audits READ with count", async () => {
+    prismaMock.appointment.findMany.mockResolvedValue([] as any)
+    await rdvAppointmentService.listInRange(
+      { from: new Date("2026-06-01"), to: new Date("2026-06-15"), memberId: 1 }, 9,
+    )
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.resource).toBe("APPOINTMENT")
+    expect(audit.resourceId).toBe("list")
+  })
+})
+
+describe("rdvAppointmentService.cancel (US-2503)", () => {
+  it("rejects already-cancelled", async () => {
+    prismaMock.appointment.findUnique.mockResolvedValue({
+      id: 1, patientId: 7, status: "cancelled",
+    } as any)
+    await expect(
+      rdvAppointmentService.cancel(1, { by: "patient" }, 9),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+  it("rejects completed", async () => {
+    prismaMock.appointment.findUnique.mockResolvedValue({
+      id: 1, patientId: 7, status: "completed",
+    } as any)
+    await expect(
+      rdvAppointmentService.cancel(1, { by: "doctor" }, 9),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+  it("audits withinGrace=true when patient cancels > 24h before", async () => {
+    const future = new Date(Date.now() + 48 * 3600_000)
+    const futureDate = new Date(future)
+    futureDate.setUTCHours(0, 0, 0, 0)
+    const futureHour = new Date(future)
+    futureHour.setUTCFullYear(1970, 0, 1)
+    prismaMock.appointment.findUnique.mockResolvedValue({
+      id: 1, patientId: 7, status: "scheduled",
+      date: futureDate, hour: futureHour, durationMinutes: 30,
+    } as any)
+    prismaMock.appointment.update.mockResolvedValue({
+      id: 1, patientId: 7, memberId: null, type: null, date: futureDate, hour: futureHour,
+      durationMinutes: 30, location: null, status: "cancelled",
+      motif: null, noteEncrypted: null,
+      proposedAlternativeAt: null, cancelledBy: "patient", cancelReason: null, cancelledAt: new Date(),
+      createdAt: new Date(), updatedAt: new Date(),
+    } as any)
+    await rdvAppointmentService.cancel(1, { by: "patient" }, 9)
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.metadata.withinGrace).toBe(true)
+  })
+})
+
+describe("rdvAppointmentService.proposeAlternative + accept (US-2503)", () => {
+  it("rejects propose when not cancelled by doctor", async () => {
+    prismaMock.appointment.findUnique.mockResolvedValue({
+      id: 1, status: "cancelled", cancelledBy: "patient",
+    } as any)
+    await expect(
+      rdvAppointmentService.proposeAlternative(1, new Date(Date.now() + 86_400_000), 9),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+  it("rejects propose in the past", async () => {
+    prismaMock.appointment.findUnique.mockResolvedValue({
+      id: 1, status: "cancelled", cancelledBy: "doctor",
+    } as any)
+    await expect(
+      rdvAppointmentService.proposeAlternative(1, new Date("2020-01-01"), 9),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+  it("accept-alternative resets the appointment to scheduled", async () => {
+    const alt = new Date(Date.now() + 86_400_000)
+    prismaMock.appointment.findUnique.mockResolvedValue({
+      id: 1, patientId: 7, memberId: 1, status: "cancelled",
+      proposedAlternativeAt: alt, durationMinutes: 30,
+    } as any)
+    prismaMock.appointment.findMany.mockResolvedValue([])
+    prismaMock.memberUnavailability.findMany.mockResolvedValue([])
+    prismaMock.appointment.update.mockResolvedValue({
+      id: 1, patientId: 7, memberId: 1, type: null, date: alt, hour: alt,
+      durationMinutes: 30, location: null, status: "scheduled",
+      motif: null, noteEncrypted: null,
+      proposedAlternativeAt: null, cancelledBy: null, cancelReason: null, cancelledAt: null,
+      createdAt: new Date(), updatedAt: new Date(),
+    } as any)
+    const out = await rdvAppointmentService.acceptAlternative(1, 9)
+    expect(out.status).toBe("scheduled")
+  })
+})
+
+describe("rdvAppointmentService.confirm (US-2505)", () => {
+  it("rejects when status != pending_validation", async () => {
+    prismaMock.appointment.findUnique.mockResolvedValue({
+      id: 1, patientId: 7, status: "scheduled",
+    } as any)
+    await expect(rdvAppointmentService.confirm(1, 9))
+      .rejects.toBeInstanceOf(ValidationError)
+  })
+  it("confirms pending → confirmed + audit", async () => {
+    prismaMock.appointment.findUnique.mockResolvedValue({
+      id: 1, patientId: 7, status: "pending_validation",
+    } as any)
+    prismaMock.appointment.update.mockResolvedValue({
+      id: 1, patientId: 7, memberId: 1, type: null, date, hour,
+      durationMinutes: 30, location: null, status: "confirmed",
+      motif: null, noteEncrypted: null,
+      proposedAlternativeAt: null, cancelledBy: null, cancelReason: null, cancelledAt: null,
+      createdAt: new Date(), updatedAt: new Date(),
+    } as any)
+    const out = await rdvAppointmentService.confirm(1, 9)
+    expect(out.status).toBe("confirmed")
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.metadata.kind).toBe("confirm")
+  })
+})
+
+describe("memberUnavailabilityService (US-2504)", () => {
+  it("rejects endAt <= startAt", async () => {
+    const start = new Date("2026-06-10T09:00:00Z")
+    const end = new Date("2026-06-10T08:00:00Z")
+    await expect(
+      memberUnavailabilityService.create({ memberId: 1, startAt: start, endAt: end }, 9),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+  it("rejects range > 365 days", async () => {
+    const start = new Date("2026-06-10T09:00:00Z")
+    const end = new Date("2028-06-10T09:00:00Z")
+    await expect(
+      memberUnavailabilityService.create({ memberId: 1, startAt: start, endAt: end }, 9),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+  it("rejects when caller is not a member of the service", async () => {
+    prismaMock.healthcareMember.findUnique.mockResolvedValue({ id: 1, serviceId: 10 } as any)
+    prismaMock.healthcareMember.findFirst.mockResolvedValue(null)
+    await expect(
+      memberUnavailabilityService.create(
+        { memberId: 1,
+          startAt: new Date("2026-06-10T09:00:00Z"),
+          endAt: new Date("2026-06-10T10:00:00Z") },
+        9,
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenError)
+  })
+  it("happy path creates + audits", async () => {
+    prismaMock.healthcareMember.findUnique.mockResolvedValue({ id: 1, serviceId: 10 } as any)
+    prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 99 } as any)
+    prismaMock.memberUnavailability.create.mockResolvedValue({
+      id: 1, memberId: 1,
+      startAt: new Date("2026-06-10T09:00:00Z"),
+      endAt: new Date("2026-06-10T10:00:00Z"),
+      reason: null,
+    } as any)
+    const out = await memberUnavailabilityService.create({
+      memberId: 1,
+      startAt: new Date("2026-06-10T09:00:00Z"),
+      endAt: new Date("2026-06-10T10:00:00Z"),
+    }, 9)
+    expect(out.id).toBe(1)
+  })
+})
+
+describe("memberBookingConfigService (US-2505)", () => {
+  it("rejects defaultAppointmentMinutes out of range", async () => {
+    await expect(
+      memberBookingConfigService.update(1, { defaultAppointmentMinutes: 5 }, 9),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+  it("rejects when caller is not member of the service", async () => {
+    prismaMock.healthcareMember.findUnique.mockResolvedValue({ id: 1, serviceId: 10 } as any)
+    prismaMock.healthcareMember.findFirst.mockResolvedValue(null)
+    await expect(
+      memberBookingConfigService.update(1, { bookingMode: "validation" }, 9),
+    ).rejects.toBeInstanceOf(ForbiddenError)
+  })
+  it("updates + audits", async () => {
+    prismaMock.healthcareMember.findUnique.mockResolvedValue({ id: 1, serviceId: 10 } as any)
+    prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 99 } as any)
+    prismaMock.healthcareMember.update.mockResolvedValue({
+      id: 1, bookingMode: "validation", defaultAppointmentMinutes: 45,
+    } as any)
+    const out = await memberBookingConfigService.update(
+      1, { bookingMode: "validation", defaultAppointmentMinutes: 45 }, 9,
+    )
+    expect(out.bookingMode).toBe("validation")
+    expect(out.defaultAppointmentMinutes).toBe(45)
+  })
+  it("get returns null when member missing", async () => {
+    prismaMock.healthcareMember.findUnique.mockResolvedValue(null)
+    const cfg = await memberBookingConfigService.get(999)
+    expect(cfg).toBeNull()
+  })
+})

--- a/tests/unit/rdv.service.test.ts
+++ b/tests/unit/rdv.service.test.ts
@@ -68,6 +68,31 @@ describe("rdvAppointmentService.create", () => {
     ).rejects.toBeInstanceOf(ValidationError)
   })
 
+  it("C3 — rejects slot overlap that starts on day-before and spills past midnight", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
+    prismaMock.healthcareMember.findUnique.mockResolvedValue({
+      id: 1, serviceId: 10, bookingMode: "auto", defaultAppointmentMinutes: null,
+    } as any)
+    // Existing appointment 2026-06-09 23:30 + 120 min → ends 2026-06-10 01:30 UTC.
+    prismaMock.appointment.findMany.mockResolvedValue([
+      {
+        date: new Date("2026-06-09"),
+        hour: new Date("1970-01-01T23:30:00Z"),
+        durationMinutes: 120,
+      } as any,
+    ])
+    prismaMock.memberUnavailability.findMany.mockResolvedValue([])
+    // New slot 2026-06-10 00:30 → must conflict.
+    await expect(
+      rdvAppointmentService.create({
+        patientId: 7, memberId: 1,
+        date: new Date("2026-06-10"),
+        hour: new Date("1970-01-01T00:30:00Z"),
+        durationMinutes: 30,
+      }, 9),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+
   it("rejects slot overlap with an unavailability", async () => {
     prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as any)
     prismaMock.healthcareMember.findUnique.mockResolvedValue({
@@ -89,8 +114,8 @@ describe("rdvAppointmentService.create", () => {
     prismaMock.memberUnavailability.findMany.mockResolvedValue([])
     prismaMock.appointment.create.mockResolvedValue({
       id: 1, patientId: 7, memberId: 1, type: null, date, hour, durationMinutes: 30,
-      location: null, status: "scheduled", motif: null, noteEncrypted: null,
-      proposedAlternativeAt: null, cancelledBy: null, cancelReason: null, cancelledAt: null,
+      location: null, status: "scheduled", motifEncrypted: null, noteEncrypted: null,
+      proposedAlternativeAt: null, cancelledBy: null, cancelReasonEncrypted: null, cancelledAt: null,
       createdAt: new Date(), updatedAt: new Date(),
     } as any)
     const out = await rdvAppointmentService.create(
@@ -108,8 +133,8 @@ describe("rdvAppointmentService.create", () => {
     prismaMock.memberUnavailability.findMany.mockResolvedValue([])
     prismaMock.appointment.create.mockResolvedValue({
       id: 1, patientId: 7, memberId: 1, type: null, date, hour, durationMinutes: 30,
-      location: null, status: "pending_validation", motif: null, noteEncrypted: null,
-      proposedAlternativeAt: null, cancelledBy: null, cancelReason: null, cancelledAt: null,
+      location: null, status: "pending_validation", motifEncrypted: null, noteEncrypted: null,
+      proposedAlternativeAt: null, cancelledBy: null, cancelReasonEncrypted: null, cancelledAt: null,
       createdAt: new Date(), updatedAt: new Date(),
     } as any)
     const out = await rdvAppointmentService.create(
@@ -143,25 +168,76 @@ describe("rdvAppointmentService.listInRange (US-2500)", () => {
   it("rejects range > 62 days", async () => {
     await expect(
       rdvAppointmentService.listInRange(
-        { from: new Date("2026-01-01"), to: new Date("2026-04-01") }, 9,
+        { from: new Date("2026-01-01"), to: new Date("2026-04-01"), memberId: 1 }, 9,
       ),
     ).rejects.toBeInstanceOf(ValidationError)
   })
   it("rejects to < from", async () => {
     await expect(
       rdvAppointmentService.listInRange(
-        { from: new Date("2026-02-01"), to: new Date("2026-01-01") }, 9,
+        { from: new Date("2026-02-01"), to: new Date("2026-01-01"), memberId: 1 }, 9,
+      ),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+  it("rejects unscoped listing (C1 — cross-tenant PHI leak)", async () => {
+    await expect(
+      rdvAppointmentService.listInRange(
+        { from: new Date("2026-06-01"), to: new Date("2026-06-15") }, 9,
       ),
     ).rejects.toBeInstanceOf(ValidationError)
   })
   it("audits READ with count", async () => {
     prismaMock.appointment.findMany.mockResolvedValue([] as any)
-    await rdvAppointmentService.listInRange(
+    const out = await rdvAppointmentService.listInRange(
       { from: new Date("2026-06-01"), to: new Date("2026-06-15"), memberId: 1 }, 9,
     )
+    expect(out.items).toEqual([])
+    expect(out.truncated).toBe(false)
     const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
     expect(audit.resource).toBe("APPOINTMENT")
     expect(audit.resourceId).toBe("list")
+  })
+  it("flags truncated=true when result exceeds limit", async () => {
+    const row = {
+      id: 1, patientId: 7, memberId: 1, type: null, date, hour,
+      durationMinutes: 30, location: null, status: "scheduled",
+      motifEncrypted: null, proposedAlternativeAt: null,
+      cancelledBy: null, cancelledAt: null,
+      createdAt: new Date(), updatedAt: new Date(),
+    }
+    prismaMock.appointment.findMany.mockResolvedValue(
+      Array.from({ length: 201 }, (_, i) => ({ ...row, id: i + 1 })) as any,
+    )
+    const out = await rdvAppointmentService.listInRange(
+      { from: new Date("2026-06-01"), to: new Date("2026-06-15"), memberId: 1 }, 9,
+    )
+    expect(out.items.length).toBe(200)
+    expect(out.truncated).toBe(true)
+  })
+})
+
+describe("rdvAppointmentService.update (H5 / H6)", () => {
+  it("H5 — rejects update on `completed`", async () => {
+    prismaMock.appointment.findUnique.mockResolvedValue({
+      id: 1, patientId: 7, status: "completed", memberId: 1, date, hour, durationMinutes: 30,
+    } as any)
+    await expect(
+      rdvAppointmentService.update(1, { type: "ide" }, 9),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+  it("H6 — explicit note=null clears the noteEncrypted column", async () => {
+    prismaMock.appointment.findUnique.mockResolvedValue({
+      id: 1, patientId: 7, status: "scheduled", memberId: 1, date, hour, durationMinutes: 30,
+    } as any)
+    prismaMock.appointment.update.mockResolvedValue({
+      id: 1, patientId: 7, memberId: 1, type: null, date, hour, durationMinutes: 30,
+      location: null, status: "scheduled", motifEncrypted: null, noteEncrypted: null,
+      proposedAlternativeAt: null, cancelledBy: null, cancelReasonEncrypted: null,
+      cancelledAt: null, createdAt: new Date(), updatedAt: new Date(),
+    } as any)
+    await rdvAppointmentService.update(1, { note: null }, 9)
+    const args = prismaMock.appointment.update.mock.calls[0][0] as any
+    expect(args.data.noteEncrypted).toBeNull()
   })
 })
 
@@ -171,7 +247,7 @@ describe("rdvAppointmentService.cancel (US-2503)", () => {
       id: 1, patientId: 7, status: "cancelled",
     } as any)
     await expect(
-      rdvAppointmentService.cancel(1, { by: "patient" }, 9),
+      rdvAppointmentService.cancel(1, { actor: "patient" }, 9),
     ).rejects.toBeInstanceOf(ValidationError)
   })
   it("rejects completed", async () => {
@@ -179,10 +255,10 @@ describe("rdvAppointmentService.cancel (US-2503)", () => {
       id: 1, patientId: 7, status: "completed",
     } as any)
     await expect(
-      rdvAppointmentService.cancel(1, { by: "doctor" }, 9),
+      rdvAppointmentService.cancel(1, { actor: "doctor" }, 9),
     ).rejects.toBeInstanceOf(ValidationError)
   })
-  it("audits withinGrace=true when patient cancels > 24h before", async () => {
+  it("audits lateCancel=false when patient cancels > 24h before", async () => {
     const future = new Date(Date.now() + 48 * 3600_000)
     const futureDate = new Date(future)
     futureDate.setUTCHours(0, 0, 0, 0)
@@ -195,13 +271,37 @@ describe("rdvAppointmentService.cancel (US-2503)", () => {
     prismaMock.appointment.update.mockResolvedValue({
       id: 1, patientId: 7, memberId: null, type: null, date: futureDate, hour: futureHour,
       durationMinutes: 30, location: null, status: "cancelled",
-      motif: null, noteEncrypted: null,
-      proposedAlternativeAt: null, cancelledBy: "patient", cancelReason: null, cancelledAt: new Date(),
+      motifEncrypted: null, noteEncrypted: null,
+      proposedAlternativeAt: null, cancelledBy: "patient",
+      cancelReasonEncrypted: null, cancelledAt: new Date(),
       createdAt: new Date(), updatedAt: new Date(),
     } as any)
-    await rdvAppointmentService.cancel(1, { by: "patient" }, 9)
+    await rdvAppointmentService.cancel(1, { actor: "patient" }, 9)
     const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
-    expect(audit.metadata.withinGrace).toBe(true)
+    expect(audit.metadata.lateCancel).toBe(false)
+  })
+
+  it("audits lateCancel=true when cancel happens within 24h", async () => {
+    const soon = new Date(Date.now() + 2 * 3600_000) // 2h ahead
+    const soonDate = new Date(soon)
+    soonDate.setUTCHours(0, 0, 0, 0)
+    const soonHour = new Date(soon)
+    soonHour.setUTCFullYear(1970, 0, 1)
+    prismaMock.appointment.findUnique.mockResolvedValue({
+      id: 1, patientId: 7, status: "scheduled",
+      date: soonDate, hour: soonHour, durationMinutes: 30,
+    } as any)
+    prismaMock.appointment.update.mockResolvedValue({
+      id: 1, patientId: 7, memberId: null, type: null, date: soonDate, hour: soonHour,
+      durationMinutes: 30, location: null, status: "cancelled",
+      motifEncrypted: null, noteEncrypted: null,
+      proposedAlternativeAt: null, cancelledBy: "patient",
+      cancelReasonEncrypted: null, cancelledAt: new Date(),
+      createdAt: new Date(), updatedAt: new Date(),
+    } as any)
+    await rdvAppointmentService.cancel(1, { actor: "patient" }, 9)
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.metadata.lateCancel).toBe(true)
   })
 })
 
@@ -222,6 +322,36 @@ describe("rdvAppointmentService.proposeAlternative + accept (US-2503)", () => {
       rdvAppointmentService.proposeAlternative(1, new Date("2020-01-01"), 9),
     ).rejects.toBeInstanceOf(ValidationError)
   })
+  it("H10 — propose checks overlap with existing appointments", async () => {
+    prismaMock.appointment.findUnique.mockResolvedValue({
+      id: 1, patientId: 7, memberId: 1, status: "cancelled",
+      cancelledBy: "doctor", durationMinutes: 30,
+    } as any)
+    prismaMock.appointment.findMany.mockResolvedValue([
+      { date: new Date("2026-07-01"), hour: new Date("1970-01-01T10:00:00Z"), durationMinutes: 30 } as any,
+    ])
+    prismaMock.memberUnavailability.findMany.mockResolvedValue([])
+    await expect(
+      rdvAppointmentService.proposeAlternative(
+        1, new Date("2026-07-01T10:15:00Z"), 9,
+      ),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+  it("M14 — accept rejects when status != cancelled", async () => {
+    prismaMock.appointment.findUnique.mockResolvedValue({
+      id: 1, status: "scheduled", proposedAlternativeAt: new Date(Date.now() + 3600_000),
+    } as any)
+    await expect(rdvAppointmentService.acceptAlternative(1, 9))
+      .rejects.toBeInstanceOf(ValidationError)
+  })
+  it("M10 — accept rejects expired proposals (TTL 7d)", async () => {
+    prismaMock.appointment.findUnique.mockResolvedValue({
+      id: 1, status: "cancelled",
+      proposedAlternativeAt: new Date(Date.now() - 8 * 86_400_000), // 8d old
+    } as any)
+    await expect(rdvAppointmentService.acceptAlternative(1, 9))
+      .rejects.toBeInstanceOf(ValidationError)
+  })
   it("accept-alternative resets the appointment to scheduled", async () => {
     const alt = new Date(Date.now() + 86_400_000)
     prismaMock.appointment.findUnique.mockResolvedValue({
@@ -233,8 +363,8 @@ describe("rdvAppointmentService.proposeAlternative + accept (US-2503)", () => {
     prismaMock.appointment.update.mockResolvedValue({
       id: 1, patientId: 7, memberId: 1, type: null, date: alt, hour: alt,
       durationMinutes: 30, location: null, status: "scheduled",
-      motif: null, noteEncrypted: null,
-      proposedAlternativeAt: null, cancelledBy: null, cancelReason: null, cancelledAt: null,
+      motifEncrypted: null, noteEncrypted: null,
+      proposedAlternativeAt: null, cancelledBy: null, cancelReasonEncrypted: null, cancelledAt: null,
       createdAt: new Date(), updatedAt: new Date(),
     } as any)
     const out = await rdvAppointmentService.acceptAlternative(1, 9)
@@ -257,8 +387,8 @@ describe("rdvAppointmentService.confirm (US-2505)", () => {
     prismaMock.appointment.update.mockResolvedValue({
       id: 1, patientId: 7, memberId: 1, type: null, date, hour,
       durationMinutes: 30, location: null, status: "confirmed",
-      motif: null, noteEncrypted: null,
-      proposedAlternativeAt: null, cancelledBy: null, cancelReason: null, cancelledAt: null,
+      motifEncrypted: null, noteEncrypted: null,
+      proposedAlternativeAt: null, cancelledBy: null, cancelReasonEncrypted: null, cancelledAt: null,
       createdAt: new Date(), updatedAt: new Date(),
     } as any)
     const out = await rdvAppointmentService.confirm(1, 9)
@@ -302,7 +432,7 @@ describe("memberUnavailabilityService (US-2504)", () => {
       id: 1, memberId: 1,
       startAt: new Date("2026-06-10T09:00:00Z"),
       endAt: new Date("2026-06-10T10:00:00Z"),
-      reason: null,
+      reasonEncrypted: null,
     } as any)
     const out = await memberUnavailabilityService.create({
       memberId: 1,
@@ -310,6 +440,26 @@ describe("memberUnavailabilityService (US-2504)", () => {
       endAt: new Date("2026-06-10T10:00:00Z"),
     }, 9)
     expect(out.id).toBe(1)
+    expect(out.reason).toBeNull()
+  })
+  it("encrypts reason before storing (H8)", async () => {
+    prismaMock.healthcareMember.findUnique.mockResolvedValue({ id: 1, serviceId: 10 } as any)
+    prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 99 } as any)
+    prismaMock.memberUnavailability.create.mockResolvedValue({
+      id: 1, memberId: 1,
+      startAt: new Date("2026-06-10T09:00:00Z"),
+      endAt: new Date("2026-06-10T10:00:00Z"),
+      reasonEncrypted: "ciphertext",
+    } as any)
+    await memberUnavailabilityService.create({
+      memberId: 1,
+      startAt: new Date("2026-06-10T09:00:00Z"),
+      endAt: new Date("2026-06-10T10:00:00Z"),
+      reason: "Congé maladie",
+    }, 9)
+    const args = prismaMock.memberUnavailability.create.mock.calls[0][0] as any
+    expect(args.data.reasonEncrypted).not.toContain("maladie")
+    expect(args.data.reasonEncrypted).toBeTruthy()
   })
 })
 

--- a/tests/unit/rdv.service.test.ts
+++ b/tests/unit/rdv.service.test.ts
@@ -10,10 +10,12 @@
  */
 import { describe, it, expect, beforeEach } from "vitest"
 import { prismaMock } from "../helpers/prisma-mock"
+import { Prisma } from "@prisma/client"
 import {
   rdvAppointmentService,
   memberUnavailabilityService,
   memberBookingConfigService,
+  assertMemberServiceAccess,
 } from "@/lib/services/rdv.service"
 import {
   ForbiddenError,
@@ -460,6 +462,57 @@ describe("memberUnavailabilityService (US-2504)", () => {
     const args = prismaMock.memberUnavailability.create.mock.calls[0][0] as any
     expect(args.data.reasonEncrypted).not.toContain("maladie")
     expect(args.data.reasonEncrypted).toBeTruthy()
+  })
+})
+
+describe("assertMemberServiceAccess (H2/H7 — cross-tenant denial)", () => {
+  it("M3 — throws ForbiddenError when caller is not in target's service", async () => {
+    prismaMock.healthcareMember.findFirst.mockResolvedValue(null)
+    await expect(assertMemberServiceAccess(9, 1))
+      .rejects.toBeInstanceOf(ForbiddenError)
+  })
+  it("M3 — throws ForbiddenError when member does not exist (no 404 oracle)", async () => {
+    prismaMock.healthcareMember.findFirst.mockResolvedValue(null)
+    await expect(assertMemberServiceAccess(9, 99999))
+      .rejects.toBeInstanceOf(ForbiddenError)
+  })
+  it("M3 — passes when caller shares the target's service", async () => {
+    prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 1 } as any)
+    await expect(assertMemberServiceAccess(9, 1)).resolves.toBeUndefined()
+  })
+})
+
+describe("memberUnavailability EXCLUDE constraint (C2/M10)", () => {
+  it("C2 — maps PrismaClientUnknownRequestError(23P01) to ValidationError", async () => {
+    prismaMock.healthcareMember.findUnique.mockResolvedValue({ id: 1, serviceId: 10 } as any)
+    prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 99 } as any)
+    const err = new Prisma.PrismaClientUnknownRequestError(
+      "exclusion violation 23P01 conflicting key range",
+      { clientVersion: "7.6.0" },
+    )
+    prismaMock.memberUnavailability.create.mockRejectedValueOnce(err)
+    await expect(
+      memberUnavailabilityService.create({
+        memberId: 1,
+        startAt: new Date("2026-06-10T09:00:00Z"),
+        endAt: new Date("2026-06-10T10:00:00Z"),
+      }, 9),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+  it("M10 — maps P2002 UNIQUE violation to ValidationError fallback", async () => {
+    prismaMock.healthcareMember.findUnique.mockResolvedValue({ id: 1, serviceId: 10 } as any)
+    prismaMock.healthcareMember.findFirst.mockResolvedValue({ id: 99 } as any)
+    const err = new Prisma.PrismaClientKnownRequestError(
+      "unique violation", { code: "P2002", clientVersion: "7.6.0", meta: {} },
+    )
+    prismaMock.memberUnavailability.create.mockRejectedValueOnce(err)
+    await expect(
+      memberUnavailabilityService.create({
+        memberId: 1,
+        startAt: new Date("2026-06-10T09:00:00Z"),
+        endAt: new Date("2026-06-10T10:00:00Z"),
+      }, 9),
+    ).rejects.toBeInstanceOf(ValidationError)
   })
 })
 


### PR DESCRIPTION
## Summary
ROADMAP **Groupe 8 — Gestion des RDV**, Batch 1 (CRUD core hors notifs). **5 US, ~36 SP**.

### US livrées
| US | Titre | Surface |
|----|-------|---------|
| **US-2500** | Calendrier RDV (3 vues) | `GET /api/appointments?from=&to=&memberId=&patientId=&status=` (range cap 62j, 500 max) |
| **US-2501** | Détail RDV CRUD + note chiffrée | `POST/GET/PUT /api/appointments[/id]` |
| **US-2503** | Annulation / report bilatéral | `cancel`, `propose-alternative`, `accept-alternative` |
| **US-2504** | Plages indisponibles médecin | `/api/team/availability` (overlap-check intra-tx) |
| **US-2505** | Config prise RDV (auto/validation) | `/api/team/booking-config/:memberId` + `confirm` |

## Architecture
- **3 nouveaux enums** : `AppointmentLocation`, `AppointmentStatus`, `BookingMode`
- **Appointment étendu** : 10 colonnes (`memberId`, `durationMinutes`, `location`, `status`, `motif`, `noteEncrypted`, `proposedAlternativeAt`, `cancelledBy/Reason/At`) + 3 indexes
- **HealthcareMember étendu** : `bookingMode`, `defaultAppointmentMinutes`
- **Nouveau modèle** : `MemberUnavailability` (FK Cascade + createdBy SetNull)
- **Migration** `20260514100000_groupe8_rdv` (purement additive)
- **Service `rdvAppointmentService`** (naming distinct du legacy `appointmentService` qui couvre l'ancien CRUD ide/diabeto/hdj)
- **10 nouveaux endpoints**

## Conventions appliquées (post-reviews PR #388-#391)
- Typed errors (`team-workflow.errors`)
- US-2268 audit pivot `metadata.patientId`
- `auditedRequireRole` (US-2265 burst) sur les 10 routes
- `canAccessPatient` + `patientShareConsent` sur les routes patient-scoped
- Transactions **Serializable** + overlap-check INTRA-tx (TOCTOU prevention sur slots)
- AES-256-GCM sur `Appointment.noteEncrypted`
- Cancellation grace period 24h audité (`withinGrace` metadata)

## Test plan
- [x] **27 tests Vitest** (CRUD, list range, cancel workflow, propose/accept, confirm, unavailability overlap, booking config)
- [x] Suite complète **1397 tests verts**
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm lint` 0 erreur
- [ ] CI verte (post-push)
- [ ] Review multi-agent à enchaîner

## Hors scope (Batch 2 à venir)
- US-2502 Rappels multi-canal email/SMS/push (scheduler)
- US-2506 Option SMS payante cabinet (provider Twilio/OVH)

🤖 Generated with [Claude Code](https://claude.com/claude-code)