### PR TITLE
Groupe 9b Batch 1 — Dashboard médecin (5 US, 34 SP)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"272342b2-8fd5-4a87-882d-64c29f48a0c2","pid":757099,"procStart":"285594674","acquiredAt":1778745390685}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"272342b2-8fd5-4a87-882d-64c29f48a0c2","pid":757099,"procStart":"285594674","acquiredAt":1778745390685}

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ Thumbs.db
 __pycache__/
 figma-export-script.js
 2026-*-*.txt
+.claude/scheduled_tasks.lock

--- a/src/app/(dashboard)/medecin/page.tsx
+++ b/src/app/(dashboard)/medecin/page.tsx
@@ -1,0 +1,36 @@
+/**
+ * US-2400 — Dashboard médecin (page conteneur).
+ *
+ * Layout responsive : 1 col mobile, 2 col grid lg+. Urgences + RDV top row
+ * (parallel), Patients à suivre row 2 full-width, KPI section row 3.
+ *
+ * Server-side guard : redirect non-DOCTOR/NURSE/ADMIN to login. The
+ * (dashboard)/layout.tsx already redirects VIEWER → /patient/dashboard.
+ */
+
+import { headers } from "next/headers"
+import { redirect } from "next/navigation"
+import { EmergencyCard } from "@/components/diabeo/dashboard/medecin/EmergencyCard"
+import { AppointmentCard } from "@/components/diabeo/dashboard/medecin/AppointmentCard"
+import { PatientsAtRiskCard } from "@/components/diabeo/dashboard/medecin/PatientsAtRiskCard"
+import { KpiSection } from "@/components/diabeo/dashboard/medecin/KpiSection"
+
+const ALLOWED_ROLES = new Set(["DOCTOR", "NURSE", "ADMIN"])
+
+export default async function MedecinDashboardPage() {
+  const headersList = await headers()
+  const role = headersList.get("x-user-role")
+  if (!role || !ALLOWED_ROLES.has(role)) redirect("/login")
+
+  return (
+    <main className="flex flex-col gap-6 p-4 lg:p-6">
+      <h1 className="text-2xl font-semibold">Tableau de bord médecin</h1>
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <EmergencyCard />
+        <AppointmentCard />
+      </div>
+      <PatientsAtRiskCard />
+      <KpiSection />
+    </main>
+  )
+}

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -1,12 +1,29 @@
 /**
- * Dashboard root redirect.
+ * Dashboard root redirect — role-based.
  *
- * The (dashboard) route group root redirects to /dashboard so that
- * navigating to "/" lands on the main glycemia dashboard after auth.
+ *  - DOCTOR / NURSE → `/medecin` (Groupe 9b Batch 1, US-2400)
+ *  - ADMIN          → `/medecin` (placeholder ; admin dashboard = future batch)
+ *  - VIEWER         → handled by `(dashboard)/layout.tsx` → `/patient/dashboard`
+ *
+ * Reads role from JWT middleware header (`x-user-role`) ; falls back to
+ * `/login` if absent (same pattern as the layout).
  */
 
+import { headers } from "next/headers"
 import { redirect } from "next/navigation"
 
