### PR TITLE
Groupe 10 Batch C — 3 US modes spéciaux (16 SP)

### DIFF
--- a/prisma/migrations/20260514140000_groupe10_batch_c_modes_speciaux/migration.sql
+++ b/prisma/migrations/20260514140000_groupe10_batch_c_modes_speciaux/migration.sql
@@ -1,0 +1,53 @@
+-- Groupe 10 Batch C — Modes spéciaux (US-2233 pédiatrique, US-2234 Ramadan, US-2235 voyage)
+--
+-- Stratégie : étendre l'enum ConfigVersionType avec 3 nouvelles valeurs
+-- (pediatric_mode, ramadan_mode, travel_mode) — les modes utilisent le hub
+-- ConfigVersion (PR #395) pour versioning + audit immutability.
+--
+-- Le mode pédiatrique nécessite des PHI (nom, téléphone aidants) qu'on
+-- isole dans une table dédiée `pediatric_caregivers` (chiffrement
+-- AES-256-GCM dans nameEncrypted/phoneEncrypted). Ramadan et voyage n'ont
+-- pas de PHI : leurs données sont dans `config_versions.config_snapshot`.
+
+-- 1. Extend ConfigVersionType enum (3 valeurs).
+ALTER TYPE config_version_type ADD VALUE IF NOT EXISTS 'pediatric_mode';
+ALTER TYPE config_version_type ADD VALUE IF NOT EXISTS 'ramadan_mode';
+ALTER TYPE config_version_type ADD VALUE IF NOT EXISTS 'travel_mode';
+
+-- 2. Table pediatric_caregivers (PHI chiffrée).
+CREATE TABLE "pediatric_caregivers" (
+    "id"              SERIAL NOT NULL,
+    "patient_id"      INTEGER NOT NULL,
+    "version_id"      INTEGER NOT NULL,
+    "rank"            INTEGER NOT NULL,
+    "name_encrypted"  TEXT NOT NULL,
+    "phone_encrypted" TEXT NOT NULL,
+    "relationship"    VARCHAR(50) NOT NULL,
+    "permission_level" VARCHAR(20) NOT NULL,
+    "is_active"       BOOLEAN NOT NULL DEFAULT true,
+    "created_at"      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "pediatric_caregivers_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "pediatric_caregivers_patient_id_rank_is_active_idx"
+    ON "pediatric_caregivers" ("patient_id", "rank", "is_active");
+
+ALTER TABLE "pediatric_caregivers"
+    ADD CONSTRAINT "pediatric_caregivers_patient_id_fkey"
+    FOREIGN KEY ("patient_id") REFERENCES "patients"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "pediatric_caregivers"
+    ADD CONSTRAINT "pediatric_caregivers_version_id_fkey"
+    FOREIGN KEY ("version_id") REFERENCES "config_versions"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- 3. Check constraints : permission_level (3 valeurs) + rank 1..5.
+ALTER TABLE "pediatric_caregivers"
+    ADD CONSTRAINT "pediatric_caregivers_permission_level_check"
+    CHECK ("permission_level" IN ('read', 'write', 'config'));
+
+ALTER TABLE "pediatric_caregivers"
+    ADD CONSTRAINT "pediatric_caregivers_rank_check"
+    CHECK ("rank" BETWEEN 1 AND 5);

--- a/prisma/migrations/20260514140000_groupe10_batch_c_modes_speciaux/migration.sql
+++ b/prisma/migrations/20260514140000_groupe10_batch_c_modes_speciaux/migration.sql
@@ -33,6 +33,11 @@ CREATE TABLE "pediatric_caregivers" (
 CREATE INDEX "pediatric_caregivers_patient_id_rank_is_active_idx"
     ON "pediatric_caregivers" ("patient_id", "rank", "is_active");
 
+-- M4 (healthcare audit) — index FK so cascade-include joins from
+-- ConfigVersion don't sequential-scan at scale.
+CREATE INDEX "pediatric_caregivers_version_id_idx"
+    ON "pediatric_caregivers" ("version_id");
+
 ALTER TABLE "pediatric_caregivers"
     ADD CONSTRAINT "pediatric_caregivers_patient_id_fkey"
     FOREIGN KEY ("patient_id") REFERENCES "patients"("id")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -164,7 +164,7 @@ enum AndroidPriority {
 enum InsulinUsage {
   bolus
   basal
-  both  // Pour les pré-mélangées (NovoMix, Humalog Mix)
+  both // Pour les pré-mélangées (NovoMix, Humalog Mix)
 }
 
 /// US-2148 — Statut compte utilisateur (suspension / archivage admin).
@@ -197,13 +197,13 @@ enum BackupStatus {
 
 /// Type d'alerte d'urgence générée par seuils CGM/cétones ou saisie manuelle.
 enum EmergencyAlertType {
-  severe_hypo      // CGM < seuil veryLow (par défaut 54 mg/dL)
-  hypo             // CGM < seuil low (par défaut 70 mg/dL)
-  severe_hyper     // CGM > seuil high (par défaut 250 mg/dL)
-  hyper            // CGM > seuil ok (par défaut 180 mg/dL)
-  ketone_dka       // Cétones > seuil DKA (par défaut 3.0 mmol/L)
-  ketone_moderate  // Cétones entre seuils modérés (par défaut 1.5–3.0 mmol/L)
-  manual           // Alerte créée manuellement (patient ou pro)
+  severe_hypo // CGM < seuil veryLow (par défaut 54 mg/dL)
+  hypo // CGM < seuil low (par défaut 70 mg/dL)
+  severe_hyper // CGM > seuil high (par défaut 250 mg/dL)
+  hyper // CGM > seuil ok (par défaut 180 mg/dL)
+  ketone_dka // Cétones > seuil DKA (par défaut 3.0 mmol/L)
+  ketone_moderate // Cétones entre seuils modérés (par défaut 1.5–3.0 mmol/L)
+  manual // Alerte créée manuellement (patient ou pro)
 }
 
 /// Sévérité clinique d'une alerte — pilote prioritisation push & UI.
@@ -246,125 +246,125 @@ enum EmergencyAlertActionType {
 // ═══════════════════════════════════════════════════════════════
 
 model User {
-  id                       Int       @id @default(autoincrement())
-  email                    String    // chiffre AES-256-GCM en production
-  emailHmac                String    @unique @map("email_hmac") // HMAC-SHA256 pour lookup unique
-  passwordHash             String    @map("password_hash")
-  title                    String?   // 'M.' | 'Mme' | 'Dr' | 'Prof'
-  firstname                String?   // chiffre
-  firstnameHmac            String?   @map("firstname_hmac") // HMAC-SHA256 pour recherche
-  firstnames               String?   // chiffre
-  usedFirstname            String?   @map("used_firstname") // chiffre
-  lastname                 String?   // chiffre
-  lastnameHmac             String?   @map("lastname_hmac") // HMAC-SHA256 pour recherche
-  usedLastname             String?   @map("used_lastname") // chiffre
-  birthday                 DateTime? @db.Date // chiffre
+  id                       Int        @id @default(autoincrement())
+  email                    String // chiffre AES-256-GCM en production
+  emailHmac                String     @unique @map("email_hmac") // HMAC-SHA256 pour lookup unique
+  passwordHash             String     @map("password_hash")
+  title                    String? // 'M.' | 'Mme' | 'Dr' | 'Prof'
+  firstname                String? // chiffre
+  firstnameHmac            String?    @map("firstname_hmac") // HMAC-SHA256 pour recherche
+  firstnames               String? // chiffre
+  usedFirstname            String?    @map("used_firstname") // chiffre
+  lastname                 String? // chiffre
+  lastnameHmac             String?    @map("lastname_hmac") // HMAC-SHA256 pour recherche
+  usedLastname             String?    @map("used_lastname") // chiffre
+  birthday                 DateTime?  @db.Date // chiffre
   sex                      Sex?
-  codeBirthPlace           String?   @map("code_birth_place") // chiffre
-  timezone                 String?   @default("Europe/Paris")
-  phone                    String?   // chiffre
-  address1                 String?   // chiffre
-  address2                 String?   // chiffre
-  cp                       String?   // chiffre
-  city                     String?   // chiffre
-  country                  String?   @db.Char(2)
+  codeBirthPlace           String?    @map("code_birth_place") // chiffre
+  timezone                 String?    @default("Europe/Paris")
+  phone                    String? // chiffre
+  address1                 String? // chiffre
+  address2                 String? // chiffre
+  cp                       String? // chiffre
+  city                     String? // chiffre
+  country                  String?    @db.Char(2)
   pic                      String?
-  language                 Language? @default(fr)
-  role                     Role      @default(VIEWER)
+  language                 Language?  @default(fr)
+  role                     Role       @default(VIEWER)
   /// US-2148 — Statut compte (active/suspended/archived). Suspension bloque
   /// le login dans /api/auth/login (vérification post-bcrypt).
   status                   UserStatus @default(active)
   /// US-2148 — Date de suspension/archivage. Set au moment de la transition.
-  statusChangedAt          DateTime? @map("status_changed_at") @db.Timestamptz()
+  statusChangedAt          DateTime?  @map("status_changed_at") @db.Timestamptz()
   /// US-2148 — User-ID de l'admin ayant effectué la transition (audit + rollback).
   /// FK Restrict : empêche la suppression DELETE d'un admin qui a effectué des
   /// transitions. RGPD Art. 17 utilise l'anonymisation (non-DELETE) — la trace
   /// reste en colonne, le user est anonymisé via `deletion.service`.
-  statusChangedBy          Int?      @map("status_changed_by")
-  mfaSecret                String?   @map("mfa_secret")
-  mfaEnabled               Boolean   @default(false) @map("mfa_enabled")
+  statusChangedBy          Int?       @map("status_changed_by")
+  mfaSecret                String?    @map("mfa_secret")
+  mfaEnabled               Boolean    @default(false) @map("mfa_enabled")
   /// Last accepted TOTP time step (RFC 6238 T counter). Prevents replay of
   /// a code within its ±1 step window. Set atomically on successful verify.
-  mfaLastUsedStep          Int?      @map("mfa_last_used_step")
-  hasSignedTerms           Boolean   @default(false) @map("has_signed_terms")
-  profileComplete          Boolean   @default(false) @map("profile_complete")
-  needDataPolicyUpdate     Boolean   @default(false) @map("need_data_policy_update")
-  dataPolicyUpdate         DateTime? @map("data_policy_update")
-  needPasswordUpdate       Boolean   @default(false) @map("need_password_update")
-  needOnboarding           Boolean   @default(false) @map("need_onboarding")
-  debug                    Boolean   @default(false)
-  nirpp                    String?   // chiffre — TRES SENSIBLE
-  nirppType                String?   @map("nirpp_type") // 'nir' | 'nia' | 'nir_key'
-  nirppPolicyholder        String?   @map("nirpp_policyholder") // chiffre
-  nirppPolicyholderType    String?   @map("nirpp_policyholder_type")
-  oid                      String?   // interne — jamais expose
-  ins                      String?   // Identite Nationale de Sante, chiffre
-  intercomHash             String?   @map("intercom_hash") // interne — jamais expose
-  deploymentKey            String?   @map("deployment_key") // interne — jamais expose
-  pro                      String?   // interne
-  photoUrl                 String?   @map("photo_url") @db.VarChar(500)
-  displayModalTlsMutual    Boolean   @default(false) @map("display_modal_tls_mutual")
-  displayModalTlsMandatory Boolean   @default(false) @map("display_modal_tls_mandatory")
-  createdAt                DateTime  @default(now()) @map("created_at")
-  updatedAt                DateTime  @updatedAt @map("updated_at")
+  mfaLastUsedStep          Int?       @map("mfa_last_used_step")
+  hasSignedTerms           Boolean    @default(false) @map("has_signed_terms")
+  profileComplete          Boolean    @default(false) @map("profile_complete")
+  needDataPolicyUpdate     Boolean    @default(false) @map("need_data_policy_update")
+  dataPolicyUpdate         DateTime?  @map("data_policy_update")
+  needPasswordUpdate       Boolean    @default(false) @map("need_password_update")
+  needOnboarding           Boolean    @default(false) @map("need_onboarding")
+  debug                    Boolean    @default(false)
+  nirpp                    String? // chiffre — TRES SENSIBLE
+  nirppType                String?    @map("nirpp_type") // 'nir' | 'nia' | 'nir_key'
+  nirppPolicyholder        String?    @map("nirpp_policyholder") // chiffre
+  nirppPolicyholderType    String?    @map("nirpp_policyholder_type")
+  oid                      String? // interne — jamais expose
+  ins                      String? // Identite Nationale de Sante, chiffre
+  intercomHash             String?    @map("intercom_hash") // interne — jamais expose
+  deploymentKey            String?    @map("deployment_key") // interne — jamais expose
+  pro                      String? // interne
+  photoUrl                 String?    @map("photo_url") @db.VarChar(500)
+  displayModalTlsMutual    Boolean    @default(false) @map("display_modal_tls_mutual")
+  displayModalTlsMandatory Boolean    @default(false) @map("display_modal_tls_mandatory")
+  createdAt                DateTime   @default(now()) @map("created_at")
+  updatedAt                DateTime   @updatedAt @map("updated_at")
 
   // Relations
-  patient              Patient?
-  unitPreferences      UserUnitPreferences?
-  notifPreferences     UserNotifPreferences?
-  privacySettings      UserPrivacySettings?
-  dayMoments           UserDayMoment[]
-  uiStates             UiStateSave[]
-  sessions             Session[]
-  accounts             Account[]
-  deviceSyncs          DeviceDataSync[]
-  dashboardConfig      DashboardConfiguration?
-  pushRegistrations    PushDeviceRegistration[]
-  pushNotifLogs        PushNotificationLog[]
-  pushScheduled        PushScheduledNotification[]
-  auditLogs            AuditLog[]
-  reviewedProposals    AdjustmentProposal[] @relation("ReviewedBy")
-  prescribedInsulins   PatientInsulin[]     @relation("PrescribedInsulins")
-  mydiabbyCredential   MyDiabbyCredential?
-  acknowledgedAlerts   EmergencyAlert[]      @relation("AlertAcknowledger")
-  resolvedAlerts       EmergencyAlert[]      @relation("AlertResolver")
-  emergencyActions     EmergencyAlertAction[] @relation("EmergencyActionPerformer")
-  statusTransitionsBy  User[]                @relation("UserStatusChangedBy")
-  statusTransitionedBy User?                 @relation("UserStatusChangedBy", fields: [statusChangedBy], references: [id], onDelete: Restrict)
-  triggeredBackups     BackupLog[]           @relation("BackupTriggeredBy")
-  managedServices      HealthcareService[]   @relation("HealthcareServiceManager")
-  createdPatientTags   PatientTag[]          @relation("PatientTagCreator")
-  assignedPatientTags  PatientTagAssignment[] @relation("PatientTagAssigner")
+  patient                           Patient?
+  unitPreferences                   UserUnitPreferences?
+  notifPreferences                  UserNotifPreferences?
+  privacySettings                   UserPrivacySettings?
+  dayMoments                        UserDayMoment[]
+  uiStates                          UiStateSave[]
+  sessions                          Session[]
+  accounts                          Account[]
+  deviceSyncs                       DeviceDataSync[]
+  dashboardConfig                   DashboardConfiguration?
+  pushRegistrations                 PushDeviceRegistration[]
+  pushNotifLogs                     PushNotificationLog[]
+  pushScheduled                     PushScheduledNotification[]
+  auditLogs                         AuditLog[]
+  reviewedProposals                 AdjustmentProposal[]              @relation("ReviewedBy")
+  prescribedInsulins                PatientInsulin[]                  @relation("PrescribedInsulins")
+  mydiabbyCredential                MyDiabbyCredential?
+  acknowledgedAlerts                EmergencyAlert[]                  @relation("AlertAcknowledger")
+  resolvedAlerts                    EmergencyAlert[]                  @relation("AlertResolver")
+  emergencyActions                  EmergencyAlertAction[]            @relation("EmergencyActionPerformer")
+  statusTransitionsBy               User[]                            @relation("UserStatusChangedBy")
+  statusTransitionedBy              User?                             @relation("UserStatusChangedBy", fields: [statusChangedBy], references: [id], onDelete: Restrict)
+  triggeredBackups                  BackupLog[]                       @relation("BackupTriggeredBy")
+  managedServices                   HealthcareService[]               @relation("HealthcareServiceManager")
+  createdPatientTags                PatientTag[]                      @relation("PatientTagCreator")
+  assignedPatientTags               PatientTagAssignment[]            @relation("PatientTagAssigner")
   // Groupe 3 — Équipe & Communication
-  createdMessageTemplates        MessageTemplate[]                 @relation("MessageTemplateCreator")
-  readReceipts                   ReadReceipt[]                     @relation("ReadReceiptUser")
-  verifiedProposalActualizations AdjustmentProposalActualization[] @relation("ProposalActualizationVerifier")
-  consultationNotes              ConsultationNote[]                @relation("ConsultationNoteAuthor")
-  delegationsRequested           DelegationRequest[]               @relation("DelegationFrom")
-  delegationsToReview            DelegationRequest[]               @relation("DelegationTo")
-  reviewedDelegations            DelegationRequest[]               @relation("DelegationReviewer")
-  handoffsSent                   HandoffNote[]                     @relation("HandoffFrom")
-  handoffsReceived               HandoffNote[]                     @relation("HandoffTo")
-  createdPatientGroups           PatientGroup[]                    @relation("PatientGroupCreator")
-  assignedPatientGroups          PatientGroupAssignment[]          @relation("PatientGroupAssigner")
-  invoicedTeleconsultActes       TeleconsultationActe[]            @relation("TeleconsultInvoicer")
+  createdMessageTemplates           MessageTemplate[]                 @relation("MessageTemplateCreator")
+  readReceipts                      ReadReceipt[]                     @relation("ReadReceiptUser")
+  verifiedProposalActualizations    AdjustmentProposalActualization[] @relation("ProposalActualizationVerifier")
+  consultationNotes                 ConsultationNote[]                @relation("ConsultationNoteAuthor")
+  delegationsRequested              DelegationRequest[]               @relation("DelegationFrom")
+  delegationsToReview               DelegationRequest[]               @relation("DelegationTo")
+  reviewedDelegations               DelegationRequest[]               @relation("DelegationReviewer")
+  handoffsSent                      HandoffNote[]                     @relation("HandoffFrom")
+  handoffsReceived                  HandoffNote[]                     @relation("HandoffTo")
+  createdPatientGroups              PatientGroup[]                    @relation("PatientGroupCreator")
+  assignedPatientGroups             PatientGroupAssignment[]          @relation("PatientGroupAssigner")
+  invoicedTeleconsultActes          TeleconsultationActe[]            @relation("TeleconsultInvoicer")
   // Groupe 5 — Insuline & Repas
-  createdInsulinAdjustmentTemplates InsulinAdjustmentTemplate[]    @relation("InsulinAdjustmentTemplateCreator")
-  validatedDiabetesEvents        DiabetesEvent[]                   @relation("DiabetesEventValidator")
-  uploadedMealPhotos             MealPhoto[]                       @relation("MealPhotoUploader")
+  createdInsulinAdjustmentTemplates InsulinAdjustmentTemplate[]       @relation("InsulinAdjustmentTemplateCreator")
+  validatedDiabetesEvents           DiabetesEvent[]                   @relation("DiabetesEventValidator")
+  uploadedMealPhotos                MealPhoto[]                       @relation("MealPhotoUploader")
   // Groupe 8 — RDV
-  createdMemberUnavailabilities  MemberUnavailability[]            @relation("MemberUnavailabilityCreator")
+  createdMemberUnavailabilities     MemberUnavailability[]            @relation("MemberUnavailabilityCreator")
   // Groupe 8 — i18n & Interopérabilité (Batch 1)
-  createdCountryCurrencies       CountryCurrency[]                 @relation("CountryCurrencyCreator")
-  createdCountryTaxRules         CountryTaxRule[]                  @relation("CountryTaxRuleCreator")
-  createdHealthcareRegulations   HealthcareRegulation[]            @relation("HealthcareRegulationCreator")
-  createdFhirInteroperability    FhirInteroperability[]            @relation("FhirInteroperabilityCreator")
-  createdFhirAllowedSystems      FhirAllowedSystem[]               @relation("FhirAllowedSystemCreator")
+  createdCountryCurrencies          CountryCurrency[]                 @relation("CountryCurrencyCreator")
+  createdCountryTaxRules            CountryTaxRule[]                  @relation("CountryTaxRuleCreator")
+  createdHealthcareRegulations      HealthcareRegulation[]            @relation("HealthcareRegulationCreator")
+  createdFhirInteroperability       FhirInteroperability[]            @relation("FhirInteroperabilityCreator")
+  createdFhirAllowedSystems         FhirAllowedSystem[]               @relation("FhirAllowedSystemCreator")
   // Groupe 10 Mirror V1 — Batches A+B
-  createdConfigVersions          ConfigVersion[]                   @relation("ConfigVersionCreator")
-  validatedConfigVersions        ConfigVersion[]                   @relation("ConfigVersionValidator")
-  createdAlertThresholdTemplates AlertThresholdTemplate[]          @relation("AlertThresholdTemplateCreator")
-  acknowledgedRiskScores         PatientRiskScore[]                @relation("PatientRiskScoreAcknowledger")
+  createdConfigVersions             ConfigVersion[]                   @relation("ConfigVersionCreator")
+  validatedConfigVersions           ConfigVersion[]                   @relation("ConfigVersionValidator")
+  createdAlertThresholdTemplates    AlertThresholdTemplate[]          @relation("AlertThresholdTemplateCreator")
+  acknowledgedRiskScores            PatientRiskScore[]                @relation("PatientRiskScoreAcknowledger")
 
   @@index([createdAt])
   @@index([firstnameHmac, lastnameHmac])
@@ -418,16 +418,16 @@ model VerificationToken {
 }
 
 model UserUnitPreferences {
-  id                Int  @id @default(autoincrement())
-  userId            Int  @unique @map("user_id")
-  unitGlycemia      Int  @default(5) @map("unit_glycemia") // 3:g/L 4:mg/dL 5:mmol/L
-  unitWeight        Int  @default(6) @map("unit_weight") // 6:kg 7:lbs
-  unitSize          Int  @default(8) @map("unit_size") // 8:cm 9:ft
-  unitCarb          Int  @default(2) @map("unit_carb") // 1:CP 2:g
-  unitHba1c         Int  @default(10) @map("unit_hba1c") // 10:% 11:mmol/mol
+  id                 Int @id @default(autoincrement())
+  userId             Int @unique @map("user_id")
+  unitGlycemia       Int @default(5) @map("unit_glycemia") // 3:g/L 4:mg/dL 5:mmol/L
+  unitWeight         Int @default(6) @map("unit_weight") // 6:kg 7:lbs
+  unitSize           Int @default(8) @map("unit_size") // 8:cm 9:ft
+  unitCarb           Int @default(2) @map("unit_carb") // 1:CP 2:g
+  unitHba1c          Int @default(10) @map("unit_hba1c") // 10:% 11:mmol/mol
   unitCarbExchangeNb Int @default(15) @map("unit_carb_exchange_nb")
-  unitKetones       Int  @default(12) @map("unit_ketones") // 12:mmol/L 13:mg/dL
-  unitBloodPressure Int  @default(14) @map("unit_blood_pressure") // 14:mmHg
+  unitKetones        Int @default(12) @map("unit_ketones") // 12:mmol/L 13:mg/dL
+  unitBloodPressure  Int @default(14) @map("unit_blood_pressure") // 14:mmHg
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -435,17 +435,17 @@ model UserUnitPreferences {
 }
 
 model UserNotifPreferences {
-  id                    Int      @id @default(autoincrement())
-  userId                Int      @unique @map("user_id")
-  notifMessageMail      Boolean  @default(true) @map("notif_message_mail")
-  notifDocumentMail     Boolean  @default(true) @map("notif_document_mail")
-  glycemiaReminders     Boolean  @default(false) @map("glycemia_reminders")
-  glycemiaReminderTimes Json?    @map("glycemia_reminder_times") // string[]
-  insulinReminders      Boolean  @default(false) @map("insulin_reminders")
-  insulinReminderTimes  Json?    @map("insulin_reminder_times") // string[]
-  medicalAppointments   Boolean  @default(true) @map("medical_appointments")
-  autoExport            Boolean  @default(false) @map("auto_export")
-  autoExportFrequency   Int?     @map("auto_export_frequency") // jours
+  id                    Int     @id @default(autoincrement())
+  userId                Int     @unique @map("user_id")
+  notifMessageMail      Boolean @default(true) @map("notif_message_mail")
+  notifDocumentMail     Boolean @default(true) @map("notif_document_mail")
+  glycemiaReminders     Boolean @default(false) @map("glycemia_reminders")
+  glycemiaReminderTimes Json?   @map("glycemia_reminder_times") // string[]
+  insulinReminders      Boolean @default(false) @map("insulin_reminders")
+  insulinReminderTimes  Json?   @map("insulin_reminder_times") // string[]
+  medicalAppointments   Boolean @default(true) @map("medical_appointments")
+  autoExport            Boolean @default(false) @map("auto_export")
+  autoExportFrequency   Int?    @map("auto_export_frequency") // jours
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -497,68 +497,70 @@ model UiStateSave {
 // ═══════════════════════════════════════════════════════════════
 
 model Patient {
-  id             Int       @id @default(autoincrement())
-  userId         Int       @unique @map("user_id")
-  pathology      Pathology
+  id            Int       @id @default(autoincrement())
+  userId        Int       @unique @map("user_id")
+  pathology     Pathology
   /// Mode grossesse (US-2232) — bascule cibles glycémiques sur defaults GD
   /// (plus stricts — cf. ACOG/ADA). Indépendant de PatientPregnancy.active
   /// pour permettre activation rapide sans saisir DPA, puis synchronisation
   /// par la couche service vers PatientPregnancy lorsque les détails sont saisis.
-  pregnancyMode  Boolean   @default(false) @map("pregnancy_mode")
-  createdAt      DateTime  @default(now()) @map("created_at")
-  deletedAt      DateTime? @map("deleted_at")
+  pregnancyMode Boolean   @default(false) @map("pregnancy_mode")
+  createdAt     DateTime  @default(now()) @map("created_at")
+  deletedAt     DateTime? @map("deleted_at")
 
-  user                  User                    @relation(fields: [userId], references: [id], onDelete: Cascade)
-  medicalData           PatientMedicalData?
-  administrative        PatientAdministrative?
-  pregnancies           PatientPregnancy[]
-  glycemiaObjectives    GlycemiaObjective[]
-  cgmObjectives         CgmObjective?
-  annexObjectives       AnnexObjective?
-  ketoneThreshold       KetoneThreshold?
-  hypoTreatmentProtocol HypoTreatmentProtocol?
-  alertThreshold        AlertThresholdConfig?
-  emergencyAlerts       EmergencyAlert[]
-  treatments            Treatment[]
+  user                   User                       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  medicalData            PatientMedicalData?
+  administrative         PatientAdministrative?
+  pregnancies            PatientPregnancy[]
+  glycemiaObjectives     GlycemiaObjective[]
+  cgmObjectives          CgmObjective?
+  annexObjectives        AnnexObjective?
+  ketoneThreshold        KetoneThreshold?
+  hypoTreatmentProtocol  HypoTreatmentProtocol?
+  alertThreshold         AlertThresholdConfig?
+  emergencyAlerts        EmergencyAlert[]
+  treatments             Treatment[]
   insulinTherapySettings InsulinTherapySettings?
-  bolusCalculationLogs  BolusCalculationLog[]
-  adjustmentProposals   AdjustmentProposal[]
-  cgmEntries            CgmEntry[]
-  glycemiaEntries       GlycemiaEntry[]
-  diabetesEvents        DiabetesEvent[]
-  insulinFlowEntries    InsulinFlowEntry[]
-  insulinFlowDeviceData InsulinFlowDeviceData[]
-  pumpEvents            PumpEvent[]
-  averageData           AverageData[]
-  devices               PatientDevice[]
-  patientServices       PatientService[]
-  referent              PatientReferent?
-  documents             MedicalDocument[]
-  appointments          Appointment[]
-  patientInsulins       PatientInsulin[]
+  bolusCalculationLogs   BolusCalculationLog[]
+  adjustmentProposals    AdjustmentProposal[]
+  cgmEntries             CgmEntry[]
+  glycemiaEntries        GlycemiaEntry[]
+  diabetesEvents         DiabetesEvent[]
+  insulinFlowEntries     InsulinFlowEntry[]
+  insulinFlowDeviceData  InsulinFlowDeviceData[]
+  pumpEvents             PumpEvent[]
+  averageData            AverageData[]
+  devices                PatientDevice[]
+  patientServices        PatientService[]
+  referent               PatientReferent?
+  documents              MedicalDocument[]
+  appointments           Appointment[]
+  patientInsulins        PatientInsulin[]
   /// US-2123 — Exports FHIR R4 référençant ce patient.
-  fhirExports           FhirInteroperability[]
+  fhirExports            FhirInteroperability[]
   /// US-2022 — Tags posés sur ce patient au sein de son/ses cabinet(s).
-  tagAssignments        PatientTagAssignment[]
+  tagAssignments         PatientTagAssignment[]
   /// US-2068 — Notes de consultation structurées.
-  consultationNotes     ConsultationNote[]
+  consultationNotes      ConsultationNote[]
   /// US-2083 — Demandes de délégation clinique (IDE → DOCTOR).
-  delegationRequests    DelegationRequest[]
+  delegationRequests     DelegationRequest[]
   /// US-2086 — Handoff entre soignants.
-  handoffNotes          HandoffNote[]
+  handoffNotes           HandoffNote[]
   /// US-2088 — Groupes-cohortes équipe.
-  groupAssignments      PatientGroupAssignment[]
+  groupAssignments       PatientGroupAssignment[]
   /// US-2065 — Accusés patient sur AdjustmentProposal (review PR #390 H10).
-  proposalAcks          AdjustmentProposalAck[]
+  proposalAcks           AdjustmentProposalAck[]
   /// US-2057 — Photos repas (review PR #391 H5 FK explicite).
-  mealPhotos            MealPhoto[]
+  mealPhotos             MealPhoto[]
   /// Groupe 10 Batch A — config versionning hub + features.
-  configVersions        ConfigVersion[]
-  emergencyContacts     EmergencyContact[]
-  escalationRules       EscalationRule[]
+  configVersions         ConfigVersion[]
+  emergencyContacts      EmergencyContact[]
+  escalationRules        EscalationRule[]
+  /// Groupe 10 Batch C — modes spéciaux (pédiatrique).
+  pediatricCaregivers    PediatricCaregiver[]
   /// Groupe 10 Batch B — analytics caches.
-  monitoringMetrics     PatientMonitoringMetrics[]
-  riskScore             PatientRiskScore?
+  monitoringMetrics      PatientMonitoringMetrics[]
+  riskScore              PatientRiskScore?
 
   @@index([deletedAt])
   @@map("patients")
@@ -615,13 +617,13 @@ model PatientAdministrative {
 }
 
 model PatientPregnancy {
-  id              Int       @id @default(autoincrement())
-  patientId       Int       @map("patient_id")
-  active          Boolean   @default(true)
-  dueDate         DateTime? @map("due_date") @db.Date
-  gestationalAge  Int?      @map("gestational_age") // semaines
-  notes           String?
-  createdAt       DateTime  @default(now()) @map("created_at")
+  id             Int       @id @default(autoincrement())
+  patientId      Int       @map("patient_id")
+  active         Boolean   @default(true)
+  dueDate        DateTime? @map("due_date") @db.Date
+  gestationalAge Int?      @map("gestational_age") // semaines
+  notes          String?
+  createdAt      DateTime  @default(now()) @map("created_at")
 
   patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
 
@@ -633,22 +635,22 @@ model PatientPregnancy {
 // ═══════════════════════════════════════════════════════════════
 
 model GlycemiaObjective {
-  id             Int      @id @default(autoincrement())
-  patientId      Int      @map("patient_id")
-  isDefault      Boolean  @default(false) @map("is_default")
-  isCurrent      Boolean  @default(true) @map("is_current")
+  id              Int      @id @default(autoincrement())
+  patientId       Int      @map("patient_id")
+  isDefault       Boolean  @default(false) @map("is_default")
+  isCurrent       Boolean  @default(true) @map("is_current")
   // Seuils blanc/vert/orange par moment repas (g/L)
-  limitEmWhite   Decimal? @map("limit_em_white") @db.Decimal(4, 2)
-  limitEmGreen   Decimal? @map("limit_em_green") @db.Decimal(4, 2)
-  limitEmOrange  Decimal? @map("limit_em_orange") @db.Decimal(4, 2)
-  limitBmWhite   Decimal? @map("limit_bm_white") @db.Decimal(4, 2)
-  limitBmGreen   Decimal? @map("limit_bm_green") @db.Decimal(4, 2)
-  limitBmOrange  Decimal? @map("limit_bm_orange") @db.Decimal(4, 2)
-  limitAmWhite   Decimal? @map("limit_am_white") @db.Decimal(4, 2)
-  limitAmGreen   Decimal? @map("limit_am_green") @db.Decimal(4, 2)
-  limitAmOrange  Decimal? @map("limit_am_orange") @db.Decimal(4, 2)
-  limitAm1hWhite Decimal? @map("limit_am1h_white") @db.Decimal(4, 2)
-  limitAm1hGreen Decimal? @map("limit_am1h_green") @db.Decimal(4, 2)
+  limitEmWhite    Decimal? @map("limit_em_white") @db.Decimal(4, 2)
+  limitEmGreen    Decimal? @map("limit_em_green") @db.Decimal(4, 2)
+  limitEmOrange   Decimal? @map("limit_em_orange") @db.Decimal(4, 2)
+  limitBmWhite    Decimal? @map("limit_bm_white") @db.Decimal(4, 2)
+  limitBmGreen    Decimal? @map("limit_bm_green") @db.Decimal(4, 2)
+  limitBmOrange   Decimal? @map("limit_bm_orange") @db.Decimal(4, 2)
+  limitAmWhite    Decimal? @map("limit_am_white") @db.Decimal(4, 2)
+  limitAmGreen    Decimal? @map("limit_am_green") @db.Decimal(4, 2)
+  limitAmOrange   Decimal? @map("limit_am_orange") @db.Decimal(4, 2)
+  limitAm1hWhite  Decimal? @map("limit_am1h_white") @db.Decimal(4, 2)
+  limitAm1hGreen  Decimal? @map("limit_am1h_green") @db.Decimal(4, 2)
   limitAm1hOrange Decimal? @map("limit_am1h_orange") @db.Decimal(4, 2)
 
   patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
@@ -672,12 +674,12 @@ model CgmObjective {
 }
 
 model AnnexObjective {
-  id                Int      @id @default(autoincrement())
-  patientId         Int      @unique @map("patient_id")
-  objectiveHba1c    Decimal? @map("objective_hba1c") @db.Decimal(4, 2)
+  id                 Int      @id @default(autoincrement())
+  patientId          Int      @unique @map("patient_id")
+  objectiveHba1c     Decimal? @map("objective_hba1c") @db.Decimal(4, 2)
   objectiveMinWeight Decimal? @map("objective_min_weight") @db.Decimal(5, 2)
   objectiveMaxWeight Decimal? @map("objective_max_weight") @db.Decimal(5, 2)
-  objectiveWalk     Int?     @map("objective_walk") // min/jour
+  objectiveWalk      Int?     @map("objective_walk") // min/jour
 
   patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
 
@@ -689,24 +691,24 @@ model AnnexObjective {
 /// permet de configurer un comportement différent (ex: alertes sur veryLow/high
 /// uniquement, pas sur low/ok), notification push, email médecin référent, etc.
 model AlertThresholdConfig {
-  id                    Int      @id @default(autoincrement())
-  patientId             Int      @unique @map("patient_id")
+  id                 Int      @id @default(autoincrement())
+  patientId          Int      @unique @map("patient_id")
   /// Émettre alertes hypo (CGM < low). Par défaut true.
-  alertOnHypo           Boolean  @default(true) @map("alert_on_hypo")
+  alertOnHypo        Boolean  @default(true) @map("alert_on_hypo")
   /// Émettre alertes hypo sévère (CGM < veryLow). Par défaut true.
-  alertOnSevereHypo     Boolean  @default(true) @map("alert_on_severe_hypo")
+  alertOnSevereHypo  Boolean  @default(true) @map("alert_on_severe_hypo")
   /// Émettre alertes hyper (CGM > ok). Par défaut false (trop bruyant).
-  alertOnHyper          Boolean  @default(false) @map("alert_on_hyper")
+  alertOnHyper       Boolean  @default(false) @map("alert_on_hyper")
   /// Émettre alertes hyper sévère (CGM > high). Par défaut true.
-  alertOnSevereHyper    Boolean  @default(true) @map("alert_on_severe_hyper")
+  alertOnSevereHyper Boolean  @default(true) @map("alert_on_severe_hyper")
   /// Notifier médecin référent par push pour alertes critiques.
-  notifyDoctorPush      Boolean  @default(true) @map("notify_doctor_push")
+  notifyDoctorPush   Boolean  @default(true) @map("notify_doctor_push")
   /// Notifier médecin référent par email (si critique uniquement).
-  notifyDoctorEmail     Boolean  @default(true) @map("notify_doctor_email")
+  notifyDoctorEmail  Boolean  @default(true) @map("notify_doctor_email")
   /// Délai en minutes avant ré-alerte sur même type (anti-spam). Min 5, max 1440.
-  cooldownMinutes       Int      @default(30) @map("cooldown_minutes")
-  createdAt             DateTime @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt             DateTime @updatedAt @map("updated_at") @db.Timestamptz()
+  cooldownMinutes    Int      @default(30) @map("cooldown_minutes")
+  createdAt          DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt          DateTime @updatedAt @map("updated_at") @db.Timestamptz()
 
   patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
 
@@ -719,20 +721,20 @@ model AlertThresholdConfig {
 /// Cétones modérées : 1.5–3.0 mmol/L → action rapide (insuline + glucides).
 /// Cétones DKA : ≥ 3.0 mmol/L → critère diagnostique DKA (ISPAD 2022).
 model KetoneThreshold {
-  id                    Int      @id @default(autoincrement())
-  patientId             Int      @unique @map("patient_id")
+  id                Int      @id @default(autoincrement())
+  patientId         Int      @unique @map("patient_id")
   /// Limite supérieure cétones « légères » (mmol/L). Par défaut 0.6.
-  lightThreshold        Decimal  @default(0.6) @map("light_threshold") @db.Decimal(3, 1)
+  lightThreshold    Decimal  @default(0.6) @map("light_threshold") @db.Decimal(3, 1)
   /// Limite supérieure cétones « modérées » (mmol/L). Par défaut 1.5.
-  moderateThreshold     Decimal  @default(1.5) @map("moderate_threshold") @db.Decimal(3, 1)
+  moderateThreshold Decimal  @default(1.5) @map("moderate_threshold") @db.Decimal(3, 1)
   /// À ce seuil ou au-dessus → DKA (urgence). Par défaut 3.0 (ISPAD 2022).
-  dkaThreshold          Decimal  @default(3.0) @map("dka_threshold") @db.Decimal(3, 1)
+  dkaThreshold      Decimal  @default(3.0) @map("dka_threshold") @db.Decimal(3, 1)
   /// Émettre alerte sur cétones modérées.
-  alertOnModerate       Boolean  @default(true) @map("alert_on_moderate")
+  alertOnModerate   Boolean  @default(true) @map("alert_on_moderate")
   /// Émettre alerte critique sur DKA.
-  alertOnDka            Boolean  @default(true) @map("alert_on_dka")
-  createdAt             DateTime @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt             DateTime @updatedAt @map("updated_at") @db.Timestamptz()
+  alertOnDka        Boolean  @default(true) @map("alert_on_dka")
+  createdAt         DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt         DateTime @updatedAt @map("updated_at") @db.Timestamptz()
 
   patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
 
@@ -744,21 +746,21 @@ model KetoneThreshold {
 /// Type de glucide adapté aux préférences/allergies. Quantité standard 15 g pour adulte,
 /// modifiable selon poids/âge/médecin.
 model HypoTreatmentProtocol {
-  id                    Int           @id @default(autoincrement())
-  patientId             Int           @unique @map("patient_id")
-  sugarType             HypoSugarType @default(glucose_tabs) @map("sugar_type")
+  id             Int           @id @default(autoincrement())
+  patientId      Int           @unique @map("patient_id")
+  sugarType      HypoSugarType @default(glucose_tabs) @map("sugar_type")
   /// Description libre si sugarType = other (ex: "miel + biscotte").
-  sugarTypeOther        String?       @map("sugar_type_other") @db.VarChar(200)
+  sugarTypeOther String?       @map("sugar_type_other") @db.VarChar(200)
   /// Grammes de glucides rapides à ingérer. Par défaut 15 g.
-  fastCarbsGrams        Int           @default(15) @map("fast_carbs_grams")
+  fastCarbsGrams Int           @default(15) @map("fast_carbs_grams")
   /// Délai (minutes) avant re-mesure glycémie. Par défaut 15 min.
-  retestMinutes         Int           @default(15) @map("retest_minutes")
+  retestMinutes  Int           @default(15) @map("retest_minutes")
   /// Allergies à éviter (chiffré AES-256-GCM si non vide).
-  allergies             String?       // chiffré
+  allergies      String? // chiffré
   /// Instructions complémentaires destinées au patient (chiffré).
-  instructions          String?       // chiffré
-  createdAt             DateTime      @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt             DateTime      @updatedAt @map("updated_at") @db.Timestamptz()
+  instructions   String? // chiffré
+  createdAt      DateTime      @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt      DateTime      @updatedAt @map("updated_at") @db.Timestamptz()
 
   patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
 
@@ -773,33 +775,33 @@ model HypoTreatmentProtocol {
 ///  - `notes`, `resolutionNotes` (texte libre clinicien),
 ///  - `contextSnapshot` (timeline CGM 30 min — données de santé).
 model EmergencyAlert {
-  id                Int                     @id @default(autoincrement())
-  patientId         Int                     @map("patient_id")
-  alertType         EmergencyAlertType      @map("alert_type")
-  severity          EmergencyAlertSeverity  @default(warning)
-  status            EmergencyAlertStatus    @default(open)
-  triggeredAt       DateTime                @default(now()) @map("triggered_at") @db.Timestamptz()
+  id               Int                    @id @default(autoincrement())
+  patientId        Int                    @map("patient_id")
+  alertType        EmergencyAlertType     @map("alert_type")
+  severity         EmergencyAlertSeverity @default(warning)
+  status           EmergencyAlertStatus   @default(open)
+  triggeredAt      DateTime               @default(now()) @map("triggered_at") @db.Timestamptz()
   /// Valeur glycémie déclencheuse (mg/dL). NULL si manuelle ou cétone.
-  glucoseValueMgdl  Decimal?                @map("glucose_value_mgdl") @db.Decimal(6, 2)
+  glucoseValueMgdl Decimal?               @map("glucose_value_mgdl") @db.Decimal(6, 2)
   /// Valeur cétones déclencheuse (mmol/L). NULL si manuelle ou glycémie.
-  ketoneValueMmol   Decimal?                @map("ketone_value_mmol") @db.Decimal(4, 2)
+  ketoneValueMmol  Decimal?               @map("ketone_value_mmol") @db.Decimal(4, 2)
   /// Timeline CGM 30 min avant trigger — chiffré base64(AES-256-GCM)
   /// d'un JSON `[{ts, mgdl}]`. Texte vide / NULL si non renseigné.
-  contextSnapshot   String?                 @map("context_snapshot") @db.Text
+  contextSnapshot  String?                @map("context_snapshot") @db.Text
   /// Texte libre clinicien — chiffré AES-256-GCM si non vide.
-  notes             String?                 @db.Text
-  acknowledgedBy    Int?                    @map("acknowledged_by")
-  acknowledgedAt    DateTime?               @map("acknowledged_at") @db.Timestamptz()
-  resolvedBy        Int?                    @map("resolved_by")
-  resolvedAt        DateTime?               @map("resolved_at") @db.Timestamptz()
+  notes            String?                @db.Text
+  acknowledgedBy   Int?                   @map("acknowledged_by")
+  acknowledgedAt   DateTime?              @map("acknowledged_at") @db.Timestamptz()
+  resolvedBy       Int?                   @map("resolved_by")
+  resolvedAt       DateTime?              @map("resolved_at") @db.Timestamptz()
   /// Notes de résolution clinicien — chiffré AES-256-GCM si non vide.
-  resolutionNotes   String?                 @map("resolution_notes") @db.Text
-  createdAt         DateTime                @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt         DateTime                @updatedAt @map("updated_at") @db.Timestamptz()
+  resolutionNotes  String?                @map("resolution_notes") @db.Text
+  createdAt        DateTime               @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt        DateTime               @updatedAt @map("updated_at") @db.Timestamptz()
 
-  patient            Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
-  acknowledgedByUser User?   @relation("AlertAcknowledger", fields: [acknowledgedBy], references: [id], onDelete: Restrict)
-  resolvedByUser     User?   @relation("AlertResolver", fields: [resolvedBy], references: [id], onDelete: Restrict)
+  patient            Patient                @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  acknowledgedByUser User?                  @relation("AlertAcknowledger", fields: [acknowledgedBy], references: [id], onDelete: Restrict)
+  resolvedByUser     User?                  @relation("AlertResolver", fields: [resolvedBy], references: [id], onDelete: Restrict)
   actions            EmergencyAlertAction[]
 
   @@index([patientId, status, triggeredAt])
@@ -813,19 +815,19 @@ model EmergencyAlert {
 /// US-2226 — Actions effectuées par un soignant face à une alerte (audit + workflow).
 /// Append-only ; jamais supprimé pour traçabilité HDS.
 model EmergencyAlertAction {
-  id           Int                       @id @default(autoincrement())
-  alertId      Int                       @map("alert_id")
-  performedBy  Int                       @map("performed_by")
-  actionType   EmergencyAlertActionType  @map("action_type")
+  id          Int                      @id @default(autoincrement())
+  alertId     Int                      @map("alert_id")
+  performedBy Int                      @map("performed_by")
+  actionType  EmergencyAlertActionType @map("action_type")
   /// Notes libres clinicien — chiffré AES-256-GCM si non vide.
-  notes        String?                   @db.Text
+  notes       String?                  @db.Text
   /// Métadonnées strictement bornées (durée, résultat). Aucune PHI/PII.
   /// Schéma applicatif : { durationSec?: number, outcome?: string }.
-  metadata     Json                      @default("{}")
-  createdAt    DateTime                  @default(now()) @map("created_at") @db.Timestamptz()
+  metadata    Json                     @default("{}")
+  createdAt   DateTime                 @default(now()) @map("created_at") @db.Timestamptz()
 
-  alert            EmergencyAlert @relation(fields: [alertId], references: [id], onDelete: Cascade)
-  performedByUser  User           @relation("EmergencyActionPerformer", fields: [performedBy], references: [id], onDelete: Restrict)
+  alert           EmergencyAlert @relation(fields: [alertId], references: [id], onDelete: Cascade)
+  performedByUser User           @relation("EmergencyActionPerformer", fields: [performedBy], references: [id], onDelete: Restrict)
 
   @@index([alertId, createdAt])
   @@index([performedBy, createdAt])
@@ -837,29 +839,29 @@ model EmergencyAlertAction {
 // ═══════════════════════════════════════════════════════════════
 
 model Treatment {
-  id            Int           @id @default(autoincrement())
-  patientId     Int           @map("patient_id")
-  type          TreatmentType
-  name          String?       @db.VarChar(100)
-  other         String?
-  posology      String?
-  posologyData  Json?         @map("posology_data")
-  treatmentId   Int?          @map("treatment_id") // ID traitement externe
-  createdAt     DateTime      @default(now()) @map("created_at")
-  updatedAt     DateTime      @updatedAt @map("updated_at")
+  id           Int           @id @default(autoincrement())
+  patientId    Int           @map("patient_id")
+  type         TreatmentType
+  name         String?       @db.VarChar(100)
+  other        String?
+  posology     String?
+  posologyData Json?         @map("posology_data")
+  treatmentId  Int?          @map("treatment_id") // ID traitement externe
+  createdAt    DateTime      @default(now()) @map("created_at")
+  updatedAt    DateTime      @updatedAt @map("updated_at")
 
-  patient            Patient              @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  patient            Patient             @relation(fields: [patientId], references: [id], onDelete: Cascade)
   basalFlowSchedules BasalFlowSchedule[]
 
   @@map("treatments")
 }
 
 model BasalFlowSchedule {
-  id            Int     @id @default(autoincrement())
-  treatmentId   Int     @map("treatment_id")
-  label         String? @db.VarChar(50)
+  id            Int      @id @default(autoincrement())
+  treatmentId   Int      @map("treatment_id")
+  label         String?  @db.VarChar(50)
   scheduleStart DateTime @map("schedule_start") @db.Time()
-  scheduleRate  Decimal @map("schedule_rate") @db.Decimal(5, 3)
+  scheduleRate  Decimal  @map("schedule_rate") @db.Decimal(5, 3)
 
   treatment Treatment @relation(fields: [treatmentId], references: [id], onDelete: Cascade)
 
@@ -876,18 +878,18 @@ model BasalFlowSchedule {
 model InsulinCatalog {
   id                       Int      @id @default(autoincrement())
   displayName              String   @unique @map("display_name") @db.VarChar(100) // Nom commercial (ex: "Humalog", "Lantus")
-  genericName              String   @map("generic_name") @db.VarChar(100)          // DCI (ex: "insulin lispro", "insulin glargine")
-  typicalOnsetMinutes      Int      @map("typical_onset_minutes")                  // Debut d'action en minutes (ex: 15 pour rapide, 60 pour lente)
-  typicalPeakMinutes       Int?     @map("typical_peak_minutes")                   // Pic d'action en minutes (null pour basales sans pic — ex: Tresiba)
+  genericName              String   @map("generic_name") @db.VarChar(100) // DCI (ex: "insulin lispro", "insulin glargine")
+  typicalOnsetMinutes      Int      @map("typical_onset_minutes") // Debut d'action en minutes (ex: 15 pour rapide, 60 pour lente)
+  typicalPeakMinutes       Int?     @map("typical_peak_minutes") // Pic d'action en minutes (null pour basales sans pic — ex: Tresiba)
   typicalDurationHours     Decimal  @map("typical_duration_hours") @db.Decimal(4, 1) // Duree d'action en heures (ex: 4.0 pour rapide, 24.0 pour lente)
-  isFasterActing           Boolean  @default(false) @map("is_faster_acting")       // Ultra-rapide (Fiasp, Lyumjev) — onset < 10 min
+  isFasterActing           Boolean  @default(false) @map("is_faster_acting") // Ultra-rapide (Fiasp, Lyumjev) — onset < 10 min
   isTraditionalRapidActing Boolean  @default(false) @map("is_traditional_rapid_acting") // Rapide classique (Humalog, NovoRapid, Apidra)
-  isLongActing             Boolean  @default(false) @map("is_long_acting")         // Basale longue duree (Lantus, Levemir, Tresiba)
-  approvalYear             Int?     @map("approval_year")                          // Annee d'approbation FDA/EMA (reference)
-  manufacturer             String?  @db.VarChar(100)                               // Fabricant (Eli Lilly, Novo Nordisk, Sanofi...)
-  isActive                 Boolean  @default(true) @map("is_active")               // Actif dans le catalogue (desactivable sans suppression)
+  isLongActing             Boolean  @default(false) @map("is_long_acting") // Basale longue duree (Lantus, Levemir, Tresiba)
+  approvalYear             Int?     @map("approval_year") // Annee d'approbation FDA/EMA (reference)
+  manufacturer             String?  @db.VarChar(100) // Fabricant (Eli Lilly, Novo Nordisk, Sanofi...)
+  isActive                 Boolean  @default(true) @map("is_active") // Actif dans le catalogue (desactivable sans suppression)
   createdAt                DateTime @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt                DateTime @updatedAt @map("updated_at") @db.Timestamptz()  // Audit: date correction donnees PK
+  updatedAt                DateTime @updatedAt @map("updated_at") @db.Timestamptz() // Audit: date correction donnees PK
 
   patientInsulins PatientInsulin[]
 
@@ -899,24 +901,24 @@ model InsulinCatalog {
 /// Historique conserve via startDate/endDate — un patient peut avoir plusieurs insulines actives.
 /// La duree d'action personnalisee (customDurationHours) override la duree du catalogue pour le calcul IOB.
 model PatientInsulin {
-  id                    Int       @id @default(autoincrement())
-  patientId             Int       @map("patient_id")
-  insulinCatalogId      Int       @map("insulin_catalog_id")
-  usage                 InsulinUsage                           // bolus, basal, ou both (pré-mélangées)
-  customDurationHours   Decimal?  @map("custom_duration_hours") @db.Decimal(4, 1) // Durée d'action personnalisée (override catalogue). Si null, utiliser catalogue.
-  customOnsetMinutes    Int?      @map("custom_onset_minutes") // Onset personnalisé (override catalogue). Si null, utiliser catalogue.
-  dosage                String?   @db.VarChar(100)             // Posologie libre (ex: "18U le soir", "6-8U avant repas")
-  isActive              Boolean   @default(true) @map("is_active")  // Actif dans le traitement actuel
-  startDate             DateTime  @default(now()) @map("start_date") @db.Date // Date de début d'utilisation
-  endDate               DateTime? @map("end_date") @db.Date         // Date de fin (null = en cours). Rempli quand on arrête une insuline.
-  prescribedBy          Int?      @map("prescribed_by")             // ID du médecin prescripteur (User.id, rôle DOCTOR)
-  notes                 String?                                     // Notes cliniques (chiffrées AES-256-GCM)
-  createdAt             DateTime  @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt             DateTime  @updatedAt @map("updated_at") @db.Timestamptz()
+  id                  Int          @id @default(autoincrement())
+  patientId           Int          @map("patient_id")
+  insulinCatalogId    Int          @map("insulin_catalog_id")
+  usage               InsulinUsage // bolus, basal, ou both (pré-mélangées)
+  customDurationHours Decimal?     @map("custom_duration_hours") @db.Decimal(4, 1) // Durée d'action personnalisée (override catalogue). Si null, utiliser catalogue.
+  customOnsetMinutes  Int?         @map("custom_onset_minutes") // Onset personnalisé (override catalogue). Si null, utiliser catalogue.
+  dosage              String?      @db.VarChar(100) // Posologie libre (ex: "18U le soir", "6-8U avant repas")
+  isActive            Boolean      @default(true) @map("is_active") // Actif dans le traitement actuel
+  startDate           DateTime     @default(now()) @map("start_date") @db.Date // Date de début d'utilisation
+  endDate             DateTime?    @map("end_date") @db.Date // Date de fin (null = en cours). Rempli quand on arrête une insuline.
+  prescribedBy        Int?         @map("prescribed_by") // ID du médecin prescripteur (User.id, rôle DOCTOR)
+  notes               String? // Notes cliniques (chiffrées AES-256-GCM)
+  createdAt           DateTime     @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt           DateTime     @updatedAt @map("updated_at") @db.Timestamptz()
 
-  patient        Patient        @relation(fields: [patientId], references: [id], onDelete: Cascade)
-  insulinCatalog InsulinCatalog @relation(fields: [insulinCatalogId], references: [id])
-  prescriber     User?          @relation("PrescribedInsulins", fields: [prescribedBy], references: [id], onDelete: SetNull)
+  patient        Patient                  @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  insulinCatalog InsulinCatalog           @relation(fields: [insulinCatalogId], references: [id])
+  prescriber     User?                    @relation("PrescribedInsulins", fields: [prescribedBy], references: [id], onDelete: SetNull)
   bolusSettings  InsulinTherapySettings[] @relation("BolusInsulinSettings")
   basalSettings  InsulinTherapySettings[] @relation("BasalInsulinSettings")
 
@@ -927,36 +929,36 @@ model PatientInsulin {
 }
 
 model InsulinTherapySettings {
-  id                    Int                   @id @default(autoincrement())
-  patientId             Int                   @unique @map("patient_id")
-  bolusInsulinId        Int?                  @map("bolus_insulin_id")    // FK → PatientInsulin (insuline bolus active)
-  basalInsulinId        Int?                  @map("basal_insulin_id")    // FK → PatientInsulin (insuline basale active)
-  deliveryMethod        InsulinDeliveryMethod @map("delivery_method")
-  lastModified          DateTime              @default(now()) @map("last_modified") @db.Timestamptz()
-  createdAt             DateTime              @default(now()) @map("created_at") @db.Timestamptz()
+  id             Int                   @id @default(autoincrement())
+  patientId      Int                   @unique @map("patient_id")
+  bolusInsulinId Int?                  @map("bolus_insulin_id") // FK → PatientInsulin (insuline bolus active)
+  basalInsulinId Int?                  @map("basal_insulin_id") // FK → PatientInsulin (insuline basale active)
+  deliveryMethod InsulinDeliveryMethod @map("delivery_method")
+  lastModified   DateTime              @default(now()) @map("last_modified") @db.Timestamptz()
+  createdAt      DateTime              @default(now()) @map("created_at") @db.Timestamptz()
 
-  patient              Patient                  @relation(fields: [patientId], references: [id], onDelete: Cascade)
-  bolusInsulin         PatientInsulin?          @relation("BolusInsulinSettings", fields: [bolusInsulinId], references: [id], onDelete: SetNull)
-  basalInsulin         PatientInsulin?          @relation("BasalInsulinSettings", fields: [basalInsulinId], references: [id], onDelete: SetNull)
-  glucoseTargets       GlucoseTarget[]
-  iobSettings          IobSettings?
+  patient               Patient                    @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  bolusInsulin          PatientInsulin?            @relation("BolusInsulinSettings", fields: [bolusInsulinId], references: [id], onDelete: SetNull)
+  basalInsulin          PatientInsulin?            @relation("BasalInsulinSettings", fields: [basalInsulinId], references: [id], onDelete: SetNull)
+  glucoseTargets        GlucoseTarget[]
+  iobSettings           IobSettings?
   extendedBolusSettings ExtendedBolusSettings?
-  sensitivityFactors   InsulinSensitivityFactor[]
-  carbRatios           CarbRatio[]
-  basalConfiguration   BasalConfiguration?
+  sensitivityFactors    InsulinSensitivityFactor[]
+  carbRatios            CarbRatio[]
+  basalConfiguration    BasalConfiguration?
 
   @@map("insulin_therapy_settings")
 }
 
 model GlucoseTarget {
-  id               String              @id @default(uuid())
-  settingsId       Int                 @map("settings_id")
-  targetGlucose    Decimal             @map("target_glucose") @db.Decimal(6, 2) // mg/dL
-  targetRangeLower Decimal             @default(0.70) @map("target_range_lower") @db.Decimal(4, 2) // g/L
-  targetRangeUpper Decimal             @default(1.80) @map("target_range_upper") @db.Decimal(4, 2) // g/L
+  id               String               @id @default(uuid())
+  settingsId       Int                  @map("settings_id")
+  targetGlucose    Decimal              @map("target_glucose") @db.Decimal(6, 2) // mg/dL
+  targetRangeLower Decimal              @default(0.70) @map("target_range_lower") @db.Decimal(4, 2) // g/L
+  targetRangeUpper Decimal              @default(1.80) @map("target_range_upper") @db.Decimal(4, 2) // g/L
   preset           GlucoseTargetPreset?
-  isActive         Boolean             @default(true) @map("is_active")
-  createdAt        DateTime            @default(now()) @map("created_at") @db.Timestamptz()
+  isActive         Boolean              @default(true) @map("is_active")
+  createdAt        DateTime             @default(now()) @map("created_at") @db.Timestamptz()
 
   settings InsulinTherapySettings @relation(fields: [settingsId], references: [id], onDelete: Cascade)
 
@@ -987,16 +989,16 @@ model ExtendedBolusSettings {
 }
 
 model InsulinSensitivityFactor {
-  id                   String   @id @default(uuid())
-  settingsId           Int      @map("settings_id")
-  startHour            Int      @map("start_hour") @db.SmallInt
-  endHour              Int      @map("end_hour") @db.SmallInt
-  startTime            DateTime @map("start_time") @db.Time()
-  endTime              DateTime @map("end_time") @db.Time()
-  sensitivityFactorGl  Decimal  @map("sensitivity_factor_gl") @db.Decimal(6, 4)
-  sensitivityFactorMgdl Decimal @map("sensitivity_factor_mgdl") @db.Decimal(6, 2)
-  createdAt            DateTime @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt            DateTime @updatedAt @map("updated_at") @db.Timestamptz()
+  id                    String   @id @default(uuid())
+  settingsId            Int      @map("settings_id")
+  startHour             Int      @map("start_hour") @db.SmallInt
+  endHour               Int      @map("end_hour") @db.SmallInt
+  startTime             DateTime @map("start_time") @db.Time()
+  endTime               DateTime @map("end_time") @db.Time()
+  sensitivityFactorGl   Decimal  @map("sensitivity_factor_gl") @db.Decimal(6, 4)
+  sensitivityFactorMgdl Decimal  @map("sensitivity_factor_mgdl") @db.Decimal(6, 2)
+  createdAt             DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt             DateTime @updatedAt @map("updated_at") @db.Timestamptz()
 
   settings InsulinTherapySettings @relation(fields: [settingsId], references: [id], onDelete: Cascade)
 
@@ -1040,41 +1042,41 @@ model BasalConfiguration {
 }
 
 model PumpBasalSlot {
-  id              String   @id @default(uuid())
-  basalConfigId   Int      @map("basal_config_id")
-  startTime       DateTime @map("start_time") @db.Time()
-  endTime         DateTime @map("end_time") @db.Time()
-  rate            Decimal  @db.Decimal(5, 3) // U/h
-  durationHours   Decimal? @map("duration_hours") @db.Decimal(5, 2)
-  createdAt       DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  id            String   @id @default(uuid())
+  basalConfigId Int      @map("basal_config_id")
+  startTime     DateTime @map("start_time") @db.Time()
+  endTime       DateTime @map("end_time") @db.Time()
+  rate          Decimal  @db.Decimal(5, 3) // U/h
+  durationHours Decimal? @map("duration_hours") @db.Decimal(5, 2)
+  createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz()
 
-  basalConfig          BasalConfiguration   @relation(fields: [basalConfigId], references: [id], onDelete: Cascade)
-  adjustmentProposals  AdjustmentProposal[]
+  basalConfig         BasalConfiguration   @relation(fields: [basalConfigId], references: [id], onDelete: Cascade)
+  adjustmentProposals AdjustmentProposal[]
 
   @@map("pump_basal_slots")
 }
 
 model BolusCalculationLog {
-  id                      String    @id @default(uuid())
-  patientId               Int       @map("patient_id")
-  calculatedAt            DateTime  @default(now()) @map("calculated_at") @db.Timestamptz()
-  inputGlucoseGl          Decimal?  @map("input_glucose_gl") @db.Decimal(6, 4)
-  inputCarbsGrams         Decimal?  @map("input_carbs_grams") @db.Decimal(6, 2)
-  targetGlucoseMgdl       Decimal   @map("target_glucose_mgdl") @db.Decimal(6, 2)
-  isfUsedGl               Decimal   @map("isf_used_gl") @db.Decimal(6, 4)
-  icrUsed                 Decimal   @map("icr_used") @db.Decimal(5, 2)
-  mealBolus               Decimal   @default(0) @map("meal_bolus") @db.Decimal(5, 2)
-  rawCorrectionDose       Decimal   @default(0) @map("raw_correction_dose") @db.Decimal(5, 2)
-  iobValue                Decimal   @default(0) @map("iob_value") @db.Decimal(5, 2)
-  iobAdjustment           Decimal   @default(0) @map("iob_adjustment") @db.Decimal(5, 2)
-  correctionDose          Decimal   @default(0) @map("correction_dose") @db.Decimal(5, 2)
-  recommendedDose         Decimal   @map("recommended_dose") @db.Decimal(5, 2)
-  wasCapped               Boolean   @default(false) @map("was_capped")
-  warnings                String[]
-  deliveryMethod          String    @map("delivery_method") @db.VarChar(20)
-  wasDelivered            Boolean   @default(false) @map("was_delivered")
-  extendedImmediatePct    Decimal?  @map("extended_immediate_pct") @db.Decimal(5, 2)
-  extendedDurationHours   Decimal?  @map("extended_duration_hours") @db.Decimal(4, 2)
+  id                    String   @id @default(uuid())
+  patientId             Int      @map("patient_id")
+  calculatedAt          DateTime @default(now()) @map("calculated_at") @db.Timestamptz()
+  inputGlucoseGl        Decimal? @map("input_glucose_gl") @db.Decimal(6, 4)
+  inputCarbsGrams       Decimal? @map("input_carbs_grams") @db.Decimal(6, 2)
+  targetGlucoseMgdl     Decimal  @map("target_glucose_mgdl") @db.Decimal(6, 2)
+  isfUsedGl             Decimal  @map("isf_used_gl") @db.Decimal(6, 4)
+  icrUsed               Decimal  @map("icr_used") @db.Decimal(5, 2)
+  mealBolus             Decimal  @default(0) @map("meal_bolus") @db.Decimal(5, 2)
+  rawCorrectionDose     Decimal  @default(0) @map("raw_correction_dose") @db.Decimal(5, 2)
+  iobValue              Decimal  @default(0) @map("iob_value") @db.Decimal(5, 2)
+  iobAdjustment         Decimal  @default(0) @map("iob_adjustment") @db.Decimal(5, 2)
+  correctionDose        Decimal  @default(0) @map("correction_dose") @db.Decimal(5, 2)
+  recommendedDose       Decimal  @map("recommended_dose") @db.Decimal(5, 2)
+  wasCapped             Boolean  @default(false) @map("was_capped")
+  warnings              String[]
+  deliveryMethod        String   @map("delivery_method") @db.VarChar(20)
+  wasDelivered          Boolean  @default(false) @map("was_delivered")
+  extendedImmediatePct  Decimal? @map("extended_immediate_pct") @db.Decimal(5, 2)
+  extendedDurationHours Decimal? @map("extended_duration_hours") @db.Decimal(4, 2)
 
   patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
 
@@ -1083,33 +1085,33 @@ model BolusCalculationLog {
 }
 
 model AdjustmentProposal {
-  id                     String              @id @default(uuid())
-  patientId              Int                 @map("patient_id")
-  parameterType          AdjustableParameter @map("parameter_type")
-  currentValue           Decimal             @map("current_value") @db.Decimal(8, 4)
-  proposedValue          Decimal             @map("proposed_value") @db.Decimal(8, 4)
-  changePercent          Decimal             @map("change_percent") @db.Decimal(5, 2)
-  confidence             ConfidenceLevel
-  reason                 AdjustmentReason
-  supportingEvents       Int                 @map("supporting_events")
-  totalEventsConsidered  Int?                @map("total_events_considered")
-  excludedEvents         Int?                @map("excluded_events")
-  averageObservedValue   Decimal?            @map("average_observed_value") @db.Decimal(8, 4)
-  timeSlotStartHour      Int?                @map("time_slot_start_hour") @db.SmallInt
-  timeSlotEndHour        Int?                @map("time_slot_end_hour") @db.SmallInt
-  carbRatioSlotStart     Int?                @map("carb_ratio_slot_start") @db.SmallInt
-  carbRatioSlotEnd       Int?                @map("carb_ratio_slot_end") @db.SmallInt
-  pumpBasalSlotId        String?             @map("pump_basal_slot_id")
-  analysisPeriod         String?             @map("analysis_period") @db.VarChar(10)
-  dataQuality            String?             @map("data_quality") @db.VarChar(20)
-  status                 ProposalStatus      @default(pending)
-  reviewedAt             DateTime?           @map("reviewed_at") @db.Timestamptz()
-  reviewedBy             Int?                @map("reviewed_by")
-  createdAt              DateTime            @default(now()) @map("created_at") @db.Timestamptz()
+  id                    String              @id @default(uuid())
+  patientId             Int                 @map("patient_id")
+  parameterType         AdjustableParameter @map("parameter_type")
+  currentValue          Decimal             @map("current_value") @db.Decimal(8, 4)
+  proposedValue         Decimal             @map("proposed_value") @db.Decimal(8, 4)
+  changePercent         Decimal             @map("change_percent") @db.Decimal(5, 2)
+  confidence            ConfidenceLevel
+  reason                AdjustmentReason
+  supportingEvents      Int                 @map("supporting_events")
+  totalEventsConsidered Int?                @map("total_events_considered")
+  excludedEvents        Int?                @map("excluded_events")
+  averageObservedValue  Decimal?            @map("average_observed_value") @db.Decimal(8, 4)
+  timeSlotStartHour     Int?                @map("time_slot_start_hour") @db.SmallInt
+  timeSlotEndHour       Int?                @map("time_slot_end_hour") @db.SmallInt
+  carbRatioSlotStart    Int?                @map("carb_ratio_slot_start") @db.SmallInt
+  carbRatioSlotEnd      Int?                @map("carb_ratio_slot_end") @db.SmallInt
+  pumpBasalSlotId       String?             @map("pump_basal_slot_id")
+  analysisPeriod        String?             @map("analysis_period") @db.VarChar(10)
+  dataQuality           String?             @map("data_quality") @db.VarChar(20)
+  status                ProposalStatus      @default(pending)
+  reviewedAt            DateTime?           @map("reviewed_at") @db.Timestamptz()
+  reviewedBy            Int?                @map("reviewed_by")
+  createdAt             DateTime            @default(now()) @map("created_at") @db.Timestamptz()
 
-  patient       Patient        @relation(fields: [patientId], references: [id], onDelete: Cascade)
-  reviewer      User?          @relation("ReviewedBy", fields: [reviewedBy], references: [id])
-  pumpBasalSlot PumpBasalSlot? @relation(fields: [pumpBasalSlotId], references: [id])
+  patient       Patient                          @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  reviewer      User?                            @relation("ReviewedBy", fields: [reviewedBy], references: [id])
+  pumpBasalSlot PumpBasalSlot?                   @relation(fields: [pumpBasalSlotId], references: [id])
   /// US-2065 — accusé patient (1:1).
   ack           AdjustmentProposalAck?
   /// US-2066 — actualisation effective (1:1).
@@ -1141,27 +1143,27 @@ model CgmEntry {
 }
 
 model GlycemiaEntry {
-  id              Int      @id @default(autoincrement())
-  patientId       Int      @map("patient_id")
-  date            DateTime @db.Date
+  id              Int       @id @default(autoincrement())
+  patientId       Int       @map("patient_id")
+  date            DateTime  @db.Date
   time            DateTime? @db.Time()
-  isProfessional  Boolean  @default(false) @map("is_professional")
-  glycemiaGl      Decimal? @map("glycemia_gl") @db.Decimal(6, 4) // g/L
-  glycemiaMgdl    Decimal? @map("glycemia_mgdl") @db.Decimal(6, 2) // mg/dL
-  weight          Decimal? @db.Decimal(5, 2)
-  hba1c           Decimal? @db.Decimal(5, 2)
-  ketones         Decimal? @db.Decimal(5, 2)
-  bpSystolic      Int?     @map("bp_systolic") @db.SmallInt
-  bpDiastolic     Int?     @map("bp_diastolic") @db.SmallInt
-  bolus           Decimal? @db.Decimal(5, 2)
-  bolusCorr       Decimal? @map("bolus_corr") @db.Decimal(5, 2)
-  basal           Decimal? @db.Decimal(5, 2)
-  insulinDevice   Int?     @map("insulin_device")
-  carb            Int?     // grammes
-  mealDescription String?  @map("meal_description")
-  mealFullStarchy Boolean? @map("meal_full_starchy")
-  mealProtein     Boolean? @map("meal_protein")
-  createdAt       DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  isProfessional  Boolean   @default(false) @map("is_professional")
+  glycemiaGl      Decimal?  @map("glycemia_gl") @db.Decimal(6, 4) // g/L
+  glycemiaMgdl    Decimal?  @map("glycemia_mgdl") @db.Decimal(6, 2) // mg/dL
+  weight          Decimal?  @db.Decimal(5, 2)
+  hba1c           Decimal?  @db.Decimal(5, 2)
+  ketones         Decimal?  @db.Decimal(5, 2)
+  bpSystolic      Int?      @map("bp_systolic") @db.SmallInt
+  bpDiastolic     Int?      @map("bp_diastolic") @db.SmallInt
+  bolus           Decimal?  @db.Decimal(5, 2)
+  bolusCorr       Decimal?  @map("bolus_corr") @db.Decimal(5, 2)
+  basal           Decimal?  @db.Decimal(5, 2)
+  insulinDevice   Int?      @map("insulin_device")
+  carb            Int? // grammes
+  mealDescription String?   @map("meal_description")
+  mealFullStarchy Boolean?  @map("meal_full_starchy")
+  mealProtein     Boolean?  @map("meal_protein")
+  createdAt       DateTime  @default(now()) @map("created_at") @db.Timestamptz()
 
   patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
 
@@ -1170,32 +1172,32 @@ model GlycemiaEntry {
 }
 
 model DiabetesEvent {
-  id                String   @id @default(uuid())
-  patientId         Int      @map("patient_id")
-  eventDate         DateTime @map("event_date") @db.Timestamptz()
+  id                String              @id @default(uuid())
+  patientId         Int                 @map("patient_id")
+  eventDate         DateTime            @map("event_date") @db.Timestamptz()
   eventTypes        DiabetesEventType[] @map("event_types")
-  glycemiaValue     Decimal? @map("glycemia_value") @db.Decimal(6, 2)
-  carbohydrates     Decimal? @db.Decimal(6, 2)
-  bolusDose         Decimal? @map("bolus_dose") @db.Decimal(5, 2)
-  basalDose         Decimal? @map("basal_dose") @db.Decimal(5, 2)
-  activityType      String?  @map("activity_type") @db.VarChar(20)
-  activityDuration  Int?     @map("activity_duration") // minutes
-  contextType       String?  @map("context_type") @db.VarChar(20)
-  weight            Decimal? @db.Decimal(5, 2)
-  hba1c             Decimal? @db.Decimal(5, 2)
-  ketones           Decimal? @db.Decimal(5, 2)
-  systolicPressure  Int?     @map("systolic_pressure") @db.SmallInt
-  diastolicPressure Int?     @map("diastolic_pressure") @db.SmallInt
+  glycemiaValue     Decimal?            @map("glycemia_value") @db.Decimal(6, 2)
+  carbohydrates     Decimal?            @db.Decimal(6, 2)
+  bolusDose         Decimal?            @map("bolus_dose") @db.Decimal(5, 2)
+  basalDose         Decimal?            @map("basal_dose") @db.Decimal(5, 2)
+  activityType      String?             @map("activity_type") @db.VarChar(20)
+  activityDuration  Int?                @map("activity_duration") // minutes
+  contextType       String?             @map("context_type") @db.VarChar(20)
+  weight            Decimal?            @db.Decimal(5, 2)
+  hba1c             Decimal?            @db.Decimal(5, 2)
+  ketones           Decimal?            @db.Decimal(5, 2)
+  systolicPressure  Int?                @map("systolic_pressure") @db.SmallInt
+  diastolicPressure Int?                @map("diastolic_pressure") @db.SmallInt
   comment           String?
   /// US-2053 — Validation soignant. `validatedBy` = User.id (NURSE+), null
   /// si l'event n'a pas (encore) été revu par un PS.
-  validatedAt       DateTime? @map("validated_at") @db.Timestamptz()
-  validatedBy       Int?      @map("validated_by")
-  createdAt         DateTime @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt         DateTime @updatedAt @map("updated_at") @db.Timestamptz()
+  validatedAt       DateTime?           @map("validated_at") @db.Timestamptz()
+  validatedBy       Int?                @map("validated_by")
+  createdAt         DateTime            @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt         DateTime            @updatedAt @map("updated_at") @db.Timestamptz()
 
-  patient   Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
-  validator User?   @relation("DiabetesEventValidator", fields: [validatedBy], references: [id], onDelete: SetNull)
+  patient    Patient     @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  validator  User?       @relation("DiabetesEventValidator", fields: [validatedBy], references: [id], onDelete: SetNull)
   /// US-2057 — Photos repas attachées à un event de type insulinMeal.
   mealPhotos MealPhoto[]
 
@@ -1210,7 +1212,7 @@ model InsulinFlowEntry {
   patientId Int      @map("patient_id")
   date      DateTime @db.Date
   flow      Decimal? @db.Decimal(6, 2) // U total journalier
-  hour      Json?    // tableau de 24 valeurs
+  hour      Json? // tableau de 24 valeurs
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz()
 
   patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
@@ -1226,7 +1228,7 @@ model InsulinFlowDeviceData {
   date      DateTime @db.Date
   flow      Decimal? @db.Decimal(6, 2)
   hour      Json?
-  events    Json?    // [{start, end, rate, temp, datas}]
+  events    Json? // [{start, end, rate, temp, datas}]
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz()
 
   patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
@@ -1244,10 +1246,10 @@ model PumpEvent {
 
   patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
 
-  @@index([patientId, timestamp])
   /// Review PR #391 C4 — dédup cross-batch sur `bulkSync` (réimport CSV).
   /// Combiné avec `skipDuplicates: true` côté Prisma → idempotence garantie.
   @@unique([patientId, timestamp, eventType])
+  @@index([patientId, timestamp])
   @@map("pump_events")
 }
 
@@ -1255,20 +1257,20 @@ model PumpEvent {
 /// rows (varchar 'current' | '7d' | '30d') remain valid after enum migration.
 enum PeriodType {
   current
-  d7  @map("7d")
-  d30 @map("30d")
+  d7      @map("7d")
+  d30     @map("30d")
 }
 
 model AverageData {
-  id          Int        @id @default(autoincrement())
-  patientId   Int        @map("patient_id")
-  periodType  PeriodType @map("period_type")
-  mealType    String     @map("meal_type") @db.VarChar(20)
-  glycemia    Decimal?   @db.Decimal(4, 2) // g/L
-  color       String?    @db.VarChar(10)
-  glycemia1h  Decimal?   @map("glycemia_1h") @db.Decimal(4, 2)
-  color1h     String?    @map("color_1h") @db.VarChar(10)
-  updatedAt   DateTime   @updatedAt @map("updated_at") @db.Timestamptz()
+  id         Int        @id @default(autoincrement())
+  patientId  Int        @map("patient_id")
+  periodType PeriodType @map("period_type")
+  mealType   String     @map("meal_type") @db.VarChar(20)
+  glycemia   Decimal?   @db.Decimal(4, 2) // g/L
+  color      String?    @db.VarChar(10)
+  glycemia1h Decimal?   @map("glycemia_1h") @db.Decimal(4, 2)
+  color1h    String?    @map("color_1h") @db.VarChar(10)
+  updatedAt  DateTime   @updatedAt @map("updated_at") @db.Timestamptz()
 
   patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
 
@@ -1316,44 +1318,44 @@ model DeviceDataSync {
 // ═══════════════════════════════════════════════════════════════
 
 model HealthcareService {
-  id            Int          @id @default(autoincrement())
-  name          String       @db.VarChar(255)
-  establishment String?      @db.VarChar(255)
+  id            Int         @id @default(autoincrement())
+  name          String      @db.VarChar(255)
+  establishment String?     @db.VarChar(255)
   /// US-2117 — Adresse complète (chiffrée AES-256-GCM si contient des PII
   /// identifiables ; ici champ de rue donc plain). Utile pour annuaire,
   /// envoi documents postaux, etc.
-  addressLine1  String?      @map("address_line1") @db.VarChar(255)
-  addressLine2  String?      @map("address_line2") @db.VarChar(255)
-  postalCode    String?      @map("postal_code") @db.VarChar(10)
-  city          String?      @db.VarChar(100)
-  country       String?      @db.Char(2)
+  addressLine1  String?     @map("address_line1") @db.VarChar(255)
+  addressLine2  String?     @map("address_line2") @db.VarChar(255)
+  postalCode    String?     @map("postal_code") @db.VarChar(10)
+  city          String?     @db.VarChar(100)
+  country       String?     @db.Char(2)
   /// US-2117 — Coordonnées de contact (publiques cabinet).
-  phone         String?      @db.VarChar(30)
-  email         String?      @db.VarChar(255)
-  website       String?      @db.VarChar(500)
+  phone         String?     @db.VarChar(30)
+  email         String?     @db.VarChar(255)
+  website       String?     @db.VarChar(500)
   /// US-2117 — Horaires d'ouverture format JSON :
   /// { mon: [["09:00","12:00"],["14:00","18:00"]], tue: [...], ..., sun: [] }
   /// Tableau vide = fermé. Validation côté service (Zod).
-  openingHours  Json?        @map("opening_hours")
+  openingHours  Json?       @map("opening_hours")
   /// US-2117 — Spécialités cliniques (libellés libres ou codes CIM).
   /// Ex: ["diabetologie", "endocrinologie", "pediatrie"]. Cardinalité 0-N.
-  specialties   String[]     @default([])
+  specialties   String[]    @default([])
   /// US-2117 — Capacité (lits / box / postes consultation). Optionnel.
   capacity      Int?
   /// US-2117 — Manager responsable (User backoffice). Différent du référent
   /// patient (qui est par patient). Le manager voit tous les patients du
   /// service via PatientService (relation existante).
-  managerId     Int?         @map("manager_id")
+  managerId     Int?        @map("manager_id")
   /// `Restrict` cohérent avec le reste du schéma (statusChangedBy, BackupLog.triggeredBy) :
   /// la suppression d'un User manager d'un service échoue côté DB, forçant un
   /// admin à réassigner explicitement avant deletion. Évite l'orphelinage silencieux
   /// d'une structure dont le manager a été supprimé.
-  manager       User?        @relation("HealthcareServiceManager", fields: [managerId], references: [id], onDelete: Restrict)
-  noVideos      Boolean      @default(false) @map("no_videos")
-  noFood        Boolean      @default(false) @map("no_food")
-  logo          String?      @db.VarChar(500)
+  manager       User?       @relation("HealthcareServiceManager", fields: [managerId], references: [id], onDelete: Restrict)
+  noVideos      Boolean     @default(false) @map("no_videos")
+  noFood        Boolean     @default(false) @map("no_food")
+  logo          String?     @db.VarChar(500)
   /// US-2118 — Type de structure (cabinet, hôpital, praticien libéral).
-  type          ServiceType  @default(clinic)
+  type          ServiceType @default(clinic)
   /// US-2118 — Numéro RPPS (11 digits) / ADELI (9 digits) pour praticiens
   /// libéraux. Validation Luhn + format côté service. Optionnel pour
   /// cabinets / hôpitaux.
@@ -1363,21 +1365,21 @@ model HealthcareService {
   /// contrainte unique inline rejetterait la création du nouveau cabinet
   /// avant suppression de l'ancien. La validation business (warning
   /// "RPPS déjà utilisé") est appliquée au service layer si besoin futur.
-  licenseNumber String?      @map("license_number") @db.VarChar(11)
+  licenseNumber String?     @map("license_number") @db.VarChar(11)
 
-  members         HealthcareMember[]
-  patientServices PatientService[]
-  referents       PatientReferent[]
+  members                    HealthcareMember[]
+  patientServices            PatientService[]
+  referents                  PatientReferent[]
   /// US-2022 — Tags (catégorisation libre) appartenant à ce cabinet.
-  patientTags     PatientTag[]
+  patientTags                PatientTag[]
   /// US-2078 — Templates de messages partagés au sein du cabinet.
-  messageTemplates MessageTemplate[]
+  messageTemplates           MessageTemplate[]
   /// Groupe 10 Batch A US-2220 — Bibliothèque de templates de seuils
-  alertThresholdTemplates AlertThresholdTemplate[]
+  alertThresholdTemplates    AlertThresholdTemplate[]
   /// Groupe 10 Batch B US-2228 — Snapshots quotidiens KPIs cohorte
-  cohortAnalyticsSnapshots CohortAnalyticsSnapshot[]
+  cohortAnalyticsSnapshots   CohortAnalyticsSnapshot[]
   /// US-2088 — Groupes patients (cohortes).
-  patientGroups   PatientGroup[]
+  patientGroups              PatientGroup[]
   /// US-2050 — Templates d'ajustement insuline (cabinet-scoped).
   insulinAdjustmentTemplates InsulinAdjustmentTemplate[]
 
@@ -1399,21 +1401,21 @@ model HealthcareMember {
   serviceId Int?   @map("service_id")
 
   /// US-2505 — Mode de prise de RDV (auto-confirm vs validation manuelle).
-  bookingMode    BookingMode @default(auto) @map("booking_mode")
+  bookingMode               BookingMode @default(auto) @map("booking_mode")
   /// US-2505 — Durée par défaut (min) appliquée si l'input ne précise pas.
-  defaultAppointmentMinutes Int? @map("default_appointment_minutes")
+  defaultAppointmentMinutes Int?        @map("default_appointment_minutes")
 
-  service         HealthcareService? @relation(fields: [serviceId], references: [id])
-  patientServices PatientService[]
-  referents       PatientReferent[]
-  documents       MedicalDocument[]
+  service          HealthcareService?     @relation(fields: [serviceId], references: [id])
+  patientServices  PatientService[]
+  referents        PatientReferent[]
+  documents        MedicalDocument[]
   /// US-2084 — Absences du membre + couvertures qu'il assure pour autrui
-  absencesAsOwner    MemberAbsence[]  @relation("MemberAbsenceOwner")
-  absencesAsCover    MemberAbsence[]  @relation("MemberAbsenceCover")
+  absencesAsOwner  MemberAbsence[]        @relation("MemberAbsenceOwner")
+  absencesAsCover  MemberAbsence[]        @relation("MemberAbsenceCover")
   /// US-2500/2501 — RDV portés par ce membre.
-  appointments       Appointment[]
+  appointments     Appointment[]
   /// US-2504 — Plages indisponibles (créneaux bloqués pour la prise de RDV).
-  unavailabilities   MemberUnavailability[]
+  unavailabilities MemberUnavailability[]
 
   @@unique([name, serviceId])
   @@map("healthcare_members")
@@ -1428,14 +1430,14 @@ model HealthcareMember {
 /// vérifie qu'aucun `Appointment.status IN scheduled/confirmed/pending_validation`
 /// ne touche l'intervalle avant insertion).
 model MemberUnavailability {
-  id        Int       @id @default(autoincrement())
-  memberId  Int       @map("member_id")
-  startAt   DateTime  @map("start_at") @db.Timestamptz()
-  endAt     DateTime  @map("end_at") @db.Timestamptz()
+  id              Int      @id @default(autoincrement())
+  memberId        Int      @map("member_id")
+  startAt         DateTime @map("start_at") @db.Timestamptz()
+  endAt           DateTime @map("end_at") @db.Timestamptz()
   /// Raison chiffrée AES-256-GCM (PHI possible : "congé maladie", "examen médical").
-  reasonEncrypted String? @map("reason_encrypted")
-  createdBy Int?      @map("created_by")
-  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz()
+  reasonEncrypted String?  @map("reason_encrypted")
+  createdBy       Int?     @map("created_by")
+  createdAt       DateTime @default(now()) @map("created_at") @db.Timestamptz()
 
   member  HealthcareMember @relation(fields: [memberId], references: [id], onDelete: Cascade)
   creator User?            @relation("MemberUnavailabilityCreator", fields: [createdBy], references: [id], onDelete: SetNull)
@@ -1528,63 +1530,63 @@ model PatientTagAssignment {
 // ═══════════════════════════════════════════════════════════════
 
 model MedicalDocument {
-  id              Int               @id @default(autoincrement())
-  patientId       Int               @map("patient_id")
-  title           String            @db.VarChar(255)
-  date            DateTime          @db.Timestamptz()
-  memberId        Int?              @map("member_id")
-  patientShare    Boolean           @default(true) @map("patient_share")
-  isAuthorPsad    Boolean           @default(false) @map("is_author_psad")
-  shareWithPsad   Boolean           @default(false) @map("share_with_psad")
-  category        DocumentCategory?
-  mimeType        String            @default("application/pdf") @map("mime_type") @db.VarChar(100)
-  fileUrl         String?           @map("file_url") @db.VarChar(500)
-  fileSize        BigInt?           @map("file_size")
-  isDownloaded    Boolean           @default(false) @map("is_downloaded")
-  isRead          Boolean           @default(false) @map("is_read")
-  createdAt       DateTime          @default(now()) @map("created_at") @db.Timestamptz()
+  id            Int               @id @default(autoincrement())
+  patientId     Int               @map("patient_id")
+  title         String            @db.VarChar(255)
+  date          DateTime          @db.Timestamptz()
+  memberId      Int?              @map("member_id")
+  patientShare  Boolean           @default(true) @map("patient_share")
+  isAuthorPsad  Boolean           @default(false) @map("is_author_psad")
+  shareWithPsad Boolean           @default(false) @map("share_with_psad")
+  category      DocumentCategory?
+  mimeType      String            @default("application/pdf") @map("mime_type") @db.VarChar(100)
+  fileUrl       String?           @map("file_url") @db.VarChar(500)
+  fileSize      BigInt?           @map("file_size")
+  isDownloaded  Boolean           @default(false) @map("is_downloaded")
+  isRead        Boolean           @default(false) @map("is_read")
+  createdAt     DateTime          @default(now()) @map("created_at") @db.Timestamptz()
 
-  patient Patient          @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  patient Patient           @relation(fields: [patientId], references: [id], onDelete: Cascade)
   member  HealthcareMember? @relation(fields: [memberId], references: [id])
 
   @@map("medical_documents")
 }
 
 model Appointment {
-  id        Int       @id @default(autoincrement())
-  patientId Int       @map("patient_id")
-  type      String?   @db.VarChar(50) // ide, diabeto, hdj...
-  date      DateTime  @db.Date
-  hour      DateTime? @db.Time()
-  comment   String?
+  id                    Int                  @id @default(autoincrement())
+  patientId             Int                  @map("patient_id")
+  type                  String?              @db.VarChar(50) // ide, diabeto, hdj...
+  date                  DateTime             @db.Date
+  hour                  DateTime?            @db.Time()
+  comment               String?
   /// US-2500/2501 — Praticien titulaire du RDV (NULL si non-affecté).
-  memberId    Int?              @map("member_id")
+  memberId              Int?                 @map("member_id")
   /// US-2501 — Durée en minutes (15-240). NULL = legacy/non-typé.
-  durationMinutes Int?          @map("duration_minutes")
+  durationMinutes       Int?                 @map("duration_minutes")
   /// US-2501 — Lieu/canal du RDV.
-  location    AppointmentLocation?
+  location              AppointmentLocation?
   /// US-2501/2503 — État du RDV. Defaults `scheduled`, état terminal `cancelled`/`completed`/`no_show`.
   ///                Workflow `pending_validation` activé si le médecin est en mode "validation" (US-2505).
-  status      AppointmentStatus @default(scheduled)
+  status                AppointmentStatus    @default(scheduled)
   /// US-2501 — Motif chiffré AES-256-GCM (base64). PHI : peut contenir nom/symptômes patient.
-  motifEncrypted String?        @map("motif_encrypted")
+  motifEncrypted        String?              @map("motif_encrypted")
   /// US-2501 — Note médicale chiffrée AES-256-GCM (base64). NULL = pas de note.
-  noteEncrypted String?         @map("note_encrypted")
+  noteEncrypted         String?              @map("note_encrypted")
   /// US-2503 — Date/heure proposée par le médecin lors d'une annulation pour
   /// re-programmer. Renseignée par `propose-alternative`, validée par le patient
   /// via `accept-alternative` (qui repasse le RDV en `scheduled` et met à jour
   /// `date` + `hour`). TTL applicatif : la proposition expire après 7 jours.
-  proposedAlternativeAt DateTime? @map("proposed_alternative_at") @db.Timestamptz()
+  proposedAlternativeAt DateTime?            @map("proposed_alternative_at") @db.Timestamptz()
   /// US-2503 — Auteur de l'annulation. Dérivé du rôle au moment du cancel.
-  cancelledBy   CancellationActor? @map("cancelled_by")
+  cancelledBy           CancellationActor?   @map("cancelled_by")
   /// US-2503 — Raison d'annulation chiffrée AES-256-GCM (PHI possible).
-  cancelReasonEncrypted String? @map("cancel_reason_encrypted")
-  cancelledAt   DateTime?       @map("cancelled_at") @db.Timestamptz()
-  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt DateTime  @updatedAt @map("updated_at") @db.Timestamptz()
+  cancelReasonEncrypted String?              @map("cancel_reason_encrypted")
+  cancelledAt           DateTime?            @map("cancelled_at") @db.Timestamptz()
+  createdAt             DateTime             @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt             DateTime             @updatedAt @map("updated_at") @db.Timestamptz()
 
-  patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
-  member  HealthcareMember? @relation(fields: [memberId], references: [id], onDelete: SetNull)
+  patient           Patient               @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  member            HealthcareMember?     @relation(fields: [memberId], references: [id], onDelete: SetNull)
   /// US-2068 — Notes consultation rattachées
   consultationNotes ConsultationNote[]
   /// US-2072 — Acte facturable si téléconsult
@@ -1644,24 +1646,24 @@ enum BookingMode {
 // ═══════════════════════════════════════════════════════════════
 
 model Announcement {
-  id                     Int      @id @default(autoincrement())
-  title                  String   @db.VarChar(255)
-  content                String   // HTML
-  callBackDelay          Int?     @map("call_back_delay")
-  displayAnnouncement    Boolean  @default(true) @map("display_announcement")
-  displayShowButton      Boolean  @default(true) @map("display_show_button")
-  createdAt              DateTime @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt              DateTime @updatedAt @map("updated_at") @db.Timestamptz()
+  id                  Int      @id @default(autoincrement())
+  title               String   @db.VarChar(255)
+  content             String // HTML
+  callBackDelay       Int?     @map("call_back_delay")
+  displayAnnouncement Boolean  @default(true) @map("display_announcement")
+  displayShowButton   Boolean  @default(true) @map("display_show_button")
+  createdAt           DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt           DateTime @updatedAt @map("updated_at") @db.Timestamptz()
 
   @@map("announcements")
 }
 
 model DashboardConfiguration {
-  id          Int      @id @default(autoincrement())
-  userId      Int      @unique @map("user_id")
-  version     Int      @default(1)
-  columnCount Int      @default(4) @map("column_count")
-  name        String?  @db.VarChar(100)
+  id           Int      @id @default(autoincrement())
+  userId       Int      @unique @map("user_id")
+  version      Int      @default(1)
+  columnCount  Int      @default(4) @map("column_count")
+  name         String?  @db.VarChar(100)
   lastModified DateTime @default(now()) @map("last_modified") @db.Timestamptz()
 
   user    User              @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -1704,24 +1706,24 @@ model UnitDefinition {
 // ═══════════════════════════════════════════════════════════════
 
 model PushDeviceRegistration {
-  id              String       @id @default(uuid())
-  userId          Int          @map("user_id")
-  platform        PushPlatform
-  pushToken       String       @unique @map("push_token") @db.VarChar(500)
-  deviceName      String?      @map("device_name") @db.VarChar(100)
-  deviceModel     String?      @map("device_model") @db.VarChar(50)
-  osVersion       String?      @map("os_version") @db.VarChar(20)
-  appVersion      String?      @map("app_version") @db.VarChar(20)
-  appBundleId     String?      @map("app_bundle_id") @db.VarChar(100)
-  endpointArn     String?      @map("endpoint_arn") @db.VarChar(500)
-  locale          String?      @default("fr") @db.VarChar(10)
-  pushTimezone    String?      @map("push_timezone") @db.VarChar(50)
-  isActive        Boolean      @default(true) @map("is_active")
-  isSandbox       Boolean      @default(false) @map("is_sandbox")
-  lastUsedAt      DateTime?    @map("last_used_at") @db.Timestamptz()
-  registeredAt    DateTime     @default(now()) @map("registered_at") @db.Timestamptz()
-  updatedAt       DateTime     @updatedAt @map("updated_at") @db.Timestamptz()
-  unregisteredAt  DateTime?    @map("unregistered_at") @db.Timestamptz()
+  id             String       @id @default(uuid())
+  userId         Int          @map("user_id")
+  platform       PushPlatform
+  pushToken      String       @unique @map("push_token") @db.VarChar(500)
+  deviceName     String?      @map("device_name") @db.VarChar(100)
+  deviceModel    String?      @map("device_model") @db.VarChar(50)
+  osVersion      String?      @map("os_version") @db.VarChar(20)
+  appVersion     String?      @map("app_version") @db.VarChar(20)
+  appBundleId    String?      @map("app_bundle_id") @db.VarChar(100)
+  endpointArn    String?      @map("endpoint_arn") @db.VarChar(500)
+  locale         String?      @default("fr") @db.VarChar(10)
+  pushTimezone   String?      @map("push_timezone") @db.VarChar(50)
+  isActive       Boolean      @default(true) @map("is_active")
+  isSandbox      Boolean      @default(false) @map("is_sandbox")
+  lastUsedAt     DateTime?    @map("last_used_at") @db.Timestamptz()
+  registeredAt   DateTime     @default(now()) @map("registered_at") @db.Timestamptz()
+  updatedAt      DateTime     @updatedAt @map("updated_at") @db.Timestamptz()
+  unregisteredAt DateTime?    @map("unregistered_at") @db.Timestamptz()
 
   user User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
   logs PushNotificationLog[]
@@ -1732,26 +1734,26 @@ model PushDeviceRegistration {
 }
 
 model PushNotificationTemplate {
-  id                   String               @id @db.VarChar(50)
-  category             String               @db.VarChar(30)
-  titleFr              String               @map("title_fr") @db.VarChar(200)
-  titleEn              String               @map("title_en") @db.VarChar(200)
-  titleAr              String               @map("title_ar") @db.VarChar(200)
-  bodyFr               String               @map("body_fr")
-  bodyEn               String               @map("body_en")
-  bodyAr               String               @map("body_ar")
-  iosSound             String?              @default("default") @map("ios_sound") @db.VarChar(50)
-  iosBadgeIncrement    Int?                 @default(1) @map("ios_badge_increment")
-  iosCategory          String?              @map("ios_category") @db.VarChar(50)
+  id                   String                @id @db.VarChar(50)
+  category             String                @db.VarChar(30)
+  titleFr              String                @map("title_fr") @db.VarChar(200)
+  titleEn              String                @map("title_en") @db.VarChar(200)
+  titleAr              String                @map("title_ar") @db.VarChar(200)
+  bodyFr               String                @map("body_fr")
+  bodyEn               String                @map("body_en")
+  bodyAr               String                @map("body_ar")
+  iosSound             String?               @default("default") @map("ios_sound") @db.VarChar(50)
+  iosBadgeIncrement    Int?                  @default(1) @map("ios_badge_increment")
+  iosCategory          String?               @map("ios_category") @db.VarChar(50)
   iosInterruptionLevel IosInterruptionLevel? @default(active) @map("ios_interruption_level")
-  androidChannelId     String?              @map("android_channel_id") @db.VarChar(50)
-  androidPriority      AndroidPriority?     @default(high) @map("android_priority")
-  androidIcon          String?              @map("android_icon") @db.VarChar(50)
-  dataPayload          Json?                @map("data_payload")
-  ttlSeconds           Int?                 @default(86400) @map("ttl_seconds")
-  isActive             Boolean              @default(true) @map("is_active")
-  createdAt            DateTime             @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt            DateTime             @updatedAt @map("updated_at") @db.Timestamptz()
+  androidChannelId     String?               @map("android_channel_id") @db.VarChar(50)
+  androidPriority      AndroidPriority?      @default(high) @map("android_priority")
+  androidIcon          String?               @map("android_icon") @db.VarChar(50)
+  dataPayload          Json?                 @map("data_payload")
+  ttlSeconds           Int?                  @default(86400) @map("ttl_seconds")
+  isActive             Boolean               @default(true) @map("is_active")
+  createdAt            DateTime              @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt            DateTime              @updatedAt @map("updated_at") @db.Timestamptz()
 
   logs      PushNotificationLog[]
   scheduled PushScheduledNotification[]
@@ -1790,23 +1792,23 @@ model PushNotificationLog {
 }
 
 model PushScheduledNotification {
-  id                 String       @id @default(uuid())
-  userId             Int          @map("user_id")
-  templateId         String       @map("template_id") @db.VarChar(50)
-  scheduleType       ScheduleType @map("schedule_type")
-  scheduledAt        DateTime?    @map("scheduled_at") @db.Timestamptz()
-  cronExpression     String?      @map("cron_expression") @db.VarChar(50)
-  cronTimezone       String       @default("Europe/Paris") @map("cron_timezone") @db.VarChar(50)
-  templateVariables  Json?        @map("template_variables")
-  platforms          PushPlatform[] @default([ios, android, web])
-  isActive           Boolean      @default(true) @map("is_active")
-  lastTriggeredAt    DateTime?    @map("last_triggered_at") @db.Timestamptz()
-  nextTriggerAt      DateTime?    @map("next_trigger_at") @db.Timestamptz()
-  maxOccurrences     Int?         @map("max_occurrences")
-  occurrencesCount   Int          @default(0) @map("occurrences_count")
-  expiresAt          DateTime?    @map("expires_at") @db.Timestamptz()
-  createdAt          DateTime     @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt          DateTime     @updatedAt @map("updated_at") @db.Timestamptz()
+  id                String         @id @default(uuid())
+  userId            Int            @map("user_id")
+  templateId        String         @map("template_id") @db.VarChar(50)
+  scheduleType      ScheduleType   @map("schedule_type")
+  scheduledAt       DateTime?      @map("scheduled_at") @db.Timestamptz()
+  cronExpression    String?        @map("cron_expression") @db.VarChar(50)
+  cronTimezone      String         @default("Europe/Paris") @map("cron_timezone") @db.VarChar(50)
+  templateVariables Json?          @map("template_variables")
+  platforms         PushPlatform[] @default([ios, android, web])
+  isActive          Boolean        @default(true) @map("is_active")
+  lastTriggeredAt   DateTime?      @map("last_triggered_at") @db.Timestamptz()
+  nextTriggerAt     DateTime?      @map("next_trigger_at") @db.Timestamptz()
+  maxOccurrences    Int?           @map("max_occurrences")
+  occurrencesCount  Int            @default(0) @map("occurrences_count")
+  expiresAt         DateTime?      @map("expires_at") @db.Timestamptz()
+  createdAt         DateTime       @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt         DateTime       @updatedAt @map("updated_at") @db.Timestamptz()
 
   user     User                     @relation(fields: [userId], references: [id], onDelete: Cascade)
   template PushNotificationTemplate @relation(fields: [templateId], references: [id])
@@ -1856,21 +1858,21 @@ model AuditLog {
 /// Table utilisée UNIQUEMENT en environnement de recette (staging).
 /// Les identifiants (email, password) sont chiffrés AES-256-GCM.
 model MyDiabbyCredential {
-  id              Int       @id @default(autoincrement())
-  userId          Int       @unique @map("user_id")
-  user            User      @relation(fields: [userId], references: [id], onDelete: Cascade)
-  mydiabbyUid     Int       @map("mydiabby_uid")
-  email           String                                    // Chiffré AES-256-GCM
-  password        String                                    // Chiffré AES-256-GCM
-  token           String?   @db.Text                        // JWT MyDiabby courant
-  refreshToken    String?   @map("refresh_token") @db.Text  // Refresh token MyDiabby
-  tokenExpiresAt  DateTime? @map("token_expires_at") @db.Timestamptz()
-  lastSyncAt      DateTime? @map("last_sync_at") @db.Timestamptz()
-  lastSequenceNum String?   @map("last_sequence_num")       // Pour sync différentielle
-  consecutiveErrors Int     @default(0) @map("consecutive_errors")
-  isActive        Boolean   @default(true) @map("is_active")
-  createdAt       DateTime  @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt       DateTime  @updatedAt @map("updated_at") @db.Timestamptz()
+  id                Int       @id @default(autoincrement())
+  userId            Int       @unique @map("user_id")
+  user              User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  mydiabbyUid       Int       @map("mydiabby_uid")
+  email             String // Chiffré AES-256-GCM
+  password          String // Chiffré AES-256-GCM
+  token             String?   @db.Text // JWT MyDiabby courant
+  refreshToken      String?   @map("refresh_token") @db.Text // Refresh token MyDiabby
+  tokenExpiresAt    DateTime? @map("token_expires_at") @db.Timestamptz()
+  lastSyncAt        DateTime? @map("last_sync_at") @db.Timestamptz()
+  lastSequenceNum   String?   @map("last_sequence_num") // Pour sync différentielle
+  consecutiveErrors Int       @default(0) @map("consecutive_errors")
+  isActive          Boolean   @default(true) @map("is_active")
+  createdAt         DateTime  @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt         DateTime  @updatedAt @map("updated_at") @db.Timestamptz()
 
   syncLogs MyDiabbySyncLog[]
 
@@ -1880,17 +1882,17 @@ model MyDiabbyCredential {
 /// Journal de chaque exécution de synchronisation MyDiabby.
 /// Permet le suivi et le diagnostic des imports.
 model MyDiabbySyncLog {
-  id              Int      @id @default(autoincrement())
-  credentialId    Int      @map("credential_id")
-  credential      MyDiabbyCredential @relation(fields: [credentialId], references: [id], onDelete: Cascade)
-  status          String   @db.VarChar(20)                  // "success" | "error" | "partial"
-  cgmCount        Int      @default(0) @map("cgm_count")
-  glycemiaCount   Int      @default(0) @map("glycemia_count")
-  eventCount      Int      @default(0) @map("event_count")
-  profileUpdated  Boolean  @default(false) @map("profile_updated")
-  errorMessage    String?  @map("error_message") @db.Text
-  durationMs      Int      @map("duration_ms")
-  createdAt       DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  id             Int                @id @default(autoincrement())
+  credentialId   Int                @map("credential_id")
+  credential     MyDiabbyCredential @relation(fields: [credentialId], references: [id], onDelete: Cascade)
+  status         String             @db.VarChar(20) // "success" | "error" | "partial"
+  cgmCount       Int                @default(0) @map("cgm_count")
+  glycemiaCount  Int                @default(0) @map("glycemia_count")
+  eventCount     Int                @default(0) @map("event_count")
+  profileUpdated Boolean            @default(false) @map("profile_updated")
+  errorMessage   String?            @map("error_message") @db.Text
+  durationMs     Int                @map("duration_ms")
+  createdAt      DateTime           @default(now()) @map("created_at") @db.Timestamptz()
 
   @@index([credentialId, createdAt])
   @@map("mydiabby_sync_logs")
@@ -1904,23 +1906,23 @@ model MyDiabbySyncLog {
 /// Source : fichier CIS_bdpm.txt (~14 000 entrées).
 /// Licence Ouverte 2.0 — attribution ANSM/BDPM requise.
 model BdpmSpecialty {
-  id            Int      @id @default(autoincrement())
-  codeCIS       String   @unique @map("code_cis") @db.VarChar(8)
-  denomination  String   @db.Text
-  formePharma   String   @map("forme_pharma") @db.VarChar(200)
-  voiesAdmin    String   @map("voies_admin") @db.VarChar(500)
-  statutAMM     String   @map("statut_amm") @db.VarChar(100)
-  procedureAMM  String?  @map("procedure_amm") @db.VarChar(100)
-  etatComm      String?  @map("etat_comm") @db.VarChar(100)
-  dateAMM       DateTime? @map("date_amm") @db.Date
-  titulaires    String?  @db.Text
-  surveillance  Boolean  @default(false)
-  atcCode       String?  @map("atc_code") @db.VarChar(10)
+  id           Int       @id @default(autoincrement())
+  codeCIS      String    @unique @map("code_cis") @db.VarChar(8)
+  denomination String    @db.Text
+  formePharma  String    @map("forme_pharma") @db.VarChar(200)
+  voiesAdmin   String    @map("voies_admin") @db.VarChar(500)
+  statutAMM    String    @map("statut_amm") @db.VarChar(100)
+  procedureAMM String?   @map("procedure_amm") @db.VarChar(100)
+  etatComm     String?   @map("etat_comm") @db.VarChar(100)
+  dateAMM      DateTime? @map("date_amm") @db.Date
+  titulaires   String?   @db.Text
+  surveillance Boolean   @default(false)
+  atcCode      String?   @map("atc_code") @db.VarChar(10)
 
   presentations BdpmPresentation[]
   compositions  BdpmComposition[]
-  createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt     DateTime @updatedAt @map("updated_at") @db.Timestamptz()
+  createdAt     DateTime           @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt     DateTime           @updatedAt @map("updated_at") @db.Timestamptz()
 
   @@index([denomination(ops: raw("gin_trgm_ops"))], type: Gin)
   @@index([atcCode])
@@ -1931,18 +1933,18 @@ model BdpmSpecialty {
 /// Présentation d'un médicament (boîte, conditionnement).
 /// Source : fichier CIS_CIP_bdpm.txt (~20 000 entrées).
 model BdpmPresentation {
-  id            Int      @id @default(autoincrement())
-  codeCIS       String   @map("code_cis") @db.VarChar(8)
-  codeCIP7      String?  @map("code_cip7") @db.VarChar(7)
-  codeCIP13     String   @unique @map("code_cip13") @db.VarChar(13)
-  libelle       String   @db.Text
-  statutAdmin   String?  @map("statut_admin") @db.VarChar(100)
-  etatComm      String?  @map("etat_comm") @db.VarChar(100)
-  tauxRemb      String?  @map("taux_remb") @db.VarChar(20)
-  prix          Decimal? @db.Decimal(10, 2)
-  createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  id          Int      @id @default(autoincrement())
+  codeCIS     String   @map("code_cis") @db.VarChar(8)
+  codeCIP7    String?  @map("code_cip7") @db.VarChar(7)
+  codeCIP13   String   @unique @map("code_cip13") @db.VarChar(13)
+  libelle     String   @db.Text
+  statutAdmin String?  @map("statut_admin") @db.VarChar(100)
+  etatComm    String?  @map("etat_comm") @db.VarChar(100)
+  tauxRemb    String?  @map("taux_remb") @db.VarChar(20)
+  prix        Decimal? @db.Decimal(10, 2)
+  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz()
 
-  specialty     BdpmSpecialty @relation(fields: [codeCIS], references: [codeCIS], onDelete: Cascade)
+  specialty BdpmSpecialty @relation(fields: [codeCIS], references: [codeCIS], onDelete: Cascade)
 
   @@index([codeCIS])
   @@map("bdpm_presentations")
@@ -1960,7 +1962,7 @@ model BdpmComposition {
   nature        String   @db.VarChar(5) // "SA" (substance active) ou "ST" (fraction thérapeutique)
   createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz()
 
-  specialty     BdpmSpecialty @relation(fields: [codeCIS], references: [codeCIS], onDelete: Cascade)
+  specialty BdpmSpecialty @relation(fields: [codeCIS], references: [codeCIS], onDelete: Cascade)
 
   @@index([codeCIS])
   @@index([substance(ops: raw("gin_trgm_ops"))], type: Gin)
@@ -2010,22 +2012,22 @@ model BdpmImportLog {
 /// **HDS** : aucune donnée patient en clair n'est stockée ici. La location
 /// (URI S3) est une référence, pas le payload chiffré du dump lui-même.
 model BackupLog {
-  id            Int          @id @default(autoincrement())
+  id           Int          @id @default(autoincrement())
   /// Identifiant opaque retourné par le worker (UUID). Unique pour idempotence.
-  backupRef     String       @unique @map("backup_ref") @db.VarChar(64)
-  status        BackupStatus @default(pending)
+  backupRef    String       @unique @map("backup_ref") @db.VarChar(64)
+  status       BackupStatus @default(pending)
   /// URI S3 où le dump est stocké (s3://bucket/path/dump.sql.gz). Nullable
   /// jusqu'à completion. Jamais loggué en clair (ANSSI RGS).
-  location      String?      @db.VarChar(500)
-  sizeBytes     BigInt?      @map("size_bytes")
-  durationMs    Int?         @map("duration_ms")
+  location     String?      @db.VarChar(500)
+  sizeBytes    BigInt?      @map("size_bytes")
+  durationMs   Int?         @map("duration_ms")
   /// User-ID de l'admin ayant déclenché le backup (NULL si cron auto).
-  triggeredBy   Int?         @map("triggered_by")
-  triggerer     User?        @relation("BackupTriggeredBy", fields: [triggeredBy], references: [id], onDelete: Restrict)
+  triggeredBy  Int?         @map("triggered_by")
+  triggerer    User?        @relation("BackupTriggeredBy", fields: [triggeredBy], references: [id], onDelete: Restrict)
   /// Brève description erreur (non-PII). Stack traces dans les logs serveur.
-  errorMessage  String?      @map("error_message") @db.VarChar(500)
-  startedAt     DateTime     @default(now()) @map("started_at") @db.Timestamptz()
-  completedAt   DateTime?    @map("completed_at") @db.Timestamptz()
+  errorMessage String?      @map("error_message") @db.VarChar(500)
+  startedAt    DateTime     @default(now()) @map("started_at") @db.Timestamptz()
+  completedAt  DateTime?    @map("completed_at") @db.Timestamptz()
 
   @@index([status, startedAt])
   @@map("backup_logs")
@@ -2045,7 +2047,7 @@ model MessageTemplate {
   id        Int      @id @default(autoincrement())
   serviceId Int      @map("service_id")
   title     String   @db.VarChar(120)
-  body      String   // free-text, max 4096 char validé service-side
+  body      String // free-text, max 4096 char validé service-side
   variables String[] @default([])
   createdBy Int?     @map("created_by")
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz()
@@ -2079,10 +2081,10 @@ model ReadReceipt {
 /// US-2065 — Accusé patient sur une AdjustmentProposal : tracking
 /// lecture / acceptation / rejet côté patient (mobile app).
 model AdjustmentProposalAck {
-  id           Int      @id @default(autoincrement())
-  proposalId   String   @unique @map("proposal_id")
-  patientId    Int      @map("patient_id")
-  acknowledged Boolean  @default(false)
+  id           Int       @id @default(autoincrement())
+  proposalId   String    @unique @map("proposal_id")
+  patientId    Int       @map("patient_id")
+  acknowledged Boolean   @default(false)
   accepted     Boolean?
   readAt       DateTime? @map("read_at") @db.Timestamptz()
   respondedAt  DateTime? @map("responded_at") @db.Timestamptz()
@@ -2123,15 +2125,15 @@ model AdjustmentProposalActualization {
 /// US-2068 — Note de consultation structurée. `content` chiffré AES-256-GCM
 /// (texte libre, peut contenir PII clinique).
 model ConsultationNote {
-  id            Int       @id @default(autoincrement())
-  patientId     Int       @map("patient_id")
-  authorId      Int       @map("author_id")
-  appointmentId Int?      @map("appointment_id")
-  content       String    // chiffré base64
+  id            Int      @id @default(autoincrement())
+  patientId     Int      @map("patient_id")
+  authorId      Int      @map("author_id")
+  appointmentId Int?     @map("appointment_id")
+  content       String // chiffré base64
   /// Catégorie structurelle (anamnèse, examen, conclusion, plan…).
-  category      String?   @db.VarChar(40)
-  createdAt     DateTime  @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt     DateTime  @updatedAt @map("updated_at") @db.Timestamptz()
+  category      String?  @db.VarChar(40)
+  createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt     DateTime @updatedAt @map("updated_at") @db.Timestamptz()
 
   patient     Patient      @relation(fields: [patientId], references: [id], onDelete: Cascade)
   author      User         @relation("ConsultationNoteAuthor", fields: [authorId], references: [id], onDelete: Restrict)
@@ -2144,22 +2146,22 @@ model ConsultationNote {
 /// US-2083 — Demande de délégation IDE → DOCTOR pour une action clinique
 /// nécessitant validation (ex: nouvelle proposition d'ajustement).
 model DelegationRequest {
-  id          Int                       @id @default(autoincrement())
-  patientId   Int                       @map("patient_id")
-  fromUserId  Int                       @map("from_user_id") // IDE qui demande
-  toUserId    Int                       @map("to_user_id")   // DOCTOR sollicité
-  action      String                    @db.VarChar(80)      // ex: "PROPOSE_ADJUSTMENT"
-  payload     Json?
-  status      DelegationRequestStatus   @default(pending)
-  reviewedAt  DateTime?                 @map("reviewed_at") @db.Timestamptz()
-  reviewedBy  Int?                      @map("reviewed_by")
-  reason      String?                   @db.VarChar(500)
-  createdAt   DateTime                  @default(now()) @map("created_at") @db.Timestamptz()
+  id         Int                     @id @default(autoincrement())
+  patientId  Int                     @map("patient_id")
+  fromUserId Int                     @map("from_user_id") // IDE qui demande
+  toUserId   Int                     @map("to_user_id") // DOCTOR sollicité
+  action     String                  @db.VarChar(80) // ex: "PROPOSE_ADJUSTMENT"
+  payload    Json?
+  status     DelegationRequestStatus @default(pending)
+  reviewedAt DateTime?               @map("reviewed_at") @db.Timestamptz()
+  reviewedBy Int?                    @map("reviewed_by")
+  reason     String?                 @db.VarChar(500)
+  createdAt  DateTime                @default(now()) @map("created_at") @db.Timestamptz()
 
-  patient    Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
-  fromUser   User    @relation("DelegationFrom", fields: [fromUserId], references: [id], onDelete: Restrict)
-  toUser     User    @relation("DelegationTo", fields: [toUserId], references: [id], onDelete: Restrict)
-  reviewer   User?   @relation("DelegationReviewer", fields: [reviewedBy], references: [id], onDelete: SetNull)
+  patient  Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  fromUser User    @relation("DelegationFrom", fields: [fromUserId], references: [id], onDelete: Restrict)
+  toUser   User    @relation("DelegationTo", fields: [toUserId], references: [id], onDelete: Restrict)
+  reviewer User?   @relation("DelegationReviewer", fields: [reviewedBy], references: [id], onDelete: SetNull)
 
   @@index([toUserId, status])
   @@index([patientId])
@@ -2178,13 +2180,13 @@ enum DelegationRequestStatus {
 /// US-2084 — Période d'absence d'un membre, avec couverture éventuelle
 /// par un autre membre du même cabinet.
 model MemberAbsence {
-  id              Int      @id @default(autoincrement())
-  memberId        Int      @map("member_id")
-  startDate       DateTime @map("start_date") @db.Date
-  endDate         DateTime @map("end_date") @db.Date
-  coverMemberId   Int?     @map("cover_member_id")
-  reason          String?  @db.VarChar(120)
-  createdAt       DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  id            Int      @id @default(autoincrement())
+  memberId      Int      @map("member_id")
+  startDate     DateTime @map("start_date") @db.Date
+  endDate       DateTime @map("end_date") @db.Date
+  coverMemberId Int?     @map("cover_member_id")
+  reason        String?  @db.VarChar(120)
+  createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz()
 
   member      HealthcareMember  @relation("MemberAbsenceOwner", fields: [memberId], references: [id], onDelete: Cascade)
   coverMember HealthcareMember? @relation("MemberAbsenceCover", fields: [coverMemberId], references: [id], onDelete: SetNull)
@@ -2202,7 +2204,7 @@ model HandoffNote {
   patientId      Int       @map("patient_id")
   fromUserId     Int       @map("from_user_id")
   toUserId       Int       @map("to_user_id")
-  note           String    // chiffré base64
+  note           String // chiffré base64
   acknowledgedAt DateTime? @map("acknowledged_at") @db.Timestamptz()
   createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamptz()
 
@@ -2256,13 +2258,13 @@ model PatientGroupAssignment {
 /// Un Appointment peut avoir un seul Acte (1:1). `billingCode` libre côté
 /// MVP — un futur référentiel `CCAM`/`NABM` pourra contraindre.
 model TeleconsultationActe {
-  id             Int       @id @default(autoincrement())
-  appointmentId  Int       @unique @map("appointment_id")
-  billingCode    String    @map("billing_code") @db.VarChar(20)
-  amountCents    Int?      @map("amount_cents")
-  invoicedAt     DateTime? @map("invoiced_at") @db.Timestamptz()
-  invoicedBy     Int?      @map("invoiced_by")
-  createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamptz()
+  id            Int       @id @default(autoincrement())
+  appointmentId Int       @unique @map("appointment_id")
+  billingCode   String    @map("billing_code") @db.VarChar(20)
+  amountCents   Int?      @map("amount_cents")
+  invoicedAt    DateTime? @map("invoiced_at") @db.Timestamptz()
+  invoicedBy    Int?      @map("invoiced_by")
+  createdAt     DateTime  @default(now()) @map("created_at") @db.Timestamptz()
 
   appointment Appointment @relation(fields: [appointmentId], references: [id], onDelete: Cascade)
   invoicer    User?       @relation("TeleconsultInvoicer", fields: [invoicedBy], references: [id], onDelete: SetNull)
@@ -2279,15 +2281,15 @@ model TeleconsultationActe {
 /// Réutilisable par profil patient (DT1/DT2/GD). `adjustments` est un JSONB
 /// structuré : { parameter: "BASAL"|"ISF"|"ICR", deltaPct: -10, slotStart: 6, ... }.
 model InsulinAdjustmentTemplate {
-  id          Int      @id @default(autoincrement())
-  serviceId   Int      @map("service_id")
-  title       String   @db.VarChar(120)
+  id          Int        @id @default(autoincrement())
+  serviceId   Int        @map("service_id")
+  title       String     @db.VarChar(120)
   pathology   Pathology?
-  parameter   String   @db.VarChar(20) // BASAL | ISF | ICR
+  parameter   String     @db.VarChar(20) // BASAL | ISF | ICR
   adjustments Json
-  createdBy   Int?     @map("created_by")
-  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt   DateTime @updatedAt @map("updated_at") @db.Timestamptz()
+  createdBy   Int?       @map("created_by")
+  createdAt   DateTime   @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt   DateTime   @updatedAt @map("updated_at") @db.Timestamptz()
 
   service HealthcareService @relation(fields: [serviceId], references: [id], onDelete: Restrict)
   creator User?             @relation("InsulinAdjustmentTemplateCreator", fields: [createdBy], references: [id], onDelete: SetNull)
@@ -2331,23 +2333,23 @@ model FoodItem {
 /// avant l'insertion. Pas de plaintext de l'image en base. Métadonnées : mime,
 /// taille, dimensions.
 model MealPhoto {
-  id        Int      @id @default(autoincrement())
-  eventId   String   @map("event_id")
-  patientId Int      @map("patient_id")
-  s3Key     String   @map("s3_key") @db.VarChar(500)
-  mimeType  String   @map("mime_type") @db.VarChar(100)
-  sizeBytes Int      @map("size_bytes")
-  width     Int?
-  height    Int?
-  uploadedBy Int?    @map("uploaded_by")
-  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  id         Int      @id @default(autoincrement())
+  eventId    String   @map("event_id")
+  patientId  Int      @map("patient_id")
+  s3Key      String   @map("s3_key") @db.VarChar(500)
+  mimeType   String   @map("mime_type") @db.VarChar(100)
+  sizeBytes  Int      @map("size_bytes")
+  width      Int?
+  height     Int?
+  uploadedBy Int?     @map("uploaded_by")
+  createdAt  DateTime @default(now()) @map("created_at") @db.Timestamptz()
 
-  event     DiabetesEvent @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  event    DiabetesEvent @relation(fields: [eventId], references: [id], onDelete: Cascade)
   /// Review PR #391 H5 — FK explicite vers Patient pour garantir l'intégrité
   /// même en cas d'écriture SQL directe (la cascade event→patient seule ne
   /// protégeait pas un éventuel re-routage de l'event).
-  patient   Patient       @relation(fields: [patientId], references: [id], onDelete: Cascade)
-  uploader  User?         @relation("MealPhotoUploader", fields: [uploadedBy], references: [id], onDelete: SetNull)
+  patient  Patient       @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  uploader User?         @relation("MealPhotoUploader", fields: [uploadedBy], references: [id], onDelete: SetNull)
 
   @@index([eventId])
   @@index([patientId, createdAt])
@@ -2362,17 +2364,17 @@ model MealPhoto {
 /// `exchangeRate` est la parité vers la devise de référence (EUR ; 1.0 pour EUR).
 /// Pas de PHI ; configuration publique gérée par ADMIN, lue par DOCTOR/NURSE.
 model CountryCurrency {
-  id            Int      @id @default(autoincrement())
-  countryCode   String   @map("country_code") @db.Char(2)   // ISO 3166-1 alpha-2 : FR, DZ
-  currencyCode  String   @map("currency_code") @db.Char(3)  // ISO 4217 : EUR, DZD
-  symbol        String   @db.VarChar(8)                     // €, DA
-  exchangeRate  Decimal  @map("exchange_rate") @db.Decimal(12, 6) // parité → EUR (référence)
-  isActive      Boolean  @default(true) @map("is_active")
-  createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt     DateTime @updatedAt @map("updated_at") @db.Timestamptz()
-  createdBy     Int?     @map("created_by")
+  id           Int      @id @default(autoincrement())
+  countryCode  String   @map("country_code") @db.Char(2) // ISO 3166-1 alpha-2 : FR, DZ
+  currencyCode String   @map("currency_code") @db.Char(3) // ISO 4217 : EUR, DZD
+  symbol       String   @db.VarChar(8) // €, DA
+  exchangeRate Decimal  @map("exchange_rate") @db.Decimal(12, 6) // parité → EUR (référence)
+  isActive     Boolean  @default(true) @map("is_active")
+  createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt    DateTime @updatedAt @map("updated_at") @db.Timestamptz()
+  createdBy    Int?     @map("created_by")
 
-  creator       User?    @relation("CountryCurrencyCreator", fields: [createdBy], references: [id], onDelete: SetNull)
+  creator User? @relation("CountryCurrencyCreator", fields: [createdBy], references: [id], onDelete: SetNull)
 
   @@unique([countryCode, currencyCode])
   @@index([countryCode, isActive])
@@ -2384,19 +2386,19 @@ model CountryCurrency {
 /// changements de taux (ex. TVA FR 19.6 → 20.0 au 01/01/2014).
 /// Pas de PHI.
 model CountryTaxRule {
-  id            Int       @id @default(autoincrement())
-  countryCode   String    @map("country_code") @db.Char(2)
-  taxType       String    @map("tax_type") @db.VarChar(30)
-  baseRate      Decimal   @map("base_rate") @db.Decimal(6, 4) // 0.2000 = 20.00 %
-  description   String?   @db.VarChar(500)
-  appliesFrom   DateTime  @map("applies_from") @db.Date
-  appliesUntil  DateTime? @map("applies_until") @db.Date
-  isActive      Boolean   @default(true) @map("is_active")
-  createdAt     DateTime  @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt     DateTime  @updatedAt @map("updated_at") @db.Timestamptz()
-  createdBy     Int?      @map("created_by")
+  id           Int       @id @default(autoincrement())
+  countryCode  String    @map("country_code") @db.Char(2)
+  taxType      String    @map("tax_type") @db.VarChar(30)
+  baseRate     Decimal   @map("base_rate") @db.Decimal(6, 4) // 0.2000 = 20.00 %
+  description  String?   @db.VarChar(500)
+  appliesFrom  DateTime  @map("applies_from") @db.Date
+  appliesUntil DateTime? @map("applies_until") @db.Date
+  isActive     Boolean   @default(true) @map("is_active")
+  createdAt    DateTime  @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt    DateTime  @updatedAt @map("updated_at") @db.Timestamptz()
+  createdBy    Int?      @map("created_by")
 
-  creator       User?     @relation("CountryTaxRuleCreator", fields: [createdBy], references: [id], onDelete: SetNull)
+  creator User? @relation("CountryTaxRuleCreator", fields: [createdBy], references: [id], onDelete: SetNull)
 
   /// Une seule règle active à la fois pour (pays, type, date début).
   @@unique([countryCode, taxType, appliesFrom])
@@ -2408,20 +2410,20 @@ model CountryTaxRule {
 /// (HDS, ANS, CNIL FR ; DPSP DZ ; etc.). Strictement référentiel —
 /// la conformité opérationnelle reste applicative.
 model HealthcareRegulation {
-  id              Int       @id @default(autoincrement())
-  countryCode     String    @map("country_code") @db.Char(2)
-  regulationType  String    @map("regulation_type") @db.VarChar(50) // RPPS, ADELI, INS, HDS, RGPD, ...
-  title           String    @db.VarChar(200)
-  rule            String    @db.Text   // texte ou JSON
-  references      String?   @db.Text   // URL légifrance / DOM, refs normatives
-  enforcedFrom    DateTime  @map("enforced_from") @db.Date
-  enforcedUntil   DateTime? @map("enforced_until") @db.Date
-  isActive        Boolean   @default(true) @map("is_active")
-  createdAt       DateTime  @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt       DateTime  @updatedAt @map("updated_at") @db.Timestamptz()
-  createdBy       Int?      @map("created_by")
+  id             Int       @id @default(autoincrement())
+  countryCode    String    @map("country_code") @db.Char(2)
+  regulationType String    @map("regulation_type") @db.VarChar(50) // RPPS, ADELI, INS, HDS, RGPD, ...
+  title          String    @db.VarChar(200)
+  rule           String    @db.Text // texte ou JSON
+  references     String?   @db.Text // URL légifrance / DOM, refs normatives
+  enforcedFrom   DateTime  @map("enforced_from") @db.Date
+  enforcedUntil  DateTime? @map("enforced_until") @db.Date
+  isActive       Boolean   @default(true) @map("is_active")
+  createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt      DateTime  @updatedAt @map("updated_at") @db.Timestamptz()
+  createdBy      Int?      @map("created_by")
 
-  creator         User?     @relation("HealthcareRegulationCreator", fields: [createdBy], references: [id], onDelete: SetNull)
+  creator User? @relation("HealthcareRegulationCreator", fields: [createdBy], references: [id], onDelete: SetNull)
 
   @@index([countryCode, regulationType, isActive])
   @@map("healthcare_regulations")
@@ -2432,20 +2434,20 @@ model HealthcareRegulation {
 /// présent dans cette table et `isActive = true`. `killSwitchActive = true`
 /// sur n'importe quelle ligne désactive instantanément tout PUSH (rejet 503).
 model FhirAllowedSystem {
-  id                Int      @id @default(autoincrement())
+  id               Int      @id @default(autoincrement())
   /// Origin (scheme://host[:port]) — pas de path/query, comparé en strict equality.
-  origin            String   @db.VarChar(255)
+  origin           String   @db.VarChar(255)
   /// Description du destinataire pour audit (`DMP Mon Espace Santé`, `EHR Cabinet X`).
-  label             String   @db.VarChar(200)
+  label            String   @db.VarChar(200)
   /// Référence du DPA signé (URL interne ou identifiant document compliance).
-  dpaReference      String   @map("dpa_reference") @db.VarChar(500)
-  isActive          Boolean  @default(true) @map("is_active")
-  killSwitchActive  Boolean  @default(false) @map("kill_switch_active")
-  createdAt         DateTime @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt         DateTime @updatedAt @map("updated_at") @db.Timestamptz()
-  createdBy         Int?     @map("created_by")
+  dpaReference     String   @map("dpa_reference") @db.VarChar(500)
+  isActive         Boolean  @default(true) @map("is_active")
+  killSwitchActive Boolean  @default(false) @map("kill_switch_active")
+  createdAt        DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt        DateTime @updatedAt @map("updated_at") @db.Timestamptz()
+  createdBy        Int?     @map("created_by")
 
-  creator           User?    @relation("FhirAllowedSystemCreator", fields: [createdBy], references: [id], onDelete: SetNull)
+  creator User? @relation("FhirAllowedSystemCreator", fields: [createdBy], references: [id], onDelete: SetNull)
 
   @@unique([origin])
   @@index([isActive, killSwitchActive])
@@ -2458,26 +2460,26 @@ model FhirAllowedSystem {
 /// (file de retry) pour résister aux indisponibilités tierces. Feature flag
 /// `FHIR_ENABLED` (env) gate l'activation.
 model FhirInteroperability {
-  id                Int       @id @default(autoincrement())
-  patientId         Int?      @map("patient_id")
-  resourceType      String    @map("resource_type") @db.VarChar(50)   // Patient, Observation, Medication, MedicationRequest, ...
-  externalSystemUrl String    @map("external_system_url") @db.VarChar(500)
-  fhirResourceId    String?   @map("fhir_resource_id") @db.VarChar(255) // ID retourné par le serveur tiers après PUSH OK
+  id                Int            @id @default(autoincrement())
+  patientId         Int?           @map("patient_id")
+  resourceType      String         @map("resource_type") @db.VarChar(50) // Patient, Observation, Medication, MedicationRequest, ...
+  externalSystemUrl String         @map("external_system_url") @db.VarChar(500)
+  fhirResourceId    String?        @map("fhir_resource_id") @db.VarChar(255) // ID retourné par le serveur tiers après PUSH OK
   /// Payload FHIR JSON chiffré (AES-256-GCM ; format IV+TAG+CIPHERTEXT en base64).
-  payloadEncrypted  String    @map("payload_encrypted") @db.Text
+  payloadEncrypted  String         @map("payload_encrypted") @db.Text
   syncStatus        FhirSyncStatus @default(pending) @map("sync_status")
-  retryCount        Int       @default(0) @map("retry_count")
-  nextRetryAt       DateTime? @map("next_retry_at") @db.Timestamptz()
-  lastSyncedAt      DateTime? @map("last_synced_at") @db.Timestamptz()
-  createdAt         DateTime  @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt         DateTime  @updatedAt @map("updated_at") @db.Timestamptz()
-  createdBy         Int?      @map("created_by")
+  retryCount        Int            @default(0) @map("retry_count")
+  nextRetryAt       DateTime?      @map("next_retry_at") @db.Timestamptz()
+  lastSyncedAt      DateTime?      @map("last_synced_at") @db.Timestamptz()
+  createdAt         DateTime       @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt         DateTime       @updatedAt @map("updated_at") @db.Timestamptz()
+  createdBy         Int?           @map("created_by")
 
   /// H2 — onDelete SetNull preserves the audit trail of PHI exports even when
   /// the patient record is hard-deleted (CNIL/ANS forensic retention).
-  patient           Patient?  @relation(fields: [patientId], references: [id], onDelete: SetNull)
-  creator           User?     @relation("FhirInteroperabilityCreator", fields: [createdBy], references: [id], onDelete: SetNull)
-  syncLogs          FhirSyncLog[]
+  patient  Patient?      @relation(fields: [patientId], references: [id], onDelete: SetNull)
+  creator  User?         @relation("FhirInteroperabilityCreator", fields: [createdBy], references: [id], onDelete: SetNull)
+  syncLogs FhirSyncLog[]
 
   @@index([syncStatus, nextRetryAt])
   @@index([patientId, resourceType])
@@ -2489,15 +2491,15 @@ model FhirInteroperability {
 /// Immuable (un log par tentative). Pas de PHI dans `errorMessage` (le
 /// service tronque/anonymise les corps de réponse).
 model FhirSyncLog {
-  id            Int      @id @default(autoincrement())
-  interopId     Int      @map("interop_id")
-  action        String   @db.VarChar(30)   // PUSH, PULL, TRANSFORM, RETRY
-  httpStatus    Int?     @map("http_status")
-  errorMessage  String?  @map("error_message") @db.Text
-  durationMs    Int?     @map("duration_ms")
-  createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  id           Int      @id @default(autoincrement())
+  interopId    Int      @map("interop_id")
+  action       String   @db.VarChar(30) // PUSH, PULL, TRANSFORM, RETRY
+  httpStatus   Int?     @map("http_status")
+  errorMessage String?  @map("error_message") @db.Text
+  durationMs   Int?     @map("duration_ms")
+  createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz()
 
-  interop       FhirInteroperability @relation(fields: [interopId], references: [id], onDelete: Cascade)
+  interop FhirInteroperability @relation(fields: [interopId], references: [id], onDelete: Cascade)
 
   @@index([interopId, createdAt])
   @@map("fhir_sync_logs")
@@ -2525,27 +2527,28 @@ enum FhirSyncStatus {
 /// utilisé par l'API history pour reconstituer un état passé sans dépendre
 /// de l'évolution future des tables filles.
 model ConfigVersion {
-  id              Int       @id @default(autoincrement())
+  id             Int                 @id @default(autoincrement())
   /// C3-NEW (re-review) — nullable for RGPD Art. 17 hard-delete compatibility :
   /// patient deletion sets this to NULL, preserving config history as orphan
   /// (audit-friendly) without violating the append-only `no_delete` trigger.
-  patientId       Int?      @map("patient_id")
-  configType      ConfigVersionType @map("config_type")
-  version         Int
-  configSnapshot  Json      @map("config_snapshot")
-  validFrom       DateTime  @default(now()) @map("valid_from") @db.Timestamptz()
-  validTo         DateTime? @map("valid_to") @db.Timestamptz()
-  status          ConfigVersionStatus @default(active)
-  createdBy       Int       @map("created_by")
-  validatedBy     Int?      @map("validated_by")
-  validatedAt     DateTime? @map("validated_at") @db.Timestamptz()
-  createdAt       DateTime  @default(now()) @map("created_at") @db.Timestamptz()
+  patientId      Int?                @map("patient_id")
+  configType     ConfigVersionType   @map("config_type")
+  version        Int
+  configSnapshot Json                @map("config_snapshot")
+  validFrom      DateTime            @default(now()) @map("valid_from") @db.Timestamptz()
+  validTo        DateTime?           @map("valid_to") @db.Timestamptz()
+  status         ConfigVersionStatus @default(active)
+  createdBy      Int                 @map("created_by")
+  validatedBy    Int?                @map("validated_by")
+  validatedAt    DateTime?           @map("validated_at") @db.Timestamptz()
+  createdAt      DateTime            @default(now()) @map("created_at") @db.Timestamptz()
 
-  patient         Patient?           @relation(fields: [patientId], references: [id], onDelete: SetNull)
-  creator         User               @relation("ConfigVersionCreator", fields: [createdBy], references: [id])
-  validator       User?              @relation("ConfigVersionValidator", fields: [validatedBy], references: [id], onDelete: SetNull)
-  contacts        EmergencyContact[]
-  escalationRules EscalationRule[]
+  patient             Patient?             @relation(fields: [patientId], references: [id], onDelete: SetNull)
+  creator             User                 @relation("ConfigVersionCreator", fields: [createdBy], references: [id])
+  validator           User?                @relation("ConfigVersionValidator", fields: [validatedBy], references: [id], onDelete: SetNull)
+  contacts            EmergencyContact[]
+  escalationRules     EscalationRule[]
+  pediatricCaregivers PediatricCaregiver[]
 
   @@unique([patientId, configType, version])
   @@index([patientId, configType, validFrom])
@@ -2557,6 +2560,12 @@ enum ConfigVersionType {
   emergency_contacts
   escalation_rules
   alert_thresholds
+  /// US-2233 — Mode pédiatrique (multi-aidants, validation DOCTOR).
+  pediatric_mode
+  /// US-2234 — Mode Ramadan (dates jeûne, sahur/iftar, ISF/ICR adaptés).
+  ramadan_mode
+  /// US-2235 — Mode voyage (fuseau horaire, protocole basal).
+  travel_mode
 
   @@map("config_version_type")
 }
@@ -2575,41 +2584,67 @@ enum ConfigVersionStatus {
 /// US-2218 — Contacts d'urgence (max 5 par patient) joignables en cas
 /// d'alerte critique. `name` et `phone` chiffrés AES-256-GCM (PHI).
 model EmergencyContact {
-  id            Int      @id @default(autoincrement())
-  patientId     Int      @map("patient_id")
-  versionId     Int      @map("version_id")
-  rank          Int
+  id             Int      @id @default(autoincrement())
+  patientId      Int      @map("patient_id")
+  versionId      Int      @map("version_id")
+  rank           Int
   /// AES-256-GCM (base64).
-  nameEncrypted  String  @map("name_encrypted") @db.Text
+  nameEncrypted  String   @map("name_encrypted") @db.Text
   /// AES-256-GCM (base64).
-  phoneEncrypted String  @map("phone_encrypted") @db.Text
-  relationship  String   @db.VarChar(50)
-  isActive      Boolean  @default(true) @map("is_active")
-  createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  phoneEncrypted String   @map("phone_encrypted") @db.Text
+  relationship   String   @db.VarChar(50)
+  isActive       Boolean  @default(true) @map("is_active")
+  createdAt      DateTime @default(now()) @map("created_at") @db.Timestamptz()
 
-  patient       Patient        @relation(fields: [patientId], references: [id], onDelete: Cascade)
-  configVersion ConfigVersion  @relation(fields: [versionId], references: [id], onDelete: Cascade)
+  patient       Patient       @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  configVersion ConfigVersion @relation(fields: [versionId], references: [id], onDelete: Cascade)
 
   @@index([patientId, rank, isActive])
   @@map("emergency_contacts")
 }
 
+/// US-2233 — Aidant pédiatrique (parent, école, baby-sitter, etc.).
+/// PHI : `name` et `phone` chiffrés AES-256-GCM (base64). FK ConfigVersion
+/// pour versioning : la création d'une nouvelle version pédiatrique crée
+/// une nouvelle ligne par aidant lié à la nouvelle `versionId`.
+model PediatricCaregiver {
+  id              Int      @id @default(autoincrement())
+  patientId       Int      @map("patient_id")
+  versionId       Int      @map("version_id")
+  rank            Int
+  /// AES-256-GCM (base64).
+  nameEncrypted   String   @map("name_encrypted") @db.Text
+  /// AES-256-GCM (base64).
+  phoneEncrypted  String   @map("phone_encrypted") @db.Text
+  relationship    String   @db.VarChar(50)
+  /// Permissions : "read" | "write" | "config".
+  permissionLevel String   @map("permission_level") @db.VarChar(20)
+  isActive        Boolean  @default(true) @map("is_active")
+  createdAt       DateTime @default(now()) @map("created_at") @db.Timestamptz()
+
+  patient       Patient       @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  configVersion ConfigVersion @relation(fields: [versionId], references: [id], onDelete: Cascade)
+
+  @@index([patientId, rank, isActive])
+  @@map("pediatric_caregivers")
+}
+
 /// US-2219 — Règles d'escalade urgence (chaîne patient → contact → médecin
 /// → SAMU). `delayMinutes` = délai d'attente avant escalade au target suivant.
 model EscalationRule {
-  id           Int      @id @default(autoincrement())
-  patientId    Int      @map("patient_id")
-  versionId    Int      @map("version_id")
+  id           Int                  @id @default(autoincrement())
+  patientId    Int                  @map("patient_id")
+  versionId    Int                  @map("version_id")
   priority     Int
   targetType   EscalationTargetType @map("target_type")
   /// FK vers EmergencyContact.id (si targetType=contact) ou User.id (si targetType=doctor).
   /// Null pour SAMU (pas de FK).
-  targetId     Int?     @map("target_id")
-  delayMinutes Int      @default(15) @map("delay_minutes")
-  createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  targetId     Int?                 @map("target_id")
+  delayMinutes Int                  @default(15) @map("delay_minutes")
+  createdAt    DateTime             @default(now()) @map("created_at") @db.Timestamptz()
 
-  patient       Patient        @relation(fields: [patientId], references: [id], onDelete: Cascade)
-  configVersion ConfigVersion  @relation(fields: [versionId], references: [id], onDelete: Cascade)
+  patient       Patient       @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  configVersion ConfigVersion @relation(fields: [versionId], references: [id], onDelete: Cascade)
 
   @@index([patientId, priority])
   @@map("escalation_rules")
@@ -2700,18 +2735,18 @@ model CohortAnalyticsSnapshot {
 /// BullMQ job. Trigger une alerte au DOCTOR si score > 70 (niveau HIGH/CRITICAL).
 /// `contributingFactors` = explicabilité du score (rule-based, pas ML pour MVP).
 model PatientRiskScore {
-  id                  Int      @id @default(autoincrement())
-  patientId           Int      @unique @map("patient_id")
-  riskScore           Int      @map("risk_score") @db.SmallInt
+  id                  Int       @id @default(autoincrement())
+  patientId           Int       @unique @map("patient_id")
+  riskScore           Int       @map("risk_score") @db.SmallInt
   riskLevel           RiskLevel @map("risk_level")
-  recentHypoCount     Int      @map("recent_hypo_count")
-  declarationRatio    Decimal  @map("declaration_ratio") @db.Decimal(4, 2)
-  dkaHistory          Boolean  @default(false) @map("dka_history")
-  contributingFactors Json     @map("contributing_factors")
+  recentHypoCount     Int       @map("recent_hypo_count")
+  declarationRatio    Decimal   @map("declaration_ratio") @db.Decimal(4, 2)
+  dkaHistory          Boolean   @default(false) @map("dka_history")
+  contributingFactors Json      @map("contributing_factors")
   flaggedAt           DateTime? @map("flagged_at") @db.Timestamptz()
-  acknowledgedBy      Int?     @map("acknowledged_by")
+  acknowledgedBy      Int?      @map("acknowledged_by")
   acknowledgedAt      DateTime? @map("acknowledged_at") @db.Timestamptz()
-  computedAt          DateTime @default(now()) @map("computed_at") @db.Timestamptz()
+  computedAt          DateTime  @default(now()) @map("computed_at") @db.Timestamptz()
 
   patient      Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
   acknowledger User?   @relation("PatientRiskScoreAcknowledger", fields: [acknowledgedBy], references: [id], onDelete: SetNull)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2619,6 +2619,10 @@ model PediatricCaregiver {
   relationship    String   @db.VarChar(50)
   /// Permissions : "read" | "write" | "config".
   permissionLevel String   @map("permission_level") @db.VarChar(20)
+  /// M2 (healthcare audit) — historical "active" flag retained for parity
+  /// with `emergency_contacts.is_active` ; truth lives in
+  /// `config_versions.status` (filter via `findFirst({ status: active })`).
+  /// Never flipped on supersede ; do NOT query raw SQL on this column.
   isActive        Boolean  @default(true) @map("is_active")
   createdAt       DateTime @default(now()) @map("created_at") @db.Timestamptz()
 
@@ -2626,6 +2630,9 @@ model PediatricCaregiver {
   configVersion ConfigVersion @relation(fields: [versionId], references: [id], onDelete: Cascade)
 
   @@index([patientId, rank, isActive])
+  /// M4 (healthcare audit) — index FK so cascade-include joins from
+  /// ConfigVersion don't sequential-scan at scale.
+  @@index([versionId])
   @@map("pediatric_caregivers")
 }
 

--- a/src/app/api/patient/modes/[type]/deactivate/route.ts
+++ b/src/app/api/patient/modes/[type]/deactivate/route.ts
@@ -1,0 +1,59 @@
+/**
+ * Groupe 10 Batch C — Deactivate active mode (US-2233/2234/2235).
+ * POST — archive the active mode for a patient. Idempotent (200 with
+ * `{ archived: false }` if no active mode). DOCTOR+ only.
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { resolvePatientIdFromQuery } from "@/lib/auth/query-helpers"
+import { requireGdprConsent } from "@/lib/gdpr"
+import {
+  MODE_TYPES, type ModeTypeParam, resolveConfigType,
+} from "@/lib/patient-modes-shared"
+import { patientModeWorkflow } from "@/lib/services/patient-modes.service"
+import {
+  auditService, extractRequestContext,
+} from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+
+type RouteCtx = { params: Promise<{ type: string }> }
+
+export async function POST(req: NextRequest, { params }: RouteCtx) {
+  const { type } = await params
+  const ctx = extractRequestContext(req)
+  try {
+    if (!MODE_TYPES.includes(type as ModeTypeParam)) {
+      return NextResponse.json({ error: "unsupportedModeType" }, { status: 400 })
+    }
+    const configType = resolveConfigType(type)!
+    const user = await auditedRequireRole(req, "DOCTOR", ctx, "CONFIG_VERSION", "deactivate")
+    const res = await resolvePatientIdFromQuery(req, user.id, user.role)
+    if (res.error) {
+      return NextResponse.json({ error: res.error }, {
+        status: res.error === "invalidPatientId" ? 400 : 404,
+      })
+    }
+    const allowed = await canAccessPatient(user.id, user.role, res.patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id, resource: "CONFIG_VERSION", resourceId: String(res.patientId),
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: { patientId: res.patientId, mode: type, endpoint: "deactivate" },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+    const hasConsent = await requireGdprConsent(user.id)
+    if (!hasConsent) {
+      return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
+    }
+    const out = await patientModeWorkflow.deactivate(
+      res.patientId, configType, user.id, ctx,
+    )
+    return NextResponse.json(out)
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, `patient/modes/${type}/deactivate POST`, ctx.requestId)
+  }
+}

--- a/src/app/api/patient/modes/[type]/history/route.ts
+++ b/src/app/api/patient/modes/[type]/history/route.ts
@@ -1,0 +1,58 @@
+/**
+ * Groupe 10 Batch C — Modes spéciaux history (US-2233/2234/2235).
+ * GET — list past versions of a mode for a patient.
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { resolvePatientIdFromQuery } from "@/lib/auth/query-helpers"
+import { requireGdprConsent } from "@/lib/gdpr"
+import {
+  MODE_TYPES, type ModeTypeParam, resolveConfigType,
+} from "@/lib/patient-modes-shared"
+import { patientModeWorkflow } from "@/lib/services/patient-modes.service"
+import {
+  auditService, extractRequestContext,
+} from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+
+type RouteCtx = { params: Promise<{ type: string }> }
+
+export async function GET(req: NextRequest, { params }: RouteCtx) {
+  const { type } = await params
+  const ctx = extractRequestContext(req)
+  try {
+    if (!MODE_TYPES.includes(type as ModeTypeParam)) {
+      return NextResponse.json({ error: "unsupportedModeType" }, { status: 400 })
+    }
+    const configType = resolveConfigType(type)!
+    const user = await auditedRequireRole(req, "VIEWER", ctx, "CONFIG_VERSION", "0")
+    const res = await resolvePatientIdFromQuery(req, user.id, user.role)
+    if (res.error) {
+      return NextResponse.json({ error: res.error }, {
+        status: res.error === "invalidPatientId" ? 400 : 404,
+      })
+    }
+    const allowed = await canAccessPatient(user.id, user.role, res.patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id, resource: "CONFIG_VERSION", resourceId: String(res.patientId),
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: { patientId: res.patientId, mode: type, endpoint: "history" },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+    const hasConsent = await requireGdprConsent(user.id)
+    if (!hasConsent) {
+      return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
+    }
+    const items = await patientModeWorkflow.listHistory(
+      res.patientId, configType, user.id, ctx,
+    )
+    return NextResponse.json({ items })
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, `patient/modes/${type}/history GET`, ctx.requestId)
+  }
+}

--- a/src/app/api/patient/modes/[type]/route.ts
+++ b/src/app/api/patient/modes/[type]/route.ts
@@ -1,0 +1,182 @@
+/**
+ * Groupe 10 Batch C — Modes spéciaux (US-2233/2234/2235).
+ * Dynamic dispatch by `type` ∈ { pediatric, ramadan, travel }.
+ *
+ * GET — read active mode for patient (VIEWER+ on own patient ; NURSE+ on
+ *       managed patient via `canAccessPatient`).
+ * PUT — upsert new version (NURSE+, requires DOCTOR `validate` to go live).
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { resolvePatientIdFromQuery } from "@/lib/auth/query-helpers"
+import { requireGdprConsent } from "@/lib/gdpr"
+import { MODE_TYPES, type ModeTypeParam } from "@/lib/patient-modes-shared"
+import {
+  pediatricModeService,
+  ramadanModeService,
+  travelModeService,
+} from "@/lib/services/patient-modes.service"
+import {
+  auditService, extractRequestContext,
+} from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+
+// Zod schemas — one per mode.
+const pediatricUpsertSchema = z.object({
+  caregivers: z.array(z.object({
+    rank: z.number().int().min(1).max(5),
+    name: z.string().min(1).max(100),
+    phone: z.string().min(1).max(20),
+    relationship: z.string().min(1).max(50),
+    permissionLevel: z.enum(["read", "write", "config"]),
+  })).min(1).max(5),
+})
+
+const ramadanUpsertSchema = z.object({
+  ramadanYear: z.number().int().min(2024).max(2050),
+  startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  sahurTime: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/),
+  iftarTime: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/),
+  allowedFastingHours: z.number().int().min(1).max(20),
+  isfMultiplier: z.number().min(0.5).max(2.0),
+  icrMultiplier: z.number().min(0.5).max(2.0),
+})
+
+const travelUpsertSchema = z.object({
+  destination: z.string().min(1).max(100),
+  timezoneOffsetHours: z.number().min(-12).max(14),
+  departureDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  returnDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  basalMultiplier: z.number().min(0.5).max(1.5),
+  basalDelayHours: z.number().int().min(0).max(24),
+})
+
+type RouteCtx = { params: Promise<{ type: string }> }
+
+export async function GET(req: NextRequest, { params }: RouteCtx) {
+  const { type } = await params
+  const ctx = extractRequestContext(req)
+  try {
+    if (!MODE_TYPES.includes(type as ModeTypeParam)) {
+      return NextResponse.json({ error: "unsupportedModeType" }, { status: 400 })
+    }
+    const user = await auditedRequireRole(req, "VIEWER", ctx, "PATIENT_MODE", "0")
+    const res = await resolvePatientIdFromQuery(req, user.id, user.role)
+    if (res.error) {
+      return NextResponse.json({ error: res.error }, {
+        status: res.error === "invalidPatientId" ? 400 : 404,
+      })
+    }
+    const allowed = await canAccessPatient(user.id, user.role, res.patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id, resource: "PATIENT_MODE", resourceId: String(res.patientId),
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: { patientId: res.patientId, mode: type, endpoint: "get" },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+    // GDPR consent required — PHI decrypt (pediatric) and clinical config reads.
+    const hasConsent = await requireGdprConsent(user.id)
+    if (!hasConsent) {
+      return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
+    }
+    switch (type as ModeTypeParam) {
+      case "pediatric": {
+        const out = await pediatricModeService.getActive(res.patientId, user.id, ctx)
+        return NextResponse.json(out)
+      }
+      case "ramadan": {
+        const out = await ramadanModeService.getActive(res.patientId, user.id, ctx)
+        return NextResponse.json(out)
+      }
+      case "travel": {
+        const out = await travelModeService.getActive(res.patientId, user.id, ctx)
+        return NextResponse.json(out)
+      }
+    }
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, `patient/modes/${type} GET`, ctx.requestId)
+  }
+}
+
+export async function PUT(req: NextRequest, { params }: RouteCtx) {
+  const { type } = await params
+  const ctx = extractRequestContext(req)
+  try {
+    if (!MODE_TYPES.includes(type as ModeTypeParam)) {
+      return NextResponse.json({ error: "unsupportedModeType" }, { status: 400 })
+    }
+    const user = await auditedRequireRole(req, "NURSE", ctx, "PATIENT_MODE", "upsert")
+    const body = await req.json()
+    const res = await resolvePatientIdFromQuery(req, user.id, user.role)
+    if (res.error) {
+      return NextResponse.json({ error: res.error }, {
+        status: res.error === "invalidPatientId" ? 400 : 404,
+      })
+    }
+    const allowed = await canAccessPatient(user.id, user.role, res.patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id, resource: "PATIENT_MODE", resourceId: String(res.patientId),
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: { patientId: res.patientId, mode: type, endpoint: "upsert" },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+    const hasConsent = await requireGdprConsent(user.id)
+    if (!hasConsent) {
+      return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
+    }
+    switch (type as ModeTypeParam) {
+      case "pediatric": {
+        const parsed = pediatricUpsertSchema.safeParse(body)
+        if (!parsed.success) {
+          return NextResponse.json(
+            { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+            { status: 400 },
+          )
+        }
+        const out = await pediatricModeService.upsert(
+          res.patientId, parsed.data.caregivers, user.id, ctx,
+        )
+        return NextResponse.json(out, { status: 201 })
+      }
+      case "ramadan": {
+        const parsed = ramadanUpsertSchema.safeParse(body)
+        if (!parsed.success) {
+          return NextResponse.json(
+            { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+            { status: 400 },
+          )
+        }
+        const out = await ramadanModeService.upsert(
+          res.patientId, parsed.data, user.id, ctx,
+        )
+        return NextResponse.json(out, { status: 201 })
+      }
+      case "travel": {
+        const parsed = travelUpsertSchema.safeParse(body)
+        if (!parsed.success) {
+          return NextResponse.json(
+            { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+            { status: 400 },
+          )
+        }
+        const out = await travelModeService.upsert(
+          res.patientId, parsed.data, user.id, ctx,
+        )
+        return NextResponse.json(out, { status: 201 })
+      }
+    }
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, `patient/modes/${type} PUT`, ctx.requestId)
+  }
+}
+

--- a/src/app/api/patient/modes/[type]/route.ts
+++ b/src/app/api/patient/modes/[type]/route.ts
@@ -31,7 +31,7 @@ const pediatricUpsertSchema = z.object({
     name: z.string().min(1).max(100),
     phone: z.string().min(1).max(20),
     relationship: z.string().min(1).max(50),
-    permissionLevel: z.enum(["read", "write", "config"]),
+    permissionLevel: z.enum(["read", "write", "propose"]),
   })).min(1).max(5),
 })
 

--- a/src/app/api/patient/modes/travel/auto-protocol/route.ts
+++ b/src/app/api/patient/modes/travel/auto-protocol/route.ts
@@ -1,0 +1,38 @@
+/**
+ * Groupe 10 Batch C — Travel mode auto-protocol helper (US-2235).
+ * GET — compute a default basal multiplier + delay from a `tzOffset` query
+ *       param. Stateless helper, no patient FK, no DB write. NURSE+ only
+ *       (UI pre-fill aid ; final values still need DOCTOR validation).
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { AuthError } from "@/lib/auth"
+import { computeBasalProtocol } from "@/lib/services/patient-modes.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+
+const querySchema = z.object({
+  tzOffsetHours: z.coerce.number().min(-12).max(14),
+})
+
+export async function GET(req: NextRequest) {
+  const ctx = extractRequestContext(req)
+  try {
+    await auditedRequireRole(req, "NURSE", ctx, "PATIENT_MODE", "auto-protocol")
+    const parsed = querySchema.safeParse(
+      Object.fromEntries(req.nextUrl.searchParams.entries()),
+    )
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+    const out = computeBasalProtocol(parsed.data.tzOffsetHours)
+    return NextResponse.json(out)
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "patient/modes/travel/auto-protocol GET", ctx.requestId)
+  }
+}

--- a/src/app/api/patient/modes/validate/route.ts
+++ b/src/app/api/patient/modes/validate/route.ts
@@ -1,0 +1,79 @@
+/**
+ * Groupe 10 Batch C — DOCTOR validates a mode version (US-2233/2234/2235).
+ * POST body: { versionId: number }
+ *
+ * Enforces : DOCTOR-only ; the ConfigVersion belongs to a patient the caller
+ * can access (canAccessPatient) ; configType is a supported mode type.
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { requireGdprConsent } from "@/lib/gdpr"
+import { prisma } from "@/lib/db/client"
+import { patientModeWorkflow } from "@/lib/services/patient-modes.service"
+import {
+  auditService, extractRequestContext,
+} from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+import { ConfigVersionType } from "@prisma/client"
+
+const SUPPORTED: ConfigVersionType[] = [
+  ConfigVersionType.pediatric_mode,
+  ConfigVersionType.ramadan_mode,
+  ConfigVersionType.travel_mode,
+]
+
+const schema = z.object({
+  versionId: z.number().int().positive(),
+})
+
+export async function POST(req: NextRequest) {
+  const ctx = extractRequestContext(req)
+  try {
+    const user = await auditedRequireRole(req, "DOCTOR", ctx, "CONFIG_VERSION", "validate")
+    const body = await req.json().catch(() => null)
+    const parsed = schema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+    // C1 — ensure the ConfigVersion exists, belongs to a supported mode type
+    // AND the caller has access to its patient (cross-tenant guard).
+    const row = await prisma.configVersion.findUnique({
+      where: { id: parsed.data.versionId },
+      select: { id: true, patientId: true, configType: true },
+    })
+    if (!row || !SUPPORTED.includes(row.configType)) {
+      return NextResponse.json({ error: "notFound" }, { status: 404 })
+    }
+    if (row.patientId === null) {
+      // Orphan (patient deleted) — refuse to validate.
+      return NextResponse.json({ error: "patientDeleted" }, { status: 410 })
+    }
+    const allowed = await canAccessPatient(user.id, user.role, row.patientId)
+    if (!allowed) {
+      await auditService.accessDenied({
+        userId: user.id, resource: "CONFIG_VERSION", resourceId: String(row.id),
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: {
+          patientId: row.patientId, configType: row.configType,
+          endpoint: "validate",
+        },
+      })
+      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+    }
+    const hasConsent = await requireGdprConsent(user.id)
+    if (!hasConsent) {
+      return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
+    }
+    const out = await patientModeWorkflow.validate(row.id, user.id, ctx)
+    return NextResponse.json(out)
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "patient/modes/validate POST", ctx.requestId)
+  }
+}

--- a/src/lib/patient-modes-shared.ts
+++ b/src/lib/patient-modes-shared.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared mode-type helpers (used by route handlers under
+ * `/api/patient/modes/[type]/*`).
+ */
+
+import { ConfigVersionType } from "@prisma/client"
+
+export const MODE_TYPES = ["pediatric", "ramadan", "travel"] as const
+export type ModeTypeParam = (typeof MODE_TYPES)[number]
+
+export function resolveConfigType(t: string): ConfigVersionType | null {
+  switch (t) {
+    case "pediatric": return ConfigVersionType.pediatric_mode
+    case "ramadan":   return ConfigVersionType.ramadan_mode
+    case "travel":    return ConfigVersionType.travel_mode
+    default: return null
+  }
+}

--- a/src/lib/services/audit.service.ts
+++ b/src/lib/services/audit.service.ts
@@ -175,6 +175,8 @@ export type AuditResource =
   | "COHORT_ANALYTICS"
   /** Groupe 10 Batch B — patient risk score (US-2229). */
   | "PATIENT_RISK_SCORE"
+  /** Groupe 10 Batch C — modes spéciaux (pédiatrique/Ramadan/voyage, US-2233/2234/2235). */
+  | "PATIENT_MODE"
 
 /**
  * Audit log entry — parameters for logging an action.

--- a/src/lib/services/patient-modes.service.ts
+++ b/src/lib/services/patient-modes.service.ts
@@ -1,0 +1,586 @@
+/**
+ * @module patient-modes.service
+ * @description Groupe 10 Batch C — Modes spéciaux (3 US, 16 SP).
+ *
+ *  - US-2233 mode pédiatrique (multi-aidants, PHI nom/téléphone chiffrés)
+ *  - US-2234 mode Ramadan (dates jeûne, sahur/iftar, multiplicateurs ISF/ICR)
+ *  - US-2235 mode voyage (fuseau horaire, protocole basal adapté)
+ *
+ * Tous les modes utilisent le hub `ConfigVersion` (PR #395) :
+ *  - chaque upsert = nouvelle ligne `ConfigVersion`, l'ancienne passe en
+ *    `status=superseded` avec `validTo` set
+ *  - immutability via trigger PostgreSQL `config_versions_immutability`
+ *  - `validate` = DOCTOR signe (validatedBy + validatedAt)
+ *  - `deactivate` = transition vers `status=archived` (manuel ou cron pour
+ *    Ramadan/voyage qui ont une date d'expiration naturelle)
+ *
+ * PHI :
+ *  - Pédiatrique : `name` et `phone` des aidants chiffrés AES-256-GCM dans
+ *    `pediatric_caregivers`. Snapshot ConfigVersion redacted (hasName/hasPhone
+ *    booléens uniquement, pas de PHI sur 6 ans de rétention).
+ *  - Ramadan/voyage : pas de PHI, snapshot plaintext autorisé.
+ */
+
+import {
+  Prisma,
+  ConfigVersionStatus,
+  ConfigVersionType,
+} from "@prisma/client"
+import { prisma, type PrismaClientOrTx as Tx } from "@/lib/db/client"
+import { encryptField, safeDecryptField } from "@/lib/crypto/fields"
+import { auditService, type AuditContext } from "./audit.service"
+import { NotFoundError, ValidationError } from "./team-workflow.errors"
+
+// ─────────────────────────────────────────────────────────────
+// Shared helpers (mirror mirror-v1-config.service patterns)
+// ─────────────────────────────────────────────────────────────
+
+const PERMISSION_LEVELS = ["read", "write", "config"] as const
+export type PermissionLevel = (typeof PERMISSION_LEVELS)[number]
+
+const MAX_CAREGIVERS = 5
+const NAME_MAX_LEN = 100
+const PHONE_MAX_LEN = 20
+const RELATIONSHIP_MAX_LEN = 50
+
+const TIME_HHMM_RE = /^([01]\d|2[0-3]):[0-5]\d$/
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+async function nextVersion(
+  tx: Tx, patientId: number, configType: ConfigVersionType,
+): Promise<number> {
+  const last = await tx.configVersion.findFirst({
+    where: { patientId, configType },
+    orderBy: { version: "desc" },
+    select: { version: true },
+  })
+  return (last?.version ?? 0) + 1
+}
+
+async function supersedePrevious(
+  tx: Tx, patientId: number, configType: ConfigVersionType, now: Date,
+): Promise<void> {
+  await tx.configVersion.updateMany({
+    where: { patientId, configType, status: ConfigVersionStatus.active },
+    data: { status: ConfigVersionStatus.superseded, validTo: now },
+  })
+}
+
+export type ConfigVersionDTO = {
+  id: number
+  patientId: number | null
+  configType: ConfigVersionType
+  version: number
+  validFrom: Date
+  validTo: Date | null
+  status: ConfigVersionStatus
+  createdBy: number
+  validatedBy: number | null
+  validatedAt: Date | null
+  createdAt: Date
+}
+
+function toConfigVersionDTO(r: {
+  id: number; patientId: number | null; configType: ConfigVersionType;
+  version: number; validFrom: Date; validTo: Date | null;
+  status: ConfigVersionStatus; createdBy: number;
+  validatedBy: number | null; validatedAt: Date | null; createdAt: Date;
+}): ConfigVersionDTO {
+  return {
+    id: r.id, patientId: r.patientId, configType: r.configType,
+    version: r.version, validFrom: r.validFrom, validTo: r.validTo,
+    status: r.status, createdBy: r.createdBy,
+    validatedBy: r.validatedBy, validatedAt: r.validatedAt,
+    createdAt: r.createdAt,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2233 — Mode pédiatrique
+// ─────────────────────────────────────────────────────────────
+
+export type PediatricCaregiverInput = {
+  rank: number
+  name: string
+  phone: string
+  relationship: string
+  permissionLevel: PermissionLevel
+}
+
+export type PediatricCaregiverDTO = {
+  id: number
+  rank: number
+  name: string | null
+  phone: string | null
+  relationship: string
+  permissionLevel: PermissionLevel
+  decryptionFailed: boolean
+}
+
+function decodeCaregiver(r: {
+  id: number; rank: number;
+  nameEncrypted: string; phoneEncrypted: string;
+  relationship: string; permissionLevel: string;
+}): PediatricCaregiverDTO {
+  const name = safeDecryptField(r.nameEncrypted)
+  const phone = safeDecryptField(r.phoneEncrypted)
+  return {
+    id: r.id, rank: r.rank,
+    name, phone,
+    relationship: r.relationship,
+    permissionLevel: r.permissionLevel as PermissionLevel,
+    decryptionFailed: name === null || phone === null,
+  }
+}
+
+function validateCaregivers(caregivers: PediatricCaregiverInput[]): void {
+  if (caregivers.length === 0) throw new ValidationError("emptyCaregivers")
+  if (caregivers.length > MAX_CAREGIVERS) throw new ValidationError("tooManyCaregivers")
+  const ranks = new Set<number>()
+  for (const c of caregivers) {
+    if (c.rank < 1 || c.rank > MAX_CAREGIVERS) throw new ValidationError("rank")
+    if (ranks.has(c.rank)) throw new ValidationError("duplicateRank")
+    ranks.add(c.rank)
+    if (!c.name || c.name.length > NAME_MAX_LEN) throw new ValidationError("name")
+    if (!c.phone || c.phone.length > PHONE_MAX_LEN) throw new ValidationError("phone")
+    if (!c.relationship || c.relationship.length > RELATIONSHIP_MAX_LEN) {
+      throw new ValidationError("relationship")
+    }
+    if (!PERMISSION_LEVELS.includes(c.permissionLevel)) {
+      throw new ValidationError("permissionLevel")
+    }
+  }
+}
+
+export const pediatricModeService = {
+  async getActive(patientId: number, auditUserId: number, ctx?: AuditContext): Promise<{
+    version: ConfigVersionDTO | null
+    caregivers: PediatricCaregiverDTO[]
+  }> {
+    const version = await prisma.configVersion.findFirst({
+      where: {
+        patientId,
+        configType: ConfigVersionType.pediatric_mode,
+        status: ConfigVersionStatus.active,
+      },
+      include: { pediatricCaregivers: { orderBy: { rank: "asc" } } },
+    })
+    await auditService.log({
+      userId: auditUserId, action: "READ", resource: "PATIENT_MODE",
+      resourceId: String(patientId),
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { patientId, kind: "pediatric.read" },
+    })
+    const caregivers = version
+      ? version.pediatricCaregivers.map(decodeCaregiver)
+      : []
+    const failed = caregivers.filter((c) => c.decryptionFailed).length
+    if (failed > 0) {
+      await auditService.log({
+        userId: auditUserId, action: "READ", resource: "PATIENT_MODE",
+        resourceId: String(patientId),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: { patientId, kind: "pediatric.decrypt.failure", count: failed },
+      })
+    }
+    return {
+      version: version ? toConfigVersionDTO(version) : null,
+      caregivers,
+    }
+  },
+
+  async upsert(
+    patientId: number, caregivers: PediatricCaregiverInput[],
+    auditUserId: number, ctx?: AuditContext,
+  ): Promise<ConfigVersionDTO> {
+    validateCaregivers(caregivers)
+    return prisma.$transaction(async (tx: Tx) => {
+      const now = new Date()
+      const version = await nextVersion(tx, patientId, ConfigVersionType.pediatric_mode)
+      await supersedePrevious(tx, patientId, ConfigVersionType.pediatric_mode, now)
+      // Snapshot redacted (no PHI) — pattern emergency_contacts (PR #395).
+      const snapshot = caregivers.map((c) => ({
+        rank: c.rank,
+        relationship: c.relationship,
+        permissionLevel: c.permissionLevel,
+        hasName: c.name.length > 0,
+        hasPhone: c.phone.length > 0,
+      })) satisfies Prisma.InputJsonValue
+      const created = await tx.configVersion.create({
+        data: {
+          patientId,
+          configType: ConfigVersionType.pediatric_mode,
+          version,
+          configSnapshot: snapshot,
+          createdBy: auditUserId,
+          pediatricCaregivers: {
+            create: caregivers.map((c) => ({
+              patientId,
+              rank: c.rank,
+              nameEncrypted: encryptField(c.name),
+              phoneEncrypted: encryptField(c.phone),
+              relationship: c.relationship,
+              permissionLevel: c.permissionLevel,
+            })),
+          },
+        },
+      })
+      await auditService.logWithTx(tx, {
+        userId: auditUserId, action: "CREATE", resource: "CONFIG_VERSION",
+        resourceId: String(created.id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: {
+          patientId, kind: "pediatric.upsert",
+          version, count: caregivers.length,
+        },
+      })
+      return toConfigVersionDTO(created)
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2234 — Mode Ramadan
+// ─────────────────────────────────────────────────────────────
+
+export type RamadanModeInput = {
+  ramadanYear: number
+  startDate: string // ISO yyyy-mm-dd
+  endDate: string
+  sahurTime: string // HH:MM
+  iftarTime: string
+  allowedFastingHours: number
+  isfMultiplier: number
+  icrMultiplier: number
+}
+
+const RAMADAN_BOUNDS = {
+  YEAR_MIN: 2024, YEAR_MAX: 2050,
+  FASTING_HOURS_MIN: 1, FASTING_HOURS_MAX: 20,
+  // Clinical bounds : adjustment must stay within ±50% of base.
+  ISF_MULT_MIN: 0.5, ISF_MULT_MAX: 2.0,
+  ICR_MULT_MIN: 0.5, ICR_MULT_MAX: 2.0,
+}
+
+function validateRamadan(input: RamadanModeInput): void {
+  if (input.ramadanYear < RAMADAN_BOUNDS.YEAR_MIN
+    || input.ramadanYear > RAMADAN_BOUNDS.YEAR_MAX) {
+    throw new ValidationError("ramadanYear")
+  }
+  if (!ISO_DATE_RE.test(input.startDate)) throw new ValidationError("startDate")
+  if (!ISO_DATE_RE.test(input.endDate)) throw new ValidationError("endDate")
+  const start = Date.parse(`${input.startDate}T00:00:00Z`)
+  const end = Date.parse(`${input.endDate}T00:00:00Z`)
+  if (Number.isNaN(start) || Number.isNaN(end)) throw new ValidationError("dateFormat")
+  if (start >= end) throw new ValidationError("dateOrder")
+  // Ramadan dure 29 ou 30 jours (lunaire). Borne large pour tolérer
+  // les ajustements de fin de mois.
+  const days = (end - start) / 86_400_000
+  if (days < 28 || days > 31) throw new ValidationError("ramadanDuration")
+  if (!TIME_HHMM_RE.test(input.sahurTime)) throw new ValidationError("sahurTime")
+  if (!TIME_HHMM_RE.test(input.iftarTime)) throw new ValidationError("iftarTime")
+  if (input.allowedFastingHours < RAMADAN_BOUNDS.FASTING_HOURS_MIN
+    || input.allowedFastingHours > RAMADAN_BOUNDS.FASTING_HOURS_MAX) {
+    throw new ValidationError("allowedFastingHours")
+  }
+  if (input.isfMultiplier < RAMADAN_BOUNDS.ISF_MULT_MIN
+    || input.isfMultiplier > RAMADAN_BOUNDS.ISF_MULT_MAX) {
+    throw new ValidationError("isfMultiplier")
+  }
+  if (input.icrMultiplier < RAMADAN_BOUNDS.ICR_MULT_MIN
+    || input.icrMultiplier > RAMADAN_BOUNDS.ICR_MULT_MAX) {
+    throw new ValidationError("icrMultiplier")
+  }
+}
+
+export const ramadanModeService = {
+  async getActive(patientId: number, auditUserId: number, ctx?: AuditContext): Promise<{
+    version: ConfigVersionDTO | null
+    config: RamadanModeInput | null
+  }> {
+    const version = await prisma.configVersion.findFirst({
+      where: {
+        patientId,
+        configType: ConfigVersionType.ramadan_mode,
+        status: ConfigVersionStatus.active,
+      },
+    })
+    await auditService.log({
+      userId: auditUserId, action: "READ", resource: "PATIENT_MODE",
+      resourceId: String(patientId),
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { patientId, kind: "ramadan.read" },
+    })
+    return {
+      version: version ? toConfigVersionDTO(version) : null,
+      config: version
+        ? (version.configSnapshot as unknown as RamadanModeInput)
+        : null,
+    }
+  },
+
+  async upsert(
+    patientId: number, input: RamadanModeInput,
+    auditUserId: number, ctx?: AuditContext,
+  ): Promise<ConfigVersionDTO> {
+    validateRamadan(input)
+    return prisma.$transaction(async (tx: Tx) => {
+      const now = new Date()
+      const version = await nextVersion(tx, patientId, ConfigVersionType.ramadan_mode)
+      await supersedePrevious(tx, patientId, ConfigVersionType.ramadan_mode, now)
+      const created = await tx.configVersion.create({
+        data: {
+          patientId,
+          configType: ConfigVersionType.ramadan_mode,
+          version,
+          configSnapshot: input satisfies Prisma.InputJsonValue,
+          createdBy: auditUserId,
+        },
+      })
+      await auditService.logWithTx(tx, {
+        userId: auditUserId, action: "CREATE", resource: "CONFIG_VERSION",
+        resourceId: String(created.id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: {
+          patientId, kind: "ramadan.upsert",
+          version, ramadanYear: input.ramadanYear,
+        },
+      })
+      return toConfigVersionDTO(created)
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2235 — Mode voyage
+// ─────────────────────────────────────────────────────────────
+
+export type TravelModeInput = {
+  destination: string
+  /** Décalage horaire entre origine et destination, en heures (-12..14). */
+  timezoneOffsetHours: number
+  departureDate: string // ISO yyyy-mm-dd
+  returnDate: string
+  /** Multiplicateur basal global appliqué pendant le voyage (0.5..1.5). */
+  basalMultiplier: number
+  /** Délai d'ajustement basal (en heures) après changement de fuseau (0..24). */
+  basalDelayHours: number
+}
+
+const TRAVEL_BOUNDS = {
+  TZ_OFFSET_MIN: -12, TZ_OFFSET_MAX: 14,
+  BASAL_MULT_MIN: 0.5, BASAL_MULT_MAX: 1.5,
+  BASAL_DELAY_MIN: 0, BASAL_DELAY_MAX: 24,
+  DESTINATION_MAX_LEN: 100,
+  TRIP_DAYS_MAX: 365,
+}
+
+function validateTravel(input: TravelModeInput): void {
+  if (!input.destination || input.destination.length > TRAVEL_BOUNDS.DESTINATION_MAX_LEN) {
+    throw new ValidationError("destination")
+  }
+  if (!Number.isFinite(input.timezoneOffsetHours)
+    || input.timezoneOffsetHours < TRAVEL_BOUNDS.TZ_OFFSET_MIN
+    || input.timezoneOffsetHours > TRAVEL_BOUNDS.TZ_OFFSET_MAX) {
+    throw new ValidationError("timezoneOffsetHours")
+  }
+  if (!ISO_DATE_RE.test(input.departureDate)) throw new ValidationError("departureDate")
+  if (!ISO_DATE_RE.test(input.returnDate)) throw new ValidationError("returnDate")
+  const dep = Date.parse(`${input.departureDate}T00:00:00Z`)
+  const ret = Date.parse(`${input.returnDate}T00:00:00Z`)
+  if (Number.isNaN(dep) || Number.isNaN(ret)) throw new ValidationError("dateFormat")
+  if (dep >= ret) throw new ValidationError("dateOrder")
+  const days = (ret - dep) / 86_400_000
+  if (days > TRAVEL_BOUNDS.TRIP_DAYS_MAX) throw new ValidationError("tripDuration")
+  if (input.basalMultiplier < TRAVEL_BOUNDS.BASAL_MULT_MIN
+    || input.basalMultiplier > TRAVEL_BOUNDS.BASAL_MULT_MAX) {
+    throw new ValidationError("basalMultiplier")
+  }
+  if (input.basalDelayHours < TRAVEL_BOUNDS.BASAL_DELAY_MIN
+    || input.basalDelayHours > TRAVEL_BOUNDS.BASAL_DELAY_MAX) {
+    throw new ValidationError("basalDelayHours")
+  }
+}
+
+/**
+ * Protocole basal généré à partir du décalage horaire.
+ *
+ * Règle métier (consensus diabéto, à valider DOCTOR avant push patient) :
+ *  - eastbound (offset > 0)  → journée raccourcie → réduire basal 5% par
+ *    tranche de 6h, capé à -10%
+ *  - westbound (offset < 0)  → journée allongée → augmenter basal 5% par
+ *    tranche de 6h, capé à +10%
+ *  - |offset| < 3h → pas d'ajustement (multiplier = 1.0)
+ *
+ * Le DOCTOR peut surcharger ces valeurs lors du `upsert` ; cette fonction
+ * sert d'aide à la décision (UI pré-remplie).
+ */
+export function computeBasalProtocol(timezoneOffsetHours: number): {
+  basalMultiplier: number
+  basalDelayHours: number
+} {
+  const abs = Math.abs(timezoneOffsetHours)
+  if (abs < 3) return { basalMultiplier: 1.0, basalDelayHours: 0 }
+  const tranches = Math.min(2, Math.floor(abs / 6) + 1)
+  const delta = 0.05 * tranches
+  return {
+    basalMultiplier: timezoneOffsetHours > 0 ? 1 - delta : 1 + delta,
+    basalDelayHours: Math.min(TRAVEL_BOUNDS.BASAL_DELAY_MAX, Math.round(abs / 2)),
+  }
+}
+
+export const travelModeService = {
+  async getActive(patientId: number, auditUserId: number, ctx?: AuditContext): Promise<{
+    version: ConfigVersionDTO | null
+    config: TravelModeInput | null
+  }> {
+    const version = await prisma.configVersion.findFirst({
+      where: {
+        patientId,
+        configType: ConfigVersionType.travel_mode,
+        status: ConfigVersionStatus.active,
+      },
+    })
+    await auditService.log({
+      userId: auditUserId, action: "READ", resource: "PATIENT_MODE",
+      resourceId: String(patientId),
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { patientId, kind: "travel.read" },
+    })
+    return {
+      version: version ? toConfigVersionDTO(version) : null,
+      config: version
+        ? (version.configSnapshot as unknown as TravelModeInput)
+        : null,
+    }
+  },
+
+  async upsert(
+    patientId: number, input: TravelModeInput,
+    auditUserId: number, ctx?: AuditContext,
+  ): Promise<ConfigVersionDTO> {
+    validateTravel(input)
+    return prisma.$transaction(async (tx: Tx) => {
+      const now = new Date()
+      const version = await nextVersion(tx, patientId, ConfigVersionType.travel_mode)
+      await supersedePrevious(tx, patientId, ConfigVersionType.travel_mode, now)
+      const created = await tx.configVersion.create({
+        data: {
+          patientId,
+          configType: ConfigVersionType.travel_mode,
+          version,
+          configSnapshot: input satisfies Prisma.InputJsonValue,
+          createdBy: auditUserId,
+        },
+      })
+      await auditService.logWithTx(tx, {
+        userId: auditUserId, action: "CREATE", resource: "CONFIG_VERSION",
+        resourceId: String(created.id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: {
+          patientId, kind: "travel.upsert",
+          version, tzOffset: input.timezoneOffsetHours,
+        },
+      })
+      return toConfigVersionDTO(created)
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+  },
+}
+
+// ─────────────────────────────────────────────────────────────
+// Common : validate (DOCTOR) + deactivate
+// ─────────────────────────────────────────────────────────────
+
+const SUPPORTED_MODE_TYPES = new Set<ConfigVersionType>([
+  ConfigVersionType.pediatric_mode,
+  ConfigVersionType.ramadan_mode,
+  ConfigVersionType.travel_mode,
+])
+
+export const patientModeWorkflow = {
+  /** DOCTOR signs off a NURSE-created mode version. */
+  async validate(
+    versionId: number, auditUserId: number, ctx?: AuditContext,
+  ): Promise<ConfigVersionDTO> {
+    return prisma.$transaction(async (tx: Tx) => {
+      const row = await tx.configVersion.findUnique({ where: { id: versionId } })
+      if (!row) throw new NotFoundError()
+      if (!SUPPORTED_MODE_TYPES.has(row.configType)) {
+        throw new ValidationError("unsupportedConfigType")
+      }
+      if (row.validatedAt !== null) throw new ValidationError("alreadyValidated")
+      if (row.status !== ConfigVersionStatus.active) {
+        throw new ValidationError("notActive")
+      }
+      const updated = await tx.configVersion.update({
+        where: { id: versionId },
+        data: { validatedBy: auditUserId, validatedAt: new Date() },
+      })
+      await auditService.logWithTx(tx, {
+        userId: auditUserId, action: "UPDATE", resource: "CONFIG_VERSION",
+        resourceId: String(versionId),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: {
+          patientId: row.patientId, configType: row.configType,
+          version: row.version, kind: "mode.validate",
+        },
+      })
+      return toConfigVersionDTO(updated)
+    })
+  },
+
+  /**
+   * Deactivate the active mode for `(patient, configType)`.
+   * Sets `status=archived` + `validTo=now`. Mode disappears from `getActive`
+   * but remains in history. Idempotent (no-op if already archived).
+   */
+  async deactivate(
+    patientId: number, configType: ConfigVersionType,
+    auditUserId: number, ctx?: AuditContext,
+  ): Promise<{ archived: boolean }> {
+    if (!SUPPORTED_MODE_TYPES.has(configType)) {
+      throw new ValidationError("unsupportedConfigType")
+    }
+    return prisma.$transaction(async (tx: Tx) => {
+      const active = await tx.configVersion.findFirst({
+        where: { patientId, configType, status: ConfigVersionStatus.active },
+      })
+      if (!active) return { archived: false }
+      await tx.configVersion.update({
+        where: { id: active.id },
+        data: { status: ConfigVersionStatus.archived, validTo: new Date() },
+      })
+      await auditService.logWithTx(tx, {
+        userId: auditUserId, action: "UPDATE", resource: "CONFIG_VERSION",
+        resourceId: String(active.id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: {
+          patientId, configType,
+          version: active.version, kind: "mode.deactivate",
+        },
+      })
+      return { archived: true }
+    })
+  },
+
+  async listHistory(
+    patientId: number, configType: ConfigVersionType,
+    auditUserId: number, ctx?: AuditContext,
+  ): Promise<ConfigVersionDTO[]> {
+    if (!SUPPORTED_MODE_TYPES.has(configType)) {
+      throw new ValidationError("unsupportedConfigType")
+    }
+    const rows = await prisma.configVersion.findMany({
+      where: { patientId, configType },
+      orderBy: { version: "desc" },
+      take: 100,
+    })
+    await auditService.log({
+      userId: auditUserId, action: "READ", resource: "CONFIG_VERSION",
+      resourceId: String(patientId),
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { patientId, kind: "mode.history", configType, count: rows.length },
+    })
+    return rows.map(toConfigVersionDTO)
+  },
+}

--- a/src/lib/services/patient-modes.service.ts
+++ b/src/lib/services/patient-modes.service.ts
@@ -14,6 +14,16 @@
  *  - `deactivate` = transition vers `status=archived` (manuel ou cron pour
  *    Ramadan/voyage qui ont une date d'expiration naturelle)
  *
+ * ⚠️ CLINICAL DISCLAIMER (medical-domain-validator C2) ⚠️
+ *
+ * Mode configs are **informational only** in this PR : `insulin.service.ts`
+ * does NOT yet read `isfMultiplier`, `icrMultiplier`, or `basalMultiplier`
+ * during bolus/basal calculation. DOCTOR review remains mandatory at
+ * `validate` step, and the UI MUST surface a "Adjustments are manual —
+ * automated dose adaptation not yet implemented" banner. Wiring into the
+ * insulin calculator is tracked as a follow-up US (modes → calculator
+ * integration with re-validation of CLINICAL_BOUNDS post-multiplier).
+ *
  * PHI :
  *  - Pédiatrique : `name` et `phone` des aidants chiffrés AES-256-GCM dans
  *    `pediatric_caregivers`. Snapshot ConfigVersion redacted (hasName/hasPhone
@@ -26,6 +36,7 @@ import {
   ConfigVersionStatus,
   ConfigVersionType,
 } from "@prisma/client"
+import { z } from "zod"
 import { prisma, type PrismaClientOrTx as Tx } from "@/lib/db/client"
 import { encryptField, safeDecryptField } from "@/lib/crypto/fields"
 import { auditService, type AuditContext } from "./audit.service"
@@ -35,8 +46,27 @@ import { NotFoundError, ValidationError } from "./team-workflow.errors"
 // Shared helpers (mirror mirror-v1-config.service patterns)
 // ─────────────────────────────────────────────────────────────
 
-const PERMISSION_LEVELS = ["read", "write", "config"] as const
+// Medical H1 — renamed "config" → "propose" : caregivers cannot mutate
+// clinical thresholds directly. "propose" grants the right to create a
+// pending AdjustmentProposal that still requires DOCTOR review (per HAS
+// pediatric T1D guidelines + ISPAD 2022 §13). UI must not expose
+// threshold-write controls to "propose"-only caregivers.
+const PERMISSION_LEVELS = ["read", "write", "propose"] as const
 export type PermissionLevel = (typeof PERMISSION_LEVELS)[number]
+
+/**
+ * Soft warnings surfaced from validation. They do NOT block the operation
+ * but are logged in audit metadata and returned to callers so the DOCTOR
+ * can acknowledge them at `validate` time.
+ */
+export type ModeWarning = {
+  code:
+    | "extendedFasting"        // Ramadan > 16h (IDF-DAR 2021 §6.4)
+    | "basalAdjustmentLarge"   // travel basal multiplier > ±20%
+    | "basalDelayLong"         // travel delay > 8h
+    | "ramadanShortMonth"      // Ramadan = 29 days (acceptable, FYI)
+  severity: "info" | "warning"
+}
 
 const MAX_CAREGIVERS = 5
 const NAME_MAX_LEN = 100
@@ -243,26 +273,53 @@ export const pediatricModeService = {
 // US-2234 — Mode Ramadan
 // ─────────────────────────────────────────────────────────────
 
-export type RamadanModeInput = {
-  ramadanYear: number
-  startDate: string // ISO yyyy-mm-dd
-  endDate: string
-  sahurTime: string // HH:MM
-  iftarTime: string
-  allowedFastingHours: number
-  isfMultiplier: number
-  icrMultiplier: number
-}
+/**
+ * Code-review H2 — Zod schema as the single source of truth for the
+ * Ramadan snapshot shape ; used to parse `configSnapshot` on read so a
+ * corrupted JSONB row degrades gracefully (returns null + audit) instead
+ * of silently emitting undefined to the calculator.
+ */
+export const ramadanSnapshotSchema = z.object({
+  ramadanYear: z.number(),
+  startDate: z.string(),
+  endDate: z.string(),
+  sahurTime: z.string(),
+  iftarTime: z.string(),
+  allowedFastingHours: z.number(),
+  isfMultiplier: z.number(),
+  icrMultiplier: z.number(),
+})
+
+export type RamadanModeInput = z.infer<typeof ramadanSnapshotSchema>
 
 const RAMADAN_BOUNDS = {
   YEAR_MIN: 2024, YEAR_MAX: 2050,
   FASTING_HOURS_MIN: 1, FASTING_HOURS_MAX: 20,
-  // Clinical bounds : adjustment must stay within ±50% of base.
+  /** Medical H3 — > 16h fasting raises an `extendedFasting` warning. */
+  FASTING_HOURS_WARN: 16,
+  /** Medical L1 — lunar Ramadan is always 29 or 30 days. */
+  DURATION_MIN_DAYS: 29, DURATION_MAX_DAYS: 30,
+  /** ±50% of base ISF/ICR (DOCTOR can downscale further). */
   ISF_MULT_MIN: 0.5, ISF_MULT_MAX: 2.0,
   ICR_MULT_MIN: 0.5, ICR_MULT_MAX: 2.0,
+} as const
+
+/**
+ * Compute fasting hours from `sahurTime` → `iftarTime` (wrapping past
+ * midnight if needed). Used by L2 sanity check (consistency with the
+ * declared `allowedFastingHours`).
+ */
+function computeFastingHours(sahur: string, iftar: string): number {
+  const [sh, sm] = sahur.split(":").map(Number) as [number, number]
+  const [ih, im] = iftar.split(":").map(Number) as [number, number]
+  const sahurMin = sh * 60 + sm
+  const iftarMin = ih * 60 + im
+  let diff = iftarMin - sahurMin
+  if (diff <= 0) diff += 24 * 60
+  return diff / 60
 }
 
-function validateRamadan(input: RamadanModeInput): void {
+function validateRamadan(input: RamadanModeInput): ModeWarning[] {
   if (input.ramadanYear < RAMADAN_BOUNDS.YEAR_MIN
     || input.ramadanYear > RAMADAN_BOUNDS.YEAR_MAX) {
     throw new ValidationError("ramadanYear")
@@ -273,15 +330,24 @@ function validateRamadan(input: RamadanModeInput): void {
   const end = Date.parse(`${input.endDate}T00:00:00Z`)
   if (Number.isNaN(start) || Number.isNaN(end)) throw new ValidationError("dateFormat")
   if (start >= end) throw new ValidationError("dateOrder")
-  // Ramadan dure 29 ou 30 jours (lunaire). Borne large pour tolérer
-  // les ajustements de fin de mois.
+  // Medical L1 — lunar Ramadan is always 29 or 30 days (moon-sighting
+  // variance ±1d ; 28 or 31-day months don't occur naturally).
   const days = (end - start) / 86_400_000
-  if (days < 28 || days > 31) throw new ValidationError("ramadanDuration")
+  if (days < RAMADAN_BOUNDS.DURATION_MIN_DAYS
+    || days > RAMADAN_BOUNDS.DURATION_MAX_DAYS) {
+    throw new ValidationError("ramadanDuration")
+  }
   if (!TIME_HHMM_RE.test(input.sahurTime)) throw new ValidationError("sahurTime")
   if (!TIME_HHMM_RE.test(input.iftarTime)) throw new ValidationError("iftarTime")
   if (input.allowedFastingHours < RAMADAN_BOUNDS.FASTING_HOURS_MIN
     || input.allowedFastingHours > RAMADAN_BOUNDS.FASTING_HOURS_MAX) {
     throw new ValidationError("allowedFastingHours")
+  }
+  // Medical L2 — sahur → iftar window must roughly match allowedFastingHours
+  //   (tolerate ±1.5h for travel time between locales).
+  const fastingFromTimes = computeFastingHours(input.sahurTime, input.iftarTime)
+  if (Math.abs(fastingFromTimes - input.allowedFastingHours) > 1.5) {
+    throw new ValidationError("fastingWindowMismatch")
   }
   if (input.isfMultiplier < RAMADAN_BOUNDS.ISF_MULT_MIN
     || input.isfMultiplier > RAMADAN_BOUNDS.ISF_MULT_MAX) {
@@ -291,12 +357,24 @@ function validateRamadan(input: RamadanModeInput): void {
     || input.icrMultiplier > RAMADAN_BOUNDS.ICR_MULT_MAX) {
     throw new ValidationError("icrMultiplier")
   }
+
+  // Soft warnings (Medical H3 / IDF-DAR 2021 §6.4).
+  const warnings: ModeWarning[] = []
+  if (input.allowedFastingHours > RAMADAN_BOUNDS.FASTING_HOURS_WARN) {
+    warnings.push({ code: "extendedFasting", severity: "warning" })
+  }
+  if (days === RAMADAN_BOUNDS.DURATION_MIN_DAYS) {
+    warnings.push({ code: "ramadanShortMonth", severity: "info" })
+  }
+  return warnings
 }
 
 export const ramadanModeService = {
   async getActive(patientId: number, auditUserId: number, ctx?: AuditContext): Promise<{
     version: ConfigVersionDTO | null
     config: RamadanModeInput | null
+    /** Code-review H2 — true when configSnapshot failed Zod validation. */
+    snapshotInvalid: boolean
   }> {
     const version = await prisma.configVersion.findFirst({
       where: {
@@ -311,28 +389,43 @@ export const ramadanModeService = {
       ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
       metadata: { patientId, kind: "ramadan.read" },
     })
+    let config: RamadanModeInput | null = null
+    let snapshotInvalid = false
+    if (version) {
+      const parsed = ramadanSnapshotSchema.safeParse(version.configSnapshot)
+      if (parsed.success) {
+        config = parsed.data
+      } else {
+        snapshotInvalid = true
+        await auditService.log({
+          userId: auditUserId, action: "READ", resource: "PATIENT_MODE",
+          resourceId: String(patientId),
+          ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+          metadata: { patientId, kind: "ramadan.snapshot.invalid", versionId: version.id },
+        })
+      }
+    }
     return {
       version: version ? toConfigVersionDTO(version) : null,
-      config: version
-        ? (version.configSnapshot as unknown as RamadanModeInput)
-        : null,
+      config,
+      snapshotInvalid,
     }
   },
 
   async upsert(
     patientId: number, input: RamadanModeInput,
     auditUserId: number, ctx?: AuditContext,
-  ): Promise<ConfigVersionDTO> {
-    validateRamadan(input)
-    return prisma.$transaction(async (tx: Tx) => {
+  ): Promise<{ version: ConfigVersionDTO; warnings: ModeWarning[] }> {
+    const warnings = validateRamadan(input)
+    const version = await prisma.$transaction(async (tx: Tx) => {
       const now = new Date()
-      const version = await nextVersion(tx, patientId, ConfigVersionType.ramadan_mode)
+      const nextVer = await nextVersion(tx, patientId, ConfigVersionType.ramadan_mode)
       await supersedePrevious(tx, patientId, ConfigVersionType.ramadan_mode, now)
       const created = await tx.configVersion.create({
         data: {
           patientId,
           configType: ConfigVersionType.ramadan_mode,
-          version,
+          version: nextVer,
           configSnapshot: input satisfies Prisma.InputJsonValue,
           createdBy: auditUserId,
         },
@@ -343,11 +436,13 @@ export const ramadanModeService = {
         ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
         metadata: {
           patientId, kind: "ramadan.upsert",
-          version, ramadanYear: input.ramadanYear,
+          version: nextVer, ramadanYear: input.ramadanYear,
+          warnings: warnings.map((w) => w.code),
         },
       })
       return toConfigVersionDTO(created)
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+    return { version, warnings }
   },
 }
 
@@ -355,27 +450,38 @@ export const ramadanModeService = {
 // US-2235 — Mode voyage
 // ─────────────────────────────────────────────────────────────
 
-export type TravelModeInput = {
-  destination: string
+/**
+ * Code-review H2 — Zod schema as the single source of truth for the
+ * Travel snapshot shape.
+ */
+export const travelSnapshotSchema = z.object({
+  destination: z.string(),
   /** Décalage horaire entre origine et destination, en heures (-12..14). */
-  timezoneOffsetHours: number
-  departureDate: string // ISO yyyy-mm-dd
-  returnDate: string
-  /** Multiplicateur basal global appliqué pendant le voyage (0.5..1.5). */
-  basalMultiplier: number
-  /** Délai d'ajustement basal (en heures) après changement de fuseau (0..24). */
-  basalDelayHours: number
-}
+  timezoneOffsetHours: z.number(),
+  departureDate: z.string(),
+  returnDate: z.string(),
+  /** Multiplicateur basal pendant la fenêtre de transition (0.7..1.3). */
+  basalMultiplier: z.number(),
+  /** Délai d'ajustement basal (en heures) après changement de fuseau (0..12). */
+  basalDelayHours: z.number(),
+})
+
+export type TravelModeInput = z.infer<typeof travelSnapshotSchema>
 
 const TRAVEL_BOUNDS = {
   TZ_OFFSET_MIN: -12, TZ_OFFSET_MAX: 14,
-  BASAL_MULT_MIN: 0.5, BASAL_MULT_MAX: 1.5,
-  BASAL_DELAY_MIN: 0, BASAL_DELAY_MAX: 24,
+  /** Medical M1 — tightened from ±50% to ±30% (ATTD/EASD 2022 consensus). */
+  BASAL_MULT_MIN: 0.7, BASAL_MULT_MAX: 1.3,
+  /** Medical M1 — warn above ±20% (typical adjustment, AACE Pump Position). */
+  BASAL_MULT_WARN_MIN: 0.8, BASAL_MULT_WARN_MAX: 1.2,
+  /** Medical M2 — tightened from 24h to 12h (typical 2-6h). */
+  BASAL_DELAY_MIN: 0, BASAL_DELAY_MAX: 12,
+  BASAL_DELAY_WARN: 8,
   DESTINATION_MAX_LEN: 100,
   TRIP_DAYS_MAX: 365,
-}
+} as const
 
-function validateTravel(input: TravelModeInput): void {
+function validateTravel(input: TravelModeInput): ModeWarning[] {
   if (!input.destination || input.destination.length > TRAVEL_BOUNDS.DESTINATION_MAX_LEN) {
     throw new ValidationError("destination")
   }
@@ -400,32 +506,69 @@ function validateTravel(input: TravelModeInput): void {
     || input.basalDelayHours > TRAVEL_BOUNDS.BASAL_DELAY_MAX) {
     throw new ValidationError("basalDelayHours")
   }
+
+  // Soft warnings (Medical M1 / M2).
+  const warnings: ModeWarning[] = []
+  if (input.basalMultiplier < TRAVEL_BOUNDS.BASAL_MULT_WARN_MIN
+    || input.basalMultiplier > TRAVEL_BOUNDS.BASAL_MULT_WARN_MAX) {
+    warnings.push({ code: "basalAdjustmentLarge", severity: "warning" })
+  }
+  if (input.basalDelayHours > TRAVEL_BOUNDS.BASAL_DELAY_WARN) {
+    warnings.push({ code: "basalDelayLong", severity: "warning" })
+  }
+  return warnings
 }
 
 /**
  * Protocole basal généré à partir du décalage horaire.
  *
- * Règle métier (consensus diabéto, à valider DOCTOR avant push patient) :
- *  - eastbound (offset > 0)  → journée raccourcie → réduire basal 5% par
- *    tranche de 6h, capé à -10%
- *  - westbound (offset < 0)  → journée allongée → augmenter basal 5% par
- *    tranche de 6h, capé à +10%
- *  - |offset| < 3h → pas d'ajustement (multiplier = 1.0)
+ * Règle métier (ATTD/EASD travel consensus 2022 ; AACE Pump Therapy
+ * Position Statement). L'ajustement n'est appliqué que pendant la fenêtre
+ * de transition (acclimatation circadienne, ~24-48h post-arrivée), pas
+ * pendant tout le séjour (medical C1 — corrige une erreur clinique).
  *
- * Le DOCTOR peut surcharger ces valeurs lors du `upsert` ; cette fonction
- * sert d'aide à la décision (UI pré-remplie).
+ *  - eastbound (offset > 0)  → journée raccourcie → réduire basal pendant
+ *    la fenêtre de transition (5% par tranche de 6h, capé à -10%)
+ *  - westbound (offset < 0)  → journée allongée → augmenter basal pendant
+ *    la fenêtre de transition (+5% par tranche de 6h, capé à +10%)
+ *  - |offset| < 3h → pas d'ajustement
+ *
+ * Le retour est UNE PROPOSITION ; `requiresDoctorReview: true` toujours
+ * vrai, le DOCTOR doit relire avant `upsert`.
+ *
+ * Cap formula : `Math.min(2, Math.ceil(abs / 6))` — 1 tranche pour [3, 6h],
+ * 2 tranches pour [6, 12h], capé à 2 (10%) au-delà (medical M4 + code-review
+ * C1 — corrige l'off-by-one sur l'ancienne formule).
  */
 export function computeBasalProtocol(timezoneOffsetHours: number): {
   basalMultiplier: number
   basalDelayHours: number
+  /** Durée de la fenêtre de transition pendant laquelle appliquer le multiplier. */
+  transitionWindowHours: number
+  /** Toujours `true` — le DOCTOR doit valider avant push patient. */
+  requiresDoctorReview: true
+  /** Source clinique pour traçabilité. */
+  reference: "ATTD-EASD-2022"
 } {
   const abs = Math.abs(timezoneOffsetHours)
-  if (abs < 3) return { basalMultiplier: 1.0, basalDelayHours: 0 }
-  const tranches = Math.min(2, Math.floor(abs / 6) + 1)
+  if (abs < 3) {
+    return {
+      basalMultiplier: 1.0,
+      basalDelayHours: 0,
+      transitionWindowHours: 0,
+      requiresDoctorReview: true,
+      reference: "ATTD-EASD-2022",
+    }
+  }
+  const tranches = Math.min(2, Math.ceil(abs / 6))
   const delta = 0.05 * tranches
   return {
     basalMultiplier: timezoneOffsetHours > 0 ? 1 - delta : 1 + delta,
-    basalDelayHours: Math.min(TRAVEL_BOUNDS.BASAL_DELAY_MAX, Math.round(abs / 2)),
+    basalDelayHours: Math.min(TRAVEL_BOUNDS.BASAL_DELAY_MAX, Math.round(abs / 3)),
+    // Transition window : ~24h pour <6h offset, 48h pour ≥6h offset.
+    transitionWindowHours: abs < 6 ? 24 : 48,
+    requiresDoctorReview: true,
+    reference: "ATTD-EASD-2022",
   }
 }
 
@@ -433,6 +576,7 @@ export const travelModeService = {
   async getActive(patientId: number, auditUserId: number, ctx?: AuditContext): Promise<{
     version: ConfigVersionDTO | null
     config: TravelModeInput | null
+    snapshotInvalid: boolean
   }> {
     const version = await prisma.configVersion.findFirst({
       where: {
@@ -447,28 +591,43 @@ export const travelModeService = {
       ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
       metadata: { patientId, kind: "travel.read" },
     })
+    let config: TravelModeInput | null = null
+    let snapshotInvalid = false
+    if (version) {
+      const parsed = travelSnapshotSchema.safeParse(version.configSnapshot)
+      if (parsed.success) {
+        config = parsed.data
+      } else {
+        snapshotInvalid = true
+        await auditService.log({
+          userId: auditUserId, action: "READ", resource: "PATIENT_MODE",
+          resourceId: String(patientId),
+          ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+          metadata: { patientId, kind: "travel.snapshot.invalid", versionId: version.id },
+        })
+      }
+    }
     return {
       version: version ? toConfigVersionDTO(version) : null,
-      config: version
-        ? (version.configSnapshot as unknown as TravelModeInput)
-        : null,
+      config,
+      snapshotInvalid,
     }
   },
 
   async upsert(
     patientId: number, input: TravelModeInput,
     auditUserId: number, ctx?: AuditContext,
-  ): Promise<ConfigVersionDTO> {
-    validateTravel(input)
-    return prisma.$transaction(async (tx: Tx) => {
+  ): Promise<{ version: ConfigVersionDTO; warnings: ModeWarning[] }> {
+    const warnings = validateTravel(input)
+    const version = await prisma.$transaction(async (tx: Tx) => {
       const now = new Date()
-      const version = await nextVersion(tx, patientId, ConfigVersionType.travel_mode)
+      const nextVer = await nextVersion(tx, patientId, ConfigVersionType.travel_mode)
       await supersedePrevious(tx, patientId, ConfigVersionType.travel_mode, now)
       const created = await tx.configVersion.create({
         data: {
           patientId,
           configType: ConfigVersionType.travel_mode,
-          version,
+          version: nextVer,
           configSnapshot: input satisfies Prisma.InputJsonValue,
           createdBy: auditUserId,
         },
@@ -479,11 +638,13 @@ export const travelModeService = {
         ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
         metadata: {
           patientId, kind: "travel.upsert",
-          version, tzOffset: input.timezoneOffsetHours,
+          version: nextVer, tzOffset: input.timezoneOffsetHours,
+          warnings: warnings.map((w) => w.code),
         },
       })
       return toConfigVersionDTO(created)
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
+    return { version, warnings }
   },
 }
 
@@ -502,6 +663,9 @@ export const patientModeWorkflow = {
   async validate(
     versionId: number, auditUserId: number, ctx?: AuditContext,
   ): Promise<ConfigVersionDTO> {
+    // H1 (healthcare audit) — Serializable so concurrent DOCTOR validates
+    //   surface cleanly as 409 (P2034) via mapErrorToResponse, instead of a
+    //   500 from the immutability trigger firing on the second commit.
     return prisma.$transaction(async (tx: Tx) => {
       const row = await tx.configVersion.findUnique({ where: { id: versionId } })
       if (!row) throw new NotFoundError()
@@ -526,7 +690,7 @@ export const patientModeWorkflow = {
         },
       })
       return toConfigVersionDTO(updated)
-    })
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
   },
 
   /**
@@ -541,6 +705,8 @@ export const patientModeWorkflow = {
     if (!SUPPORTED_MODE_TYPES.has(configType)) {
       throw new ValidationError("unsupportedConfigType")
     }
+    // H1 (healthcare audit) — Serializable so concurrent deactivates collapse
+    //   to a single update + audit row (no duplicate audit on the second tx).
     return prisma.$transaction(async (tx: Tx) => {
       const active = await tx.configVersion.findFirst({
         where: { patientId, configType, status: ConfigVersionStatus.active },
@@ -560,7 +726,7 @@ export const patientModeWorkflow = {
         },
       })
       return { archived: true }
-    })
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
   },
 
   async listHistory(

--- a/tests/unit/patient-modes.service.test.ts
+++ b/tests/unit/patient-modes.service.test.ts
@@ -1,0 +1,397 @@
+/**
+ * Test suite: patient-modes.service (Groupe 10 Batch C — 3 US, 16 SP)
+ *
+ * Couvre :
+ *  - US-2233 pédiatrique : encrypt PHI, redacted snapshot, version increment,
+ *    supersede prev, decrypt failure audit
+ *  - US-2234 Ramadan : validation dates (29-30 jours), bornes ISF/ICR
+ *    multipliers, sahur/iftar format HH:MM, year range
+ *  - US-2235 voyage : tz offset bounds, basal multiplier bounds,
+ *    departureDate < returnDate, trip < 365j
+ *  - patientModeWorkflow : validate DOCTOR-only path, deactivate idempotent,
+ *    listHistory restricts to supported mode types
+ *  - computeBasalProtocol : 0/±3h/±6h/±12h → expected (multiplier, delay)
+ */
+import { describe, it, expect, beforeEach } from "vitest"
+import { ConfigVersionStatus, ConfigVersionType } from "@prisma/client"
+import { prismaMock } from "../helpers/prisma-mock"
+import {
+  pediatricModeService,
+  ramadanModeService,
+  travelModeService,
+  patientModeWorkflow,
+  computeBasalProtocol,
+} from "@/lib/services/patient-modes.service"
+import {
+  NotFoundError,
+  ValidationError,
+} from "@/lib/services/team-workflow.errors"
+
+beforeEach(() => {
+  prismaMock.auditLog.create.mockResolvedValue({} as any)
+  prismaMock.$transaction.mockImplementation(async (fn: any) => fn(prismaMock))
+})
+
+// ─────────────────────────────────────────────────────────────
+// US-2233 — Pediatric mode
+// ─────────────────────────────────────────────────────────────
+
+describe("pediatricModeService (US-2233)", () => {
+  const validCaregivers = [
+    { rank: 1, name: "Marie", phone: "0600000001", relationship: "mother", permissionLevel: "config" as const },
+    { rank: 2, name: "Paul", phone: "0600000002", relationship: "father", permissionLevel: "write" as const },
+  ]
+
+  it("upsert rejects empty caregiver list", async () => {
+    await expect(pediatricModeService.upsert(7, [], 9)).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("upsert rejects > 5 caregivers", async () => {
+    const six = Array.from({ length: 6 }, (_, i) => ({
+      ...validCaregivers[0]!, rank: i + 1,
+    }))
+    await expect(pediatricModeService.upsert(7, six, 9)).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("upsert rejects duplicate ranks", async () => {
+    const dup = [validCaregivers[0]!, { ...validCaregivers[1]!, rank: 1 }]
+    await expect(pediatricModeService.upsert(7, dup, 9)).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("upsert rejects invalid permissionLevel", async () => {
+    const bad = [{ ...validCaregivers[0]!, permissionLevel: "admin" as any }]
+    await expect(pediatricModeService.upsert(7, bad, 9)).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("upsert creates new version, supersedes prev, redacted snapshot", async () => {
+    prismaMock.configVersion.findFirst.mockResolvedValue({ version: 2 } as any)
+    prismaMock.configVersion.updateMany.mockResolvedValue({ count: 1 } as any)
+    prismaMock.configVersion.create.mockResolvedValue({
+      id: 100, patientId: 7, configType: ConfigVersionType.pediatric_mode,
+      version: 3, validFrom: new Date(), validTo: null,
+      status: ConfigVersionStatus.active, createdBy: 9,
+      validatedBy: null, validatedAt: null, createdAt: new Date(),
+    } as any)
+    const out = await pediatricModeService.upsert(7, validCaregivers, 9)
+    expect(out.version).toBe(3)
+    expect(prismaMock.configVersion.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          patientId: 7, configType: ConfigVersionType.pediatric_mode,
+          status: ConfigVersionStatus.active,
+        }),
+      }),
+    )
+    // Snapshot redacted : no plaintext name/phone.
+    const created = prismaMock.configVersion.create.mock.calls[0]![0]
+    const snapshot = (created.data as any).configSnapshot as Array<Record<string, unknown>>
+    expect(snapshot).toHaveLength(2)
+    for (const s of snapshot) {
+      expect(s).not.toHaveProperty("name")
+      expect(s).not.toHaveProperty("phone")
+      expect(s).toHaveProperty("hasName", true)
+      expect(s).toHaveProperty("hasPhone", true)
+      expect(s).toHaveProperty("permissionLevel")
+    }
+  })
+
+  it("getActive audits decrypt failures separately", async () => {
+    prismaMock.configVersion.findFirst.mockResolvedValue({
+      id: 100, patientId: 7, configType: ConfigVersionType.pediatric_mode,
+      version: 1, validFrom: new Date(), validTo: null,
+      status: ConfigVersionStatus.active, createdBy: 9,
+      validatedBy: null, validatedAt: null, createdAt: new Date(),
+      pediatricCaregivers: [
+        // Invalid base64 → safeDecryptField returns null.
+        {
+          id: 1, rank: 1, nameEncrypted: "$$$invalid$$$",
+          phoneEncrypted: "$$$invalid$$$",
+          relationship: "mother", permissionLevel: "config",
+        },
+      ],
+    } as any)
+    const out = await pediatricModeService.getActive(7, 9)
+    expect(out.caregivers[0]!.decryptionFailed).toBe(true)
+    // Should emit 2 audit rows : read + decrypt.failure.
+    expect(prismaMock.auditLog.create).toHaveBeenCalledTimes(2)
+    const lastCall = prismaMock.auditLog.create.mock.calls.at(-1)![0]
+    expect((lastCall.data as any).metadata.kind).toBe("pediatric.decrypt.failure")
+  })
+
+  it("getActive returns empty when no active version", async () => {
+    prismaMock.configVersion.findFirst.mockResolvedValue(null)
+    const out = await pediatricModeService.getActive(7, 9)
+    expect(out.version).toBeNull()
+    expect(out.caregivers).toEqual([])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// US-2234 — Ramadan mode
+// ─────────────────────────────────────────────────────────────
+
+describe("ramadanModeService (US-2234)", () => {
+  const valid = {
+    ramadanYear: 2026,
+    startDate: "2026-03-01", endDate: "2026-03-30",
+    sahurTime: "05:30", iftarTime: "18:45",
+    allowedFastingHours: 14,
+    isfMultiplier: 1.2, icrMultiplier: 1.1,
+  }
+
+  it("rejects out-of-range year", async () => {
+    await expect(ramadanModeService.upsert(7, { ...valid, ramadanYear: 2099 }, 9))
+      .rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("rejects malformed startDate", async () => {
+    await expect(ramadanModeService.upsert(7, { ...valid, startDate: "01/03/2026" }, 9))
+      .rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("rejects end before start", async () => {
+    await expect(ramadanModeService.upsert(7, {
+      ...valid, startDate: "2026-03-30", endDate: "2026-03-01",
+    }, 9)).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("rejects duration outside [28-31] days", async () => {
+    await expect(ramadanModeService.upsert(7, {
+      ...valid, startDate: "2026-03-01", endDate: "2026-04-15", // 45 days
+    }, 9)).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("rejects invalid HH:MM sahurTime", async () => {
+    await expect(ramadanModeService.upsert(7, { ...valid, sahurTime: "25:00" }, 9))
+      .rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("rejects ISF multiplier out of clinical bounds", async () => {
+    await expect(ramadanModeService.upsert(7, { ...valid, isfMultiplier: 2.5 }, 9))
+      .rejects.toBeInstanceOf(ValidationError)
+    await expect(ramadanModeService.upsert(7, { ...valid, isfMultiplier: 0.3 }, 9))
+      .rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("upsert happy path increments version + audits", async () => {
+    prismaMock.configVersion.findFirst.mockResolvedValue({ version: 0 } as any)
+    prismaMock.configVersion.updateMany.mockResolvedValue({ count: 0 } as any)
+    prismaMock.configVersion.create.mockResolvedValue({
+      id: 200, patientId: 7, configType: ConfigVersionType.ramadan_mode,
+      version: 1, validFrom: new Date(), validTo: null,
+      status: ConfigVersionStatus.active, createdBy: 9,
+      validatedBy: null, validatedAt: null, createdAt: new Date(),
+    } as any)
+    const out = await ramadanModeService.upsert(7, valid, 9)
+    expect(out.version).toBe(1)
+    expect(prismaMock.auditLog.create).toHaveBeenCalled()
+  })
+
+  it("getActive deserializes snapshot back to config", async () => {
+    prismaMock.configVersion.findFirst.mockResolvedValue({
+      id: 200, patientId: 7, configType: ConfigVersionType.ramadan_mode,
+      version: 1, validFrom: new Date(), validTo: null,
+      status: ConfigVersionStatus.active, createdBy: 9,
+      validatedBy: null, validatedAt: null, createdAt: new Date(),
+      configSnapshot: valid,
+    } as any)
+    const out = await ramadanModeService.getActive(7, 9)
+    expect(out.config).toMatchObject({
+      ramadanYear: 2026, sahurTime: "05:30", iftarTime: "18:45",
+    })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// US-2235 — Travel mode
+// ─────────────────────────────────────────────────────────────
+
+describe("travelModeService (US-2235)", () => {
+  const valid = {
+    destination: "Tokyo",
+    timezoneOffsetHours: 8,
+    departureDate: "2026-06-15", returnDate: "2026-06-22",
+    basalMultiplier: 0.95,
+    basalDelayHours: 4,
+  }
+
+  it("rejects tz offset out of [-12, 14]", async () => {
+    await expect(travelModeService.upsert(7, { ...valid, timezoneOffsetHours: 15 }, 9))
+      .rejects.toBeInstanceOf(ValidationError)
+    await expect(travelModeService.upsert(7, { ...valid, timezoneOffsetHours: -13 }, 9))
+      .rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("rejects return before departure", async () => {
+    await expect(travelModeService.upsert(7, {
+      ...valid, departureDate: "2026-06-22", returnDate: "2026-06-15",
+    }, 9)).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("rejects trip > 365 days", async () => {
+    await expect(travelModeService.upsert(7, {
+      ...valid, departureDate: "2026-01-01", returnDate: "2027-06-15",
+    }, 9)).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("rejects basal multiplier out of clinical bounds", async () => {
+    await expect(travelModeService.upsert(7, { ...valid, basalMultiplier: 2.0 }, 9))
+      .rejects.toBeInstanceOf(ValidationError)
+    await expect(travelModeService.upsert(7, { ...valid, basalMultiplier: 0.3 }, 9))
+      .rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("upsert happy path", async () => {
+    prismaMock.configVersion.findFirst.mockResolvedValue(null)
+    prismaMock.configVersion.updateMany.mockResolvedValue({ count: 0 } as any)
+    prismaMock.configVersion.create.mockResolvedValue({
+      id: 300, patientId: 7, configType: ConfigVersionType.travel_mode,
+      version: 1, validFrom: new Date(), validTo: null,
+      status: ConfigVersionStatus.active, createdBy: 9,
+      validatedBy: null, validatedAt: null, createdAt: new Date(),
+    } as any)
+    const out = await travelModeService.upsert(7, valid, 9)
+    expect(out.version).toBe(1)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// computeBasalProtocol — clinical helper
+// ─────────────────────────────────────────────────────────────
+
+describe("computeBasalProtocol", () => {
+  it("returns identity for |offset| < 3h", () => {
+    expect(computeBasalProtocol(0)).toEqual({ basalMultiplier: 1.0, basalDelayHours: 0 })
+    expect(computeBasalProtocol(2)).toEqual({ basalMultiplier: 1.0, basalDelayHours: 0 })
+    expect(computeBasalProtocol(-2)).toEqual({ basalMultiplier: 1.0, basalDelayHours: 0 })
+  })
+
+  it("reduces basal eastbound (positive offset)", () => {
+    const out = computeBasalProtocol(8)
+    expect(out.basalMultiplier).toBeLessThan(1.0)
+    expect(out.basalMultiplier).toBeGreaterThanOrEqual(0.9)
+  })
+
+  it("increases basal westbound (negative offset)", () => {
+    const out = computeBasalProtocol(-8)
+    expect(out.basalMultiplier).toBeGreaterThan(1.0)
+    expect(out.basalMultiplier).toBeLessThanOrEqual(1.1)
+  })
+
+  it("caps adjustment at ±10% regardless of offset magnitude", () => {
+    const out = computeBasalProtocol(14)
+    expect(out.basalMultiplier).toBeGreaterThanOrEqual(0.9)
+    expect(out.basalMultiplier).toBeLessThanOrEqual(0.95)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// patientModeWorkflow — validate + deactivate + history
+// ─────────────────────────────────────────────────────────────
+
+describe("patientModeWorkflow", () => {
+  it("validate refuses non-mode configType", async () => {
+    prismaMock.configVersion.findUnique.mockResolvedValue({
+      id: 1, configType: ConfigVersionType.emergency_contacts,
+      validatedAt: null, status: ConfigVersionStatus.active,
+    } as any)
+    await expect(patientModeWorkflow.validate(1, 9))
+      .rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("validate refuses already-validated row", async () => {
+    prismaMock.configVersion.findUnique.mockResolvedValue({
+      id: 1, configType: ConfigVersionType.pediatric_mode,
+      validatedAt: new Date(), status: ConfigVersionStatus.active,
+    } as any)
+    await expect(patientModeWorkflow.validate(1, 9))
+      .rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("validate refuses non-active row", async () => {
+    prismaMock.configVersion.findUnique.mockResolvedValue({
+      id: 1, configType: ConfigVersionType.pediatric_mode,
+      validatedAt: null, status: ConfigVersionStatus.superseded,
+    } as any)
+    await expect(patientModeWorkflow.validate(1, 9))
+      .rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("validate happy path sets validatedBy + validatedAt", async () => {
+    prismaMock.configVersion.findUnique.mockResolvedValue({
+      id: 1, patientId: 7, configType: ConfigVersionType.pediatric_mode,
+      version: 1, validatedAt: null, status: ConfigVersionStatus.active,
+    } as any)
+    prismaMock.configVersion.update.mockResolvedValue({
+      id: 1, patientId: 7, configType: ConfigVersionType.pediatric_mode,
+      version: 1, validFrom: new Date(), validTo: null,
+      status: ConfigVersionStatus.active, createdBy: 5,
+      validatedBy: 9, validatedAt: new Date(), createdAt: new Date(),
+    } as any)
+    const out = await patientModeWorkflow.validate(1, 9)
+    expect(out.validatedBy).toBe(9)
+    expect(out.validatedAt).not.toBeNull()
+  })
+
+  it("validate throws NotFoundError when missing", async () => {
+    prismaMock.configVersion.findUnique.mockResolvedValue(null)
+    await expect(patientModeWorkflow.validate(999, 9))
+      .rejects.toBeInstanceOf(NotFoundError)
+  })
+
+  it("deactivate is idempotent — returns { archived:false } when no active", async () => {
+    prismaMock.configVersion.findFirst.mockResolvedValue(null)
+    const out = await patientModeWorkflow.deactivate(
+      7, ConfigVersionType.ramadan_mode, 9,
+    )
+    expect(out.archived).toBe(false)
+    expect(prismaMock.configVersion.update).not.toHaveBeenCalled()
+  })
+
+  it("deactivate archives + audits when active row exists", async () => {
+    prismaMock.configVersion.findFirst.mockResolvedValue({
+      id: 1, patientId: 7, configType: ConfigVersionType.ramadan_mode, version: 1,
+    } as any)
+    prismaMock.configVersion.update.mockResolvedValue({} as any)
+    const out = await patientModeWorkflow.deactivate(
+      7, ConfigVersionType.ramadan_mode, 9,
+    )
+    expect(out.archived).toBe(true)
+    const updateCall = prismaMock.configVersion.update.mock.calls[0]![0]
+    expect((updateCall.data as any).status).toBe(ConfigVersionStatus.archived)
+  })
+
+  it("deactivate rejects non-mode configType", async () => {
+    await expect(patientModeWorkflow.deactivate(
+      7, ConfigVersionType.emergency_contacts, 9,
+    )).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("listHistory rejects non-mode configType", async () => {
+    await expect(patientModeWorkflow.listHistory(
+      7, ConfigVersionType.alert_thresholds, 9,
+    )).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("listHistory returns rows sorted DESC + audits", async () => {
+    prismaMock.configVersion.findMany.mockResolvedValue([
+      {
+        id: 3, patientId: 7, configType: ConfigVersionType.travel_mode,
+        version: 3, validFrom: new Date(), validTo: null,
+        status: ConfigVersionStatus.active, createdBy: 9,
+        validatedBy: null, validatedAt: null, createdAt: new Date(),
+      },
+      {
+        id: 2, patientId: 7, configType: ConfigVersionType.travel_mode,
+        version: 2, validFrom: new Date(), validTo: new Date(),
+        status: ConfigVersionStatus.superseded, createdBy: 9,
+        validatedBy: null, validatedAt: null, createdAt: new Date(),
+      },
+    ] as any)
+    const out = await patientModeWorkflow.listHistory(
+      7, ConfigVersionType.travel_mode, 9,
+    )
+    expect(out).toHaveLength(2)
+    expect(out[0]!.version).toBe(3)
+  })
+})

--- a/tests/unit/patient-modes.service.test.ts
+++ b/tests/unit/patient-modes.service.test.ts
@@ -38,7 +38,7 @@ beforeEach(() => {
 
 describe("pediatricModeService (US-2233)", () => {
   const validCaregivers = [
-    { rank: 1, name: "Marie", phone: "0600000001", relationship: "mother", permissionLevel: "config" as const },
+    { rank: 1, name: "Marie", phone: "0600000001", relationship: "mother", permissionLevel: "propose" as const },
     { rank: 2, name: "Paul", phone: "0600000002", relationship: "father", permissionLevel: "write" as const },
   ]
 
@@ -106,7 +106,7 @@ describe("pediatricModeService (US-2233)", () => {
         {
           id: 1, rank: 1, nameEncrypted: "$$$invalid$$$",
           phoneEncrypted: "$$$invalid$$$",
-          relationship: "mother", permissionLevel: "config",
+          relationship: "mother", permissionLevel: "propose",
         },
       ],
     } as any)
@@ -131,11 +131,12 @@ describe("pediatricModeService (US-2233)", () => {
 // ─────────────────────────────────────────────────────────────
 
 describe("ramadanModeService (US-2234)", () => {
+  // 29-day month (Medical L1) ; sahur→iftar window matches allowedFastingHours.
   const valid = {
     ramadanYear: 2026,
     startDate: "2026-03-01", endDate: "2026-03-30",
-    sahurTime: "05:30", iftarTime: "18:45",
-    allowedFastingHours: 14,
+    sahurTime: "05:30", iftarTime: "18:30",
+    allowedFastingHours: 13,
     isfMultiplier: 1.2, icrMultiplier: 1.1,
   }
 
@@ -155,9 +156,25 @@ describe("ramadanModeService (US-2234)", () => {
     }, 9)).rejects.toBeInstanceOf(ValidationError)
   })
 
-  it("rejects duration outside [28-31] days", async () => {
+  it("rejects duration outside [29-30] days (medical L1)", async () => {
+    // 45 days
     await expect(ramadanModeService.upsert(7, {
-      ...valid, startDate: "2026-03-01", endDate: "2026-04-15", // 45 days
+      ...valid, startDate: "2026-03-01", endDate: "2026-04-15",
+    }, 9)).rejects.toBeInstanceOf(ValidationError)
+    // 28 days (clinically impossible — lunar month is 29 or 30)
+    await expect(ramadanModeService.upsert(7, {
+      ...valid, startDate: "2026-03-01", endDate: "2026-03-29",
+    }, 9)).rejects.toBeInstanceOf(ValidationError)
+    // 31 days (impossible)
+    await expect(ramadanModeService.upsert(7, {
+      ...valid, startDate: "2026-03-01", endDate: "2026-04-01",
+    }, 9)).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("rejects sahur→iftar window that doesn't match allowedFastingHours (L2)", async () => {
+    // sahur 05:30 → iftar 18:30 = 13h, declared 8h → reject.
+    await expect(ramadanModeService.upsert(7, {
+      ...valid, allowedFastingHours: 8,
     }, 9)).rejects.toBeInstanceOf(ValidationError)
   })
 
@@ -173,7 +190,7 @@ describe("ramadanModeService (US-2234)", () => {
       .rejects.toBeInstanceOf(ValidationError)
   })
 
-  it("upsert happy path increments version + audits", async () => {
+  it("upsert happy path increments version + audits + emits warnings", async () => {
     prismaMock.configVersion.findFirst.mockResolvedValue({ version: 0 } as any)
     prismaMock.configVersion.updateMany.mockResolvedValue({ count: 0 } as any)
     prismaMock.configVersion.create.mockResolvedValue({
@@ -183,8 +200,42 @@ describe("ramadanModeService (US-2234)", () => {
       validatedBy: null, validatedAt: null, createdAt: new Date(),
     } as any)
     const out = await ramadanModeService.upsert(7, valid, 9)
-    expect(out.version).toBe(1)
+    expect(out.version.version).toBe(1)
+    expect(out.warnings).toBeDefined()
     expect(prismaMock.auditLog.create).toHaveBeenCalled()
+  })
+
+  it("upsert with allowedFastingHours > 16 emits extendedFasting warning (H3)", async () => {
+    prismaMock.configVersion.findFirst.mockResolvedValue({ version: 0 } as any)
+    prismaMock.configVersion.updateMany.mockResolvedValue({ count: 0 } as any)
+    prismaMock.configVersion.create.mockResolvedValue({
+      id: 200, patientId: 7, configType: ConfigVersionType.ramadan_mode,
+      version: 1, validFrom: new Date(), validTo: null,
+      status: ConfigVersionStatus.active, createdBy: 9,
+      validatedBy: null, validatedAt: null, createdAt: new Date(),
+    } as any)
+    // sahur 03:00 → iftar 21:00 = 18h window.
+    const out = await ramadanModeService.upsert(7, {
+      ...valid, sahurTime: "03:00", iftarTime: "21:00", allowedFastingHours: 18,
+    }, 9)
+    expect(out.warnings.map((w) => w.code)).toContain("extendedFasting")
+  })
+
+  it("getActive flags snapshotInvalid + audits on corrupted JSONB (code-review H2)", async () => {
+    prismaMock.configVersion.findFirst.mockResolvedValue({
+      id: 200, patientId: 7, configType: ConfigVersionType.ramadan_mode,
+      version: 1, validFrom: new Date(), validTo: null,
+      status: ConfigVersionStatus.active, createdBy: 9,
+      validatedBy: null, validatedAt: null, createdAt: new Date(),
+      configSnapshot: { ramadanYear: "not-a-number" }, // schema violation
+    } as any)
+    const out = await ramadanModeService.getActive(7, 9)
+    expect(out.snapshotInvalid).toBe(true)
+    expect(out.config).toBeNull()
+    expect(prismaMock.auditLog.create).toHaveBeenCalledTimes(2)
+    expect(
+      (prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any).metadata.kind,
+    ).toBe("ramadan.snapshot.invalid")
   })
 
   it("getActive deserializes snapshot back to config", async () => {
@@ -197,8 +248,9 @@ describe("ramadanModeService (US-2234)", () => {
     } as any)
     const out = await ramadanModeService.getActive(7, 9)
     expect(out.config).toMatchObject({
-      ramadanYear: 2026, sahurTime: "05:30", iftarTime: "18:45",
+      ramadanYear: 2026, sahurTime: "05:30", iftarTime: "18:30",
     })
+    expect(out.snapshotInvalid).toBe(false)
   })
 })
 
@@ -211,7 +263,7 @@ describe("travelModeService (US-2235)", () => {
     destination: "Tokyo",
     timezoneOffsetHours: 8,
     departureDate: "2026-06-15", returnDate: "2026-06-22",
-    basalMultiplier: 0.95,
+    basalMultiplier: 0.9,
     basalDelayHours: 4,
   }
 
@@ -234,10 +286,15 @@ describe("travelModeService (US-2235)", () => {
     }, 9)).rejects.toBeInstanceOf(ValidationError)
   })
 
-  it("rejects basal multiplier out of clinical bounds", async () => {
-    await expect(travelModeService.upsert(7, { ...valid, basalMultiplier: 2.0 }, 9))
+  it("rejects basal multiplier out of clinical bounds 0.7..1.3 (M1)", async () => {
+    await expect(travelModeService.upsert(7, { ...valid, basalMultiplier: 1.5 }, 9))
       .rejects.toBeInstanceOf(ValidationError)
-    await expect(travelModeService.upsert(7, { ...valid, basalMultiplier: 0.3 }, 9))
+    await expect(travelModeService.upsert(7, { ...valid, basalMultiplier: 0.5 }, 9))
+      .rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it("rejects basal delay > 12h (M2)", async () => {
+    await expect(travelModeService.upsert(7, { ...valid, basalDelayHours: 24 }, 9))
       .rejects.toBeInstanceOf(ValidationError)
   })
 
@@ -251,7 +308,33 @@ describe("travelModeService (US-2235)", () => {
       validatedBy: null, validatedAt: null, createdAt: new Date(),
     } as any)
     const out = await travelModeService.upsert(7, valid, 9)
-    expect(out.version).toBe(1)
+    expect(out.version.version).toBe(1)
+  })
+
+  it("upsert with basalMultiplier outside [0.8, 1.2] emits warning (M1)", async () => {
+    prismaMock.configVersion.findFirst.mockResolvedValue(null)
+    prismaMock.configVersion.updateMany.mockResolvedValue({ count: 0 } as any)
+    prismaMock.configVersion.create.mockResolvedValue({
+      id: 300, patientId: 7, configType: ConfigVersionType.travel_mode,
+      version: 1, validFrom: new Date(), validTo: null,
+      status: ConfigVersionStatus.active, createdBy: 9,
+      validatedBy: null, validatedAt: null, createdAt: new Date(),
+    } as any)
+    const out = await travelModeService.upsert(7, { ...valid, basalMultiplier: 0.75 }, 9)
+    expect(out.warnings.map((w) => w.code)).toContain("basalAdjustmentLarge")
+  })
+
+  it("upsert with basalDelay > 8h emits warning (M2)", async () => {
+    prismaMock.configVersion.findFirst.mockResolvedValue(null)
+    prismaMock.configVersion.updateMany.mockResolvedValue({ count: 0 } as any)
+    prismaMock.configVersion.create.mockResolvedValue({
+      id: 300, patientId: 7, configType: ConfigVersionType.travel_mode,
+      version: 1, validFrom: new Date(), validTo: null,
+      status: ConfigVersionStatus.active, createdBy: 9,
+      validatedBy: null, validatedAt: null, createdAt: new Date(),
+    } as any)
+    const out = await travelModeService.upsert(7, { ...valid, basalDelayHours: 10 }, 9)
+    expect(out.warnings.map((w) => w.code)).toContain("basalDelayLong")
   })
 })
 
@@ -260,28 +343,41 @@ describe("travelModeService (US-2235)", () => {
 // ─────────────────────────────────────────────────────────────
 
 describe("computeBasalProtocol", () => {
-  it("returns identity for |offset| < 3h", () => {
-    expect(computeBasalProtocol(0)).toEqual({ basalMultiplier: 1.0, basalDelayHours: 0 })
-    expect(computeBasalProtocol(2)).toEqual({ basalMultiplier: 1.0, basalDelayHours: 0 })
-    expect(computeBasalProtocol(-2)).toEqual({ basalMultiplier: 1.0, basalDelayHours: 0 })
+  it("returns identity + transitionWindow=0 + requiresDoctorReview for |offset| < 3h", () => {
+    const out0 = computeBasalProtocol(0)
+    expect(out0.basalMultiplier).toBe(1.0)
+    expect(out0.basalDelayHours).toBe(0)
+    expect(out0.transitionWindowHours).toBe(0)
+    expect(out0.requiresDoctorReview).toBe(true)
+    expect(out0.reference).toBe("ATTD-EASD-2022")
+    expect(computeBasalProtocol(2).basalMultiplier).toBe(1.0)
+    expect(computeBasalProtocol(-2).basalMultiplier).toBe(1.0)
   })
 
-  it("reduces basal eastbound (positive offset)", () => {
-    const out = computeBasalProtocol(8)
-    expect(out.basalMultiplier).toBeLessThan(1.0)
-    expect(out.basalMultiplier).toBeGreaterThanOrEqual(0.9)
+  it("uses ceil(abs/6) tranches — boundary at 6h between 1 and 2 tranches", () => {
+    // offset=3 → ceil(3/6)=1 → 5% reduction eastbound (medical M4 / code-review C1)
+    const out3 = computeBasalProtocol(3)
+    expect(out3.basalMultiplier).toBeCloseTo(0.95, 2)
+    expect(out3.transitionWindowHours).toBe(24)
+    // offset=6 → ceil(6/6)=1 → 5% reduction
+    const out6 = computeBasalProtocol(6)
+    expect(out6.basalMultiplier).toBeCloseTo(0.95, 2)
+    expect(out6.transitionWindowHours).toBe(48) // |offset|>=6 → 48h window
+    // offset=7 → ceil(7/6)=2 → 10% reduction
+    const out7 = computeBasalProtocol(7)
+    expect(out7.basalMultiplier).toBeCloseTo(0.9, 2)
+    // offset=12 → ceil(12/6)=2 → 10% reduction
+    expect(computeBasalProtocol(12).basalMultiplier).toBeCloseTo(0.9, 2)
   })
 
-  it("increases basal westbound (negative offset)", () => {
-    const out = computeBasalProtocol(-8)
-    expect(out.basalMultiplier).toBeGreaterThan(1.0)
-    expect(out.basalMultiplier).toBeLessThanOrEqual(1.1)
+  it("reduces basal eastbound, increases westbound", () => {
+    expect(computeBasalProtocol(8).basalMultiplier).toBeLessThan(1.0)
+    expect(computeBasalProtocol(-8).basalMultiplier).toBeGreaterThan(1.0)
   })
 
-  it("caps adjustment at ±10% regardless of offset magnitude", () => {
-    const out = computeBasalProtocol(14)
-    expect(out.basalMultiplier).toBeGreaterThanOrEqual(0.9)
-    expect(out.basalMultiplier).toBeLessThanOrEqual(0.95)
+  it("caps adjustment at ±10% regardless of offset magnitude (medical M4)", () => {
+    expect(computeBasalProtocol(14).basalMultiplier).toBeCloseTo(0.9, 2)
+    expect(computeBasalProtocol(-12).basalMultiplier).toBeCloseTo(1.1, 2)
   })
 })
 


### PR DESCRIPTION
## Summary

**Groupe 10 Batch C — Modes spéciaux** (3 US, ~16 SP).

- **US-2233** Mode pédiatrique (8 SP) — multi-aidants avec PHI chiffrée AES-256-GCM (nom/téléphone) dans table dédiée `pediatric_caregivers`. Snapshot ConfigVersion redacted (hasName/hasPhone booléens) pour audit 6 ans sans rétention PHI. Max 5 caregivers par patient, `permissionLevel ∈ {read, write, config}`.
- **US-2234** Mode Ramadan (5 SP) — dates jeûne (28-31 jours), sahur/iftar `HH:MM`, `allowedFastingHours` 1-20, multiplicateurs ISF/ICR ±50% (clinical bounds). Pas de PHI : `configSnapshot` plaintext autorisé.
- **US-2235** Mode voyage (3 SP) — `tzOffset` -12..14h, multiplicateur basal 0.5..1.5, trajet ≤ 365j. Helper `computeBasalProtocol` génère un protocole basal pré-rempli (-10% est, +10% ouest, capé) pour UI ; DOCTOR override possible avant validation.

## Architecture

- **Hub ConfigVersion** (PR #395) étendu avec 3 valeurs d'enum (`pediatric_mode`, `ramadan_mode`, `travel_mode`). Pattern emergency_contacts/escalation_rules réutilisé : chaque upsert crée une nouvelle ligne, l'ancienne passe `superseded` + `validTo`. Append-only via trigger PostgreSQL `config_versions_immutability`.
- **`patientModeWorkflow`** : `validate` (DOCTOR-only signe le row, refuse non-mode/non-active/déjà-validé), `deactivate` (idempotent, status=`archived` + `validTo`), `listHistory`.
- **Routes** :
  - `/api/patient/modes/[type]` GET/PUT (dynamic dispatch par `type ∈ {pediatric,ramadan,travel}`)
  - `/api/patient/modes/[type]/history` GET
  - `/api/patient/modes/[type]/deactivate` POST (DOCTOR)
  - `/api/patient/modes/validate` POST (DOCTOR, par `versionId`)
  - `/api/patient/modes/travel/auto-protocol` GET (helper stateless)

## Sécurité

Toutes les routes appliquent le pattern de défense en profondeur de PR #395 :
- `auditedRequireRole` (auto-`accessDenied` audit sur 403)
- `canAccessPatient` (cross-tenant guard pour PHI/clinical reads)
- `requireGdprConsent` (Article 9 conformité)
- `validate` : extra cross-tenant guard sur `versionId` (lookup patientId du ConfigVersion avant `canAccessPatient`)
- PHI : `safeDecryptField` + audit `decrypt.failure` distinct sur échec (KMS rotation gap detection, RGPD Art. 32 §1.b)

## Test plan

- [x] 34 nouveaux unit tests : 1584/1584 verts (108 → 109 fichiers)
- [x] tsc clean, lint 0 errors (21 warnings pré-existants)
- [x] Schema/migration drift OK localement
- [ ] CI green (drift gate + tests + coverage)
- [ ] Multi-agent review (healthcare-security-auditor + medical-domain-validator + code-reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)