-export default function DashboardRootPage() {
-  redirect("/dashboard")
+export default async function DashboardRootPage() {
+  const headersList = await headers()
+  const role = headersList.get("x-user-role")
+  if (!role) redirect("/login")
+  switch (role) {
+    case "DOCTOR":
+    case "NURSE":
+    case "ADMIN":
+      redirect("/medecin")
+    case "VIEWER":
+      redirect("/patient/dashboard")
+    default:
+      redirect("/login")
+  }
 }

--- a/src/app/api/dashboard/medecin/appointments/route.ts
+++ b/src/app/api/dashboard/medecin/appointments/route.ts
@@ -1,0 +1,22 @@
+/**
+ * Groupe 9b Batch 1 — US-2402 : RDV du jour pour le médecin.
+ * GET — max 3 RDV du jour, scope portefeuille, triés par heure.
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { AuthError } from "@/lib/auth"
+import { appointmentsQuery } from "@/lib/services/doctor-dashboard.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+
+export async function GET(req: NextRequest) {
+  const ctx = extractRequestContext(req)
+  try {
+    const user = await auditedRequireRole(req, "NURSE", ctx, "APPOINTMENT", "0")
+    const items = await appointmentsQuery.forCaller(user.id, user.role, user.id, ctx)
+    return NextResponse.json({ items })
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "dashboard/medecin/appointments GET", ctx.requestId)
+  }
+}

--- a/src/app/api/dashboard/medecin/kpi/route.ts
+++ b/src/app/api/dashboard/medecin/kpi/route.ts
@@ -1,0 +1,23 @@
+/**
+ * Groupe 9b Batch 1 — US-2404 : KPI cabinet 14j pour le médecin.
+ * GET — 4 KPI cards : patients actifs, TIR moyen, urgences sem, propositions
+ * en attente. Trend vs 14j précédents quand calculable.
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { AuthError } from "@/lib/auth"
+import { kpisQuery } from "@/lib/services/doctor-dashboard.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+
+export async function GET(req: NextRequest) {
+  const ctx = extractRequestContext(req)
+  try {
+    const user = await auditedRequireRole(req, "DOCTOR", ctx, "PATIENT", "0")
+    const items = await kpisQuery.forCaller(user.id, user.role, user.id, ctx)
+    return NextResponse.json({ items })
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "dashboard/medecin/kpi GET", ctx.requestId)
+  }
+}

--- a/src/app/api/dashboard/medecin/patients-at-risk/route.ts
+++ b/src/app/api/dashboard/medecin/patients-at-risk/route.ts
@@ -1,0 +1,24 @@
+/**
+ * Groupe 9b Batch 1 — US-2403 : patients à suivre pour le médecin.
+ * GET — top 3 patients à risque (hypos 7j, silence saisie), computed
+ * on-demand. DOCTOR-only (jugement clinique). Exclut les patients déjà
+ * en urgence ouverte (visibles dans US-2401 card).
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { AuthError } from "@/lib/auth"
+import { patientsAtRiskQuery } from "@/lib/services/doctor-dashboard.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+
+export async function GET(req: NextRequest) {
+  const ctx = extractRequestContext(req)
+  try {
+    const user = await auditedRequireRole(req, "DOCTOR", ctx, "PATIENT", "0")
+    const items = await patientsAtRiskQuery.forCaller(user.id, user.role, user.id, ctx)
+    return NextResponse.json({ items })
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "dashboard/medecin/patients-at-risk GET", ctx.requestId)
+  }
+}

--- a/src/app/api/dashboard/medecin/urgencies/route.ts
+++ b/src/app/api/dashboard/medecin/urgencies/route.ts
@@ -1,0 +1,24 @@
+/**
+ * Groupe 9b Batch 1 — US-2401 : urgences en cours pour le médecin.
+ * GET — max 5 alerts triées par criticité, scope portefeuille.
+ *
+ * Polling client : 30s (ADR session Samir 2026-05-13 — WS reporté V2/V3).
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { AuthError } from "@/lib/auth"
+import { urgenciesQuery } from "@/lib/services/doctor-dashboard.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+
+export async function GET(req: NextRequest) {
+  const ctx = extractRequestContext(req)
+  try {
+    const user = await auditedRequireRole(req, "NURSE", ctx, "EMERGENCY_ALERT", "0")
+    const items = await urgenciesQuery.forCaller(user.id, user.role, user.id, ctx)
+    return NextResponse.json({ items })
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "dashboard/medecin/urgencies GET", ctx.requestId)
+  }
+}

--- a/src/components/diabeo/dashboard/medecin/AppointmentCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/AppointmentCard.tsx
@@ -1,0 +1,87 @@
+/**
+ * US-2402 — RDV du jour (médecin). Max 3, tri chronologique. Polling 5min.
+ */
+
+"use client"
+
+import { DiabeoCard } from "@/components/diabeo/DiabeoCard"
+import { DiabeoEmptyState } from "@/components/diabeo/DiabeoEmptyState"
+import { Badge } from "@/components/ui/badge"
+import { usePollingFetch } from "@/hooks/usePollingFetch"
+import type { AppointmentItem } from "@/lib/services/doctor-dashboard.service"
+
+type ApiResponse = { items: AppointmentItem[] }
+
+function formatHour(d: Date | null): string {
+  if (!d) return "—"
+  const date = new Date(d)
+  return date.toLocaleTimeString("fr-FR", {
+    hour: "2-digit", minute: "2-digit", timeZone: "UTC",
+  })
+}
+
+function minutesUntil(hour: Date | null): number | null {
+  if (!hour) return null
+  return Math.round((new Date(hour).getTime() - Date.now()) / 60_000)
+}
+
+export function AppointmentCard() {
+  const { data, error, loading } = usePollingFetch<ApiResponse>(
+    "/api/dashboard/medecin/appointments",
+    5 * 60_000,
+  )
+  const items = data?.items ?? []
+  const hasError = error !== null && data === null
+
+  return (
+    <DiabeoCard role="region" aria-labelledby="card-appointments-title">
+      <header className="flex items-center justify-between px-4 pt-4">
+        <h2 id="card-appointments-title" className="text-base font-semibold">
+          RDV du jour
+        </h2>
+        <span className="text-xs text-muted-foreground">{items.length} prévu(s)</span>
+      </header>
+
+      <div className="px-4 pb-4">
+        {loading && items.length === 0 && (
+          <p className="text-sm text-muted-foreground">Chargement…</p>
+        )}
+        {hasError && (
+          <p className="text-sm text-glycemia-critical">Impossible de charger les RDV.</p>
+        )}
+        {!loading && !hasError && items.length === 0 && (
+          <DiabeoEmptyState
+            variant="noData"
+            title="Aucun RDV"
+            message="Pas de RDV programmés aujourd'hui."
+          />
+        )}
+        {items.length > 0 && (
+          <ul className="space-y-2">
+            {items.map((a) => {
+              const mins = minutesUntil(a.hour)
+              const imminent = mins !== null && mins <= 30 && mins >= 0
+              return (
+                <li
+                  key={a.id}
+                  className="flex items-center gap-3 rounded-md border border-border bg-card px-3 py-2"
+                >
+                  <Badge variant={imminent ? "default" : "outline"}>
+                    {formatHour(a.hour)}
+                  </Badge>
+                  <span className="flex-1 truncate text-sm font-medium">
+                    {a.patientFirstName || "Patient"}
+                    {a.pathology ? ` · ${a.pathology}` : ""}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {a.location === "video" ? "Visio" : a.type ?? "Présence"}
+                  </span>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+    </DiabeoCard>
+  )
+}

--- a/src/components/diabeo/dashboard/medecin/AppointmentCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/AppointmentCard.tsx
@@ -6,6 +6,7 @@
 
 import { DiabeoCard } from "@/components/diabeo/DiabeoCard"
 import { DiabeoEmptyState } from "@/components/diabeo/DiabeoEmptyState"
+import { StaleBanner } from "@/components/diabeo/dashboard/medecin/StaleBanner"
 import { Badge } from "@/components/ui/badge"
 import { usePollingFetch } from "@/hooks/usePollingFetch"
 import type { AppointmentItem } from "@/lib/services/doctor-dashboard.service"
@@ -45,11 +46,7 @@ export function AppointmentCard() {
         </h2>
         <span className="text-xs text-muted-foreground">{items.length} prévu(s)</span>
       </header>
-      {isStale && (
-        <p className="px-4 text-xs text-glycemia-high" role="status">
-          Données obsolètes — rafraîchissement en attente.
-        </p>
-      )}
+      {isStale && <StaleBanner />}
 
       <div className="px-4 pb-4">
         {loading && items.length === 0 && (

--- a/src/components/diabeo/dashboard/medecin/AppointmentCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/AppointmentCard.tsx
@@ -12,11 +12,14 @@ import type { AppointmentItem } from "@/lib/services/doctor-dashboard.service"
 
 type ApiResponse = { items: AppointmentItem[] }
 
+// code-review M6 — render time in Europe/Paris cabinet timezone, matching
+//   server `todayBounds` semantics. UTC display would shift wall-clock by
+//   1-2h on Paris timestamps.
 function formatHour(d: Date | null): string {
   if (!d) return "—"
   const date = new Date(d)
   return date.toLocaleTimeString("fr-FR", {
-    hour: "2-digit", minute: "2-digit", timeZone: "UTC",
+    hour: "2-digit", minute: "2-digit", timeZone: "Europe/Paris",
   })
 }
 
@@ -26,11 +29,12 @@ function minutesUntil(hour: Date | null): number | null {
 }
 
 export function AppointmentCard() {
-  const { data, error, loading } = usePollingFetch<ApiResponse>(
+  const { data, error, loading, isStale } = usePollingFetch<ApiResponse>(
     "/api/dashboard/medecin/appointments",
     5 * 60_000,
   )
-  const items = data?.items ?? []
+  // code-review H5 — defensive against malformed response.
+  const items = Array.isArray(data?.items) ? data!.items : []
   const hasError = error !== null && data === null
 
   return (
@@ -41,6 +45,11 @@ export function AppointmentCard() {
         </h2>
         <span className="text-xs text-muted-foreground">{items.length} prévu(s)</span>
       </header>
+      {isStale && (
+        <p className="px-4 text-xs text-glycemia-high" role="status">
+          Données obsolètes — rafraîchissement en attente.
+        </p>
+      )}
 
       <div className="px-4 pb-4">
         {loading && items.length === 0 && (
@@ -66,8 +75,13 @@ export function AppointmentCard() {
                   key={a.id}
                   className="flex items-center gap-3 rounded-md border border-border bg-card px-3 py-2"
                 >
-                  <Badge variant={imminent ? "default" : "outline"}>
+                  <Badge
+                    variant={imminent ? "default" : "outline"}
+                    aria-label={imminent ? `${formatHour(a.hour)} — imminent` : formatHour(a.hour)}
+                  >
                     {formatHour(a.hour)}
+                    {/* code-review M2 — text fallback for color-only imminent signal. */}
+                    {imminent && <span className="ml-1 sr-only">imminent</span>}
                   </Badge>
                   <span className="flex-1 truncate text-sm font-medium">
                     {a.patientFirstName || "Patient"}

--- a/src/components/diabeo/dashboard/medecin/EmergencyCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/EmergencyCard.tsx
@@ -32,12 +32,13 @@ const SEVERITY_VARIANT: Record<string, "default" | "secondary" | "destructive" |
 }
 
 export function EmergencyCard() {
-  const { data, error, loading, lastUpdatedAt } = usePollingFetch<ApiResponse>(
+  const { data, error, loading, lastUpdatedAt, isStale } = usePollingFetch<ApiResponse>(
     "/api/dashboard/medecin/urgencies",
     30_000,
   )
 
-  const items = data?.items ?? []
+  // code-review H5 — defensive : assume nothing about response shape.
+  const items = Array.isArray(data?.items) ? data!.items : []
   const hasError = error !== null && data === null
 
   return (
@@ -46,12 +47,21 @@ export function EmergencyCard() {
         <h2 id="card-urgencies-title" className="text-base font-semibold text-glycemia-critical">
           Urgences en cours
         </h2>
-        <span className="text-xs text-muted-foreground" aria-live="polite">
+        <span className="text-xs text-muted-foreground">
           {lastUpdatedAt ? `MAJ ${new Date(lastUpdatedAt).toLocaleTimeString("fr-FR")}` : "—"}
         </span>
       </header>
+      {isStale && (
+        <p className="px-4 text-xs text-glycemia-high" role="status">
+          Données obsolètes — rafraîchissement en attente.
+        </p>
+      )}
 
-      <div className="px-4 pb-4" role="status" aria-live="polite" aria-atomic="true">
+      {/* code-review M1 — separate live regions :
+            - "polite" announces transitions (loading/empty/error) without
+              interrupting reader flow.
+            - "assertive" on the count below interrupts for new urgencies. */}
+      <div className="px-4 pb-1" role="status" aria-live="polite">
         {loading && items.length === 0 && (
           <p className="text-sm text-muted-foreground">Chargement…</p>
         )}
@@ -65,6 +75,11 @@ export function EmergencyCard() {
             message="Patients stables sur le portefeuille."
           />
         )}
+      </div>
+      <div className="px-4 pb-4">
+        <p className="sr-only" role="alert" aria-live="assertive">
+          {items.length > 0 ? `${items.length} urgence${items.length > 1 ? "s" : ""} en cours` : ""}
+        </p>
         {items.length > 0 && (
           <ul className="space-y-2">
             {items.map((u) => (

--- a/src/components/diabeo/dashboard/medecin/EmergencyCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/EmergencyCard.tsx
@@ -10,6 +10,7 @@
 import { Badge } from "@/components/ui/badge"
 import { DiabeoCard } from "@/components/diabeo/DiabeoCard"
 import { DiabeoEmptyState } from "@/components/diabeo/DiabeoEmptyState"
+import { StaleBanner } from "@/components/diabeo/dashboard/medecin/StaleBanner"
 import { usePollingFetch } from "@/hooks/usePollingFetch"
 import type { UrgencyItem } from "@/lib/services/doctor-dashboard.service"
 
@@ -51,11 +52,7 @@ export function EmergencyCard() {
           {lastUpdatedAt ? `MAJ ${new Date(lastUpdatedAt).toLocaleTimeString("fr-FR")}` : "—"}
         </span>
       </header>
-      {isStale && (
-        <p className="px-4 text-xs text-glycemia-high" role="status">
-          Données obsolètes — rafraîchissement en attente.
-        </p>
-      )}
+      {isStale && <StaleBanner />}
 
       {/* code-review M1 — separate live regions :
             - "polite" announces transitions (loading/empty/error) without

--- a/src/components/diabeo/dashboard/medecin/EmergencyCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/EmergencyCard.tsx
@@ -1,0 +1,96 @@
+/**
+ * US-2401 — Urgences en cours (médecin).
+ *
+ * Polling 30s (ADR session Samir 2026-05-13). `role="region"` + live region
+ * for screen readers when alerts arrive. Empty state = green "all stable".
+ */
+
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import { DiabeoCard } from "@/components/diabeo/DiabeoCard"
+import { DiabeoEmptyState } from "@/components/diabeo/DiabeoEmptyState"
+import { usePollingFetch } from "@/hooks/usePollingFetch"
+import type { UrgencyItem } from "@/lib/services/doctor-dashboard.service"
+
+type ApiResponse = { items: UrgencyItem[] }
+
+const ALERT_LABELS: Record<string, string> = {
+  severe_hypo: "Hypoglycémie sévère",
+  hypo: "Hypoglycémie",
+  hyper: "Hyperglycémie",
+  severe_hyper: "Hyperglycémie sévère",
+  ketone_dka: "Cétoacidose",
+  ketone_moderate: "Cétones modérées",
+  manual: "Alerte manuelle",
+}
+
+const SEVERITY_VARIANT: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
+  info: "secondary",
+  warning: "outline",
+  critical: "destructive",
+}
+
+export function EmergencyCard() {
+  const { data, error, loading, lastUpdatedAt } = usePollingFetch<ApiResponse>(
+    "/api/dashboard/medecin/urgencies",
+    30_000,
+  )
+
+  const items = data?.items ?? []
+  const hasError = error !== null && data === null
+
+  return (
+    <DiabeoCard className="border-s-4 border-s-glycemia-critical" role="region" aria-labelledby="card-urgencies-title">
+      <header className="flex items-center justify-between px-4 pt-4">
+        <h2 id="card-urgencies-title" className="text-base font-semibold text-glycemia-critical">
+          Urgences en cours
+        </h2>
+        <span className="text-xs text-muted-foreground" aria-live="polite">
+          {lastUpdatedAt ? `MAJ ${new Date(lastUpdatedAt).toLocaleTimeString("fr-FR")}` : "—"}
+        </span>
+      </header>
+
+      <div className="px-4 pb-4" role="status" aria-live="polite" aria-atomic="true">
+        {loading && items.length === 0 && (
+          <p className="text-sm text-muted-foreground">Chargement…</p>
+        )}
+        {hasError && (
+          <p className="text-sm text-glycemia-critical">Impossible de charger les urgences.</p>
+        )}
+        {!loading && !hasError && items.length === 0 && (
+          <DiabeoEmptyState
+            variant="noData"
+            title="Aucune urgence"
+            message="Patients stables sur le portefeuille."
+          />
+        )}
+        {items.length > 0 && (
+          <ul className="space-y-2">
+            {items.map((u) => (
+              <li
+                key={u.id}
+                className="flex items-center gap-3 rounded-md border border-border bg-card px-3 py-2"
+              >
+                <Badge variant={SEVERITY_VARIANT[u.severity] ?? "default"}>
+                  {ALERT_LABELS[u.alertType] ?? u.alertType}
+                </Badge>
+                <span className="flex-1 truncate text-sm font-medium">
+                  {u.patientFirstName || "Patient"}
+                  {u.pathology ? ` · ${u.pathology}` : ""}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {u.glucoseValueMgdl !== null
+                    ? `${u.glucoseValueMgdl} mg/dL`
+                    : u.ketoneValueMmol !== null
+                    ? `${u.ketoneValueMmol} mmol/L`
+                    : "—"}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </DiabeoCard>
+  )
+}

--- a/src/components/diabeo/dashboard/medecin/KpiSection.tsx
+++ b/src/components/diabeo/dashboard/medecin/KpiSection.tsx
@@ -25,11 +25,12 @@ function mapTrendDirection(t: KpiCard["trend"]): "up" | "down" | "stable" | unde
 }
 
 export function KpiSection() {
-  const { data, error, loading } = usePollingFetch<ApiResponse>(
+  const { data, error, loading, isStale } = usePollingFetch<ApiResponse>(
     "/api/dashboard/medecin/kpi",
     10 * 60_000,
   )
-  const items = data?.items ?? []
+  // code-review H5 — defensive against malformed response.
+  const items = Array.isArray(data?.items) ? data!.items : []
   const hasError = error !== null && data === null
 
   return (
@@ -40,6 +41,11 @@ export function KpiSection() {
       {hasError && (
         <p className="mb-2 text-sm text-glycemia-critical">
           Impossible de charger les KPI.
+        </p>
+      )}
+      {isStale && (
+        <p className="mb-2 text-xs text-glycemia-high" role="status">
+          Données obsolètes — rafraîchissement en attente.
         </p>
       )}
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">

--- a/src/components/diabeo/dashboard/medecin/KpiSection.tsx
+++ b/src/components/diabeo/dashboard/medecin/KpiSection.tsx
@@ -6,6 +6,7 @@
 "use client"
 
 import { MetricCard } from "@/components/diabeo/MetricCard"
+import { StaleBanner } from "@/components/diabeo/dashboard/medecin/StaleBanner"
 import { usePollingFetch } from "@/hooks/usePollingFetch"
 import type { KpiCard } from "@/lib/services/doctor-dashboard.service"
 
@@ -44,9 +45,9 @@ export function KpiSection() {
         </p>
       )}
       {isStale && (
-        <p className="mb-2 text-xs text-glycemia-high" role="status">
-          Données obsolètes — rafraîchissement en attente.
-        </p>
+        <div className="mb-2">
+          <StaleBanner />
+        </div>
       )}
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
         {(loading && items.length === 0

--- a/src/components/diabeo/dashboard/medecin/KpiSection.tsx
+++ b/src/components/diabeo/dashboard/medecin/KpiSection.tsx
@@ -1,0 +1,71 @@
+/**
+ * US-2404 — KPI cabinet 14j (médecin). 4 cards : patients actifs, TIR moyen,
+ * urgences sem, propositions en attente. Polling 10min.
+ */
+
+"use client"
+
+import { MetricCard } from "@/components/diabeo/MetricCard"
+import { usePollingFetch } from "@/hooks/usePollingFetch"
+import type { KpiCard } from "@/lib/services/doctor-dashboard.service"
+
+type ApiResponse = { items: KpiCard[] }
+
+const KPI_LABELS: Record<KpiCard["code"], string> = {
+  activePatients: "Patients actifs (14j)",
+  avgTir: "TIR moyen (14j)",
+  weekUrgencies: "Urgences (7j)",
+  pendingProposals: "Propositions en attente",
+}
+
+function mapTrendDirection(t: KpiCard["trend"]): "up" | "down" | "stable" | undefined {
+  if (t === null) return undefined
+  if (t === "flat") return "stable"
+  return t
+}
+
+export function KpiSection() {
+  const { data, error, loading } = usePollingFetch<ApiResponse>(
+    "/api/dashboard/medecin/kpi",
+    10 * 60_000,
+  )
+  const items = data?.items ?? []
+  const hasError = error !== null && data === null
+
+  return (
+    <section aria-labelledby="kpi-section-title">
+      <h2 id="kpi-section-title" className="mb-3 text-base font-semibold">
+        KPI cabinet — 14 derniers jours
+      </h2>
+      {hasError && (
+        <p className="mb-2 text-sm text-glycemia-critical">
+          Impossible de charger les KPI.
+        </p>
+      )}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {(loading && items.length === 0
+          ? (["activePatients", "avgTir", "weekUrgencies", "pendingProposals"] as const).map(
+              (code) => ({ code, value: 0, delta: null, trend: null, unit: null }),
+            )
+          : items
+        ).map((k) => (
+          <MetricCard
+            key={k.code}
+            title={KPI_LABELS[k.code]}
+            value={k.value}
+            unit={k.unit ?? undefined}
+            loading={loading && items.length === 0}
+            trend={
+              k.delta !== null && k.trend !== null && k.trend !== "flat"
+                ? {
+                    direction: mapTrendDirection(k.trend)!,
+                    value: `${k.delta > 0 ? "+" : ""}${k.delta}${k.unit ?? ""}`,
+                  }
+                : undefined
+            }
+          />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/diabeo/dashboard/medecin/PatientsAtRiskCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/PatientsAtRiskCard.tsx
@@ -1,0 +1,85 @@
+/**
+ * US-2403 — Patients à suivre (médecin). Top 3 par score on-demand.
+ * Polling 5min. DOCTOR-only (jugement clinique).
+ */
+
+"use client"
+
+import Link from "next/link"
+import { DiabeoCard } from "@/components/diabeo/DiabeoCard"
+import { DiabeoEmptyState } from "@/components/diabeo/DiabeoEmptyState"
+import { Badge } from "@/components/ui/badge"
+import { usePollingFetch } from "@/hooks/usePollingFetch"
+import type { PatientAtRiskItem } from "@/lib/services/doctor-dashboard.service"
+
+type ApiResponse = { items: PatientAtRiskItem[] }
+
+const REASON_LABELS: Record<string, { label: string; variant: "destructive" | "outline" | "secondary" }> = {
+  recentHypos: { label: "Hypos récentes", variant: "destructive" },
+  silentMonitoring: { label: "Silence saisie", variant: "outline" },
+  tirDrop: { label: "TIR en baisse", variant: "secondary" },
+}
+
+export function PatientsAtRiskCard() {
+  const { data, error, loading } = usePollingFetch<ApiResponse>(
+    "/api/dashboard/medecin/patients-at-risk",
+    5 * 60_000,
+  )
+  const items = data?.items ?? []
+  const hasError = error !== null && data === null
+
+  return (
+    <DiabeoCard role="region" aria-labelledby="card-risk-title">
+      <header className="flex items-center justify-between px-4 pt-4">
+        <h2 id="card-risk-title" className="text-base font-semibold">
+          Patients à suivre
+        </h2>
+        <span className="text-xs text-muted-foreground">Top {items.length || 0}</span>
+      </header>
+
+      <div className="px-4 pb-4">
+        {loading && items.length === 0 && (
+          <p className="text-sm text-muted-foreground">Chargement…</p>
+        )}
+        {hasError && (
+          <p className="text-sm text-glycemia-critical">
+            Impossible de charger les patients à risque.
+          </p>
+        )}
+        {!loading && !hasError && items.length === 0 && (
+          <DiabeoEmptyState
+            variant="noData"
+            title="Tous stables"
+            message="Aucun patient ne déclenche d'indicateur de suivi."
+          />
+        )}
+        {items.length > 0 && (
+          <ul className="space-y-2">
+            {items.map((p) => {
+              const meta = REASON_LABELS[p.reason] ?? { label: p.reason, variant: "outline" as const }
+              return (
+                <li
+                  key={p.patientId}
+                  className="flex items-center gap-3 rounded-md border border-border bg-card px-3 py-2"
+                >
+                  <span className="flex h-8 w-8 items-center justify-center rounded-full bg-muted text-sm font-semibold">
+                    {(p.patientFirstName || "?").charAt(0).toUpperCase()}
+                  </span>
+                  <Link
+                    href={`/patients/${p.patientId}`}
+                    className="flex-1 truncate text-sm font-medium hover:underline"
+                  >
+                    {p.patientFirstName || "Patient"}
+                    {p.pathology ? ` · ${p.pathology}` : ""}
+                  </Link>
+                  <Badge variant={meta.variant}>{meta.label}</Badge>
+                  <span className="text-xs text-muted-foreground">{p.metricLabel}</span>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+    </DiabeoCard>
+  )
+}

--- a/src/components/diabeo/dashboard/medecin/PatientsAtRiskCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/PatientsAtRiskCard.tsx
@@ -8,6 +8,7 @@
 import Link from "next/link"
 import { DiabeoCard } from "@/components/diabeo/DiabeoCard"
 import { DiabeoEmptyState } from "@/components/diabeo/DiabeoEmptyState"
+import { StaleBanner } from "@/components/diabeo/dashboard/medecin/StaleBanner"
 import { Badge } from "@/components/ui/badge"
 import { usePollingFetch } from "@/hooks/usePollingFetch"
 import type { PatientAtRiskItem } from "@/lib/services/doctor-dashboard.service"
@@ -37,11 +38,7 @@ export function PatientsAtRiskCard() {
         </h2>
         <span className="text-xs text-muted-foreground">Top {items.length || 0}</span>
       </header>
-      {isStale && (
-        <p className="px-4 text-xs text-glycemia-high" role="status">
-          Données obsolètes — rafraîchissement en attente.
-        </p>
-      )}
+      {isStale && <StaleBanner />}
 
       <div className="px-4 pb-4">
         {loading && items.length === 0 && (

--- a/src/components/diabeo/dashboard/medecin/PatientsAtRiskCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/PatientsAtRiskCard.tsx
@@ -21,11 +21,12 @@ const REASON_LABELS: Record<string, { label: string; variant: "destructive" | "o
 }
 
 export function PatientsAtRiskCard() {
-  const { data, error, loading } = usePollingFetch<ApiResponse>(
+  const { data, error, loading, isStale } = usePollingFetch<ApiResponse>(
     "/api/dashboard/medecin/patients-at-risk",
     5 * 60_000,
   )
-  const items = data?.items ?? []
+  // code-review H5 — defensive against malformed response.
+  const items = Array.isArray(data?.items) ? data!.items : []
   const hasError = error !== null && data === null
 
   return (
@@ -36,6 +37,11 @@ export function PatientsAtRiskCard() {
         </h2>
         <span className="text-xs text-muted-foreground">Top {items.length || 0}</span>
       </header>
+      {isStale && (
+        <p className="px-4 text-xs text-glycemia-high" role="status">
+          Données obsolètes — rafraîchissement en attente.
+        </p>
+      )}
 
       <div className="px-4 pb-4">
         {loading && items.length === 0 && (

--- a/src/components/diabeo/dashboard/medecin/StaleBanner.tsx
+++ b/src/components/diabeo/dashboard/medecin/StaleBanner.tsx
@@ -1,0 +1,27 @@
+/**
+ * Shared stale-data banner for dashboard cards.
+ *
+ * code-review M3 (re-review) — the orange `text-glycemia-high` tint alone
+ * is too close to muted text to register as a visual signal at a glance.
+ * Adding a clock icon + bold weight makes the obsolete state legible
+ * without screen-reader announcement (WCAG 1.4.1 use-of-color : passes
+ * even at the cost of icon support).
+ */
+
+"use client"
+
+import { Clock } from "lucide-react"
+
+export function StaleBanner({ message = "Données obsolètes — rafraîchissement en attente." }: {
+  message?: string
+}) {
+  return (
+    <p
+      role="status"
+      className="flex items-center gap-1.5 px-4 text-xs font-medium text-glycemia-high"
+    >
+      <Clock size={12} aria-hidden="true" />
+      <span>{message}</span>
+    </p>
+  )
+}

--- a/src/hooks/usePollingFetch.ts
+++ b/src/hooks/usePollingFetch.ts
@@ -1,11 +1,18 @@
 /**
  * Generic polling fetch hook for backoffice dashboard cards.
  *
- * - Initial fetch on mount.
- * - Periodic refresh every `intervalMs` ms (default 30s).
- * - Pause when `document.visibilityState !== "visible"` (battery + perf).
- * - Cleanup on unmount.
- * - Manual refetch via returned `refetch()` callback.
+ *  - Initial fetch on mount.
+ *  - Periodic refresh every `intervalMs` ms (default 30s).
+ *  - **visibilitychange** listener clears the interval when the tab is
+ *    hidden (avoids 960 wakeups/8h idle ; code-review H4).
+ *  - Cleanup on unmount.
+ *  - Manual refetch via returned `refetch()` callback.
+ *  - **Auth termination** : on HTTP 401, stop the interval permanently
+ *    and trigger a single `window.location` redirect to `/login`
+ *    (healthcare L3 — avoid pounding `/api/**` after JWT expiry).
+ *  - **Staleness signal** : `isStale=true` when last successful fetch is
+ *    older than 2× `intervalMs` (code-review C1 — surface silent polling
+ *    failures so the UI can display "données obsolètes").
  *
  * Errors don't replace prior data ; they live in `error` while last good
  * data stays in `data` (so cards don't flicker empty on transient 5xx).
@@ -21,8 +28,12 @@ export type PollingState<T> = {
   loading: boolean
   /** ms since UNIX epoch of last successful fetch. null until first success. */
   lastUpdatedAt: number | null
+  /** True when last successful fetch is older than 2× intervalMs. */
+  isStale: boolean
   refetch: () => void
 }
+
+const STALE_FACTOR = 2
 
 export function usePollingFetch<T>(
   url: string,
@@ -33,8 +44,10 @@ export function usePollingFetch<T>(
   const [loading, setLoading] = useState<boolean>(true)
   const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null)
   const abortRef = useRef<AbortController | null>(null)
+  const stoppedRef = useRef<boolean>(false)
 
   const fetchOnce = useCallback(async (silent: boolean = false) => {
+    if (stoppedRef.current) return
     abortRef.current?.abort()
     const controller = new AbortController()
     abortRef.current = controller
@@ -45,6 +58,12 @@ export function usePollingFetch<T>(
         headers: { "X-Requested-With": "fetch" },
         signal: controller.signal,
       })
+      if (res.status === 401) {
+        // healthcare L3 — JWT expired ; stop polling and bounce to login.
+        stoppedRef.current = true
+        if (typeof window !== "undefined") window.location.href = "/login"
+        return
+      }
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       const json = (await res.json()) as T
       setData(json)
@@ -60,16 +79,44 @@ export function usePollingFetch<T>(
 
   useEffect(() => {
     void fetchOnce(false)
-    const id = setInterval(() => {
-      if (typeof document !== "undefined" && document.visibilityState !== "visible") return
-      void fetchOnce(true)
-    }, intervalMs)
+    let intervalId: ReturnType<typeof setInterval> | null = null
+    const start = () => {
+      if (intervalId !== null || stoppedRef.current) return
+      intervalId = setInterval(() => void fetchOnce(true), intervalMs)
+    }
+    const stop = () => {
+      if (intervalId !== null) {
+        clearInterval(intervalId)
+        intervalId = null
+      }
+    }
+    const onVisibility = () => {
+      if (typeof document === "undefined") return
+      if (document.visibilityState === "visible") {
+        // Catch up immediately when tab regains focus.
+        void fetchOnce(true)
+        start()
+      } else {
+        stop()
+      }
+    }
+    if (typeof document === "undefined" || document.visibilityState === "visible") {
+      start()
+    }
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", onVisibility)
+    }
     return () => {
-      clearInterval(id)
+      stop()
+      if (typeof document !== "undefined") {
+        document.removeEventListener("visibilitychange", onVisibility)
+      }
       abortRef.current?.abort()
     }
   }, [fetchOnce, intervalMs])
 
   const refetch = useCallback(() => void fetchOnce(false), [fetchOnce])
-  return { data, error, loading, lastUpdatedAt, refetch }
+  const isStale = lastUpdatedAt !== null
+    && Date.now() - lastUpdatedAt > STALE_FACTOR * intervalMs
+  return { data, error, loading, lastUpdatedAt, isStale, refetch }
 }

--- a/src/hooks/usePollingFetch.ts
+++ b/src/hooks/usePollingFetch.ts
@@ -35,6 +35,12 @@ export type PollingState<T> = {
 
 const STALE_FACTOR = 2
 
+// code-review L3 (re-review) — module-level guard : when ANY card receives
+// 401, this flag stays true for the rest of the page lifetime. Subsequent
+// polls from sibling cards short-circuit before issuing a network request,
+// avoiding 4 simultaneous 401s in the audit log + 4 redundant redirects.
+let authDead = false
+
 export function usePollingFetch<T>(
   url: string,
   intervalMs: number = 30_000,
@@ -47,7 +53,7 @@ export function usePollingFetch<T>(
   const stoppedRef = useRef<boolean>(false)
 
   const fetchOnce = useCallback(async (silent: boolean = false) => {
-    if (stoppedRef.current) return
+    if (stoppedRef.current || authDead) return
     abortRef.current?.abort()
     const controller = new AbortController()
     abortRef.current = controller
@@ -61,7 +67,10 @@ export function usePollingFetch<T>(
       if (res.status === 401) {
         // healthcare L3 — JWT expired ; stop polling and bounce to login.
         stoppedRef.current = true
-        if (typeof window !== "undefined") window.location.href = "/login"
+        if (!authDead) {
+          authDead = true
+          if (typeof window !== "undefined") window.location.href = "/login"
+        }
         return
       }
       if (!res.ok) throw new Error(`HTTP ${res.status}`)

--- a/src/hooks/usePollingFetch.ts
+++ b/src/hooks/usePollingFetch.ts
@@ -1,0 +1,75 @@
+/**
+ * Generic polling fetch hook for backoffice dashboard cards.
+ *
+ * - Initial fetch on mount.
+ * - Periodic refresh every `intervalMs` ms (default 30s).
+ * - Pause when `document.visibilityState !== "visible"` (battery + perf).
+ * - Cleanup on unmount.
+ * - Manual refetch via returned `refetch()` callback.
+ *
+ * Errors don't replace prior data ; they live in `error` while last good
+ * data stays in `data` (so cards don't flicker empty on transient 5xx).
+ */
+
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+export type PollingState<T> = {
+  data: T | null
+  error: string | null
+  loading: boolean
+  /** ms since UNIX epoch of last successful fetch. null until first success. */
+  lastUpdatedAt: number | null
+  refetch: () => void
+}
+
+export function usePollingFetch<T>(
+  url: string,
+  intervalMs: number = 30_000,
+): PollingState<T> {
+  const [data, setData] = useState<T | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState<boolean>(true)
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  const fetchOnce = useCallback(async (silent: boolean = false) => {
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+    if (!silent) setLoading(true)
+    try {
+      const res = await fetch(url, {
+        credentials: "include",
+        headers: { "X-Requested-With": "fetch" },
+        signal: controller.signal,
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const json = (await res.json()) as T
+      setData(json)
+      setLastUpdatedAt(Date.now())
+      setError(null)
+    } catch (e) {
+      if (e instanceof DOMException && e.name === "AbortError") return
+      setError(e instanceof Error ? e.message : "fetchFailed")
+    } finally {
+      if (!silent) setLoading(false)
+    }
+  }, [url])
+
+  useEffect(() => {
+    void fetchOnce(false)
+    const id = setInterval(() => {
+      if (typeof document !== "undefined" && document.visibilityState !== "visible") return
+      void fetchOnce(true)
+    }, intervalMs)
+    return () => {
+      clearInterval(id)
+      abortRef.current?.abort()
+    }
+  }, [fetchOnce, intervalMs])
+
+  const refetch = useCallback(() => void fetchOnce(false), [fetchOnce])
+  return { data, error, loading, lastUpdatedAt, refetch }
+}

--- a/src/lib/services/doctor-dashboard.service.ts
+++ b/src/lib/services/doctor-dashboard.service.ts
@@ -1,0 +1,523 @@
+/**
+ * @module doctor-dashboard.service
+ * @description Groupe 9b Batch 1 — Dashboard médecin (5 US, ~34 SP).
+ *
+ *  - US-2400 page principale (page conteneur)
+ *  - US-2401 urgences en cours (polling 30s, max 5, criticité desc)
+ *  - US-2402 RDV du jour (today's appointments, max 3)
+ *  - US-2403 patients à suivre (computed on-demand, no nightly batch)
+ *  - US-2404 KPI cabinet 14j (4 KPIs : actifs, TIR moyen, urgences sem, propositions)
+ *
+ * Tous les endpoints sont DOCTOR/NURSE-gated et scopés au portefeuille du
+ * caller via `getAccessiblePatientIds` (RBAC). ADMIN = no restriction.
+ *
+ * Patients-à-suivre est calculé on-demand sur le portefeuille (hypos 7j,
+ * silence saisie 5j, sans persister de table flag) — décision pragmatique
+ * pour shipper le batch sans batch job nocturne. Ré-évaluable en V2 si
+ * le coût compute devient un problème.
+ */
+
+import {
+  EmergencyAlertStatus,
+  EmergencyAlertType,
+  EmergencyAlertSeverity,
+  AppointmentStatus,
+  type Prisma,
+} from "@prisma/client"
+import { prisma } from "@/lib/db/client"
+import { getAccessiblePatientIds } from "@/lib/access-control"
+import { auditService, type AuditContext } from "./audit.service"
+import { safeDecryptField } from "@/lib/crypto/fields"
+import type { Role } from "@prisma/client"
+
+// ─────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Build the patient-portfolio `WHERE` clause for cross-patient queries.
+ * Returns `{}` for ADMIN (no restriction) ; otherwise an `IN` filter.
+ * Empty array → forces no rows (caller has empty portfolio).
+ */
+function patientScopeWhere(
+  ids: number[] | null,
+): { patientId?: { in: number[] } } | null {
+  if (ids === null) return {} // ADMIN — no restriction
+  if (ids.length === 0) return null // empty portfolio → no rows
+  return { patientId: { in: ids } }
+}
+
+const CRITICALITY_ORDER: Record<EmergencyAlertType, number> = {
+  ketone_dka: 0,
+  severe_hypo: 1,
+  ketone_moderate: 2,
+  hypo: 3,
+  severe_hyper: 4,
+  hyper: 5,
+  manual: 6,
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2401 — Urgencies in progress
+// ─────────────────────────────────────────────────────────────
+
+export type UrgencyItem = {
+  id: number
+  patientId: number
+  alertType: EmergencyAlertType
+  severity: EmergencyAlertSeverity
+  status: EmergencyAlertStatus
+  triggeredAt: Date
+  glucoseValueMgdl: number | null
+  ketoneValueMmol: number | null
+  /** First-name only (privacy on dashboard) — empty string if decryption fails. */
+  patientFirstName: string
+  pathology: string | null
+}
+
+const URGENCY_LIMIT = 5
+
+export const urgenciesQuery = {
+  async forCaller(
+    userId: number, role: Role,
+    auditUserId: number, ctx?: AuditContext,
+  ): Promise<UrgencyItem[]> {
+    const ids = await getAccessiblePatientIds(userId, role)
+    const scope = patientScopeWhere(ids)
+    if (scope === null) return [] // empty portfolio
+    const rows = await prisma.emergencyAlert.findMany({
+      where: {
+        ...scope,
+        status: { in: [EmergencyAlertStatus.open, EmergencyAlertStatus.acknowledged] },
+        patient: { deletedAt: null },
+      },
+      include: {
+        patient: {
+          select: {
+            id: true, pathology: true,
+            user: { select: { firstname: true } },
+          },
+        },
+      },
+      orderBy: [{ triggeredAt: "desc" }],
+      // Over-fetch then sort by criticality in-memory (small N, K ≤ 5).
+      take: 50,
+    })
+    const sorted = rows
+      .sort((a, b) => {
+        const cmp = CRITICALITY_ORDER[a.alertType] - CRITICALITY_ORDER[b.alertType]
+        if (cmp !== 0) return cmp
+        return b.triggeredAt.getTime() - a.triggeredAt.getTime()
+      })
+      .slice(0, URGENCY_LIMIT)
+
+    await auditService.log({
+      userId: auditUserId, action: "READ", resource: "EMERGENCY_ALERT",
+      resourceId: "0",
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { kind: "dashboard.medecin.urgencies", count: sorted.length },
+    })
+
+    return sorted.map((r) => ({
+      id: r.id,
+      patientId: r.patientId,
+      alertType: r.alertType,
+      severity: r.severity,
+      status: r.status,
+      triggeredAt: r.triggeredAt,
+      glucoseValueMgdl: r.glucoseValueMgdl?.toNumber() ?? null,
+      ketoneValueMmol: r.ketoneValueMmol?.toNumber() ?? null,
+      patientFirstName: safeDecryptField(r.patient.user.firstname ?? "") ?? "",
+      pathology: r.patient.pathology,
+    }))
+  },
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2402 — Today's appointments
+// ─────────────────────────────────────────────────────────────
+
+export type AppointmentItem = {
+  id: number
+  patientId: number
+  date: Date
+  hour: Date | null
+  type: string | null
+  status: AppointmentStatus
+  location: string | null
+  patientFirstName: string
+  pathology: string | null
+}
+
+const APPOINTMENTS_LIMIT = 3
+
+function todayBounds(now = new Date()): { start: Date; end: Date } {
+  const start = new Date(now)
+  start.setUTCHours(0, 0, 0, 0)
+  const end = new Date(start)
+  end.setUTCDate(end.getUTCDate() + 1)
+  return { start, end }
+}
+
+export const appointmentsQuery = {
+  async forCaller(
+    userId: number, role: Role,
+    auditUserId: number, ctx?: AuditContext,
+  ): Promise<AppointmentItem[]> {
+    const ids = await getAccessiblePatientIds(userId, role)
+    const scope = patientScopeWhere(ids)
+    if (scope === null) return []
+    const { start, end } = todayBounds()
+    const where: Prisma.AppointmentWhereInput = {
+      ...scope,
+      date: { gte: start, lt: end },
+      status: { in: [AppointmentStatus.scheduled, AppointmentStatus.pending_validation] },
+      patient: { deletedAt: null },
+    }
+    const rows = await prisma.appointment.findMany({
+      where,
+      include: {
+        patient: {
+          select: {
+            id: true, pathology: true,
+            user: { select: { firstname: true } },
+          },
+        },
+      },
+      orderBy: [{ hour: "asc" }],
+      take: APPOINTMENTS_LIMIT,
+    })
+
+    await auditService.log({
+      userId: auditUserId, action: "READ", resource: "APPOINTMENT",
+      resourceId: "0",
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { kind: "dashboard.medecin.appointments", count: rows.length },
+    })
+
+    return rows.map((r) => ({
+      id: r.id,
+      patientId: r.patientId,
+      date: r.date,
+      hour: r.hour,
+      type: r.type,
+      status: r.status,
+      location: r.location ?? null,
+      patientFirstName: safeDecryptField(r.patient.user.firstname ?? "") ?? "",
+      pathology: r.patient.pathology,
+    }))
+  },
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2403 — Patients at risk (on-demand, no batch job)
+// ─────────────────────────────────────────────────────────────
+
+export type RiskReason = "recentHypos" | "silentMonitoring" | "tirDrop"
+
+export type PatientAtRiskItem = {
+  patientId: number
+  patientFirstName: string
+  pathology: string | null
+  reason: RiskReason
+  /** Free-form metric label (e.g. "4 hypos / 7j", "12 jours sans saisie"). */
+  metricLabel: string
+  /** Higher = more critical. Used for sort. */
+  score: number
+}
+
+const RISK_LIMIT = 3
+/** ≥ this hypos in window = flag. */
+const HYPO_THRESHOLD_7D = 3
+/** No CGM/manual entry in N days = silent. */
+const SILENT_DAYS = 5
+
+export const patientsAtRiskQuery = {
+  /**
+   * Compute risk flags on-demand for the caller's portfolio. NOT a nightly
+   * batch — re-runs on every dashboard load. At small N (≤ 200 patients),
+   * cost is acceptable ; revisit with cache (Redis TTL ~5min) at scale.
+   *
+   * Excludes patients that currently have an OPEN urgency (they're already
+   * surfaced in the urgencies card).
+   */
+  async forCaller(
+    userId: number, role: Role,
+    auditUserId: number, ctx?: AuditContext,
+  ): Promise<PatientAtRiskItem[]> {
+    const ids = await getAccessiblePatientIds(userId, role)
+    if (ids !== null && ids.length === 0) return []
+    const now = new Date()
+    const sevenDaysAgo = new Date(now.getTime() - 7 * 86_400_000)
+    const silentCutoff = new Date(now.getTime() - SILENT_DAYS * 86_400_000)
+
+    // Patients with open urgencies (excluded from list).
+    const inUrgencyRows = await prisma.emergencyAlert.findMany({
+      where: {
+        ...(ids ? { patientId: { in: ids } } : {}),
+        status: { in: [EmergencyAlertStatus.open, EmergencyAlertStatus.acknowledged] },
+      },
+      select: { patientId: true },
+      distinct: ["patientId"],
+    })
+    const exclude = new Set(inUrgencyRows.map((r) => r.patientId))
+
+    // Hypo count last 7 days, by patient.
+    const hypoCounts = await prisma.emergencyAlert.groupBy({
+      by: ["patientId"],
+      where: {
+        ...(ids ? { patientId: { in: ids } } : {}),
+        alertType: { in: [EmergencyAlertType.hypo, EmergencyAlertType.severe_hypo] },
+        triggeredAt: { gte: sevenDaysAgo },
+      },
+      _count: { patientId: true },
+    })
+
+    // Silence detection : latest cgmEntry timestamp per patient.
+    const latestCgm = await prisma.cgmEntry.groupBy({
+      by: ["patientId"],
+      where: ids ? { patientId: { in: ids } } : undefined,
+      _max: { timestamp: true },
+    })
+    const latestByPatient = new Map(
+      latestCgm.map((r) => [r.patientId, r._max.timestamp]),
+    )
+
+    // Build candidate flags.
+    const flags = new Map<number, PatientAtRiskItem & { _patientId: number }>()
+    for (const hp of hypoCounts) {
+      if (exclude.has(hp.patientId)) continue
+      const count = hp._count.patientId
+      if (count >= HYPO_THRESHOLD_7D) {
+        flags.set(hp.patientId, {
+          _patientId: hp.patientId,
+          patientId: hp.patientId,
+          patientFirstName: "",
+          pathology: null,
+          reason: "recentHypos",
+          metricLabel: `${count} hypos / 7j`,
+          score: 100 + count, // 3+ hypos = base 103
+        })
+      }
+    }
+
+    // Silent monitoring : patients whose latest CGM is older than cutoff,
+    // OR patients in portfolio with NO CGM entries at all.
+    const portfolioIds = ids ?? Array.from(latestByPatient.keys())
+    for (const pid of portfolioIds) {
+      if (exclude.has(pid) || flags.has(pid)) continue
+      const last = latestByPatient.get(pid)
+      if (last === undefined || last === null || last < silentCutoff) {
+        const days = last
+          ? Math.floor((now.getTime() - last.getTime()) / 86_400_000)
+          : Math.max(SILENT_DAYS + 1, 14)
+        flags.set(pid, {
+          _patientId: pid,
+          patientId: pid,
+          patientFirstName: "",
+          pathology: null,
+          reason: "silentMonitoring",
+          metricLabel: `${days} j sans saisie`,
+          score: 50 + Math.min(50, days), // capped contribution
+        })
+      }
+    }
+
+    const top = Array.from(flags.values())
+      .sort((a, b) => b.score - a.score)
+      .slice(0, RISK_LIMIT)
+
+    if (top.length === 0) {
+      await auditService.log({
+        userId: auditUserId, action: "READ", resource: "PATIENT",
+        resourceId: "0",
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: { kind: "dashboard.medecin.patientsAtRisk", count: 0 },
+      })
+      return []
+    }
+
+    // Hydrate first-name (via User) + pathology for the top N only.
+    const patients = await prisma.patient.findMany({
+      where: { id: { in: top.map((t) => t.patientId) }, deletedAt: null },
+      select: {
+        id: true, pathology: true,
+        user: { select: { firstname: true } },
+      },
+    })
+    const byId = new Map(patients.map((p) => [p.id, p]))
+
+    // Per-patient audit row (forensic pivot per US-2268).
+    await Promise.all(top.map((t) =>
+      auditService.log({
+        userId: auditUserId, action: "READ", resource: "PATIENT",
+        resourceId: String(t.patientId),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: {
+          patientId: t.patientId,
+          kind: "dashboard.medecin.patientsAtRisk",
+          reason: t.reason,
+        },
+      }),
+    ))
+
+    return top.map((t) => {
+      const p = byId.get(t.patientId)
+      return {
+        patientId: t.patientId,
+        patientFirstName: safeDecryptField(p?.user?.firstname ?? "") ?? "",
+        pathology: p?.pathology ?? null,
+        reason: t.reason,
+        metricLabel: t.metricLabel,
+        score: t.score,
+      }
+    })
+  },
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2404 — KPI cabinet 14j
+// ─────────────────────────────────────────────────────────────
+
+export type KpiCard = {
+  /** Stable identifier — drives drill-down navigation. */
+  code: "activePatients" | "avgTir" | "weekUrgencies" | "pendingProposals"
+  value: number
+  /** Optional delta (raw difference vs previous window). */
+  delta: number | null
+  /** Optional trend direction ; null when no comparable. */
+  trend: "up" | "down" | "flat" | null
+  unit: string | null
+}
+
+// CgmEntry stores `valueGl` in g/L. Thresholds : 70 mg/dL = 0.70 g/L,
+// 180 mg/dL = 1.80 g/L (1 g/L = 100 mg/dL). Standard TIR window per ATTD 2019.
+const TIR_LOW_GL = 0.70
+const TIR_HIGH_GL = 1.80
+
+export const kpisQuery = {
+  async forCaller(
+    userId: number, role: Role,
+    auditUserId: number, ctx?: AuditContext,
+  ): Promise<KpiCard[]> {
+    const ids = await getAccessiblePatientIds(userId, role)
+    const scope = patientScopeWhere(ids)
+    if (scope === null) {
+      // Empty portfolio → all KPIs zeroed.
+      const zero: KpiCard[] = [
+        { code: "activePatients", value: 0, delta: null, trend: null, unit: null },
+        { code: "avgTir", value: 0, delta: null, trend: null, unit: "%" },
+        { code: "weekUrgencies", value: 0, delta: null, trend: null, unit: null },
+        { code: "pendingProposals", value: 0, delta: null, trend: null, unit: null },
+      ]
+      return zero
+    }
+
+    const now = new Date()
+    const fourteenDaysAgo = new Date(now.getTime() - 14 * 86_400_000)
+    const twentyEightDaysAgo = new Date(now.getTime() - 28 * 86_400_000)
+    const sevenDaysAgo = new Date(now.getTime() - 7 * 86_400_000)
+    const fourteenDaysAgoPrev = new Date(now.getTime() - 14 * 86_400_000)
+
+    // 1. Active patients = patient with ≥ 1 CGM entry in last 14d.
+    const activeNow = await prisma.cgmEntry.groupBy({
+      by: ["patientId"],
+      where: {
+        ...scope,
+        timestamp: { gte: fourteenDaysAgo },
+      },
+      _count: { _all: true },
+    })
+    const activePrev = await prisma.cgmEntry.groupBy({
+      by: ["patientId"],
+      where: {
+        ...scope,
+        timestamp: { gte: twentyEightDaysAgo, lt: fourteenDaysAgoPrev },
+      },
+      _count: { _all: true },
+    })
+    const activeNowCount = activeNow.length
+    const activePrevCount = activePrev.length
+    const activeDelta = activeNowCount - activePrevCount
+
+    // 2. Avg TIR : aggregate CGM readings last 14d, fraction in [0.70, 1.80] g/L.
+    const tirTotalNow = await prisma.cgmEntry.count({
+      where: { ...scope, timestamp: { gte: fourteenDaysAgo } },
+    })
+    const tirInRangeNow = await prisma.cgmEntry.count({
+      where: {
+        ...scope,
+        timestamp: { gte: fourteenDaysAgo },
+        valueGl: { gte: TIR_LOW_GL, lte: TIR_HIGH_GL },
+      },
+    })
+    const tirNow = tirTotalNow > 0
+      ? Math.round((tirInRangeNow / tirTotalNow) * 1000) / 10
+      : 0
+
+    const tirTotalPrev = await prisma.cgmEntry.count({
+      where: {
+        ...scope,
+        timestamp: { gte: twentyEightDaysAgo, lt: fourteenDaysAgoPrev },
+      },
+    })
+    const tirInRangePrev = await prisma.cgmEntry.count({
+      where: {
+        ...scope,
+        timestamp: { gte: twentyEightDaysAgo, lt: fourteenDaysAgoPrev },
+        valueGl: { gte: TIR_LOW_GL, lte: TIR_HIGH_GL },
+      },
+    })
+    const tirPrev = tirTotalPrev > 0
+      ? Math.round((tirInRangePrev / tirTotalPrev) * 1000) / 10
+      : 0
+    const tirDelta = tirTotalPrev > 0
+      ? Math.round((tirNow - tirPrev) * 10) / 10
+      : null
+
+    // 3. Week urgencies = critical alerts triggered last 7 days.
+    const weekUrg = await prisma.emergencyAlert.count({
+      where: {
+        ...scope,
+        triggeredAt: { gte: sevenDaysAgo },
+        severity: EmergencyAlertSeverity.critical,
+      },
+    })
+
+    // 4. Pending adjustment proposals in portfolio.
+    const pendingProposals = await prisma.adjustmentProposal.count({
+      where: {
+        ...scope,
+        status: "pending",
+      },
+    })
+
+    await auditService.log({
+      userId: auditUserId, action: "READ", resource: "PATIENT",
+      resourceId: "0",
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { kind: "dashboard.medecin.kpi" },
+    })
+
+    return [
+      {
+        code: "activePatients", value: activeNowCount,
+        delta: activeDelta, unit: null,
+        trend: activeDelta > 0 ? "up" : activeDelta < 0 ? "down" : "flat",
+      },
+      {
+        code: "avgTir", value: tirNow,
+        delta: tirDelta, unit: "%",
+        trend: tirDelta === null ? null : tirDelta > 0 ? "up" : tirDelta < 0 ? "down" : "flat",
+      },
+      {
+        code: "weekUrgencies", value: weekUrg,
+        delta: null, trend: null, unit: null,
+      },
+      {
+        code: "pendingProposals", value: pendingProposals,
+        delta: null, trend: null, unit: null,
+      },
+    ]
+  },
+}

--- a/src/lib/services/doctor-dashboard.service.ts
+++ b/src/lib/services/doctor-dashboard.service.ts
@@ -39,13 +39,30 @@ import type { Role } from "@prisma/client"
  * Returns `{}` for ADMIN (no restriction) ; otherwise an `IN` filter.
  * Empty array → forces no rows (caller has empty portfolio).
  */
+/**
+ * Build the patient-portfolio `WHERE` clause for cross-patient queries.
+ *
+ * **Three return states** (code-review L1 re-review — discriminated by
+ * caller via null check + presence of `patientId`) :
+ *  - `null`       → caller's portfolio is empty ; query should be skipped
+ *                    to avoid scanning the whole table.
+ *  - `{ patient: { deletedAt: null } }`
+ *                 → ADMIN, no portfolio restriction beyond soft-delete.
+ *  - `{ patientId: { in: ids }, patient: { deletedAt: null } }`
+ *                 → DOCTOR/NURSE, restricted to managed patients.
+ *
+ * **healthcare H1** — even for ADMIN, exclude soft-deleted patients to
+ * honour RGPD Art. 17 (no resurfacing of erased patients on aggregate
+ * dashboards).
+ *
+ * Callers MUST NOT redeclare a `patient:` relation filter at the call site
+ * — it would silently override the one inserted here (re-review H1).
+ */
 function patientScopeWhere(
   ids: number[] | null,
 ): { patientId?: { in: number[] }; patient?: { deletedAt: null } } | null {
-  // healthcare H1 — even for ADMIN, exclude soft-deleted patients to honour
-  // RGPD Art. 17 (no resurfacing of erased patients on aggregate dashboards).
   if (ids === null) return { patient: { deletedAt: null } }
-  if (ids.length === 0) return null // empty portfolio → no rows
+  if (ids.length === 0) return null
   return { patientId: { in: ids }, patient: { deletedAt: null } }
 }
 
@@ -108,12 +125,19 @@ export const urgenciesQuery = {
         },
       },
     } as const
+    // code-review M1 (re-review) — uncap `criticalRows` to a generous
+    //   ceiling (50) instead of `URGENCY_LIMIT=5`. A mass-event scenario
+    //   (sensor outage, multi-patient DKA on a heatwave) shouldn't hide
+    //   the 6th critical alert behind newer non-critical noise. 50 is large
+    //   enough to dominate the URGENCY_LIMIT slice and small enough to
+    //   bound query cost.
+    const CRITICAL_OVERFETCH = 50
     const [criticalRows, recentRows] = await Promise.all([
       prisma.emergencyAlert.findMany({
         where: { ...baseWhere, severity: EmergencyAlertSeverity.critical },
         include,
         orderBy: [{ triggeredAt: "desc" }],
-        take: URGENCY_LIMIT,
+        take: CRITICAL_OVERFETCH,
       }),
       prisma.emergencyAlert.findMany({
         where: baseWhere,
@@ -140,12 +164,24 @@ export const urgenciesQuery = {
       })
       .slice(0, URGENCY_LIMIT)
 
+    // code-review M2 (re-review) — summary + per-patient pivot.
     await auditService.log({
       userId: auditUserId, action: "READ", resource: "EMERGENCY_ALERT",
       resourceId: "0",
       ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
       metadata: { kind: "dashboard.medecin.urgencies", count: sorted.length },
     })
+    await Promise.allSettled(sorted.map((r) =>
+      auditService.log({
+        userId: auditUserId, action: "READ", resource: "EMERGENCY_ALERT",
+        resourceId: String(r.id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: {
+          patientId: r.patientId,
+          kind: "dashboard.medecin.urgencies",
+        },
+      }),
+    ))
 
     return sorted.map((r) => ({
       id: r.id,
@@ -216,11 +252,14 @@ export const appointmentsQuery = {
     const scope = patientScopeWhere(ids)
     if (scope === null) return []
     const { start, end } = todayBounds()
+    // code-review H1 (re-review) — `scope` already carries
+    //   `patient: { deletedAt: null }` ; don't override it here. Adding a
+    //   literal `patient:` below would silently drop any future sub-filter
+    //   introduced in `patientScopeWhere` (e.g. status filtering).
     const where: Prisma.AppointmentWhereInput = {
       ...scope,
       date: { gte: start, lt: end },
       status: { in: [AppointmentStatus.scheduled, AppointmentStatus.pending_validation] },
-      patient: { deletedAt: null },
     }
     const rows = await prisma.appointment.findMany({
       where,
@@ -236,12 +275,28 @@ export const appointmentsQuery = {
       take: APPOINTMENTS_LIMIT,
     })
 
+    // code-review M2 (re-review) — emit both summary AND per-patient pivot
+    //   audit rows. Appointments expose decrypted firstname + pathology per
+    //   patient ; CNIL forensic query "who saw patient X today" must surface
+    //   the dashboard view via `auditService.getByPatient(X)` (ADR #18).
+    //   KPI stays summary-only (aggregate metrics, no per-patient PHI).
     await auditService.log({
       userId: auditUserId, action: "READ", resource: "APPOINTMENT",
       resourceId: "0",
       ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
       metadata: { kind: "dashboard.medecin.appointments", count: rows.length },
     })
+    await Promise.allSettled(rows.map((r) =>
+      auditService.log({
+        userId: auditUserId, action: "READ", resource: "APPOINTMENT",
+        resourceId: String(r.id),
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: {
+          patientId: r.patientId,
+          kind: "dashboard.medecin.appointments",
+        },
+      }),
+    ))
 
     return rows.map((r) => ({
       id: r.id,
@@ -370,6 +425,10 @@ export const patientsAtRiskQuery = {
 
     // Silent monitoring : patients whose latest CGM is older than cutoff,
     // OR patients in portfolio with NO CGM entries at all.
+    // code-review L2 (re-review) — `last === null` retained at the type
+    //   level (Map value type from `_max.timestamp` is `Date | null`)
+    //   though semantically dead : the column is `@db.Timestamptz()`
+    //   non-null, so a row only exists with a non-null timestamp.
     const portfolioIds = ids ?? (adminPortfolio ?? []).map((p) => p.id)
     for (const pid of portfolioIds) {
       if (exclude.has(pid) || flags.has(pid)) continue
@@ -396,11 +455,19 @@ export const patientsAtRiskQuery = {
 
     // healthcare M2 — always emit a summary `resourceId:"0"` audit row,
     //   matching the other 3 dashboard endpoints' telemetry convention.
+    // code-review L4 (re-review) — flag when the ADMIN seed list was
+    //   truncated at 1000 so forensics knows the silent-monitoring count
+    //   under-reports.
+    const adminTruncated = ids === null && (adminPortfolio?.length ?? 0) >= 1000
     await auditService.log({
       userId: auditUserId, action: "READ", resource: "PATIENT",
       resourceId: "0",
       ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
-      metadata: { kind: "dashboard.medecin.patientsAtRisk", count: top.length },
+      metadata: {
+        kind: "dashboard.medecin.patientsAtRisk",
+        count: top.length,
+        ...(adminTruncated ? { wasTruncated: true } : {}),
+      },
     })
 
     if (top.length === 0) return []
@@ -551,7 +618,11 @@ export const kpisQuery = {
     const tirPrev = tirTotalPrev > 0
       ? Math.round((tirInRangePrev / tirTotalPrev) * 1000) / 10
       : 0
-    const tirDelta = tirTotalPrev > 0
+    // code-review H2 (re-review) — only compute delta when BOTH windows
+    //   have data. Otherwise a quiet portfolio (no CGM uploads this
+    //   fortnight) would surface a fake "down trend" of -tirPrev. Clinical
+    //   UX risk: doctor sees catastrophic drop on a stable patient.
+    const tirDelta = tirTotalNow > 0 && tirTotalPrev > 0
       ? Math.round((tirNow - tirPrev) * 10) / 10
       : null
 

--- a/src/lib/services/doctor-dashboard.service.ts
+++ b/src/lib/services/doctor-dashboard.service.ts
@@ -41,13 +41,20 @@ import type { Role } from "@prisma/client"
  */
 function patientScopeWhere(
   ids: number[] | null,
-): { patientId?: { in: number[] } } | null {
-  if (ids === null) return {} // ADMIN — no restriction
+): { patientId?: { in: number[] }; patient?: { deletedAt: null } } | null {
+  // healthcare H1 — even for ADMIN, exclude soft-deleted patients to honour
+  // RGPD Art. 17 (no resurfacing of erased patients on aggregate dashboards).
+  if (ids === null) return { patient: { deletedAt: null } }
   if (ids.length === 0) return null // empty portfolio → no rows
-  return { patientId: { in: ids } }
+  return { patientId: { in: ids }, patient: { deletedAt: null } }
 }
 
-const CRITICALITY_ORDER: Record<EmergencyAlertType, number> = {
+/**
+ * code-review L1 — exported so tests can assert criticality invariants.
+ * Lower value = higher priority. Ordering matches IDF/EASD severity scale
+ * (DKA > severe hypo > moderate ketone > hypo > severe hyper > hyper > manual).
+ */
+export const CRITICALITY_ORDER: Record<EmergencyAlertType, number> = {
   ketone_dka: 0,
   severe_hypo: 1,
   ketone_moderate: 2,
@@ -85,25 +92,47 @@ export const urgenciesQuery = {
     const ids = await getAccessiblePatientIds(userId, role)
     const scope = patientScopeWhere(ids)
     if (scope === null) return [] // empty portfolio
-    const rows = await prisma.emergencyAlert.findMany({
-      where: {
-        ...scope,
-        status: { in: [EmergencyAlertStatus.open, EmergencyAlertStatus.acknowledged] },
-        patient: { deletedAt: null },
-      },
-      include: {
-        patient: {
-          select: {
-            id: true, pathology: true,
-            user: { select: { firstname: true } },
-          },
+    const baseWhere = {
+      ...scope,
+      status: { in: [EmergencyAlertStatus.open, EmergencyAlertStatus.acknowledged] },
+    }
+    // healthcare M1 — two-pass : always surface critical-severity alerts
+    // (DKA, severe hypo, severe hyper) regardless of trigger time ; then
+    // top up with newer non-critical to URGENCY_LIMIT. Eliminates the
+    // "DKA hidden behind 50 newer hypers" failure mode.
+    const include = {
+      patient: {
+        select: {
+          id: true, pathology: true,
+          user: { select: { firstname: true } },
         },
       },
-      orderBy: [{ triggeredAt: "desc" }],
-      // Over-fetch then sort by criticality in-memory (small N, K ≤ 5).
-      take: 50,
-    })
-    const sorted = rows
+    } as const
+    const [criticalRows, recentRows] = await Promise.all([
+      prisma.emergencyAlert.findMany({
+        where: { ...baseWhere, severity: EmergencyAlertSeverity.critical },
+        include,
+        orderBy: [{ triggeredAt: "desc" }],
+        take: URGENCY_LIMIT,
+      }),
+      prisma.emergencyAlert.findMany({
+        where: baseWhere,
+        include,
+        orderBy: [{ triggeredAt: "desc" }],
+        take: URGENCY_LIMIT * 2,
+      }),
+    ])
+    // Dedupe by id (critical rows are a subset of recent in time) preserving
+    // criticalRows first so they survive the limit cut.
+    const seen = new Set<number>()
+    const merged: typeof criticalRows = []
+    for (const r of criticalRows) {
+      if (!seen.has(r.id)) { seen.add(r.id); merged.push(r) }
+    }
+    for (const r of recentRows) {
+      if (!seen.has(r.id)) { seen.add(r.id); merged.push(r) }
+    }
+    const sorted = merged
       .sort((a, b) => {
         const cmp = CRITICALITY_ORDER[a.alertType] - CRITICALITY_ORDER[b.alertType]
         if (cmp !== 0) return cmp
@@ -150,10 +179,29 @@ export type AppointmentItem = {
 }
 
 const APPOINTMENTS_LIMIT = 3
+const CABINET_TIMEZONE = "Europe/Paris"
 
+/**
+ * code-review C3 / M6 — return [start, end) covering "today" in the cabinet's
+ * timezone (Europe/Paris). The `appointment.date` column is `@db.Date`
+ * (timezone-naive), so we must build the boundary against Paris wall-clock,
+ * not the server's UTC midnight. At 01h Paris (= 23h UTC previous day), the
+ * previous UTC-midnight implementation showed yesterday's RDV instead of
+ * today's morning slots.
+ */
 function todayBounds(now = new Date()): { start: Date; end: Date } {
-  const start = new Date(now)
-  start.setUTCHours(0, 0, 0, 0)
+  // Compute the Paris YYYY-MM-DD for `now`, then build the start of that
+  // local day and the start of the next local day as UTC instants.
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone: CABINET_TIMEZONE,
+    year: "numeric", month: "2-digit", day: "2-digit",
+  })
+  const parts = fmt.format(now) // "YYYY-MM-DD"
+  // `@db.Date` columns are stored as Postgres DATE (no time/tz). Comparing
+  // against a UTC-midnight Date works because Prisma serialises Date → DATE
+  // via the date portion only. Using UTC midnight of the *Paris-local* date
+  // means we filter for the right calendar day.
+  const start = new Date(`${parts}T00:00:00Z`)
   const end = new Date(start)
   end.setUTCDate(end.getUTCDate() + 1)
   return { start, end }
@@ -213,7 +261,9 @@ export const appointmentsQuery = {
 // US-2403 — Patients at risk (on-demand, no batch job)
 // ─────────────────────────────────────────────────────────────
 
-export type RiskReason = "recentHypos" | "silentMonitoring" | "tirDrop"
+// code-review L6 — dropped `tirDrop` (defined but never produced) ;
+//   reintroduce when prior-window TIR per patient is implemented.
+export type RiskReason = "recentHypos" | "silentMonitoring"
 
 export type PatientAtRiskItem = {
   patientId: number
@@ -250,35 +300,52 @@ export const patientsAtRiskQuery = {
     const now = new Date()
     const sevenDaysAgo = new Date(now.getTime() - 7 * 86_400_000)
     const silentCutoff = new Date(now.getTime() - SILENT_DAYS * 86_400_000)
-
-    // Patients with open urgencies (excluded from list).
-    const inUrgencyRows = await prisma.emergencyAlert.findMany({
-      where: {
-        ...(ids ? { patientId: { in: ids } } : {}),
-        status: { in: [EmergencyAlertStatus.open, EmergencyAlertStatus.acknowledged] },
-      },
-      select: { patientId: true },
-      distinct: ["patientId"],
-    })
+    // healthcare H1 — soft-delete filter on every cross-patient aggregation,
+    //   including ADMIN (ids=null).
+    const patientFilter = { patient: { deletedAt: null } }
+    // code-review M5 — parallelize 3 independent queries (3x latency win).
+    // healthcare H2 — for ADMIN with no portfolio restriction, fetch the
+    //   full non-deleted patient list to seed silence detection ; otherwise
+    //   `Array.from(latestByPatient.keys())` would miss patients with no CGM.
+    const [inUrgencyRows, hypoCounts, latestCgm, adminPortfolio] = await Promise.all([
+      prisma.emergencyAlert.findMany({
+        where: {
+          ...(ids ? { patientId: { in: ids } } : {}),
+          ...patientFilter,
+          status: { in: [EmergencyAlertStatus.open, EmergencyAlertStatus.acknowledged] },
+        },
+        select: { patientId: true },
+        distinct: ["patientId"],
+      }),
+      prisma.emergencyAlert.groupBy({
+        by: ["patientId"],
+        where: {
+          ...(ids ? { patientId: { in: ids } } : {}),
+          ...patientFilter,
+          alertType: { in: [EmergencyAlertType.hypo, EmergencyAlertType.severe_hypo] },
+          triggeredAt: { gte: sevenDaysAgo },
+        },
+        _count: { patientId: true },
+      }),
+      prisma.cgmEntry.groupBy({
+        by: ["patientId"],
+        where: {
+          ...(ids ? { patientId: { in: ids } } : {}),
+          ...patientFilter,
+        },
+        _max: { timestamp: true },
+      }),
+      // ADMIN seed : full non-deleted patient list (cap 1000 to bound audit
+      // explosion). DOCTOR/NURSE rely on their `ids` portfolio.
+      ids === null
+        ? prisma.patient.findMany({
+            where: { deletedAt: null },
+            select: { id: true },
+            take: 1000,
+          })
+        : Promise.resolve(null),
+    ])
     const exclude = new Set(inUrgencyRows.map((r) => r.patientId))
-
-    // Hypo count last 7 days, by patient.
-    const hypoCounts = await prisma.emergencyAlert.groupBy({
-      by: ["patientId"],
-      where: {
-        ...(ids ? { patientId: { in: ids } } : {}),
-        alertType: { in: [EmergencyAlertType.hypo, EmergencyAlertType.severe_hypo] },
-        triggeredAt: { gte: sevenDaysAgo },
-      },
-      _count: { patientId: true },
-    })
-
-    // Silence detection : latest cgmEntry timestamp per patient.
-    const latestCgm = await prisma.cgmEntry.groupBy({
-      by: ["patientId"],
-      where: ids ? { patientId: { in: ids } } : undefined,
-      _max: { timestamp: true },
-    })
     const latestByPatient = new Map(
       latestCgm.map((r) => [r.patientId, r._max.timestamp]),
     )
@@ -303,7 +370,7 @@ export const patientsAtRiskQuery = {
 
     // Silent monitoring : patients whose latest CGM is older than cutoff,
     // OR patients in portfolio with NO CGM entries at all.
-    const portfolioIds = ids ?? Array.from(latestByPatient.keys())
+    const portfolioIds = ids ?? (adminPortfolio ?? []).map((p) => p.id)
     for (const pid of portfolioIds) {
       if (exclude.has(pid) || flags.has(pid)) continue
       const last = latestByPatient.get(pid)
@@ -327,15 +394,16 @@ export const patientsAtRiskQuery = {
       .sort((a, b) => b.score - a.score)
       .slice(0, RISK_LIMIT)
 
-    if (top.length === 0) {
-      await auditService.log({
-        userId: auditUserId, action: "READ", resource: "PATIENT",
-        resourceId: "0",
-        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
-        metadata: { kind: "dashboard.medecin.patientsAtRisk", count: 0 },
-      })
-      return []
-    }
+    // healthcare M2 — always emit a summary `resourceId:"0"` audit row,
+    //   matching the other 3 dashboard endpoints' telemetry convention.
+    await auditService.log({
+      userId: auditUserId, action: "READ", resource: "PATIENT",
+      resourceId: "0",
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { kind: "dashboard.medecin.patientsAtRisk", count: top.length },
+    })
+
+    if (top.length === 0) return []
 
     // Hydrate first-name (via User) + pathology for the top N only.
     const patients = await prisma.patient.findMany({
@@ -348,7 +416,9 @@ export const patientsAtRiskQuery = {
     const byId = new Map(patients.map((p) => [p.id, p]))
 
     // Per-patient audit row (forensic pivot per US-2268).
-    await Promise.all(top.map((t) =>
+    // code-review L8 — `allSettled` so a single audit failure doesn't 500
+    //   the dashboard call after data is already computed.
+    await Promise.allSettled(top.map((t) =>
       auditService.log({
         userId: auditUserId, action: "READ", resource: "PATIENT",
         resourceId: String(t.patientId),
@@ -414,83 +484,76 @@ export const kpisQuery = {
     }
 
     const now = new Date()
+    // code-review C2 — windowed dates : current 14d window is `[now-14d, now)`,
+    //   previous 14d window is `[now-28d, now-14d)`. `fourteenDaysAgo` doubles
+    //   as the upper bound of the previous window — no duplicate constant.
     const fourteenDaysAgo = new Date(now.getTime() - 14 * 86_400_000)
     const twentyEightDaysAgo = new Date(now.getTime() - 28 * 86_400_000)
     const sevenDaysAgo = new Date(now.getTime() - 7 * 86_400_000)
-    const fourteenDaysAgoPrev = new Date(now.getTime() - 14 * 86_400_000)
 
-    // 1. Active patients = patient with ≥ 1 CGM entry in last 14d.
-    const activeNow = await prisma.cgmEntry.groupBy({
-      by: ["patientId"],
-      where: {
-        ...scope,
-        timestamp: { gte: fourteenDaysAgo },
-      },
-      _count: { _all: true },
-    })
-    const activePrev = await prisma.cgmEntry.groupBy({
-      by: ["patientId"],
-      where: {
-        ...scope,
-        timestamp: { gte: twentyEightDaysAgo, lt: fourteenDaysAgoPrev },
-      },
-      _count: { _all: true },
-    })
+    // code-review H3 — 8 independent queries parallelized in one Promise.all
+    //   (~6x latency win on first paint vs sequential awaits).
+    const [
+      activeNow, activePrev,
+      tirTotalNow, tirInRangeNow,
+      tirTotalPrev, tirInRangePrev,
+      weekUrg, pendingProposals,
+    ] = await Promise.all([
+      prisma.cgmEntry.groupBy({
+        by: ["patientId"],
+        where: { ...scope, timestamp: { gte: fourteenDaysAgo } },
+        _count: { patientId: true },
+      }),
+      prisma.cgmEntry.groupBy({
+        by: ["patientId"],
+        where: { ...scope, timestamp: { gte: twentyEightDaysAgo, lt: fourteenDaysAgo } },
+        _count: { patientId: true },
+      }),
+      prisma.cgmEntry.count({
+        where: { ...scope, timestamp: { gte: fourteenDaysAgo } },
+      }),
+      prisma.cgmEntry.count({
+        where: {
+          ...scope,
+          timestamp: { gte: fourteenDaysAgo },
+          valueGl: { gte: TIR_LOW_GL, lte: TIR_HIGH_GL },
+        },
+      }),
+      prisma.cgmEntry.count({
+        where: { ...scope, timestamp: { gte: twentyEightDaysAgo, lt: fourteenDaysAgo } },
+      }),
+      prisma.cgmEntry.count({
+        where: {
+          ...scope,
+          timestamp: { gte: twentyEightDaysAgo, lt: fourteenDaysAgo },
+          valueGl: { gte: TIR_LOW_GL, lte: TIR_HIGH_GL },
+        },
+      }),
+      prisma.emergencyAlert.count({
+        where: {
+          ...scope,
+          triggeredAt: { gte: sevenDaysAgo },
+          severity: EmergencyAlertSeverity.critical,
+        },
+      }),
+      prisma.adjustmentProposal.count({
+        where: { ...scope, status: "pending" },
+      }),
+    ])
+
     const activeNowCount = activeNow.length
     const activePrevCount = activePrev.length
     const activeDelta = activeNowCount - activePrevCount
 
-    // 2. Avg TIR : aggregate CGM readings last 14d, fraction in [0.70, 1.80] g/L.
-    const tirTotalNow = await prisma.cgmEntry.count({
-      where: { ...scope, timestamp: { gte: fourteenDaysAgo } },
-    })
-    const tirInRangeNow = await prisma.cgmEntry.count({
-      where: {
-        ...scope,
-        timestamp: { gte: fourteenDaysAgo },
-        valueGl: { gte: TIR_LOW_GL, lte: TIR_HIGH_GL },
-      },
-    })
     const tirNow = tirTotalNow > 0
       ? Math.round((tirInRangeNow / tirTotalNow) * 1000) / 10
       : 0
-
-    const tirTotalPrev = await prisma.cgmEntry.count({
-      where: {
-        ...scope,
-        timestamp: { gte: twentyEightDaysAgo, lt: fourteenDaysAgoPrev },
-      },
-    })
-    const tirInRangePrev = await prisma.cgmEntry.count({
-      where: {
-        ...scope,
-        timestamp: { gte: twentyEightDaysAgo, lt: fourteenDaysAgoPrev },
-        valueGl: { gte: TIR_LOW_GL, lte: TIR_HIGH_GL },
-      },
-    })
     const tirPrev = tirTotalPrev > 0
       ? Math.round((tirInRangePrev / tirTotalPrev) * 1000) / 10
       : 0
     const tirDelta = tirTotalPrev > 0
       ? Math.round((tirNow - tirPrev) * 10) / 10
       : null
-
-    // 3. Week urgencies = critical alerts triggered last 7 days.
-    const weekUrg = await prisma.emergencyAlert.count({
-      where: {
-        ...scope,
-        triggeredAt: { gte: sevenDaysAgo },
-        severity: EmergencyAlertSeverity.critical,
-      },
-    })
-
-    // 4. Pending adjustment proposals in portfolio.
-    const pendingProposals = await prisma.adjustmentProposal.count({
-      where: {
-        ...scope,
-        status: "pending",
-      },
-    })
 
     await auditService.log({
       userId: auditUserId, action: "READ", resource: "PATIENT",

--- a/tests/components/dashboard-medecin-format-hour.test.ts
+++ b/tests/components/dashboard-medecin-format-hour.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Regression test for code-review M6 (PR #399 re-review) — `formatHour`
+ * must render in Europe/Paris cabinet timezone, not UTC.
+ *
+ * The function lives inline in AppointmentCard.tsx but is exercised
+ * through an exported helper here. We test the contract directly via
+ * Intl.DateTimeFormat to lock down the expectation : at 08:00 UTC in
+ * May 2026 (CEST = UTC+2), the cabinet-local wall clock is 10:00.
+ */
+import { describe, it, expect } from "vitest"
+
+// Replicate the production helper exactly. If AppointmentCard inlines it,
+// this test pins the contract; if extracted to a util later, swap the
+// import and the test continues to guard the contract.
+function formatHour(d: Date | null): string {
+  if (!d) return "—"
+  const date = new Date(d)
+  return date.toLocaleTimeString("fr-FR", {
+    hour: "2-digit", minute: "2-digit", timeZone: "Europe/Paris",
+  })
+}
+
+describe("formatHour (PR #399 M6 re-review regression)", () => {
+  it("renders 08:00 UTC in May as 10:00 Paris (CEST UTC+2)", () => {
+    const utcMorning = new Date("2026-05-14T08:00:00Z")
+    expect(formatHour(utcMorning)).toBe("10:00")
+  })
+
+  it("renders 08:00 UTC in January as 09:00 Paris (CET UTC+1)", () => {
+    const utcWinter = new Date("2026-01-14T08:00:00Z")
+    expect(formatHour(utcWinter)).toBe("09:00")
+  })
+
+  it("renders 23:00 UTC in May as 01:00 Paris (next day)", () => {
+    const utcLate = new Date("2026-05-14T23:00:00Z")
+    expect(formatHour(utcLate)).toBe("01:00")
+  })
+
+  it("returns dash when null", () => {
+    expect(formatHour(null)).toBe("—")
+  })
+})

--- a/tests/unit/doctor-dashboard.service.test.ts
+++ b/tests/unit/doctor-dashboard.service.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Test suite : doctor-dashboard.service (Groupe 9b Batch 1 — 5 US, ~34 SP).
+ *
+ * Couvre :
+ *  - US-2401 urgencies : portfolio scoping, criticality sort, limit=5
+ *  - US-2402 appointments : today window, scope, limit=3
+ *  - US-2403 patients-at-risk : hypo threshold, silent detection, exclusion
+ *    of open-urgency patients
+ *  - US-2404 KPI : trend up/down/flat, TIR fraction, empty portfolio
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import {
+  EmergencyAlertStatus, EmergencyAlertType, EmergencyAlertSeverity,
+  AppointmentStatus,
+} from "@prisma/client"
+import { prismaMock } from "../helpers/prisma-mock"
+
+vi.mock("@/lib/access-control", () => ({
+  getAccessiblePatientIds: vi.fn(),
+}))
+import {
+  urgenciesQuery, appointmentsQuery,
+  patientsAtRiskQuery, kpisQuery,
+} from "@/lib/services/doctor-dashboard.service"
+import { getAccessiblePatientIds } from "@/lib/access-control"
+
+const mockedAccessible = vi.mocked(getAccessiblePatientIds)
+
+beforeEach(() => {
+  prismaMock.auditLog.create.mockResolvedValue({} as any)
+  mockedAccessible.mockReset()
+})
+
+// ─── US-2401 urgencies ───────────────────────────────────────────────────
+
+describe("urgenciesQuery (US-2401)", () => {
+  it("returns [] when caller has empty portfolio", async () => {
+    mockedAccessible.mockResolvedValue([])
+    const out = await urgenciesQuery.forCaller(1, "DOCTOR", 1)
+    expect(out).toEqual([])
+    expect(prismaMock.emergencyAlert.findMany).not.toHaveBeenCalled()
+  })
+
+  it("sorts by criticality (DKA before hypo), limits to 5", async () => {
+    mockedAccessible.mockResolvedValue([10, 20, 30])
+    const now = new Date("2026-05-14T10:00:00Z")
+    prismaMock.emergencyAlert.findMany.mockResolvedValue([
+      {
+        id: 1, patientId: 10, alertType: EmergencyAlertType.hypo,
+        severity: EmergencyAlertSeverity.warning,
+        status: EmergencyAlertStatus.open,
+        triggeredAt: now, glucoseValueMgdl: null, ketoneValueMmol: null,
+        patient: { id: 10, pathology: "DT1", user: { firstname: null } },
+      },
+      {
+        id: 2, patientId: 20, alertType: EmergencyAlertType.ketone_dka,
+        severity: EmergencyAlertSeverity.critical,
+        status: EmergencyAlertStatus.open,
+        triggeredAt: now, glucoseValueMgdl: null, ketoneValueMmol: null,
+        patient: { id: 20, pathology: "DT1", user: { firstname: null } },
+      },
+    ] as any)
+    const out = await urgenciesQuery.forCaller(1, "DOCTOR", 1)
+    expect(out[0]!.alertType).toBe("ketone_dka") // most critical first
+    expect(out).toHaveLength(2)
+  })
+
+  it("emits 1 audit row with kind = dashboard.medecin.urgencies", async () => {
+    mockedAccessible.mockResolvedValue([10])
+    prismaMock.emergencyAlert.findMany.mockResolvedValue([] as any)
+    await urgenciesQuery.forCaller(1, "DOCTOR", 1)
+    const meta = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(meta.metadata.kind).toBe("dashboard.medecin.urgencies")
+  })
+})
+
+// ─── US-2402 appointments ────────────────────────────────────────────────
+
+describe("appointmentsQuery (US-2402)", () => {
+  it("returns [] when empty portfolio", async () => {
+    mockedAccessible.mockResolvedValue([])
+    const out = await appointmentsQuery.forCaller(1, "NURSE", 1)
+    expect(out).toEqual([])
+  })
+
+  it("queries today's scheduled+pending_validation, limit 3", async () => {
+    mockedAccessible.mockResolvedValue([10])
+    prismaMock.appointment.findMany.mockResolvedValue([
+      {
+        id: 1, patientId: 10, date: new Date(), hour: new Date("2026-05-14T08:00:00Z"),
+        type: "diabeto", status: AppointmentStatus.scheduled, location: "video",
+        patient: { id: 10, pathology: "DT2", user: { firstname: null } },
+      },
+    ] as any)
+    const out = await appointmentsQuery.forCaller(1, "NURSE", 1)
+    expect(out).toHaveLength(1)
+    expect(out[0]!.location).toBe("video")
+    const callArg = prismaMock.appointment.findMany.mock.calls[0]![0]
+    expect(callArg!.take).toBe(3)
+  })
+})
+
+// ─── US-2403 patients-at-risk ────────────────────────────────────────────
+
+describe("patientsAtRiskQuery (US-2403)", () => {
+  it("returns [] when empty portfolio", async () => {
+    mockedAccessible.mockResolvedValue([])
+    const out = await patientsAtRiskQuery.forCaller(1, "DOCTOR", 1)
+    expect(out).toEqual([])
+  })
+
+  it("flags hypos >=3/7d and excludes patients with open urgencies", async () => {
+    mockedAccessible.mockResolvedValue([10, 20])
+    // Patient 20 is in open urgency → excluded entirely.
+    prismaMock.emergencyAlert.findMany.mockResolvedValue([
+      { patientId: 20 },
+    ] as any)
+    prismaMock.emergencyAlert.groupBy.mockResolvedValue([
+      { patientId: 10, _count: { patientId: 4 } }, // flag recentHypos
+      { patientId: 20, _count: { patientId: 5 } }, // excluded
+    ] as any)
+    // Patient 10 has recent CGM (no silence flag).
+    prismaMock.cgmEntry.groupBy.mockResolvedValue([
+      { patientId: 10, _max: { timestamp: new Date() } },
+      { patientId: 20, _max: { timestamp: new Date() } },
+    ] as any)
+    prismaMock.patient.findMany.mockResolvedValue([
+      { id: 10, pathology: "DT1", user: { firstname: null } },
+    ] as any)
+    const out = await patientsAtRiskQuery.forCaller(1, "DOCTOR", 1)
+    expect(out).toHaveLength(1)
+    expect(out[0]!.patientId).toBe(10)
+    expect(out[0]!.reason).toBe("recentHypos")
+  })
+
+  it("flags silence > 5 days without CGM activity", async () => {
+    mockedAccessible.mockResolvedValue([10])
+    prismaMock.emergencyAlert.findMany.mockResolvedValue([] as any)
+    prismaMock.emergencyAlert.groupBy.mockResolvedValue([] as any)
+    const oldCgm = new Date(Date.now() - 10 * 86_400_000)
+    prismaMock.cgmEntry.groupBy.mockResolvedValue([
+      { patientId: 10, _max: { timestamp: oldCgm } },
+    ] as any)
+    prismaMock.patient.findMany.mockResolvedValue([
+      { id: 10, pathology: "DT1", user: { firstname: null } },
+    ] as any)
+    const out = await patientsAtRiskQuery.forCaller(1, "DOCTOR", 1)
+    expect(out).toHaveLength(1)
+    expect(out[0]!.reason).toBe("silentMonitoring")
+  })
+
+  it("flags patients with no CGM entry at all (assumed silent ≥ SILENT_DAYS+1)", async () => {
+    mockedAccessible.mockResolvedValue([10])
+    prismaMock.emergencyAlert.findMany.mockResolvedValue([] as any)
+    prismaMock.emergencyAlert.groupBy.mockResolvedValue([] as any)
+    prismaMock.cgmEntry.groupBy.mockResolvedValue([] as any) // no rows for 10
+    prismaMock.patient.findMany.mockResolvedValue([
+      { id: 10, pathology: "DT1", user: { firstname: null } },
+    ] as any)
+    const out = await patientsAtRiskQuery.forCaller(1, "DOCTOR", 1)
+    expect(out).toHaveLength(1)
+    expect(out[0]!.reason).toBe("silentMonitoring")
+  })
+
+  it("audits per-patient (US-2268 pivot)", async () => {
+    mockedAccessible.mockResolvedValue([10])
+    prismaMock.emergencyAlert.findMany.mockResolvedValue([] as any)
+    prismaMock.emergencyAlert.groupBy.mockResolvedValue([
+      { patientId: 10, _count: { patientId: 5 } },
+    ] as any)
+    prismaMock.cgmEntry.groupBy.mockResolvedValue([] as any)
+    prismaMock.patient.findMany.mockResolvedValue([
+      { id: 10, pathology: "DT1", user: { firstname: null } },
+    ] as any)
+    await patientsAtRiskQuery.forCaller(1, "DOCTOR", 1)
+    // Last audit row has metadata.patientId = 10 (per-patient pivot).
+    const meta = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(meta.metadata.patientId).toBe(10)
+    expect(meta.metadata.kind).toBe("dashboard.medecin.patientsAtRisk")
+  })
+})
+
+// ─── US-2404 KPIs ────────────────────────────────────────────────────────
+
+describe("kpisQuery (US-2404)", () => {
+  it("returns zeroed cards when empty portfolio (DOCTOR with no service)", async () => {
+    mockedAccessible.mockResolvedValue([])
+    const out = await kpisQuery.forCaller(1, "DOCTOR", 1)
+    expect(out).toHaveLength(4)
+    expect(out.every((c) => c.value === 0)).toBe(true)
+  })
+
+  it("computes activePatients + TIR + urgencies + proposals with trend", async () => {
+    mockedAccessible.mockResolvedValue([10, 20])
+    // 2 patients active now, 1 prev → delta +1, trend up.
+    prismaMock.cgmEntry.groupBy
+      .mockResolvedValueOnce([{ patientId: 10 }, { patientId: 20 }] as any)
+      .mockResolvedValueOnce([{ patientId: 10 }] as any)
+    prismaMock.cgmEntry.count
+      .mockResolvedValueOnce(100) // total now
+      .mockResolvedValueOnce(70)  // in range now → 70%
+      .mockResolvedValueOnce(80)  // total prev
+      .mockResolvedValueOnce(56)  // in range prev → 70%
+    prismaMock.emergencyAlert.count.mockResolvedValueOnce(3)
+    prismaMock.adjustmentProposal.count.mockResolvedValueOnce(5)
+    const out = await kpisQuery.forCaller(1, "DOCTOR", 1)
+    const byCode = Object.fromEntries(out.map((c) => [c.code, c]))
+    expect(byCode.activePatients!.value).toBe(2)
+    expect(byCode.activePatients!.delta).toBe(1)
+    expect(byCode.activePatients!.trend).toBe("up")
+    expect(byCode.avgTir!.value).toBe(70)
+    expect(byCode.weekUrgencies!.value).toBe(3)
+    expect(byCode.pendingProposals!.value).toBe(5)
+  })
+
+  it("returns null trend for TIR when no prior data", async () => {
+    mockedAccessible.mockResolvedValue([10])
+    prismaMock.cgmEntry.groupBy
+      .mockResolvedValueOnce([{ patientId: 10 }] as any)
+      .mockResolvedValueOnce([] as any)
+    prismaMock.cgmEntry.count
+      .mockResolvedValueOnce(50)
+      .mockResolvedValueOnce(40)
+      .mockResolvedValueOnce(0) // no prev
+      .mockResolvedValueOnce(0)
+    prismaMock.emergencyAlert.count.mockResolvedValueOnce(0)
+    prismaMock.adjustmentProposal.count.mockResolvedValueOnce(0)
+    const out = await kpisQuery.forCaller(1, "DOCTOR", 1)
+    const tir = out.find((c) => c.code === "avgTir")!
+    expect(tir.trend).toBeNull()
+    expect(tir.delta).toBeNull()
+  })
+})

--- a/tests/unit/doctor-dashboard.service.test.ts
+++ b/tests/unit/doctor-dashboard.service.test.ts
@@ -243,4 +243,106 @@ describe("kpisQuery (US-2404)", () => {
     expect(tir.trend).toBeNull()
     expect(tir.delta).toBeNull()
   })
+
+  // ─── code-review L4 — TIR drop scenario (down trend) ───────────────────
+  it("L4 — TIR drop from prior window emits down trend + negative delta", async () => {
+    mockedAccessible.mockResolvedValue([10])
+    pm.cgmEntry.groupBy
+      .mockResolvedValueOnce([{ patientId: 10 }] as any)
+      .mockResolvedValueOnce([{ patientId: 10 }] as any)
+    prismaMock.cgmEntry.count
+      .mockResolvedValueOnce(100) // total now
+      .mockResolvedValueOnce(50)  // in range now → 50%
+      .mockResolvedValueOnce(100) // total prev
+      .mockResolvedValueOnce(80)  // in range prev → 80%
+    prismaMock.emergencyAlert.count.mockResolvedValueOnce(0)
+    prismaMock.adjustmentProposal.count.mockResolvedValueOnce(0)
+    const out = await kpisQuery.forCaller(1, "DOCTOR", 1)
+    const tir = out.find((c) => c.code === "avgTir")!
+    expect(tir.value).toBe(50)
+    expect(tir.delta).toBe(-30) // 50 - 80
+    expect(tir.trend).toBe("down")
+  })
+})
+
+// ─── code-review L1 — CRITICALITY_ORDER invariants ─────────────────────
+
+describe("CRITICALITY_ORDER (L1)", () => {
+  it("orders DKA before severe_hypo before hypo before manual", async () => {
+    const { CRITICALITY_ORDER } = await import(
+      "@/lib/services/doctor-dashboard.service"
+    )
+    expect(CRITICALITY_ORDER.ketone_dka).toBeLessThan(CRITICALITY_ORDER.severe_hypo)
+    expect(CRITICALITY_ORDER.severe_hypo).toBeLessThan(CRITICALITY_ORDER.hypo)
+    expect(CRITICALITY_ORDER.hypo).toBeLessThan(CRITICALITY_ORDER.manual)
+    expect(CRITICALITY_ORDER.ketone_moderate).toBeLessThan(CRITICALITY_ORDER.hypo)
+  })
+})
+
+// ─── code-review L3 — HYPO_THRESHOLD_7D boundary ──────────────────────
+
+describe("patientsAtRiskQuery boundaries (L3)", () => {
+  it("does NOT flag at 2 hypos (below threshold)", async () => {
+    mockedAccessible.mockResolvedValue([10])
+    prismaMock.emergencyAlert.findMany.mockResolvedValue([] as any)
+    pm.emergencyAlert.groupBy.mockResolvedValue([
+      { patientId: 10, _count: { patientId: 2 } },
+    ] as any)
+    pm.cgmEntry.groupBy.mockResolvedValue([
+      { patientId: 10, _max: { timestamp: new Date() } },
+    ] as any)
+    prismaMock.patient.findMany.mockResolvedValue([] as any)
+    const out = await patientsAtRiskQuery.forCaller(1, "DOCTOR", 1)
+    expect(out).toEqual([])
+  })
+
+  it("flags at exactly 3 hypos (boundary)", async () => {
+    mockedAccessible.mockResolvedValue([10])
+    prismaMock.emergencyAlert.findMany.mockResolvedValue([] as any)
+    pm.emergencyAlert.groupBy.mockResolvedValue([
+      { patientId: 10, _count: { patientId: 3 } },
+    ] as any)
+    pm.cgmEntry.groupBy.mockResolvedValue([
+      { patientId: 10, _max: { timestamp: new Date() } },
+    ] as any)
+    prismaMock.patient.findMany.mockResolvedValue([
+      { id: 10, pathology: "DT1", user: { firstname: null } },
+    ] as any)
+    const out = await patientsAtRiskQuery.forCaller(1, "DOCTOR", 1)
+    expect(out).toHaveLength(1)
+    expect(out[0]!.reason).toBe("recentHypos")
+  })
+})
+
+// ─── healthcare M2 — summary audit always emitted ─────────────────────
+
+describe("patientsAtRiskQuery summary audit (healthcare M2)", () => {
+  it("emits summary resourceId:0 row even on non-empty result", async () => {
+    mockedAccessible.mockResolvedValue([10])
+    prismaMock.emergencyAlert.findMany.mockResolvedValue([] as any)
+    pm.emergencyAlert.groupBy.mockResolvedValue([
+      { patientId: 10, _count: { patientId: 5 } },
+    ] as any)
+    pm.cgmEntry.groupBy.mockResolvedValue([
+      { patientId: 10, _max: { timestamp: new Date() } },
+    ] as any)
+    prismaMock.patient.findMany.mockResolvedValue([
+      { id: 10, pathology: "DT1", user: { firstname: null } },
+    ] as any)
+    await patientsAtRiskQuery.forCaller(1, "DOCTOR", 1)
+    // Summary row should have resourceId="0" AND a per-patient row should
+    // have metadata.patientId set.
+    const calls = prismaMock.auditLog.create.mock.calls.map((c) => (c[0].data as any))
+    const summary = calls.find((d) =>
+      d.resourceId === "0"
+      && d.metadata?.kind === "dashboard.medecin.patientsAtRisk"
+      && d.metadata?.count === 1,
+    )
+    expect(summary).toBeDefined()
+    const perPatient = calls.find((d) =>
+      d.metadata?.patientId === 10
+      && d.metadata?.kind === "dashboard.medecin.patientsAtRisk",
+    )
+    expect(perPatient).toBeDefined()
+  })
 })

--- a/tests/unit/doctor-dashboard.service.test.ts
+++ b/tests/unit/doctor-dashboard.service.test.ts
@@ -25,6 +25,19 @@ import {
 import { getAccessiblePatientIds } from "@/lib/access-control"
 
 const mockedAccessible = vi.mocked(getAccessiblePatientIds)
+// Prisma's `groupBy` has a complex generic signature that defeats
+// vitest-mock-extended's deep auto-mock typing ; cast once here so test
+// `mockResolvedValue` calls type-check under CI's stricter tsc.
+const pm = prismaMock as unknown as {
+  emergencyAlert: {
+    findMany: any; count: any; groupBy: any;
+  }
+  cgmEntry: { findMany: any; count: any; groupBy: any }
+  appointment: { findMany: any }
+  patient: { findMany: any }
+  adjustmentProposal: { count: any }
+  auditLog: { create: any }
+}
 
 beforeEach(() => {
   prismaMock.auditLog.create.mockResolvedValue({} as any)
@@ -115,12 +128,12 @@ describe("patientsAtRiskQuery (US-2403)", () => {
     prismaMock.emergencyAlert.findMany.mockResolvedValue([
       { patientId: 20 },
     ] as any)
-    prismaMock.emergencyAlert.groupBy.mockResolvedValue([
+    pm.emergencyAlert.groupBy.mockResolvedValue([
       { patientId: 10, _count: { patientId: 4 } }, // flag recentHypos
       { patientId: 20, _count: { patientId: 5 } }, // excluded
     ] as any)
     // Patient 10 has recent CGM (no silence flag).
-    prismaMock.cgmEntry.groupBy.mockResolvedValue([
+    pm.cgmEntry.groupBy.mockResolvedValue([
       { patientId: 10, _max: { timestamp: new Date() } },
       { patientId: 20, _max: { timestamp: new Date() } },
     ] as any)
@@ -136,9 +149,9 @@ describe("patientsAtRiskQuery (US-2403)", () => {
   it("flags silence > 5 days without CGM activity", async () => {
     mockedAccessible.mockResolvedValue([10])
     prismaMock.emergencyAlert.findMany.mockResolvedValue([] as any)
-    prismaMock.emergencyAlert.groupBy.mockResolvedValue([] as any)
+    pm.emergencyAlert.groupBy.mockResolvedValue([] as any)
     const oldCgm = new Date(Date.now() - 10 * 86_400_000)
-    prismaMock.cgmEntry.groupBy.mockResolvedValue([
+    pm.cgmEntry.groupBy.mockResolvedValue([
       { patientId: 10, _max: { timestamp: oldCgm } },
     ] as any)
     prismaMock.patient.findMany.mockResolvedValue([
@@ -152,8 +165,8 @@ describe("patientsAtRiskQuery (US-2403)", () => {
   it("flags patients with no CGM entry at all (assumed silent ≥ SILENT_DAYS+1)", async () => {
     mockedAccessible.mockResolvedValue([10])
     prismaMock.emergencyAlert.findMany.mockResolvedValue([] as any)
-    prismaMock.emergencyAlert.groupBy.mockResolvedValue([] as any)
-    prismaMock.cgmEntry.groupBy.mockResolvedValue([] as any) // no rows for 10
+    pm.emergencyAlert.groupBy.mockResolvedValue([] as any)
+    pm.cgmEntry.groupBy.mockResolvedValue([] as any) // no rows for 10
     prismaMock.patient.findMany.mockResolvedValue([
       { id: 10, pathology: "DT1", user: { firstname: null } },
     ] as any)
@@ -165,10 +178,10 @@ describe("patientsAtRiskQuery (US-2403)", () => {
   it("audits per-patient (US-2268 pivot)", async () => {
     mockedAccessible.mockResolvedValue([10])
     prismaMock.emergencyAlert.findMany.mockResolvedValue([] as any)
-    prismaMock.emergencyAlert.groupBy.mockResolvedValue([
+    pm.emergencyAlert.groupBy.mockResolvedValue([
       { patientId: 10, _count: { patientId: 5 } },
     ] as any)
-    prismaMock.cgmEntry.groupBy.mockResolvedValue([] as any)
+    pm.cgmEntry.groupBy.mockResolvedValue([] as any)
     prismaMock.patient.findMany.mockResolvedValue([
       { id: 10, pathology: "DT1", user: { firstname: null } },
     ] as any)
@@ -193,7 +206,7 @@ describe("kpisQuery (US-2404)", () => {
   it("computes activePatients + TIR + urgencies + proposals with trend", async () => {
     mockedAccessible.mockResolvedValue([10, 20])
     // 2 patients active now, 1 prev → delta +1, trend up.
-    prismaMock.cgmEntry.groupBy
+    pm.cgmEntry.groupBy
       .mockResolvedValueOnce([{ patientId: 10 }, { patientId: 20 }] as any)
       .mockResolvedValueOnce([{ patientId: 10 }] as any)
     prismaMock.cgmEntry.count
@@ -215,7 +228,7 @@ describe("kpisQuery (US-2404)", () => {
 
   it("returns null trend for TIR when no prior data", async () => {
     mockedAccessible.mockResolvedValue([10])
-    prismaMock.cgmEntry.groupBy
+    pm.cgmEntry.groupBy
       .mockResolvedValueOnce([{ patientId: 10 }] as any)
       .mockResolvedValueOnce([] as any)
     prismaMock.cgmEntry.count


### PR DESCRIPTION
## Summary

**Groupe 9b Batch 1 — Dashboard médecin** (5 US, ~34 SP).

- **US-2400** Page dashboard médecin (8 SP) — `/medecin` sous-route avec layout responsive (1 col → 2 col lg). Server-side role guard.
- **US-2401** Card urgences en cours (8 SP) — polling **30s** (ADR session Samir 2026-05-13), max 5, tri criticité (ketone_dka > severe_hypo > ketone_moderate > hypo > severe_hyper > hyper > manual), `role="region"` + live region SR.
- **US-2402** Card RDV du jour (5 SP) — polling 5min, max 3, today bounds UTC, badge teal si < 30min, support visio (location=video).
- **US-2403** Card patients à suivre (8 SP) — **DOCTOR-only**, computed on-demand. 2 reasons : `recentHypos` (≥3/7j) et `silentMonitoring` (>5j sans saisie CGM). Exclut patients avec urgence OPEN active. **Pragmatique** : pas de batch job/table flag dans ce PR — ré-évaluable V2 si compute coûteux.
- **US-2404** KPI cabinet 14j (5 SP) — 4 MetricCard : patients actifs, TIR moyen [0.70-1.80 g/L], urgences sem (critical), propositions pending. Trend up/down/flat.

## Architecture

- **Service** `doctor-dashboard.service.ts` — 4 sub-queries scoped via `getAccessiblePatientIds` (RBAC : ADMIN no restriction, DOCTOR/NURSE = portfolio).
- **Routes** `/api/dashboard/medecin/{urgencies,appointments,patients-at-risk,kpi}` :
  - NURSE+ pour urgencies/appointments
  - DOCTOR pour patients-at-risk + KPI (jugement clinique)
- **Hook** `usePollingFetch` : AbortController on unmount, pause on `document.visibilityState !== "visible"`, silent re-fetch (no flicker), last-good data retained on error.
- **Root redirect** `/dashboard` désormais role-based : DOCTOR/NURSE/ADMIN → `/medecin`, VIEWER déjà routé vers `/patient/dashboard` par layout.
- **4 card components** dans `src/components/diabeo/dashboard/medecin/`.

## Sécurité

- PHI `firstname` fetché via User (AES-256-GCM), decrypt via `safeDecryptField` avec fallback empty string.
- Audit **per-patient pivot** (ADR #18 / US-2268) sur patients-at-risk hydration.
- `auditedRequireRole` sur toutes les routes (403 auto-audit).
- Portfolio scoping via `getAccessiblePatientIds` empêche cross-tenant.

## Test plan

- [x] 13 nouveaux unit tests (1596 → 1609 verts)
- [x] tsc clean, lint 0 errors (21 warnings pré-existants)
- [ ] CI green
- [ ] Multi-agent review (healthcare-security-auditor + medical-domain-validator + code-reviewer)
- [ ] Merge **uniquement sur GO explicite** per CLAUDE.md règle

🤖 Generated with [Claude Code](https://claude.com/claude-code)