### PR TITLE
feat(rdv): US-2500-UI iter 6 — modal création RDV + bouton + Nouveau RDV

### DIFF
--- a/docs/UserStory/pro-user-stories/23-rdv/US-2500-UI-calendrier-rdv-pro.md
+++ b/docs/UserStory/pro-user-stories/23-rdv/US-2500-UI-calendrier-rdv-pro.md
@@ -93,16 +93,17 @@ Le backend RDV est livré et déployé en prod depuis **PR #392** (Groupe 8 RDV 
 
 ### Création / édition
 
-- [ ] Bouton **"+ Nouveau RDV"** en haut à droite
-- [ ] Modal formulaire :
-  - patient (search-select)
-  - date+heure
-  - durée (15-240 min)
-  - location (in_person / video / phone)
-  - motif (chiffré)
-  - member (auto si DOCTOR seul, dropdown sinon)
-- [ ] Validation client : pas de double-booking sur le même slot membre (visuel + API enforce EXCLUDE GiST)
-- [ ] Si `bookingMode = "manual_validation"` → RDV créé en status `pending_validation`, badge orange jusqu'à `/confirm` DOCTOR+
+- [x] Bouton **"+ Nouveau RDV"** en haut à droite ✅ iter 6
+- [x] Modal formulaire ✅ iter 6 :
+  - patient (combobox autocomplete via `<datalist>` + `usePatientList`)
+  - date+heure (input date + time natifs, min=aujourd'hui)
+  - durée (15-240 min, select avec presets 15/30/45/60/90/120)
+  - location (in_person / video / phone, select)
+  - type (diabeto / ide / hdj / other)
+  - motif (textarea max 200c, chiffré AES-256-GCM côté backend)
+  - member auto-résolu via `effectiveMemberId` du parent (iter 4)
+- [ ] Validation client : pas de double-booking sur le même slot membre (visuel + API enforce EXCLUDE GiST) — V1.5 (backend déjà enforce 409)
+- [ ] Si `bookingMode = "manual_validation"` → RDV créé en status `pending_validation`, badge orange jusqu'à `/confirm` DOCTOR+ — V1.5 (champ HealthcareService.bookingMode à ajouter au schema)
 
 ### Workflow annulation / alternative
 

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -339,7 +339,19 @@
     "actorDoctor": "مهني صحي (العيادة)",
     "actorPatient": "المريض (بناءً على طلبه)",
     "proposeAltTitle": "اقتراح موعد بديل",
-    "proposeAltDescription": "سيحتاج المريض إلى قبول التاريخ الجديد من تطبيقه."
+    "proposeAltDescription": "سيحتاج المريض إلى قبول التاريخ الجديد من تطبيقه.",
+    "newAppointmentButton": "+ موعد جديد",
+    "createTitle": "موعد جديد",
+    "createDescription": "أدخل تفاصيل الموعد. السبب مشفر.",
+    "createError": "تعذر إنشاء الموعد — تحقق من الحقول أو أعد المحاولة.",
+    "actionConfirmCreate": "إنشاء الموعد",
+    "typeLabel": "النوع",
+    "motifPlaceholder": "اختياري — يظهر فقط للمهنيين المخولين.",
+    "motifEncryptedNote": "مشفر على الخادم",
+    "patientPlaceholder": "اكتب اسم المريض أو لقبه",
+    "patientListError": "تعذر تحميل قائمة المرضى.",
+    "patientSelected": "تم اختيار المريض",
+    "patientHint": "{count, plural, =0 {لم يتم العثور على مريض} one {مريض واحد متاح} other {# مرضى متاحون}}"
   },
   "weekly": {
     "title": "العرض الأسبوعي",

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -344,6 +344,14 @@
     "createTitle": "موعد جديد",
     "createDescription": "أدخل تفاصيل الموعد. السبب مشفر.",
     "createError": "تعذر إنشاء الموعد — تحقق من الحقول أو أعد المحاولة.",
+    "createErrorConflict": "الموعد محجوز بالفعل — يرجى اختيار وقت آخر.",
+    "createErrorConsent": "لم يوافق المريض على مشاركة بياناته. لا يمكن المتابعة.",
+    "createErrorForbidden": "ليس لديك صلاحية الوصول إلى هذا المريض.",
+    "createErrorValidation": "تحقق من الحقول: التاريخ والوقت والمدة يجب أن تكون صحيحة.",
+    "createErrorGeneric": "خطأ غير متوقع — أعد المحاولة أو تواصل مع الدعم.",
+    "createDatePastWarning": "التاريخ المحدد في الماضي — يرجى اختيار تاريخ مستقبلي.",
+    "createRecap": "ملخص: {datetime}",
+    "createdSuccess": "✓ تم إنشاء الموعد بنجاح",
     "actionConfirmCreate": "إنشاء الموعد",
     "typeLabel": "النوع",
     "motifPlaceholder": "اختياري — يظهر فقط للمهنيين المخولين.",
@@ -351,7 +359,9 @@
     "patientPlaceholder": "اكتب اسم المريض أو لقبه",
     "patientListError": "تعذر تحميل قائمة المرضى.",
     "patientSelected": "تم اختيار المريض",
-    "patientHint": "{count, plural, =0 {لم يتم العثور على مريض} one {مريض واحد متاح} other {# مرضى متاحون}}"
+    "patientNoResults": "لا يوجد مريض يطابق بحثك.",
+    "patientHint": "{count, plural, =0 {لا يوجد مريض متاح} one {مريض واحد متاح} two {مريضان متاحان} few {# مرضى متاحون} many {# مريضاً متاحاً} other {# مريض متاح}}",
+    "scopeMissingChooseFirst": "يرجى اختيار عضو العيادة أولاً لإنشاء موعد."
   },
   "weekly": {
     "title": "العرض الأسبوعي",

--- a/messages/en.json
+++ b/messages/en.json
@@ -344,6 +344,14 @@
     "createTitle": "New appointment",
     "createDescription": "Fill in the appointment details. The reason is encrypted.",
     "createError": "Could not create appointment — check fields or retry.",
+    "createErrorConflict": "Slot already taken — please choose another time.",
+    "createErrorConsent": "The patient has not accepted data sharing. Action denied.",
+    "createErrorForbidden": "You do not have access to this patient.",
+    "createErrorValidation": "Please check fields: date, time and duration must be valid.",
+    "createErrorGeneric": "Unexpected error — please retry or contact support.",
+    "createDatePastWarning": "Selected date is in the past — please choose a future date.",
+    "createRecap": "Summary: {datetime}",
+    "createdSuccess": "✓ Appointment created successfully",
     "actionConfirmCreate": "Create appointment",
     "typeLabel": "Type",
     "motifPlaceholder": "Optional — only visible to authorised staff.",
@@ -351,7 +359,9 @@
     "patientPlaceholder": "Type patient name or surname",
     "patientListError": "Could not load patient list.",
     "patientSelected": "Patient selected",
-    "patientHint": "{count, plural, =0 {No patient found} one {1 patient available} other {# patients available}}"
+    "patientNoResults": "No patient matches your search.",
+    "patientHint": "{count, plural, =0 {No patient available} one {1 patient available} other {# patients available}}",
+    "scopeMissingChooseFirst": "Please select a practice member first to create an appointment."
   },
   "weekly": {
     "title": "Weekly View",

--- a/messages/en.json
+++ b/messages/en.json
@@ -339,7 +339,19 @@
     "actorDoctor": "Healthcare staff (practice)",
     "actorPatient": "Patient (on their request)",
     "proposeAltTitle": "Propose an alternative",
-    "proposeAltDescription": "The patient will need to accept the new date from their app."
+    "proposeAltDescription": "The patient will need to accept the new date from their app.",
+    "newAppointmentButton": "+ New appointment",
+    "createTitle": "New appointment",
+    "createDescription": "Fill in the appointment details. The reason is encrypted.",
+    "createError": "Could not create appointment — check fields or retry.",
+    "actionConfirmCreate": "Create appointment",
+    "typeLabel": "Type",
+    "motifPlaceholder": "Optional — only visible to authorised staff.",
+    "motifEncryptedNote": "encrypted server-side",
+    "patientPlaceholder": "Type patient name or surname",
+    "patientListError": "Could not load patient list.",
+    "patientSelected": "Patient selected",
+    "patientHint": "{count, plural, =0 {No patient found} one {1 patient available} other {# patients available}}"
   },
   "weekly": {
     "title": "Weekly View",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -344,6 +344,14 @@
     "createTitle": "Nouveau rendez-vous",
     "createDescription": "Renseignez les informations du RDV. Le motif est chiffré.",
     "createError": "Impossible de créer le RDV — vérifiez les champs ou réessayez.",
+    "createErrorConflict": "Le créneau est déjà pris — choisissez un autre horaire.",
+    "createErrorConsent": "Le patient n'a pas accepté le partage de ses données. Action impossible.",
+    "createErrorForbidden": "Vous n'avez pas accès à ce patient.",
+    "createErrorValidation": "Vérifiez les champs : date, heure, durée doivent être valides.",
+    "createErrorGeneric": "Erreur inattendue — réessayez ou contactez le support.",
+    "createDatePastWarning": "La date sélectionnée est dans le passé — choisissez une date future.",
+    "createRecap": "Récapitulatif : {datetime}",
+    "createdSuccess": "✓ Rendez-vous créé avec succès",
     "actionConfirmCreate": "Créer le RDV",
     "typeLabel": "Type",
     "motifPlaceholder": "Optionnel — visible uniquement par les soignants autorisés.",
@@ -351,7 +359,9 @@
     "patientPlaceholder": "Tapez le nom ou prénom du patient",
     "patientListError": "Impossible de charger la liste des patients.",
     "patientSelected": "Patient sélectionné",
-    "patientHint": "{count, plural, =0 {Aucun patient trouvé} one {1 patient disponible} other {# patients disponibles}}"
+    "patientNoResults": "Aucun patient ne correspond à votre recherche.",
+    "patientHint": "{count, plural, =0 {Aucun patient disponible} one {1 patient disponible} other {# patients disponibles}}",
+    "scopeMissingChooseFirst": "Sélectionnez d'abord un membre cabinet pour créer un RDV."
   },
   "weekly": {
     "title": "Vue hebdomadaire",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -339,7 +339,19 @@
     "actorDoctor": "Soignant (cabinet)",
     "actorPatient": "Patient (sur sa demande)",
     "proposeAltTitle": "Proposer une alternative",
-    "proposeAltDescription": "Le patient devra accepter la nouvelle date depuis son application."
+    "proposeAltDescription": "Le patient devra accepter la nouvelle date depuis son application.",
+    "newAppointmentButton": "+ Nouveau RDV",
+    "createTitle": "Nouveau rendez-vous",
+    "createDescription": "Renseignez les informations du RDV. Le motif est chiffré.",
+    "createError": "Impossible de créer le RDV — vérifiez les champs ou réessayez.",
+    "actionConfirmCreate": "Créer le RDV",
+    "typeLabel": "Type",
+    "motifPlaceholder": "Optionnel — visible uniquement par les soignants autorisés.",
+    "motifEncryptedNote": "chiffré côté serveur",
+    "patientPlaceholder": "Tapez le nom ou prénom du patient",
+    "patientListError": "Impossible de charger la liste des patients.",
+    "patientSelected": "Patient sélectionné",
+    "patientHint": "{count, plural, =0 {Aucun patient trouvé} one {1 patient disponible} other {# patients disponibles}}"
   },
   "weekly": {
     "title": "Vue hebdomadaire",

--- a/src/app/api/appointments/route.ts
+++ b/src/app/api/appointments/route.ts
@@ -12,7 +12,7 @@ import {
 } from "@/lib/services/rdv.service"
 import { auditService, extractRequestContext } from "@/lib/services/audit.service"
 import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
-import { HOUR_RE } from "@/lib/appointments-route-helpers"
+import { HOUR_RE, setAppointmentSecurityHeaders } from "@/lib/appointments-route-helpers"
 
 const listSchema = z.object({
   from: z.coerce.date(),
@@ -78,30 +78,40 @@ export async function GET(req: NextRequest) {
     }
 
     const out = await rdvAppointmentService.listInRange(parsed.data, user.id, ctx)
-    const res = NextResponse.json(out)
-    // Fix H-2 round 2 review PR #431 — Headers ANSSI RGS §4.5 + RGPD
-    // Art. 32 sur la réponse list qui contient PHI déchiffrée (motif).
-    // Empêche cache browser disk + CDN/proxy entreprise + back button.
-    res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, private")
-    res.headers.set("Pragma", "no-cache")
-    res.headers.set("Referrer-Policy", "no-referrer")
-    res.headers.set("X-Content-Type-Options", "nosniff")
-    return res
+    // Fix H-2 round 2 review PR #431 + factorisé via helper partagé (HSA-2-10
+    // round 2 PR #433) — Headers ANSSI RGS §4.5 + RGPD Art. 32 sur la réponse
+    // list qui contient PHI déchiffrée (motif).
+    return setAppointmentSecurityHeaders(NextResponse.json(out))
   } catch (e) {
-    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
-    return mapErrorToResponse(e, "appointments GET", ctx.requestId)
+    if (e instanceof AuthError) {
+      return setAppointmentSecurityHeaders(
+        NextResponse.json({ error: e.message }, { status: e.status }),
+      )
+    }
+    return setAppointmentSecurityHeaders(
+      mapErrorToResponse(e, "appointments GET", ctx.requestId),
+    )
   }
 }
 
+/**
+ * US-2500-UI iter 6 — création RDV depuis le modal `<AppointmentCreateModal>`.
+ *
+ * Headers ANSSI RGS §4.5 + RGPD Art. 32 via helper factorisé (HSA-2-10) :
+ * la réponse 201 contient `AppointmentDTO` complet déchiffré (motif). Sans
+ * `no-store`, bfcache + proxies cacheables retiendraient le payload PHI.
+ */
 export async function POST(req: NextRequest) {
   const ctx = extractRequestContext(req)
   try {
     const body = await req.json()
     const parsed = createSchema.safeParse(body)
     if (!parsed.success) {
-      return NextResponse.json(
-        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
-        { status: 400 },
+      return setAppointmentSecurityHeaders(
+        NextResponse.json(
+          { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+          { status: 400 },
+        ),
       )
     }
     const user = await auditedRequireRole(req, "NURSE", ctx, "APPOINTMENT", "create")
@@ -113,10 +123,16 @@ export async function POST(req: NextRequest) {
         ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
         metadata: { patientId: parsed.data.patientId, endpoint: "create" },
       })
-      return NextResponse.json({ error: "forbidden" }, { status: 403 })
+      return setAppointmentSecurityHeaders(
+        NextResponse.json({ error: "forbidden" }, { status: 403 }),
+      )
     }
     const consent = await patientShareConsent(parsed.data.patientId)
-    if (!consent.ok) return NextResponse.json({ error: consent.error }, { status: consent.status })
+    if (!consent.ok) {
+      return setAppointmentSecurityHeaders(
+        NextResponse.json({ error: consent.error }, { status: consent.status }),
+      )
+    }
 
     const out = await rdvAppointmentService.create(
       {
@@ -132,9 +148,15 @@ export async function POST(req: NextRequest) {
       },
       user.id, ctx,
     )
-    return NextResponse.json(out, { status: 201 })
+    return setAppointmentSecurityHeaders(NextResponse.json(out, { status: 201 }))
   } catch (e) {
-    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
-    return mapErrorToResponse(e, "appointments POST", ctx.requestId)
+    if (e instanceof AuthError) {
+      return setAppointmentSecurityHeaders(
+        NextResponse.json({ error: e.message }, { status: e.status }),
+      )
+    }
+    return setAppointmentSecurityHeaders(
+      mapErrorToResponse(e, "appointments POST", ctx.requestId),
+    )
   }
 }

--- a/src/app/api/patients/search/route.ts
+++ b/src/app/api/patients/search/route.ts
@@ -22,6 +22,26 @@ import { getAccessiblePatientIds } from "@/lib/access-control"
 import { patientService } from "@/lib/services/patient.service"
 import { extractRequestContext } from "@/lib/services/audit.service"
 
+/**
+ * Fix CR-H1 round 1 review PR #434 — Headers ANSSI RGS §4.5 + RGPD Art. 32
+ * sur la réponse qui contient des PHI déchiffrés (`user.firstname`/`lastname`
+ * de tous les patients accessibles via RBAC). Sans `no-store`, le bfcache
+ * navigateur + proxies cacheables (Nginx mal configuré, CDN client-side)
+ * peuvent retenir la liste patients.
+ *
+ * Asymétrie corrigée vs autres routes PHI (cf. helper partagé
+ * `setAppointmentSecurityHeaders` pour `/api/appointments/*` PR #433).
+ * Pas factorisé dans un helper global pour rester scope minimal — pattern
+ * à généraliser V1.5 via middleware Next.js (cf. HSA-2-10 PR #433).
+ */
+function setPatientsSearchSecurityHeaders(res: NextResponse): NextResponse {
+  res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, private")
+  res.headers.set("Pragma", "no-cache")
+  res.headers.set("Referrer-Policy", "no-referrer")
+  res.headers.set("X-Content-Type-Options", "nosniff")
+  return res
+}
+
 const querySchema = z.object({
   search: z.string().trim().min(1).max(100).optional(),
   pathology: z.enum(Pathology).optional(),
@@ -38,9 +58,11 @@ export async function GET(req: NextRequest) {
       Object.fromEntries(req.nextUrl.searchParams.entries()),
     )
     if (!parsed.success) {
-      return NextResponse.json(
-        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
-        { status: 400 },
+      return setPatientsSearchSecurityHeaders(
+        NextResponse.json(
+          { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+          { status: 400 },
+        ),
       )
     }
 
@@ -56,13 +78,17 @@ export async function GET(req: NextRequest) {
       user.id,
       ctx,
     )
-    return NextResponse.json(result)
+    return setPatientsSearchSecurityHeaders(NextResponse.json(result))
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.status })
+      return setPatientsSearchSecurityHeaders(
+        NextResponse.json({ error: error.message }, { status: error.status }),
+      )
     }
     const msg = error instanceof Error ? error.message : "Unknown error"
     console.error("[patients/search]", msg)
-    return NextResponse.json({ error: "serverError" }, { status: 500 })
+    return setPatientsSearchSecurityHeaders(
+      NextResponse.json({ error: "serverError" }, { status: 500 }),
+    )
   }
 }

--- a/src/components/diabeo/appointments/AppointmentCalendar.tsx
+++ b/src/components/diabeo/appointments/AppointmentCalendar.tsx
@@ -48,6 +48,8 @@ import { MemberFilter } from "./MemberFilter"
 import { useMyMemberships } from "./useMyMemberships"
 import { useAppointmentDetail } from "./useAppointmentDetail"
 import { AppointmentDetailModal } from "./AppointmentDetailModal"
+import { AppointmentCreateModal } from "./AppointmentCreateModal"
+import { Button } from "@/components/ui/button"
 
 /**
  * Fix M-10 round 2 review PR #431 — Locale Schedule-X dynamique selon
@@ -188,6 +190,10 @@ export function AppointmentCalendar({
   const [openedApptId, setOpenedApptId] = useState<number | null>(null)
   const detailState = useAppointmentDetail(openedApptId)
 
+  // US-2500-UI iter 6 — state du modal création RDV (bouton "+ Nouveau RDV").
+  // Mount-on-open + `key` (cohérent pattern iter 5) pour reset state interne.
+  const [createOpen, setCreateOpen] = useState(false)
+
   const events = useMemo(() => items.map(appointmentToScheduleXEvent), [items])
 
   // Fix CR-1 round 2 review PR #431 — `useNextCalendarApp` ne re-crée
@@ -272,6 +278,14 @@ export function AppointmentCalendar({
   // que le calendrier reflète immédiatement le nouveau statut.
   const handleActionSuccess = useCallback(() => { void refetch() }, [refetch])
 
+  // US-2500-UI iter 6 — handlers create modal.
+  const handleOpenCreate = useCallback(() => setCreateOpen(true), [])
+  const handleCloseCreate = useCallback(() => setCreateOpen(false), [])
+  const handleCreated = useCallback(() => {
+    setCreateOpen(false)
+    void refetch() // refresh calendar avec le nouveau RDV
+  }, [refetch])
+
   // Fix CR-1 + FE-5 + FE-12 round 1 + FE-2-4 round 2 review PR #433 —
   // Modal TOUJOURS monté + `key={openedApptId ?? "closed"}` :
   //   - À l'ouverture d'un nouveau RDV (key change), React remount complet le
@@ -294,10 +308,43 @@ export function AppointmentCalendar({
     />
   )
 
+  // US-2500-UI iter 6 — modal création RDV.
+  // Mount-on-open via render condition + `key` reset state au cycle d'ouverture
+  // (cohérent pattern iter 5 : drafts toujours frais, anti-PHI résiduel).
+  // `memberId={effectiveMemberId}` requis — donc bouton "+ Nouveau RDV" est
+  // disabled si scope membre pas résolu (cas multi-cabinets sans pick).
+  const createModal = createOpen && effectiveMemberId !== undefined ? (
+    <AppointmentCreateModal
+      key={`create-${effectiveMemberId}`}
+      open={createOpen}
+      memberId={effectiveMemberId}
+      onClose={handleCloseCreate}
+      onCreated={handleCreated}
+    />
+  ) : null
+
+  // Bouton "+ Nouveau RDV" rendu dans la barre d'actions header.
+  // Disabled si `effectiveMemberId` undefined (scope manquant — le user doit
+  // d'abord sélectionner un membre cabinet via `<MemberFilter>`).
+  const newApptButton = (
+    <Button
+      variant="default"
+      size="sm"
+      onClick={handleOpenCreate}
+      disabled={effectiveMemberId === undefined}
+      aria-label={t("createTitle")}
+    >
+      {t("newAppointmentButton")}
+    </Button>
+  )
+
   if (scopeMissing) {
     return (
       <div className="flex flex-col gap-3">
-        {filterEl}
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          {filterEl}
+          {newApptButton}
+        </div>
         <div className="rounded-lg border border-border bg-card p-12 text-center">
           <h2 className="text-lg font-medium text-foreground">
             {t(scopeMissingTitleKey)}
@@ -307,6 +354,7 @@ export function AppointmentCalendar({
           </p>
         </div>
         {detailModal}
+        {createModal}
       </div>
     )
   }
@@ -315,7 +363,12 @@ export function AppointmentCalendar({
 
   return (
     <div className="flex flex-col gap-3">
-      {filterEl}
+      {/* US-2500-UI iter 6 — header avec filtre cabinet à gauche + bouton
+          "+ Nouveau RDV" à droite. Flex-wrap pour responsive mobile. */}
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        {filterEl}
+        {newApptButton}
+      </div>
 
       {/* Status bar — fix M-6 (isInitialLoading silent polling) +
           fix H-7 (stale items conservés sur erreur) +
@@ -353,6 +406,7 @@ export function AppointmentCalendar({
       </div>
 
       {detailModal}
+      {createModal}
     </div>
   )
 }

--- a/src/components/diabeo/appointments/AppointmentCalendar.tsx
+++ b/src/components/diabeo/appointments/AppointmentCalendar.tsx
@@ -281,8 +281,14 @@ export function AppointmentCalendar({
   // US-2500-UI iter 6 — handlers create modal.
   const handleOpenCreate = useCallback(() => setCreateOpen(true), [])
   const handleCloseCreate = useCallback(() => setCreateOpen(false), [])
+  // Fix FE-12 round 1 review PR #434 — flag temporaire pour aria-live polite
+  // qui annonce le succès création (vs ancien close silent).
+  const [justCreated, setJustCreated] = useState(false)
   const handleCreated = useCallback(() => {
     setCreateOpen(false)
+    setJustCreated(true)
+    // Auto-clear après 4s pour ne pas polluer le live region indéfiniment.
+    setTimeout(() => setJustCreated(false), 4000)
     void refetch() // refresh calendar avec le nouveau RDV
   }, [refetch])
 
@@ -326,17 +332,30 @@ export function AppointmentCalendar({
   // Bouton "+ Nouveau RDV" rendu dans la barre d'actions header.
   // Disabled si `effectiveMemberId` undefined (scope manquant — le user doit
   // d'abord sélectionner un membre cabinet via `<MemberFilter>`).
+  //
+  // Fix FE-14 round 1 review PR #434 — `aria-label` retiré (était redondant
+  // avec le texte visible "+ Nouveau RDV" = WCAG 2.5.3 violation "Label in Name").
+  // Fix CR-L7 round 1 — `title` tooltip si disabled pour expliquer "sélectionnez
+  // un membre cabinet d'abord" au médecin qui clique sans comprendre.
   const newApptButton = (
     <Button
       variant="default"
       size="sm"
       onClick={handleOpenCreate}
       disabled={effectiveMemberId === undefined}
-      aria-label={t("createTitle")}
+      title={effectiveMemberId === undefined ? t("scopeMissingChooseFirst") : undefined}
     >
       {t("newAppointmentButton")}
     </Button>
   )
+
+  // Fix FE-12 round 1 review PR #434 — Live region pour annonce succès création
+  // (SR users + visuel discret). `aria-live="polite"` non-bloquant.
+  const successAnnounce = justCreated ? (
+    <p role="status" aria-live="polite" className="text-xs text-emerald-700">
+      {t("createdSuccess")}
+    </p>
+  ) : null
 
   if (scopeMissing) {
     return (
@@ -399,6 +418,8 @@ export function AppointmentCalendar({
           )}
         </div>
       </div>
+
+      {successAnnounce}
 
       {/* Fix L-1 — Tailwind class au lieu de magic inline style. */}
       <div className="rounded-lg border border-border bg-card overflow-hidden min-h-[640px]">

--- a/src/components/diabeo/appointments/AppointmentCreateModal.tsx
+++ b/src/components/diabeo/appointments/AppointmentCreateModal.tsx
@@ -1,0 +1,293 @@
+"use client"
+
+/**
+ * AppointmentCreateModal — modal création RDV depuis le bouton "+ Nouveau RDV"
+ * du calendrier.
+ *
+ * US-2500-UI iter 6 — formulaire shadcn Dialog avec :
+ *   - patient (combobox autocomplete via `usePatientList`)
+ *   - date + heure
+ *   - durée (15-240 min, défaut 30)
+ *   - location (in_person | video | phone)
+ *   - type (diabeto / ide / hdj / other — whitelist alignée adapter.ts)
+ *   - motif (chiffré côté backend AES-256-GCM, max 200 chars)
+ *
+ * **Architecture lifecycle** (réutilise pattern iter 5 AppointmentDetailModal) :
+ *   Le parent ne monte ce composant que lorsque `open=true`, et applique
+ *   `key` pour reset state à chaque ouverture (anti-PHI résiduel + anti-
+ *   draft pollué entre ouvertures).
+ *
+ * **memberId** : non saisi par le user — auto-résolu par le parent
+ * (`<AppointmentCalendar>`) via le pattern `effectiveMemberId` (iter 4).
+ *
+ * **Sécurité** :
+ *   - Backend valide via Zod + RBAC + consent + audit (POST /api/appointments)
+ *   - `motif`/`note` chiffrés à l'insertion en base (AES-256-GCM)
+ *   - Aucun PHI dans audit metadata
+ *   - Headers ANSSI sur réponse 201
+ *
+ * **UX** :
+ *   - Date prérempli aujourd'hui, heure prérempli 09:00
+ *   - Durée par défaut 30 min
+ *   - Location par défaut "in_person"
+ *   - Bouton disabled tant que `patientId` non sélectionné
+ *
+ * @see useCreateAppointment
+ * @see usePatientList
+ * @see PatientCombobox
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { useTranslations } from "next-intl"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { PatientCombobox } from "./PatientCombobox"
+import { useCreateAppointment, type CreateAppointmentInput } from "./useCreateAppointment"
+
+const APPOINTMENT_TYPES = ["diabeto", "ide", "hdj", "other"] as const
+const LOCATIONS = ["in_person", "video", "phone"] as const
+type AppointmentType = (typeof APPOINTMENT_TYPES)[number]
+type Location = (typeof LOCATIONS)[number]
+
+export interface AppointmentCreateModalProps {
+  /** Modal open state (contrôlé par le parent). */
+  open: boolean
+  /** memberId résolu par le parent (effectiveMemberId du calendrier). */
+  memberId: number
+  /** Callback fermeture (parent reset state). */
+  onClose: () => void
+  /** Callback succès création — parent refresh la liste calendar. */
+  onCreated: (newId: number) => void
+}
+
+export function AppointmentCreateModal({
+  open,
+  memberId,
+  onClose,
+  onCreated,
+}: AppointmentCreateModalProps) {
+  const t = useTranslations("appointments")
+  const { loading, error, submit, reset } = useCreateAppointment()
+
+  // Pré-remplir date = aujourd'hui (snapshot lazy au mount — Fix H-4 pattern iter 5).
+  const [today] = useState(() => new Date().toISOString().split("T")[0])
+
+  const [patientId, setPatientId] = useState<number | null>(null)
+  const [dateStr, setDateStr] = useState(today)
+  const [hourStr, setHourStr] = useState("09:00")
+  const [durationMinutes, setDurationMinutes] = useState(30)
+  const [location, setLocation] = useState<Location>("in_person")
+  const [type, setType] = useState<AppointmentType>("diabeto")
+  const [motif, setMotif] = useState("")
+  // Fix FE-2-5 pattern iter 5 — nonce pour re-mount du `<p role=alert>` même
+  // si message d'erreur identique sur retry → screen reader re-vocalise.
+  const [errorNonce, setErrorNonce] = useState(0)
+
+  // Reset hook state au close (defense-in-depth — parent unmount aussi via `key`).
+  useEffect(() => {
+    if (!open) reset()
+  }, [open, reset])
+
+  const canSubmit = useMemo(
+    () => patientId !== null && dateStr.length > 0 && hourStr.length > 0 && !loading,
+    [patientId, dateStr, hourStr, loading],
+  )
+
+  const handleClose = useCallback(() => {
+    if (loading) return // garde anti-fermeture pendant submit
+    onClose()
+  }, [loading, onClose])
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault()
+      if (!canSubmit || patientId === null || loading) return
+
+      const input: CreateAppointmentInput = {
+        patientId,
+        memberId,
+        date: dateStr,
+        hour: hourStr,
+        durationMinutes,
+        location,
+        type,
+        motif: motif.trim() || undefined,
+      }
+      const newId = await submit(input)
+      if (newId !== null) {
+        onCreated(newId)
+      } else {
+        setErrorNonce((n) => n + 1)
+      }
+    },
+    [
+      canSubmit,
+      patientId,
+      memberId,
+      dateStr,
+      hourStr,
+      durationMinutes,
+      location,
+      type,
+      motif,
+      loading,
+      submit,
+      onCreated,
+    ],
+  )
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) handleClose() }}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{t("createTitle")}</DialogTitle>
+          <DialogDescription>{t("createDescription")}</DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="grid gap-4 py-2">
+          {/* Patient combobox — search + select. Loading/error gérés en interne. */}
+          <div className="grid gap-2">
+            <Label htmlFor="create-patient">{t("patientLabel")}</Label>
+            <PatientCombobox
+              id="create-patient"
+              value={patientId}
+              onChange={setPatientId}
+              disabled={loading}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="grid gap-2">
+              <Label htmlFor="create-date">{t("dateLabel")}</Label>
+              <input
+                type="date"
+                id="create-date"
+                value={dateStr}
+                min={today}
+                onChange={(e) => setDateStr(e.target.value)}
+                required
+                disabled={loading}
+                className="border border-input rounded-md p-2 text-sm bg-background disabled:opacity-50"
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="create-hour">{t("hourLabel")}</Label>
+              <input
+                type="time"
+                id="create-hour"
+                value={hourStr}
+                onChange={(e) => setHourStr(e.target.value)}
+                required
+                disabled={loading}
+                className="border border-input rounded-md p-2 text-sm bg-background disabled:opacity-50"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="grid gap-2">
+              <Label htmlFor="create-duration">{t("durationLabel")}</Label>
+              <select
+                id="create-duration"
+                value={durationMinutes}
+                onChange={(e) => setDurationMinutes(Number(e.target.value))}
+                disabled={loading}
+                className="border border-input rounded-md p-2 text-sm bg-background disabled:opacity-50"
+              >
+                <option value={15}>15 {t("minutesShort")}</option>
+                <option value={30}>30 {t("minutesShort")}</option>
+                <option value={45}>45 {t("minutesShort")}</option>
+                <option value={60}>60 {t("minutesShort")}</option>
+                <option value={90}>90 {t("minutesShort")}</option>
+                <option value={120}>120 {t("minutesShort")}</option>
+              </select>
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="create-location">{t("locationLabel")}</Label>
+              <select
+                id="create-location"
+                value={location}
+                onChange={(e) => setLocation(e.target.value as Location)}
+                disabled={loading}
+                className="border border-input rounded-md p-2 text-sm bg-background disabled:opacity-50"
+              >
+                {LOCATIONS.map((loc) => (
+                  <option key={loc} value={loc}>
+                    {t(`location.${loc}`)}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="create-type">{t("typeLabel")}</Label>
+            <select
+              id="create-type"
+              value={type}
+              onChange={(e) => setType(e.target.value as AppointmentType)}
+              disabled={loading}
+              className="border border-input rounded-md p-2 text-sm bg-background disabled:opacity-50"
+            >
+              {APPOINTMENT_TYPES.map((tp) => (
+                <option key={tp} value={tp}>
+                  {t(`type.${tp}`)}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="create-motif">{t("motifLabel")}</Label>
+            <textarea
+              id="create-motif"
+              value={motif}
+              onChange={(e) => setMotif(e.target.value)}
+              maxLength={200}
+              rows={2}
+              disabled={loading}
+              className="border border-input rounded-md p-2 text-sm bg-background resize-none disabled:opacity-50"
+              placeholder={t("motifPlaceholder")}
+              aria-describedby="create-motif-help"
+            />
+            <p id="create-motif-help" className="text-xs text-muted-foreground">
+              {motif.length} / 200 · {t("motifEncryptedNote")}
+            </p>
+          </div>
+
+          {error && (
+            <p
+              key={`${error}-${errorNonce}`}
+              role="alert"
+              aria-live="assertive"
+              className="text-sm text-red-600"
+            >
+              {/* Defense-in-depth : on render UNIQUEMENT la clé i18n générique,
+                  jamais le code backend brut (HSA-3 pattern iter 5). */}
+              {t("createError")}
+            </p>
+          )}
+
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={handleClose} disabled={loading}>
+              {t("actionClose")}
+            </Button>
+            <Button type="submit" disabled={!canSubmit}>
+              {loading ? t("loading") : t("actionConfirmCreate")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/diabeo/appointments/AppointmentCreateModal.tsx
+++ b/src/components/diabeo/appointments/AppointmentCreateModal.tsx
@@ -38,7 +38,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import {
   Dialog,
   DialogContent,
@@ -50,12 +50,83 @@ import {
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
 import { PatientCombobox } from "./PatientCombobox"
-import { useCreateAppointment, type CreateAppointmentInput } from "./useCreateAppointment"
+import {
+  useCreateAppointment,
+  type CreateAppointmentInput,
+  type CreateAppointmentErrorCode,
+} from "./useCreateAppointment"
 
 const APPOINTMENT_TYPES = ["diabeto", "ide", "hdj", "other"] as const
 const LOCATIONS = ["in_person", "video", "phone"] as const
+// Fix FE-13 round 1 review PR #434 — Presets durée étendus :
+// +20 (consultation flash) +75 (HDJ court) +180/240 (HDJ long).
+const DURATION_PRESETS = [15, 20, 30, 45, 60, 75, 90, 120, 180, 240] as const
 type AppointmentType = (typeof APPOINTMENT_TYPES)[number]
 type Location = (typeof LOCATIONS)[number]
+
+/**
+ * Fix CR-H2 + HSA-3 round 1 review PR #434 — Mapping code erreur backend
+ * (whitelist normalisée par le hook) vers clé i18n distincte. Donne au médecin
+ * un feedback actionnable :
+ *   - slotConflict (409) : "Le créneau est déjà pris — choisissez un autre"
+ *   - gdprConsentRequired (422) : "Le patient n'a pas accepté le partage"
+ *   - forbidden (403) : "Vous n'avez pas accès à ce patient"
+ *   - validationFailed (400) : "Vérifiez les champs"
+ *   - networkError / unexpectedError : "Erreur inattendue — réessayez"
+ */
+function errorCodeToI18nKey(code: CreateAppointmentErrorCode): string {
+  switch (code) {
+    case "slotConflict":
+      return "createErrorConflict"
+    case "gdprConsentRequired":
+      return "createErrorConsent"
+    case "forbidden":
+      return "createErrorForbidden"
+    case "validationFailed":
+      return "createErrorValidation"
+    case "networkError":
+    case "unexpectedError":
+    default:
+      return "createErrorGeneric"
+  }
+}
+
+/**
+ * Format wall-clock "DD/MM/YYYY à HH:MM" en locale next-intl pour récap
+ * visuel au-dessus du bouton submit (Fix FE-11 round 1 review PR #434).
+ * Utilise `timeZone: "UTC"` cohérent avec contrat wall-clock iter 5.
+ */
+function formatRecap(date: string, hour: string, locale: string): string {
+  try {
+    const [y, m, d] = date.split("-").map(Number)
+    const [h, mi] = hour.split(":").map(Number)
+    const dt = new Date(Date.UTC(y, m - 1, d, h, mi, 0))
+    return new Intl.DateTimeFormat(locale, {
+      day: "2-digit",
+      month: "long",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZone: "UTC",
+    }).format(dt)
+  } catch {
+    return `${date} ${hour}`
+  }
+}
+
+/** Vérifie si `date + hour` est dans le futur (Fix CR-M4 round 1). */
+function isInFuture(date: string, hour: string): boolean {
+  if (!date || !hour) return false
+  try {
+    const [y, m, d] = date.split("-").map(Number)
+    const [h, mi] = hour.split(":").map(Number)
+    // Utilise heure locale du navigateur pour comparer (wall-clock du user).
+    const target = new Date(y, m - 1, d, h, mi, 0)
+    return target.getTime() > Date.now()
+  } catch {
+    return false
+  }
+}
 
 export interface AppointmentCreateModalProps {
   /** Modal open state (contrôlé par le parent). */
@@ -75,6 +146,7 @@ export function AppointmentCreateModal({
   onCreated,
 }: AppointmentCreateModalProps) {
   const t = useTranslations("appointments")
+  const locale = useLocale()
   const { loading, error, submit, reset } = useCreateAppointment()
 
   // Pré-remplir date = aujourd'hui (snapshot lazy au mount — Fix H-4 pattern iter 5).
@@ -90,15 +162,38 @@ export function AppointmentCreateModal({
   // Fix FE-2-5 pattern iter 5 — nonce pour re-mount du `<p role=alert>` même
   // si message d'erreur identique sur retry → screen reader re-vocalise.
   const [errorNonce, setErrorNonce] = useState(0)
+  // Fix FE-16 round 1 review PR #434 — tracker submit échoué pour `aria-invalid`
+  // sur les inputs (signal SR users du champ fautif).
+  const [submitFailed, setSubmitFailed] = useState(false)
 
   // Reset hook state au close (defense-in-depth — parent unmount aussi via `key`).
   useEffect(() => {
     if (!open) reset()
   }, [open, reset])
 
+  // Fix CR-M4 round 1 review PR #434 — validation date+hour future client-side.
+  // Empêche la création d'un RDV dans le passé par mégarde (e.g. RDV 09:00 today
+  // alors qu'il est 14:00). Backend Zod ne valide pas le futur — defense-in-depth.
+  const dateTimeIsFuture = useMemo(
+    () => isInFuture(dateStr, hourStr),
+    [dateStr, hourStr],
+  )
+
   const canSubmit = useMemo(
-    () => patientId !== null && dateStr.length > 0 && hourStr.length > 0 && !loading,
-    [patientId, dateStr, hourStr, loading],
+    () =>
+      patientId !== null
+      && dateStr.length > 0
+      && hourStr.length > 0
+      && dateTimeIsFuture
+      && !loading,
+    [patientId, dateStr, hourStr, dateTimeIsFuture, loading],
+  )
+
+  // Fix FE-11 round 1 — récap visuel "12 juin 2026 à 09:00" pour que l'user
+  // confirme visuellement ce qu'il s'apprête à créer (vs juste un bouton).
+  const recap = useMemo(
+    () => (dateStr && hourStr ? formatRecap(dateStr, hourStr, locale) : ""),
+    [dateStr, hourStr, locale],
   )
 
   const handleClose = useCallback(() => {
@@ -123,8 +218,10 @@ export function AppointmentCreateModal({
       }
       const newId = await submit(input)
       if (newId !== null) {
+        setSubmitFailed(false)
         onCreated(newId)
       } else {
+        setSubmitFailed(true)
         setErrorNonce((n) => n + 1)
       }
     },
@@ -167,6 +264,8 @@ export function AppointmentCreateModal({
           <div className="grid grid-cols-2 gap-3">
             <div className="grid gap-2">
               <Label htmlFor="create-date">{t("dateLabel")}</Label>
+              {/* Fix FE-15 round 1 — aria-required + Fix FE-16 — aria-invalid si
+                  submitFailed OU date dans le passé (validation CR-M4). */}
               <input
                 type="date"
                 id="create-date"
@@ -174,6 +273,8 @@ export function AppointmentCreateModal({
                 min={today}
                 onChange={(e) => setDateStr(e.target.value)}
                 required
+                aria-required="true"
+                aria-invalid={submitFailed || !dateTimeIsFuture ? "true" : undefined}
                 disabled={loading}
                 className="border border-input rounded-md p-2 text-sm bg-background disabled:opacity-50"
               />
@@ -187,11 +288,20 @@ export function AppointmentCreateModal({
                 value={hourStr}
                 onChange={(e) => setHourStr(e.target.value)}
                 required
+                aria-required="true"
+                aria-invalid={submitFailed || !dateTimeIsFuture ? "true" : undefined}
                 disabled={loading}
                 className="border border-input rounded-md p-2 text-sm bg-background disabled:opacity-50"
               />
             </div>
           </div>
+
+          {/* Fix CR-M4 round 1 — message d'avertissement si date+heure dans le passé. */}
+          {!dateTimeIsFuture && dateStr.length > 0 && hourStr.length > 0 && (
+            <p role="status" aria-live="polite" className="text-xs text-amber-700">
+              {t("createDatePastWarning")}
+            </p>
+          )}
 
           <div className="grid grid-cols-2 gap-3">
             <div className="grid gap-2">
@@ -203,12 +313,12 @@ export function AppointmentCreateModal({
                 disabled={loading}
                 className="border border-input rounded-md p-2 text-sm bg-background disabled:opacity-50"
               >
-                <option value={15}>15 {t("minutesShort")}</option>
-                <option value={30}>30 {t("minutesShort")}</option>
-                <option value={45}>45 {t("minutesShort")}</option>
-                <option value={60}>60 {t("minutesShort")}</option>
-                <option value={90}>90 {t("minutesShort")}</option>
-                <option value={120}>120 {t("minutesShort")}</option>
+                {/* Fix FE-13 round 1 — presets étendus 15→240 min. */}
+                {DURATION_PRESETS.map((d) => (
+                  <option key={d} value={d}>
+                    {d} {t("minutesShort")}
+                  </option>
+                ))}
               </select>
             </div>
 
@@ -272,9 +382,20 @@ export function AppointmentCreateModal({
               aria-live="assertive"
               className="text-sm text-red-600"
             >
-              {/* Defense-in-depth : on render UNIQUEMENT la clé i18n générique,
-                  jamais le code backend brut (HSA-3 pattern iter 5). */}
-              {t("createError")}
+              {/* Fix CR-H2 + HSA-3 round 1 review PR #434 — map vers clé i18n
+                  distincte selon le code backend (whitelist normalisée par hook).
+                  Donne au médecin un feedback actionnable vs ancien `createError`
+                  générique qui poussait au re-clic en boucle. */}
+              {t(errorCodeToI18nKey(error))}
+            </p>
+          )}
+
+          {/* Fix FE-11 round 1 — récap visuel "12 juin 2026 à 09:00" au-dessus du
+              bouton submit pour que l'user confirme visuellement le RDV qu'il
+              s'apprête à créer. Pattern UX standard "confirm before commit". */}
+          {recap && dateTimeIsFuture && (
+            <p className="text-xs text-muted-foreground" aria-live="polite">
+              {t("createRecap", { datetime: recap })}
             </p>
           )}
 

--- a/src/components/diabeo/appointments/PatientCombobox.tsx
+++ b/src/components/diabeo/appointments/PatientCombobox.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+/**
+ * PatientCombobox — search-select pour le modal création RDV.
+ *
+ * US-2500-UI iter 6 — autocomplete patient avec :
+ *   - fetch initial `/api/patients/search?limit=50` (cabinet standard)
+ *   - filtre client-side par nom/prénom (insensitive case + accent-aware via
+ *     `localeCompare`)
+ *   - debounce 250ms du `search` côté backend si user tape (HMAC exact match)
+ *
+ * **Stratégie** : V1 simple — `<input>` + `<datalist>` natif HTML5 pour éviter
+ * d'ajouter Command/Popover shadcn. UX : autocomplete navigateur natif (Chrome,
+ * Safari, Firefox supportent <datalist>). Limitation : pas de keyboard nav
+ * "first letter highlight" optimal, mais suffisant pour MVP.
+ *
+ * V1.5 : migration vers `<Command>` shadcn (cmdk) ou `<Combobox>` HeadlessUI
+ * pour UX premium si > 20 patients.
+ *
+ * **Sécurité** :
+ *   - Nom/prénom PHI déchiffré côté backend (RBAC scope automatique).
+ *   - Liste reset au unmount du modal (le hook `usePatientList` reset state
+ *     quand `enabled=false`).
+ *
+ * **Controlled** : `value={patientId | null}`, `onChange(id | null)`.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { useTranslations } from "next-intl"
+import { usePatientList } from "./usePatientList"
+
+export interface PatientComboboxProps {
+  /** id input DOM pour association `<Label>`. */
+  id: string
+  /** patientId sélectionné (controlled). */
+  value: number | null
+  /** Callback sélection changée. */
+  onChange: (patientId: number | null) => void
+  /** Désactive le combobox (e.g. pendant submit). */
+  disabled?: boolean
+}
+
+const SEARCH_DEBOUNCE_MS = 250
+
+function patientLabel(p: { firstname: string | null; lastname: string | null }): string {
+  const parts = [p.firstname, p.lastname].filter(Boolean)
+  return parts.join(" ").trim() || "(?)"
+}
+
+export function PatientCombobox({ id, value, onChange, disabled }: PatientComboboxProps) {
+  const t = useTranslations("appointments")
+  const [inputValue, setInputValue] = useState("")
+  const [debouncedSearch, setDebouncedSearch] = useState<string | undefined>(undefined)
+
+  // Debounce input → fetch backend si user tape (HMAC exact match — utile si
+  // > 50 patients, sinon le filtre client-side suffit).
+  //
+  // React Compiler warn "setState synchronously in effect" sur le path empty :
+  // c'est inhérent au debounce qui doit propager l'empty state immédiatement
+  // (sinon on garde un debouncedSearch obsolète qui filtre le fetch).
+  // Le `setTimeout` non-vide ne déclenche pas le warn.
+  useEffect(() => {
+    const trimmed = inputValue.trim()
+    if (trimmed.length === 0) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- debounce empty path requires immediate sync
+      setDebouncedSearch(undefined)
+      return
+    }
+    const timer = setTimeout(() => {
+      setDebouncedSearch(trimmed)
+    }, SEARCH_DEBOUNCE_MS)
+    return () => clearTimeout(timer)
+  }, [inputValue])
+
+  const { items, loading, error } = usePatientList({
+    enabled: true, // composant n'est rendu que dans modal ouvert (parent gate)
+    search: debouncedSearch,
+  })
+
+  // Filtre client-side fallback (utile pour les 50 premiers sans search backend).
+  const filtered = useMemo(() => {
+    const q = inputValue.trim().toLowerCase()
+    if (q.length === 0) return items
+    return items.filter((p) => patientLabel(p).toLowerCase().includes(q))
+  }, [items, inputValue])
+
+  // Note : pas de sync prop `value` → state `inputValue`. Le combobox est
+  // uncontrolled-mostly : la frappe user pilote l'input, et `handleInputChange`
+  // remonte `onChange(matchedId)` au parent. Si le parent clear `value`
+  // externally (rare), l'input n'est pas reset — pattern acceptable car le
+  // modal est mount-on-open avec `key` reset (cf. AppointmentCalendar) →
+  // chaque ouverture démarre fresh.
+
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const next = e.target.value
+      setInputValue(next)
+      // Si l'input matche exactement un patient de la liste, on sélectionne.
+      // Sinon on clear le `value` (l'user est en train d'éditer).
+      const match = items.find(
+        (p) => patientLabel(p).toLowerCase() === next.trim().toLowerCase(),
+      )
+      onChange(match ? match.id : null)
+    },
+    [items, onChange],
+  )
+
+  return (
+    <div className="grid gap-1">
+      <input
+        id={id}
+        type="text"
+        list={`${id}-options`}
+        value={inputValue}
+        onChange={handleInputChange}
+        disabled={disabled || loading}
+        autoComplete="off"
+        spellCheck={false}
+        className="border border-input rounded-md p-2 text-sm bg-background disabled:opacity-50"
+        placeholder={t("patientPlaceholder")}
+        aria-describedby={`${id}-help`}
+      />
+      <datalist id={`${id}-options`}>
+        {filtered.map((p) => (
+          <option key={p.id} value={patientLabel(p)} />
+        ))}
+      </datalist>
+      <p id={`${id}-help`} className="text-xs text-muted-foreground">
+        {loading && t("loading")}
+        {error && (
+          <span role="alert" className="text-red-600">
+            {t("patientListError")}
+          </span>
+        )}
+        {!loading && !error && (
+          value !== null
+            ? t("patientSelected")
+            : t("patientHint", { count: filtered.length })
+        )}
+      </p>
+    </div>
+  )
+}

--- a/src/components/diabeo/appointments/PatientCombobox.tsx
+++ b/src/components/diabeo/appointments/PatientCombobox.tsx
@@ -5,27 +5,35 @@
  *
  * US-2500-UI iter 6 — autocomplete patient avec :
  *   - fetch initial `/api/patients/search?limit=50` (cabinet standard)
- *   - filtre client-side par nom/prénom (insensitive case + accent-aware via
- *     `localeCompare`)
- *   - debounce 250ms du `search` côté backend si user tape (HMAC exact match)
+ *   - filtre client-side **accent-aware** + insensitive case via
+ *     `String.prototype.normalize("NFD")` (Fix CR-H3/FE-1 round 1 PR #434 :
+ *     "Müller" matche "muller", "Pérez" matche "perez", "Šimić" matche "simic")
+ *   - **disambiguation #id** dans le label affiché (Fix CR-H3/FE-6 round 1 :
+ *     2 patients homonymes "Jean Martin" deviennent "Jean Martin #42" vs
+ *     "Jean Martin #43" → médecin distingue visuellement, élimine le risque
+ *     clinique de RDV créé pour le mauvais patient)
+ *   - debounce 250ms via `useDeferredValue` React 19 (Fix FE-2 round 1 :
+ *     plus de setState-in-effect anti-pattern)
  *
  * **Stratégie** : V1 simple — `<input>` + `<datalist>` natif HTML5 pour éviter
  * d'ajouter Command/Popover shadcn. UX : autocomplete navigateur natif (Chrome,
- * Safari, Firefox supportent <datalist>). Limitation : pas de keyboard nav
- * "first letter highlight" optimal, mais suffisant pour MVP.
+ * Safari, Firefox supportent <datalist>). Limitations connues :
+ *   - Safari iOS rendering inconsistant (impact limité — backoffice desktop)
+ *   - Pas de keyboard nav "first letter highlight" optimal
+ *   - Pas de stylage CSS du dropdown
  *
- * V1.5 : migration vers `<Command>` shadcn (cmdk) ou `<Combobox>` HeadlessUI
- * pour UX premium si > 20 patients.
+ * V1.5 (issue à créer) : migration vers `<Command>` shadcn (cmdk) ou
+ * `<Combobox>` HeadlessUI pour UX premium si > 20 patients + a11y
+ * `aria-listbox` standardisée (vs `<datalist>` a11y limitée).
  *
  * **Sécurité** :
  *   - Nom/prénom PHI déchiffré côté backend (RBAC scope automatique).
- *   - Liste reset au unmount du modal (le hook `usePatientList` reset state
- *     quand `enabled=false`).
+ *   - Liste reset au unmount du modal (key remount au close — pattern iter 5).
  *
  * **Controlled** : `value={patientId | null}`, `onChange(id | null)`.
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useDeferredValue, useMemo, useState } from "react"
 import { useTranslations } from "next-intl"
 import { usePatientList } from "./usePatientList"
 
@@ -40,70 +48,80 @@ export interface PatientComboboxProps {
   disabled?: boolean
 }
 
-const SEARCH_DEBOUNCE_MS = 250
-
-function patientLabel(p: { firstname: string | null; lastname: string | null }): string {
+/**
+ * Fix CR-H3/FE-1/FE-6 round 1 review PR #434 — Label avec disambiguation
+ * `#id` pour distinguer homonymes ("Jean Martin #42" vs "Jean Martin #43").
+ */
+function patientLabel(p: { id: number; firstname: string | null; lastname: string | null }): string {
   const parts = [p.firstname, p.lastname].filter(Boolean)
-  return parts.join(" ").trim() || "(?)"
+  const name = parts.join(" ").trim() || "(?)"
+  return `${name} #${p.id}`
+}
+
+/**
+ * Fix CR-H3/FE-1 round 1 review PR #434 — Normalisation accent-aware pour
+ * comparaisons :
+ *   - NFD : décompose les caractères accentués (é → e + combining acute)
+ *   - replace Diacritic : supprime les marques diacritiques (combining acute)
+ *   - toLowerCase : insensitive case
+ *
+ * Résultat : "Müller", "Pérez", "Šimić" matchent respectivement "muller",
+ * "perez", "simic" sans accent.
+ */
+function normalize(s: string): string {
+  return s.normalize("NFD").replace(/\p{Diacritic}/gu, "").toLowerCase()
 }
 
 export function PatientCombobox({ id, value, onChange, disabled }: PatientComboboxProps) {
   const t = useTranslations("appointments")
   const [inputValue, setInputValue] = useState("")
-  const [debouncedSearch, setDebouncedSearch] = useState<string | undefined>(undefined)
-
-  // Debounce input → fetch backend si user tape (HMAC exact match — utile si
-  // > 50 patients, sinon le filtre client-side suffit).
-  //
-  // React Compiler warn "setState synchronously in effect" sur le path empty :
-  // c'est inhérent au debounce qui doit propager l'empty state immédiatement
-  // (sinon on garde un debouncedSearch obsolète qui filtre le fetch).
-  // Le `setTimeout` non-vide ne déclenche pas le warn.
-  useEffect(() => {
-    const trimmed = inputValue.trim()
-    if (trimmed.length === 0) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- debounce empty path requires immediate sync
-      setDebouncedSearch(undefined)
-      return
-    }
-    const timer = setTimeout(() => {
-      setDebouncedSearch(trimmed)
-    }, SEARCH_DEBOUNCE_MS)
-    return () => clearTimeout(timer)
-  }, [inputValue])
+  // Fix FE-2 round 1 review PR #434 — `useDeferredValue` React 19 (vs ancien
+  // pattern setState-in-effect + setTimeout custom). Le rendu utilise la valeur
+  // "fraîche" pour l'input mais la valeur "deferred" pour le fetch backend.
+  // React 19 ajuste automatiquement le délai selon la charge CPU.
+  const deferredInput = useDeferredValue(inputValue)
 
   const { items, loading, error } = usePatientList({
     enabled: true, // composant n'est rendu que dans modal ouvert (parent gate)
-    search: debouncedSearch,
+    search: deferredInput.trim().length > 0 ? deferredInput.trim() : undefined,
   })
 
   // Filtre client-side fallback (utile pour les 50 premiers sans search backend).
+  // Accent-aware via `normalize()` — couvre "Müller" tapé "muller".
   const filtered = useMemo(() => {
-    const q = inputValue.trim().toLowerCase()
+    const q = normalize(inputValue.trim())
     if (q.length === 0) return items
-    return items.filter((p) => patientLabel(p).toLowerCase().includes(q))
+    return items.filter((p) => normalize(patientLabel(p)).includes(q))
   }, [items, inputValue])
 
   // Note : pas de sync prop `value` → state `inputValue`. Le combobox est
   // uncontrolled-mostly : la frappe user pilote l'input, et `handleInputChange`
-  // remonte `onChange(matchedId)` au parent. Si le parent clear `value`
-  // externally (rare), l'input n'est pas reset — pattern acceptable car le
-  // modal est mount-on-open avec `key` reset (cf. AppointmentCalendar) →
-  // chaque ouverture démarre fresh.
+  // remonte `onChange(matchedId)` au parent. Modal mount-on-open avec `key`
+  // reset → chaque ouverture démarre fresh.
 
   const handleInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const next = e.target.value
       setInputValue(next)
-      // Si l'input matche exactement un patient de la liste, on sélectionne.
-      // Sinon on clear le `value` (l'user est en train d'éditer).
+      // Match accent-aware via normalize() (Fix CR-H3 — sinon "Müller" ne
+      // match jamais après frappe "müller #42").
+      const normalizedInput = normalize(next.trim())
       const match = items.find(
-        (p) => patientLabel(p).toLowerCase() === next.trim().toLowerCase(),
+        (p) => normalize(patientLabel(p)) === normalizedInput,
       )
       onChange(match ? match.id : null)
     },
     [items, onChange],
   )
+
+  // Fix FE-7 round 1 review PR #434 — états distincts du hint :
+  //   - loading → "Chargement…"
+  //   - error → role=alert
+  //   - no-results (user a tapé + filter vide) → "Aucun patient trouvé"
+  //   - selected (value !== null) → "Patient sélectionné"
+  //   - idle (default) → "X patient(s) disponible(s)" avec total backend
+  const isSearching = inputValue.trim().length > 0
+  const noResults = !loading && !error && isSearching && filtered.length === 0
 
   return (
     <div className="grid gap-1">
@@ -116,6 +134,8 @@ export function PatientCombobox({ id, value, onChange, disabled }: PatientCombob
         disabled={disabled || loading}
         autoComplete="off"
         spellCheck={false}
+        aria-required="true"
+        aria-invalid={value === null && isSearching ? "true" : undefined}
         className="border border-input rounded-md p-2 text-sm bg-background disabled:opacity-50"
         placeholder={t("patientPlaceholder")}
         aria-describedby={`${id}-help`}
@@ -125,17 +145,25 @@ export function PatientCombobox({ id, value, onChange, disabled }: PatientCombob
           <option key={p.id} value={patientLabel(p)} />
         ))}
       </datalist>
-      <p id={`${id}-help`} className="text-xs text-muted-foreground">
+      <p id={`${id}-help`} className="text-xs text-muted-foreground" aria-live="polite">
         {loading && t("loading")}
         {error && (
           <span role="alert" className="text-red-600">
             {t("patientListError")}
           </span>
         )}
-        {!loading && !error && (
+        {noResults && (
+          <span role="status" className="text-amber-700">
+            {t("patientNoResults")}
+          </span>
+        )}
+        {!loading && !error && !noResults && (
           value !== null
             ? t("patientSelected")
-            : t("patientHint", { count: filtered.length })
+            // Fix FE-9 round 1 review PR #434 — count NON-filtré (`items.length`)
+            // pour ne pas mentir : "50 patients disponibles" reflète le total
+            // backend, pas le filtre client-side trompeur.
+            : t("patientHint", { count: items.length })
         )}
       </p>
     </div>

--- a/src/components/diabeo/appointments/useCreateAppointment.ts
+++ b/src/components/diabeo/appointments/useCreateAppointment.ts
@@ -27,7 +27,7 @@
  * (EXCLUDE GiST slot membre), 422 consent (gdprConsentRequired).
  */
 
-import { useCallback, useState } from "react"
+import { useCallback, useRef, useState } from "react"
 
 export interface CreateAppointmentInput {
   patientId: number
@@ -41,14 +41,49 @@ export interface CreateAppointmentInput {
   note?: string
 }
 
+/**
+ * Fix CR-H2 + HSA-3 round 1 review PR #434 — Whitelist stricte des codes
+ * d'erreur backend acceptés. Tout code non-listé tombe sur `unexpectedError`
+ * pour empêcher le leak d'un message verbeux backend dans le state React
+ * (defense-in-depth contre régression future qui exposerait du PHI/PII
+ * dans `body.error`).
+ *
+ * Le composant `<AppointmentCreateModal>` map ces codes vers des i18n keys
+ * distinctes pour donner un feedback médecin actionnable (vs "L'action a
+ * échoué" générique qui pousse au re-clic en boucle).
+ */
+export type CreateAppointmentErrorCode =
+  | "slotConflict"
+  | "gdprConsentRequired"
+  | "forbidden"
+  | "validationFailed"
+  | "networkError"
+  | "unexpectedError"
+
+const ACCEPTED_ERROR_CODES: ReadonlySet<CreateAppointmentErrorCode> = new Set([
+  "slotConflict",
+  "gdprConsentRequired",
+  "forbidden",
+  "validationFailed",
+  "networkError",
+])
+
+function normalizeError(raw: string | undefined): CreateAppointmentErrorCode {
+  if (raw === undefined) return "unexpectedError"
+  if (ACCEPTED_ERROR_CODES.has(raw as CreateAppointmentErrorCode)) {
+    return raw as CreateAppointmentErrorCode
+  }
+  return "unexpectedError"
+}
+
 export interface CreateAppointmentResult {
   loading: boolean
   /**
-   * Code d'erreur stable côté backend OU null si succès / pas submitté.
-   * Le composant le map vers une i18n key générique pour l'affichage UI
-   * (HSA-3 defense-in-depth — ne JAMAIS render brut).
+   * Code d'erreur normalisé côté hook (whitelist stricte) OU null si succès.
+   * Le composant le map vers une i18n key distincte pour l'affichage UI
+   * (HSA-3 defense-in-depth — ne JAMAIS render brut côté UI).
    */
-  error: string | null
+  error: CreateAppointmentErrorCode | null
   /** Submit le formulaire. Retourne `newId` (201) ou `null` si erreur. */
   submit: (input: CreateAppointmentInput) => Promise<number | null>
   /** Reset state (utile entre 2 ouvertures du modal). */
@@ -57,14 +92,25 @@ export interface CreateAppointmentResult {
 
 export function useCreateAppointment(): CreateAppointmentResult {
   const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [error, setError] = useState<CreateAppointmentErrorCode | null>(null)
+  // Fix FE-5 round 1 review PR #434 — AbortController cohérent pattern iter 5
+  // (`useAppointmentDetail`). Cancel le POST si modal close pendant submit.
+  // Conséquence : si user ferme le modal entre setActionLoading(true) et la
+  // réponse, on évite le setState fantôme côté hook (warn React 19 silent).
+  const abortRef = useRef<AbortController | null>(null)
 
   const reset = useCallback(() => {
+    abortRef.current?.abort()
     setError(null)
     setLoading(false)
   }, [])
 
   const submit = useCallback(async (input: CreateAppointmentInput): Promise<number | null> => {
+    abortRef.current?.abort()
+    const ctrl = new AbortController()
+    abortRef.current = ctrl
+    const myCtrl = ctrl
+
     setLoading(true)
     setError(null)
     try {
@@ -77,7 +123,10 @@ export function useCreateAppointment(): CreateAppointmentResult {
           "X-Requested-With": "XMLHttpRequest",
         },
         body: JSON.stringify(input),
+        signal: myCtrl.signal,
       })
+
+      if (myCtrl.signal.aborted) return null
 
       if (!res.ok) {
         if (res.status === 401 && typeof window !== "undefined") {
@@ -85,17 +134,21 @@ export function useCreateAppointment(): CreateAppointmentResult {
           return null
         }
         const body = (await res.json().catch(() => ({}))) as { error?: string }
-        setError(body.error ?? `httpError:${res.status}`)
+        if (myCtrl.signal.aborted) return null
+        setError(normalizeError(body.error))
         return null
       }
 
       const data = (await res.json()) as { id: number }
+      if (myCtrl.signal.aborted) return null
       return data.id
     } catch (err) {
-      setError(err instanceof Error ? err.message : "networkError")
+      if (err instanceof Error && err.name === "AbortError") return null
+      if (myCtrl.signal.aborted) return null
+      setError(normalizeError(err instanceof Error ? err.message : undefined))
       return null
     } finally {
-      setLoading(false)
+      if (!myCtrl.signal.aborted) setLoading(false)
     }
   }, [])
 

--- a/src/components/diabeo/appointments/useCreateAppointment.ts
+++ b/src/components/diabeo/appointments/useCreateAppointment.ts
@@ -1,0 +1,103 @@
+"use client"
+
+/**
+ * useCreateAppointment — hook submit POST `/api/appointments` (création).
+ *
+ * US-2500-UI iter 6 — utilisé par `<AppointmentCreateModal>` pour soumettre
+ * le formulaire. Backend valide via Zod, applique RBAC + consent + audit,
+ * retourne `AppointmentDTO` (201).
+ *
+ * **Contrat backend** (cf. `src/app/api/appointments/route.ts:25-35`) :
+ *   - `patientId` (int positive, required)
+ *   - `memberId` (int positive, required)
+ *   - `date` (yyyy-mm-dd, required)
+ *   - `hour` (HH:MM, required)
+ *   - `durationMinutes` (15-240, optional default 30)
+ *   - `location` (`in_person` | `video` | `phone`, optional)
+ *   - `type` (max 50, optional)
+ *   - `motif` (max 200, optional — sera chiffré AES-256-GCM côté backend)
+ *   - `note` (max 4096, optional — sera chiffré aussi)
+ *
+ * **Sécurité** :
+ *   - Backend headers ANSSI sur réponse 201 (HSA-2-1 round 2 fix)
+ *   - `motif`/`note` chiffrés à l'insertion en base via `encryptField`
+ *   - Audit `CREATE` resource=APPOINTMENT, resourceId=newId, metadata.patientId
+ *
+ * **Errors** : 400 validation, 403 forbidden (canAccessPatient), 409 conflict
+ * (EXCLUDE GiST slot membre), 422 consent (gdprConsentRequired).
+ */
+
+import { useCallback, useState } from "react"
+
+export interface CreateAppointmentInput {
+  patientId: number
+  memberId: number
+  date: string // yyyy-mm-dd
+  hour: string // HH:MM
+  durationMinutes?: number
+  location?: "in_person" | "video" | "phone"
+  type?: string
+  motif?: string
+  note?: string
+}
+
+export interface CreateAppointmentResult {
+  loading: boolean
+  /**
+   * Code d'erreur stable côté backend OU null si succès / pas submitté.
+   * Le composant le map vers une i18n key générique pour l'affichage UI
+   * (HSA-3 defense-in-depth — ne JAMAIS render brut).
+   */
+  error: string | null
+  /** Submit le formulaire. Retourne `newId` (201) ou `null` si erreur. */
+  submit: (input: CreateAppointmentInput) => Promise<number | null>
+  /** Reset state (utile entre 2 ouvertures du modal). */
+  reset: () => void
+}
+
+export function useCreateAppointment(): CreateAppointmentResult {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const reset = useCallback(() => {
+    setError(null)
+    setLoading(false)
+  }, [])
+
+  const submit = useCallback(async (input: CreateAppointmentInput): Promise<number | null> => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch("/api/appointments", {
+        method: "POST",
+        credentials: "include",
+        cache: "no-store",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Requested-With": "XMLHttpRequest",
+        },
+        body: JSON.stringify(input),
+      })
+
+      if (!res.ok) {
+        if (res.status === 401 && typeof window !== "undefined") {
+          window.location.href = "/login?expired=1"
+          return null
+        }
+        const body = (await res.json().catch(() => ({}))) as { error?: string }
+        setError(body.error ?? `httpError:${res.status}`)
+        return null
+      }
+
+      const data = (await res.json()) as { id: number }
+      return data.id
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "networkError")
+      return null
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  return { loading, error, submit, reset }
+}

--- a/src/components/diabeo/appointments/usePatientList.ts
+++ b/src/components/diabeo/appointments/usePatientList.ts
@@ -1,0 +1,130 @@
+"use client"
+
+/**
+ * usePatientList — hook fetch liste patients accessibles pour le modal
+ * création RDV (`<AppointmentCreateModal>`).
+ *
+ * US-2500-UI iter 6 — alimente le `<PatientCombobox>` autocomplete.
+ *
+ * **Stratégie** : fetch `limit=50` initial (cabinet typique < 50 patients
+ * actifs), filtrage côté client par nom/prénom. Si > 50 patients, le user
+ * tape le nom EXACT pour déclencher un fetch ciblé (param `search` HMAC).
+ *
+ * Endpoint : `GET /api/patients/search?limit=50` (US-2019).
+ * Réponse : `{ items: [{ id, user: { firstname, lastname, ... } }], nextCursor }`.
+ *
+ * **Sécurité** :
+ *   - Scope automatique côté backend (RBAC ADMIN/DOCTOR/NURSE = patients
+ *     du service ; VIEWER = self) — pas de cross-tenant leak.
+ *   - PHI nom/prénom déchiffré côté backend, présent en mémoire React tant
+ *     que le modal est ouvert. Hook reset au modal close (cf. modal parent).
+ *
+ * **Lifecycle** :
+ *   - `enabled=false` (modal fermé) → idle, pas de fetch
+ *   - `enabled=true` → fetch initial + refetch sur `search` change (debounced)
+ *
+ * @see src/app/api/patients/search/route.ts
+ * @see src/lib/services/patient.service.ts → search
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+export interface PatientListItem {
+  id: number
+  firstname: string | null
+  lastname: string | null
+}
+
+export interface UsePatientListResult {
+  items: PatientListItem[]
+  loading: boolean
+  error: string | null
+  refetch: () => Promise<void>
+}
+
+export interface UsePatientListParams {
+  /** Active le fetch (false = modal fermé, hook idle). */
+  enabled: boolean
+  /** Search exact match (HMAC backend) — débouncing fait par le composant parent. */
+  search?: string
+}
+
+export function usePatientList({ enabled, search }: UsePatientListParams): UsePatientListResult {
+  const [items, setItems] = useState<PatientListItem[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  const refetch = useCallback(async () => {
+    if (!enabled) {
+      abortRef.current?.abort()
+      setItems([])
+      setError(null)
+      setLoading(false)
+      return
+    }
+
+    abortRef.current?.abort()
+    const ctrl = new AbortController()
+    abortRef.current = ctrl
+    const myCtrl = ctrl
+
+    setLoading(true)
+    setError(null)
+
+    try {
+      const params = new URLSearchParams({ limit: "50" })
+      if (search && search.trim().length > 0) {
+        params.set("search", search.trim())
+      }
+
+      const res = await fetch(`/api/patients/search?${params.toString()}`, {
+        credentials: "include",
+        cache: "no-store",
+        headers: { "X-Requested-With": "XMLHttpRequest" },
+        signal: myCtrl.signal,
+      })
+
+      if (myCtrl.signal.aborted) return
+
+      if (!res.ok) {
+        if (res.status === 401 && typeof window !== "undefined") {
+          window.location.href = "/login?expired=1"
+          return
+        }
+        const body = (await res.json().catch(() => ({}))) as { error?: string }
+        if (myCtrl.signal.aborted) return
+        setError(body.error ?? `httpError:${res.status}`)
+        return
+      }
+
+      const data = (await res.json()) as {
+        items: Array<{ id: number; user: { firstname: string | null; lastname: string | null } }>
+      }
+      if (myCtrl.signal.aborted) return
+      // Flatten en `PatientListItem` (firstname/lastname directement sur l'item)
+      setItems(
+        (data.items ?? []).map((p) => ({
+          id: p.id,
+          firstname: p.user?.firstname ?? null,
+          lastname: p.user?.lastname ?? null,
+        })),
+      )
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return
+      if (myCtrl.signal.aborted) return
+      setError(err instanceof Error ? err.message : "networkError")
+    } finally {
+      if (!myCtrl.signal.aborted) setLoading(false)
+    }
+  }, [enabled, search])
+
+  useEffect(() => {
+    void refetch()
+    return () => {
+      abortRef.current?.abort()
+    }
+  }, [refetch])
+
+  return { items, loading, error, refetch }
+}

--- a/tests/integration/api-appointment-mutation-headers.test.ts
+++ b/tests/integration/api-appointment-mutation-headers.test.ts
@@ -27,7 +27,27 @@ vi.mock("@/lib/services/rdv.service", async (orig) => {
       proposeAlternative: vi.fn(),
       acceptAlternative: vi.fn(),
       confirm: vi.fn(),
+      create: vi.fn(),
     },
+    assertMemberServiceAccess: vi.fn().mockResolvedValue(undefined),
+  }
+})
+
+vi.mock("@/lib/access-control", () => ({
+  canAccessPatient: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock("@/lib/consent", () => ({
+  patientShareConsent: vi.fn().mockResolvedValue({ ok: true }),
+}))
+
+vi.mock("@/lib/team-route-helpers", async (orig) => {
+  const actual = await orig<typeof import("@/lib/team-route-helpers")>()
+  return {
+    ...actual,
+    auditedRequireRole: vi.fn().mockResolvedValue({
+      id: 1, role: "DOCTOR", email: "doctor@test.local",
+    }),
   }
 })
 
@@ -66,6 +86,8 @@ const { POST: acceptPOST } = await import(
 const { POST: confirmPOST } = await import(
   "@/app/api/appointments/[id]/confirm/route"
 )
+// US-2500-UI iter 6 — POST /api/appointments (création).
+const { POST: createPOST } = await import("@/app/api/appointments/route")
 
 function makeReq(method: string, body?: unknown): NextRequest {
   const headers = new Headers()
@@ -287,5 +309,36 @@ describe("HSA-2-2 — POST /confirm headers", () => {
     const res = await confirmPOST(makeReq("POST"), makeParams())
     expect(res.status).toBe(403)
     assertSecurityHeaders(res, "confirm 403")
+  })
+})
+
+/**
+ * Fix régression iter 6 — POST /api/appointments (création) avait aussi été
+ * oublié dans HSA-2-1/2 round 2. Maintenant couvert par helper factorisé.
+ */
+describe("HSA-2-1 corollaire — POST /api/appointments (création) headers", () => {
+  it("201 création réussie → 4 headers présents (PHI déchiffré dans response)", async () => {
+    vi.mocked(rdvAppointmentService.create).mockResolvedValue(stubAppointmentDTO as never)
+
+    const validBody = {
+      patientId: 7,
+      memberId: 1,
+      date: "2026-05-25",
+      hour: "09:30",
+      durationMinutes: 30,
+      location: "in_person",
+      type: "diabeto",
+    }
+    const res = await createPOST(makeReq("POST", validBody))
+    expect(res.status).toBe(201)
+    assertSecurityHeaders(res, "create 201")
+  })
+
+  it("400 validation failed → 4 headers présents", async () => {
+    const res = await createPOST(
+      makeReq("POST", { patientId: -1 }), // invalid
+    )
+    expect(res.status).toBe(400)
+    assertSecurityHeaders(res, "create 400")
   })
 })

--- a/tests/integration/api-appointment-mutation-headers.test.ts
+++ b/tests/integration/api-appointment-mutation-headers.test.ts
@@ -341,4 +341,69 @@ describe("HSA-2-1 corollaire — POST /api/appointments (création) headers", ()
     expect(res.status).toBe(400)
     assertSecurityHeaders(res, "create 400")
   })
+
+  /**
+   * Fix HSA-8 round 1 review PR #434 — couverture des paths 403/422/500
+   * (absents du test initial PR #434 round 0). Tous les paths return du
+   * POST DOIVENT passer par `setAppointmentSecurityHeaders` — defense-in-depth
+   * vs régression future.
+   */
+  it("HSA-8 round 1 — 403 forbidden (canAccessPatient refuse) → 4 headers présents", async () => {
+    const { canAccessPatient } = await import("@/lib/access-control")
+    vi.mocked(canAccessPatient).mockResolvedValueOnce(false)
+
+    const validBody = {
+      patientId: 7,
+      memberId: 1,
+      date: "2026-05-25",
+      hour: "09:30",
+      durationMinutes: 30,
+      location: "in_person",
+      type: "diabeto",
+    }
+    const res = await createPOST(makeReq("POST", validBody))
+    expect(res.status).toBe(403)
+    assertSecurityHeaders(res, "create 403 (canAccess)")
+  })
+
+  it("HSA-8 round 1 — 422 gdprConsentRequired → 4 headers présents", async () => {
+    const { patientShareConsent } = await import("@/lib/consent")
+    vi.mocked(patientShareConsent).mockResolvedValueOnce({
+      ok: false,
+      error: "gdprConsentRequired",
+      status: 422,
+    } as never)
+
+    const validBody = {
+      patientId: 7,
+      memberId: 1,
+      date: "2026-05-25",
+      hour: "09:30",
+      durationMinutes: 30,
+      location: "in_person",
+      type: "diabeto",
+    }
+    const res = await createPOST(makeReq("POST", validBody))
+    expect(res.status).toBe(422)
+    assertSecurityHeaders(res, "create 422 (consent)")
+  })
+
+  it("HSA-8 round 1 — 500 service throw → 4 headers présents (mapErrorToResponse)", async () => {
+    vi.mocked(rdvAppointmentService.create).mockRejectedValueOnce(
+      new Error("Prisma connection timeout"),
+    )
+
+    const validBody = {
+      patientId: 7,
+      memberId: 1,
+      date: "2026-05-25",
+      hour: "09:30",
+      durationMinutes: 30,
+      location: "in_person",
+      type: "diabeto",
+    }
+    const res = await createPOST(makeReq("POST", validBody))
+    expect(res.status).toBe(500)
+    assertSecurityHeaders(res, "create 500")
+  })
 })

--- a/tests/integration/api-patients-search-headers.test.ts
+++ b/tests/integration/api-patients-search-headers.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @description Fix CR-H1 round 1 review PR #434 — Integration test sur les
+ * headers ANSSI/HDS de la route `GET /api/patients/search`.
+ *
+ * Régression révélée par PR #434 iter 6 : la route servait des PHI déchiffrés
+ * (`user.firstname`/`lastname` jusqu'à 50 patients) sans `Cache-Control: no-store`
+ * ni les 3 autres headers ANSSI. Asymétrie corrigée par `setPatientsSearchSecurityHeaders`
+ * helper local dans la route (pattern à généraliser V1.5 via middleware).
+ *
+ * Couvre 200 + 400 + 500 paths return.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { NextRequest } from "next/server"
+
+vi.mock("@/lib/db/client", () => ({ prisma: {} }))
+
+vi.mock("@/lib/services/patient.service", async (orig) => {
+  const actual = await orig<typeof import("@/lib/services/patient.service")>()
+  return {
+    ...actual,
+    patientService: {
+      ...actual.patientService,
+      search: vi.fn(),
+    },
+  }
+})
+
+vi.mock("@/lib/access-control", () => ({
+  getAccessiblePatientIds: vi.fn().mockResolvedValue([1, 2, 3]),
+}))
+
+import { patientService } from "@/lib/services/patient.service"
+
+const { GET } = await import("@/app/api/patients/search/route")
+
+function makeReq(query: string = ""): NextRequest {
+  const headers = new Headers()
+  headers.set("x-user-id", "1")
+  headers.set("x-user-role", "DOCTOR")
+  headers.set("x-request-id", "test-req-id")
+  return new NextRequest(new URL(`/api/patients/search${query}`, "http://test.local"), {
+    method: "GET",
+    headers,
+  })
+}
+
+function assertSecurityHeaders(res: Response, label: string) {
+  expect(res.headers.get("Cache-Control"), `${label}: Cache-Control`).toBe(
+    "no-store, no-cache, must-revalidate, private",
+  )
+  expect(res.headers.get("Pragma"), `${label}: Pragma`).toBe("no-cache")
+  expect(res.headers.get("Referrer-Policy"), `${label}: Referrer-Policy`).toBe("no-referrer")
+  expect(res.headers.get("X-Content-Type-Options"), `${label}: X-Content-Type-Options`).toBe(
+    "nosniff",
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("CR-H1 round 1 — GET /api/patients/search headers ANSSI/HDS", () => {
+  it("200 succès → 4 headers présents (PHI firstname/lastname déchiffrés)", async () => {
+    vi.mocked(patientService.search).mockResolvedValue({
+      items: [
+        { id: 1, user: { firstname: "Jean", lastname: "Durand" } } as never,
+      ],
+      nextCursor: null,
+    })
+
+    const res = await GET(makeReq("?limit=50"))
+    expect(res.status).toBe(200)
+    assertSecurityHeaders(res, "search 200")
+
+    const body = await res.json()
+    // PHI déchiffrés dans le payload — c'est précisément pourquoi
+    // `Cache-Control: no-store` est obligatoire (CR-H1).
+    expect(body.items[0].user.firstname).toBe("Jean")
+  })
+
+  it("400 validation failed → 4 headers présents", async () => {
+    // search > 100 chars = invalid
+    const res = await GET(makeReq("?search=" + "x".repeat(150)))
+    expect(res.status).toBe(400)
+    assertSecurityHeaders(res, "search 400")
+  })
+
+  it("500 service throw → 4 headers présents", async () => {
+    vi.mocked(patientService.search).mockRejectedValue(new Error("DB connection refused"))
+
+    const res = await GET(makeReq("?limit=50"))
+    expect(res.status).toBe(500)
+    assertSecurityHeaders(res, "search 500")
+  })
+
+  it("401 sans x-user-id → headers présents (couvre AuthError path)", async () => {
+    const headers = new Headers()
+    headers.set("x-request-id", "test-req-id")
+    // Pas de x-user-id ni x-user-role → requireRole throw AuthError
+    const req = new NextRequest(new URL("/api/patients/search", "http://test.local"), {
+      method: "GET",
+      headers,
+    })
+    const res = await GET(req)
+    expect(res.status).toBe(401)
+    assertSecurityHeaders(res, "search 401")
+  })
+})

--- a/tests/unit/AppointmentCreateModal.test.tsx
+++ b/tests/unit/AppointmentCreateModal.test.tsx
@@ -65,6 +65,30 @@ afterEach(() => {
   })
 })
 
+/**
+ * Fix CR-M4 round 1 PR #434 — la nouvelle validation `isInFuture(date, hour)`
+ * refuse les submits avec date+heure dans le passé. Les tests doivent donc
+ * positionner une date FUTURE (vs ancien default `today + 09:00` qui pouvait
+ * être passé selon l'heure de run).
+ *
+ * Helper : sélectionne un patient + change la date à demain 14:00 → garantit
+ * futur quelle que soit l'heure de run du test.
+ */
+function setupValidForm(patientIdValue = "7") {
+  fireEvent.change(screen.getByTestId("mock-patient-combobox") as HTMLInputElement, {
+    target: { value: patientIdValue },
+  })
+  // Demain dans l'année courante — toujours futur.
+  const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000)
+  const isoDate = tomorrow.toISOString().split("T")[0]
+  fireEvent.change(screen.getByLabelText("dateLabel") as HTMLInputElement, {
+    target: { value: isoDate },
+  })
+  fireEvent.change(screen.getByLabelText("hourLabel") as HTMLInputElement, {
+    target: { value: "14:00" },
+  })
+}
+
 describe("<AppointmentCreateModal>", () => {
   const onClose = vi.fn()
   const onCreated = vi.fn()
@@ -105,9 +129,8 @@ describe("<AppointmentCreateModal>", () => {
     const submitBtn = screen.getByText("actionConfirmCreate").closest("button") as HTMLButtonElement
     expect(submitBtn.disabled).toBe(true)
 
-    // Sélectionne un patient via le mock combobox
-    const combobox = screen.getByTestId("mock-patient-combobox") as HTMLInputElement
-    fireEvent.change(combobox, { target: { value: "42" } })
+    // Helper : sélectionne patient + ajuste date+heure dans le futur
+    setupValidForm("42")
 
     // Bouton enabled maintenant
     expect((screen.getByText("actionConfirmCreate").closest("button") as HTMLButtonElement).disabled).toBe(false)
@@ -129,9 +152,7 @@ describe("<AppointmentCreateModal>", () => {
       />,
     )
 
-    fireEvent.change(screen.getByTestId("mock-patient-combobox") as HTMLInputElement, {
-      target: { value: "7" },
-    })
+    setupValidForm("7")
     fireEvent.click(screen.getByText("actionConfirmCreate"))
 
     await waitFor(() => expect(onCreated).toHaveBeenCalledWith(99))
@@ -156,9 +177,7 @@ describe("<AppointmentCreateModal>", () => {
       />,
     )
 
-    fireEvent.change(screen.getByTestId("mock-patient-combobox") as HTMLInputElement, {
-      target: { value: "7" },
-    })
+    setupValidForm("7")
     fireEvent.change(screen.getByLabelText("motifLabel") as HTMLTextAreaElement, {
       target: { value: "Test motif" },
     })
@@ -173,7 +192,8 @@ describe("<AppointmentCreateModal>", () => {
     expect(body.type).toBe("diabeto")
     expect(body.motif).toBe("Test motif")
     expect(body.date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
-    expect(body.hour).toBe("09:00")
+    // setupValidForm fixe hour à 14:00
+    expect(body.hour).toBe("14:00")
   })
 
   it("submit échec validation 400 → error visible (role=alert) + onCreated PAS appelé", async () => {
@@ -192,15 +212,106 @@ describe("<AppointmentCreateModal>", () => {
       />,
     )
 
-    fireEvent.change(screen.getByTestId("mock-patient-combobox") as HTMLInputElement, {
-      target: { value: "7" },
-    })
+    setupValidForm("7")
     fireEvent.click(screen.getByText("actionConfirmCreate"))
 
     await waitFor(() => expect(screen.getByRole("alert")).toBeTruthy())
     expect(onCreated).not.toHaveBeenCalled()
-    // Le message rendu est `t("createError")` générique (HSA-3 defense-in-depth)
-    expect(screen.getByRole("alert").textContent).toContain("createError")
+    // Fix CR-H2 round 1 — le message rendu est `t("createErrorValidation")`
+    // distinct du générique. Donne feedback médecin actionable.
+    expect(screen.getByRole("alert").textContent).toContain("createErrorValidation")
+  })
+
+  it("CR-H2 round 1 — 409 slotConflict → t('createErrorConflict') (vs ancien générique)", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({ error: "slotConflict" }),
+    } as Response)
+
+    render(
+      <AppointmentCreateModal
+        open
+        memberId={1}
+        onClose={onClose}
+        onCreated={onCreated}
+      />,
+    )
+    setupValidForm("7")
+    fireEvent.click(screen.getByText("actionConfirmCreate"))
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeTruthy())
+    expect(screen.getByRole("alert").textContent).toContain("createErrorConflict")
+  })
+
+  it("CR-H2 round 1 — 422 gdprConsentRequired → t('createErrorConsent')", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 422,
+      json: async () => ({ error: "gdprConsentRequired" }),
+    } as Response)
+
+    render(
+      <AppointmentCreateModal
+        open
+        memberId={1}
+        onClose={onClose}
+        onCreated={onCreated}
+      />,
+    )
+    setupValidForm("7")
+    fireEvent.click(screen.getByText("actionConfirmCreate"))
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeTruthy())
+    expect(screen.getByRole("alert").textContent).toContain("createErrorConsent")
+  })
+
+  it("CR-H2 round 1 — 403 forbidden → t('createErrorForbidden')", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: "forbidden" }),
+    } as Response)
+
+    render(
+      <AppointmentCreateModal
+        open
+        memberId={1}
+        onClose={onClose}
+        onCreated={onCreated}
+      />,
+    )
+    setupValidForm("7")
+    fireEvent.click(screen.getByText("actionConfirmCreate"))
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeTruthy())
+    expect(screen.getByRole("alert").textContent).toContain("createErrorForbidden")
+  })
+
+  it("HSA-3 round 1 — backend leak verbose code non-whitelisté → t('createErrorGeneric')", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "Failed to decrypt motif for patient 4242" }),
+    } as Response)
+
+    render(
+      <AppointmentCreateModal
+        open
+        memberId={1}
+        onClose={onClose}
+        onCreated={onCreated}
+      />,
+    )
+    setupValidForm("7")
+    fireEvent.click(screen.getByText("actionConfirmCreate"))
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeTruthy())
+    // Le code backend brut est REMPLACÉ par "createErrorGeneric" (defense-in-depth).
+    expect(screen.getByRole("alert").textContent).toContain("createErrorGeneric")
+    // Le message PHI brut NE doit JAMAIS apparaître dans le DOM.
+    expect(document.body.textContent).not.toContain("Failed to decrypt motif")
+    expect(document.body.textContent).not.toContain("4242")
   })
 
   it("aria-live='assertive' sur alerte erreur (FE-9 pattern iter 5)", async () => {
@@ -218,15 +329,113 @@ describe("<AppointmentCreateModal>", () => {
         onCreated={onCreated}
       />,
     )
-    fireEvent.change(screen.getByTestId("mock-patient-combobox") as HTMLInputElement, {
-      target: { value: "7" },
-    })
+    setupValidForm("7")
     fireEvent.click(screen.getByText("actionConfirmCreate"))
 
     await waitFor(() => {
       const alert = screen.getByRole("alert")
       expect(alert.getAttribute("aria-live")).toBe("assertive")
     })
+  })
+
+  it("CR-M4 round 1 — date passée → submit disabled + message warning", async () => {
+    render(
+      <AppointmentCreateModal
+        open
+        memberId={1}
+        onClose={onClose}
+        onCreated={onCreated}
+      />,
+    )
+    // Setup patient sélectionné mais date 2020-01-01 (passé)
+    fireEvent.change(screen.getByTestId("mock-patient-combobox") as HTMLInputElement, {
+      target: { value: "7" },
+    })
+    fireEvent.change(screen.getByLabelText("dateLabel") as HTMLInputElement, {
+      target: { value: "2020-01-01" },
+    })
+    fireEvent.change(screen.getByLabelText("hourLabel") as HTMLInputElement, {
+      target: { value: "14:00" },
+    })
+
+    const submitBtn = screen.getByText("actionConfirmCreate").closest("button") as HTMLButtonElement
+    expect(submitBtn.disabled).toBe(true)
+    // Le warning visuel "createDatePastWarning" est rendu
+    expect(document.body.textContent).toContain("createDatePastWarning")
+  })
+
+  it("FE-11 round 1 — récap visuel affiché si date+heure valide", () => {
+    render(
+      <AppointmentCreateModal
+        open
+        memberId={1}
+        onClose={onClose}
+        onCreated={onCreated}
+      />,
+    )
+    setupValidForm("7")
+    // Le récap "createRecap" doit apparaître
+    expect(document.body.textContent).toContain("createRecap")
+  })
+
+  it("FE-15 round 1 — inputs date+hour avec aria-required='true'", () => {
+    render(
+      <AppointmentCreateModal
+        open
+        memberId={1}
+        onClose={onClose}
+        onCreated={onCreated}
+      />,
+    )
+    const dateInput = screen.getByLabelText("dateLabel")
+    const hourInput = screen.getByLabelText("hourLabel")
+    expect(dateInput.getAttribute("aria-required")).toBe("true")
+    expect(hourInput.getAttribute("aria-required")).toBe("true")
+  })
+
+  it("FE-16 round 1 — aria-invalid posé sur date+hour après submit échoué", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "serverError" }),
+    } as Response)
+
+    render(
+      <AppointmentCreateModal
+        open
+        memberId={1}
+        onClose={onClose}
+        onCreated={onCreated}
+      />,
+    )
+    setupValidForm("7")
+    // Au mount : aria-invalid absent (champ valide)
+    expect(screen.getByLabelText("dateLabel").getAttribute("aria-invalid")).toBeNull()
+
+    fireEvent.click(screen.getByText("actionConfirmCreate"))
+
+    // Après échec : aria-invalid="true" posé pour signal SR users
+    await waitFor(() => {
+      expect(screen.getByLabelText("dateLabel").getAttribute("aria-invalid")).toBe("true")
+      expect(screen.getByLabelText("hourLabel").getAttribute("aria-invalid")).toBe("true")
+    })
+  })
+
+  it("FE-13 round 1 — presets durée incluent 20/75/180/240 min", () => {
+    render(
+      <AppointmentCreateModal
+        open
+        memberId={1}
+        onClose={onClose}
+        onCreated={onCreated}
+      />,
+    )
+    const durationSelect = screen.getByLabelText("durationLabel") as HTMLSelectElement
+    const values = Array.from(durationSelect.options).map((o) => Number(o.value))
+    expect(values).toContain(20)
+    expect(values).toContain(75)
+    expect(values).toContain(180)
+    expect(values).toContain(240)
   })
 
   it("clic 'Fermer' → onClose appelé (si pas en loading)", () => {
@@ -254,9 +463,7 @@ describe("<AppointmentCreateModal>", () => {
         onCreated={onCreated}
       />,
     )
-    fireEvent.change(screen.getByTestId("mock-patient-combobox") as HTMLInputElement, {
-      target: { value: "7" },
-    })
+    setupValidForm("7")
     fireEvent.click(screen.getByText("actionConfirmCreate"))
 
     // Wait actionLoading propagé : bouton submit affiche "loading"

--- a/tests/unit/AppointmentCreateModal.test.tsx
+++ b/tests/unit/AppointmentCreateModal.test.tsx
@@ -1,0 +1,282 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests unitaires pour le composant `<AppointmentCreateModal>`.
+ *
+ * US-2500-UI iter 6 — couvre :
+ *   - Render initial (open=true) — form visible avec defaults
+ *   - Submit happy path → POST + onCreated avec newId
+ *   - Submit échec validation → error visible
+ *   - canSubmit gating (patientId requis)
+ *   - Bouton "Fermer" → onClose
+ *   - Locking modal pendant submit (handleClose gate)
+ *   - aria-live sur erreur + nonce ré-annonce
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (k: string, v?: Record<string, unknown>) => {
+    if (v && "count" in v) return `${k}=${v.count}`
+    return k
+  },
+  useLocale: () => "fr-FR",
+}))
+
+// Mock PatientCombobox pour éviter de tester son détail interne.
+// Le combobox réel a son propre test suite (usePatientList.test.tsx).
+vi.mock("@/components/diabeo/appointments/PatientCombobox", () => ({
+  PatientCombobox: ({ value, onChange, id }: {
+    value: number | null
+    onChange: (v: number | null) => void
+    id: string
+  }) => (
+    <input
+      id={id}
+      type="number"
+      value={value ?? ""}
+      onChange={(e) => onChange(e.target.value ? Number(e.target.value) : null)}
+      data-testid="mock-patient-combobox"
+    />
+  ),
+}))
+
+const { AppointmentCreateModal } = await import(
+  "@/components/diabeo/appointments/AppointmentCreateModal"
+)
+
+const originalLocation = window.location
+
+beforeEach(() => {
+  Object.defineProperty(window, "location", {
+    writable: true,
+    configurable: true,
+    value: { href: "/appointments" },
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  Object.defineProperty(window, "location", {
+    writable: true,
+    configurable: true,
+    value: originalLocation,
+  })
+})
+
+describe("<AppointmentCreateModal>", () => {
+  const onClose = vi.fn()
+  const onCreated = vi.fn()
+
+  beforeEach(() => {
+    onClose.mockClear()
+    onCreated.mockClear()
+  })
+
+  it("render initial : form visible + defaults (date today, hour 09:00, type diabeto, location in_person)", () => {
+    render(
+      <AppointmentCreateModal
+        open
+        memberId={1}
+        onClose={onClose}
+        onCreated={onCreated}
+      />,
+    )
+    expect(screen.getByText("createTitle")).toBeTruthy()
+    expect(screen.getByLabelText("dateLabel")).toBeTruthy()
+    expect(screen.getByLabelText("hourLabel")).toBeTruthy()
+    expect(screen.getByLabelText("durationLabel")).toBeTruthy()
+    expect(screen.getByLabelText("locationLabel")).toBeTruthy()
+    expect(screen.getByLabelText("typeLabel")).toBeTruthy()
+    expect(screen.getByLabelText("motifLabel")).toBeTruthy()
+    expect(screen.getByText("actionConfirmCreate")).toBeTruthy()
+  })
+
+  it("canSubmit gating : bouton disabled tant que patientId pas sélectionné", () => {
+    render(
+      <AppointmentCreateModal
+        open
+        memberId={1}
+        onClose={onClose}
+        onCreated={onCreated}
+      />,
+    )
+    const submitBtn = screen.getByText("actionConfirmCreate").closest("button") as HTMLButtonElement
+    expect(submitBtn.disabled).toBe(true)
+
+    // Sélectionne un patient via le mock combobox
+    const combobox = screen.getByTestId("mock-patient-combobox") as HTMLInputElement
+    fireEvent.change(combobox, { target: { value: "42" } })
+
+    // Bouton enabled maintenant
+    expect((screen.getByText("actionConfirmCreate").closest("button") as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it("submit happy path : POST 201 → onCreated(newId) + onClose", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ id: 99 }),
+    } as Response)
+
+    render(
+      <AppointmentCreateModal
+        open
+        memberId={1}
+        onClose={onClose}
+        onCreated={onCreated}
+      />,
+    )
+
+    fireEvent.change(screen.getByTestId("mock-patient-combobox") as HTMLInputElement, {
+      target: { value: "7" },
+    })
+    fireEvent.click(screen.getByText("actionConfirmCreate"))
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith(99))
+    // Note : onClose n'est PAS appelé directement par le modal ; c'est le parent
+    // (`handleCreated`) qui set `createOpen=false` après onCreated. Le modal
+    // unmount via `key` change.
+  })
+
+  it("submit body : patientId + memberId + date + hour + durationMinutes + location + type + motif", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ id: 99 }),
+    } as Response)
+
+    render(
+      <AppointmentCreateModal
+        open
+        memberId={3}
+        onClose={onClose}
+        onCreated={onCreated}
+      />,
+    )
+
+    fireEvent.change(screen.getByTestId("mock-patient-combobox") as HTMLInputElement, {
+      target: { value: "7" },
+    })
+    fireEvent.change(screen.getByLabelText("motifLabel") as HTMLTextAreaElement, {
+      target: { value: "Test motif" },
+    })
+    fireEvent.click(screen.getByText("actionConfirmCreate"))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const body = JSON.parse(fetchMock.mock.calls[0]![1]!.body as string)
+    expect(body.patientId).toBe(7)
+    expect(body.memberId).toBe(3)
+    expect(body.durationMinutes).toBe(30)
+    expect(body.location).toBe("in_person")
+    expect(body.type).toBe("diabeto")
+    expect(body.motif).toBe("Test motif")
+    expect(body.date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    expect(body.hour).toBe("09:00")
+  })
+
+  it("submit échec validation 400 → error visible (role=alert) + onCreated PAS appelé", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: "validationFailed" }),
+    } as Response)
+
+    render(
+      <AppointmentCreateModal
+        open
+        memberId={1}
+        onClose={onClose}
+        onCreated={onCreated}
+      />,
+    )
+
+    fireEvent.change(screen.getByTestId("mock-patient-combobox") as HTMLInputElement, {
+      target: { value: "7" },
+    })
+    fireEvent.click(screen.getByText("actionConfirmCreate"))
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeTruthy())
+    expect(onCreated).not.toHaveBeenCalled()
+    // Le message rendu est `t("createError")` générique (HSA-3 defense-in-depth)
+    expect(screen.getByRole("alert").textContent).toContain("createError")
+  })
+
+  it("aria-live='assertive' sur alerte erreur (FE-9 pattern iter 5)", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "serverError" }),
+    } as Response)
+
+    render(
+      <AppointmentCreateModal
+        open
+        memberId={1}
+        onClose={onClose}
+        onCreated={onCreated}
+      />,
+    )
+    fireEvent.change(screen.getByTestId("mock-patient-combobox") as HTMLInputElement, {
+      target: { value: "7" },
+    })
+    fireEvent.click(screen.getByText("actionConfirmCreate"))
+
+    await waitFor(() => {
+      const alert = screen.getByRole("alert")
+      expect(alert.getAttribute("aria-live")).toBe("assertive")
+    })
+  })
+
+  it("clic 'Fermer' → onClose appelé (si pas en loading)", () => {
+    render(
+      <AppointmentCreateModal
+        open
+        memberId={1}
+        onClose={onClose}
+        onCreated={onCreated}
+      />,
+    )
+    fireEvent.click(screen.getByText("actionClose"))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it("handleClose gate : Escape pendant submit ne ferme PAS le modal", async () => {
+    const pendingResponse = new Promise<Response>(() => { /* never */ })
+    vi.spyOn(global, "fetch").mockReturnValue(pendingResponse)
+
+    render(
+      <AppointmentCreateModal
+        open
+        memberId={1}
+        onClose={onClose}
+        onCreated={onCreated}
+      />,
+    )
+    fireEvent.change(screen.getByTestId("mock-patient-combobox") as HTMLInputElement, {
+      target: { value: "7" },
+    })
+    fireEvent.click(screen.getByText("actionConfirmCreate"))
+
+    // Wait actionLoading propagé : bouton submit affiche "loading"
+    await waitFor(() => {
+      expect(screen.queryByText("actionConfirmCreate")).toBeNull()
+    })
+
+    fireEvent.keyDown(document, { key: "Escape" })
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it("open=false → Dialog non rendu (mode contrôlé)", () => {
+    render(
+      <AppointmentCreateModal
+        open={false}
+        memberId={1}
+        onClose={onClose}
+        onCreated={onCreated}
+      />,
+    )
+    expect(document.querySelector('[role="dialog"]')).toBeNull()
+  })
+})

--- a/tests/unit/PatientCombobox.test.tsx
+++ b/tests/unit/PatientCombobox.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests unitaires pour le composant `<PatientCombobox>`.
+ *
+ * Fix FE-20 round 1 review PR #434 — couverture explicit du combobox autonome
+ * (le test modal le mock pour découpler). Couvre :
+ *   - Render initial : input + datalist + hint count total backend (FE-9)
+ *   - Filter accent-aware via normalize NFD (CR-H3/FE-1)
+ *   - Disambiguation #id dans le label (CR-H3/FE-6)
+ *   - Match exact onChange (lowercase + normalize)
+ *   - No-results state (FE-7)
+ *   - aria-required + aria-invalid (FE-15/16)
+ *   - Loading state
+ *   - Error state (role=alert)
+ *   - useDeferredValue debouncing (smoke — vérifie pas de setState in effect)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (k: string, v?: Record<string, unknown>) => {
+    if (v && "count" in v) return `${k}=${v.count}`
+    return k
+  },
+}))
+
+// Mock usePatientList pour contrôler les items + loading + error indépendamment.
+const mockUsePatientList = vi.fn()
+vi.mock("@/components/diabeo/appointments/usePatientList", () => ({
+  usePatientList: (...args: unknown[]) => mockUsePatientList(...args),
+}))
+
+const { PatientCombobox } = await import(
+  "@/components/diabeo/appointments/PatientCombobox"
+)
+
+const baseItems = [
+  { id: 1, firstname: "Jean", lastname: "Durand" },
+  { id: 2, firstname: "Claire", lastname: "Bernard" },
+  { id: 42, firstname: "Jean", lastname: "Martin" },
+  { id: 43, firstname: "Jean", lastname: "Martin" }, // homonyme
+  { id: 7, firstname: "Müller", lastname: "Pérez" }, // accents
+]
+
+function setMockHook(opts: {
+  items?: typeof baseItems
+  loading?: boolean
+  error?: string | null
+} = {}) {
+  mockUsePatientList.mockReturnValue({
+    items: opts.items ?? baseItems,
+    loading: opts.loading ?? false,
+    error: opts.error ?? null,
+    refetch: vi.fn(),
+  })
+}
+
+beforeEach(() => {
+  setMockHook()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("<PatientCombobox>", () => {
+  it("render initial : input + datalist + hint count total backend (FE-9)", () => {
+    const onChange = vi.fn()
+    render(<PatientCombobox id="test-combobox" value={null} onChange={onChange} />)
+
+    const input = screen.getByRole("combobox")
+    expect(input).toBeTruthy()
+    const datalist = document.getElementById("test-combobox-options")
+    expect(datalist).not.toBeNull()
+    // Hint affiche le total backend (5 items) — pas le filtré (FE-9 fix)
+    expect(document.body.textContent).toContain("patientHint=5")
+  })
+
+  it("CR-H3/FE-6 — disambiguation #id dans les options datalist (homonymes)", () => {
+    render(<PatientCombobox id="test-combobox" value={null} onChange={vi.fn()} />)
+    const options = document.querySelectorAll("#test-combobox-options option")
+    const labels = Array.from(options).map((o) => (o as HTMLOptionElement).value)
+    // Les 2 "Jean Martin" doivent être disambiguées par #id
+    expect(labels).toContain("Jean Martin #42")
+    expect(labels).toContain("Jean Martin #43")
+    expect(labels).toContain("Jean Durand #1")
+  })
+
+  it("CR-H3/FE-1 — filter accent-aware via normalize NFD", () => {
+    render(<PatientCombobox id="test-combobox" value={null} onChange={vi.fn()} />)
+    // Tape "muller" sans accent → match "Müller Pérez #7"
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "muller" } })
+    // Les options datalist sont filtrées côté client
+    const options = document.querySelectorAll("#test-combobox-options option")
+    const labels = Array.from(options).map((o) => (o as HTMLOptionElement).value)
+    expect(labels).toContain("Müller Pérez #7")
+    // Et n'inclut PAS les autres
+    expect(labels).not.toContain("Jean Durand #1")
+  })
+
+  it("CR-H3/FE-1 — filter insensitive case", () => {
+    render(<PatientCombobox id="test-combobox" value={null} onChange={vi.fn()} />)
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "JEAN" } })
+    const options = document.querySelectorAll("#test-combobox-options option")
+    const labels = Array.from(options).map((o) => (o as HTMLOptionElement).value)
+    // 3 patients "Jean" (Durand, Martin #42, Martin #43)
+    expect(labels.length).toBe(3)
+  })
+
+  it("CR-H3 — onChange match exact via normalize (lowercase + accent)", () => {
+    const onChange = vi.fn()
+    render(<PatientCombobox id="test-combobox" value={null} onChange={onChange} />)
+
+    // Tape exactement le label "Jean Martin #42"
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "Jean Martin #42" } })
+    expect(onChange).toHaveBeenCalledWith(42)
+
+    // Tape le label avec casse différente — toujours match (insensitive)
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "jean martin #43" } })
+    expect(onChange).toHaveBeenCalledWith(43)
+
+    // Tape accent absent ("muller perez #7" → match "Müller Pérez #7")
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "muller perez #7" } })
+    expect(onChange).toHaveBeenCalledWith(7)
+  })
+
+  it("CR-H3 — partial input (pas exact match) → onChange(null)", () => {
+    const onChange = vi.fn()
+    render(<PatientCombobox id="test-combobox" value={null} onChange={onChange} />)
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "Jean" } })
+    expect(onChange).toHaveBeenCalledWith(null)
+  })
+
+  it("FE-7 — no-results state : input avec text + filtered empty → message warning", () => {
+    setMockHook({ items: [] })
+    render(<PatientCombobox id="test-combobox" value={null} onChange={vi.fn()} />)
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "Inexistant" } })
+
+    // Le hint affiche "patientNoResults" via role=status
+    expect(document.body.textContent).toContain("patientNoResults")
+  })
+
+  it("FE-15 — aria-required='true' posé sur l'input", () => {
+    render(<PatientCombobox id="test-combobox" value={null} onChange={vi.fn()} />)
+    const input = screen.getByRole("combobox")
+    expect(input.getAttribute("aria-required")).toBe("true")
+  })
+
+  it("FE-16 — aria-invalid='true' si value null ET user a tapé (signal SR)", () => {
+    render(<PatientCombobox id="test-combobox" value={null} onChange={vi.fn()} />)
+    const input = screen.getByRole("combobox")
+    // Avant frappe : aria-invalid absent
+    expect(input.getAttribute("aria-invalid")).toBeNull()
+    // Frappe partielle → no match → aria-invalid="true"
+    fireEvent.change(input, { target: { value: "Jean" } })
+    expect(input.getAttribute("aria-invalid")).toBe("true")
+  })
+
+  it("FE-16 — aria-invalid absent si value sélectionné (match)", () => {
+    render(<PatientCombobox id="test-combobox" value={1} onChange={vi.fn()} />)
+    const input = screen.getByRole("combobox")
+    expect(input.getAttribute("aria-invalid")).toBeNull()
+  })
+
+  it("hint 'Patient sélectionné' si value !== null", () => {
+    render(<PatientCombobox id="test-combobox" value={1} onChange={vi.fn()} />)
+    expect(document.body.textContent).toContain("patientSelected")
+  })
+
+  it("loading state : hint affiche 'loading' + input disabled", () => {
+    setMockHook({ loading: true })
+    render(<PatientCombobox id="test-combobox" value={null} onChange={vi.fn()} />)
+    const input = screen.getByRole("combobox") as HTMLInputElement
+    expect(input.disabled).toBe(true)
+    expect(document.body.textContent).toContain("loading")
+  })
+
+  it("error state : hint affiche role='alert' + i18n key 'patientListError'", () => {
+    setMockHook({ error: "networkError" })
+    render(<PatientCombobox id="test-combobox" value={null} onChange={vi.fn()} />)
+    const alert = screen.getByRole("alert")
+    expect(alert).toBeTruthy()
+    expect(alert.textContent).toContain("patientListError")
+  })
+
+  it("autoComplete='off' + spellCheck=false (anti history input + anti spell check PHI)", () => {
+    render(<PatientCombobox id="test-combobox" value={null} onChange={vi.fn()} />)
+    const input = screen.getByRole("combobox")
+    expect(input.getAttribute("autoComplete")).toBe("off")
+    expect(input.getAttribute("spellCheck")).toBe("false")
+  })
+
+  it("FE-2 round 1 — useDeferredValue (pas de setState-in-effect) — smoke : no warn after multi-frappes", async () => {
+    render(<PatientCombobox id="test-combobox" value={null} onChange={vi.fn()} />)
+    const input = screen.getByRole("combobox")
+    // Multi-frappes rapides
+    fireEvent.change(input, { target: { value: "J" } })
+    fireEvent.change(input, { target: { value: "Je" } })
+    fireEvent.change(input, { target: { value: "Jea" } })
+    fireEvent.change(input, { target: { value: "Jean" } })
+    // Pas de crash + hint stable
+    await waitFor(() => {
+      expect(screen.getByRole("combobox")).toBeTruthy()
+    })
+  })
+})

--- a/tests/unit/useCreateAppointment.test.tsx
+++ b/tests/unit/useCreateAppointment.test.tsx
@@ -70,7 +70,7 @@ describe("useCreateAppointment", () => {
     expect(result.current.error).toBeNull()
   })
 
-  it("400 validation → retourne null + error code stable", async () => {
+  it("400 validation → retourne null + code normalisé 'validationFailed'", async () => {
     vi.spyOn(global, "fetch").mockResolvedValue({
       ok: false,
       status: 400,
@@ -87,7 +87,7 @@ describe("useCreateAppointment", () => {
     expect(result.current.error).toBe("validationFailed")
   })
 
-  it("403 forbidden → retourne null + error code", async () => {
+  it("403 forbidden → retourne null + code normalisé 'forbidden'", async () => {
     vi.spyOn(global, "fetch").mockResolvedValue({
       ok: false,
       status: 403,
@@ -104,7 +104,7 @@ describe("useCreateAppointment", () => {
     expect(result.current.error).toBe("forbidden")
   })
 
-  it("409 conflict slot membre (EXCLUDE GiST) → retourne null + error code", async () => {
+  it("409 conflict slot (EXCLUDE GiST) → retourne null + code 'slotConflict'", async () => {
     vi.spyOn(global, "fetch").mockResolvedValue({
       ok: false,
       status: 409,
@@ -119,6 +119,38 @@ describe("useCreateAppointment", () => {
 
     expect(returned).toBeNull()
     expect(result.current.error).toBe("slotConflict")
+  })
+
+  it("HSA-3 round 1 — backend code non-whitelisté → normalisé 'unexpectedError' (defense-in-depth)", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 500,
+      // Simule un leak verbeux backend : "Failed to decrypt motif for patient 4242"
+      json: async () => ({ error: "Failed to decrypt motif for patient 4242: invalid GCM tag" }),
+    } as Response)
+
+    const { result } = renderHook(() => useCreateAppointment())
+    await act(async () => {
+      await result.current.submit(validInput)
+    })
+
+    // Code normalisé vs raw — empêche futur dev d'afficher message PHI brut.
+    expect(result.current.error).toBe("unexpectedError")
+  })
+
+  it("HSA-3 round 1 — body.error absent → 'unexpectedError'", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    } as Response)
+
+    const { result } = renderHook(() => useCreateAppointment())
+    await act(async () => {
+      await result.current.submit(validInput)
+    })
+
+    expect(result.current.error).toBe("unexpectedError")
   })
 
   it("401 → redirect /login?expired=1 (auth perdue)", async () => {
@@ -136,7 +168,7 @@ describe("useCreateAppointment", () => {
     await waitFor(() => expect(window.location.href).toBe("/login?expired=1"))
   })
 
-  it("network error → retourne null + 'networkError' code", async () => {
+  it("network error → retourne null + code normalisé 'unexpectedError' (whitelist)", async () => {
     vi.spyOn(global, "fetch").mockRejectedValue(new Error("Failed to fetch"))
 
     const { result } = renderHook(() => useCreateAppointment())
@@ -146,7 +178,9 @@ describe("useCreateAppointment", () => {
     })
 
     expect(returned).toBeNull()
-    expect(result.current.error).toBe("Failed to fetch")
+    // Fix HSA-3 round 1 — message brut "Failed to fetch" non-whitelisté →
+    // normalisé "unexpectedError" pour empêcher leak verbeux dans state React.
+    expect(result.current.error).toBe("unexpectedError")
   })
 
   it("fetch options : credentials + cache:no-store + X-Requested-With + Content-Type", async () => {

--- a/tests/unit/useCreateAppointment.test.tsx
+++ b/tests/unit/useCreateAppointment.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests unitaires pour le hook `useCreateAppointment`.
+ *
+ * US-2500-UI iter 6 — couvre :
+ *   - Happy path : POST 201 → retourne newId
+ *   - Validation 400 → retourne null + error code
+ *   - Forbidden 403 (canAccessPatient) → retourne null + error code
+ *   - Conflict 409 (EXCLUDE GiST slot membre) → retourne null + error code
+ *   - 401 → redirect /login?expired=1
+ *   - Network error → retourne null + networkError code
+ *   - Body request : Content-Type + credentials + cache:no-store + X-Requested-With
+ *   - reset() : reset state entre 2 submits
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, act, waitFor } from "@testing-library/react"
+import { useCreateAppointment } from "@/components/diabeo/appointments/useCreateAppointment"
+
+const validInput = {
+  patientId: 7,
+  memberId: 1,
+  date: "2026-05-25",
+  hour: "09:30",
+  durationMinutes: 30,
+  location: "in_person" as const,
+  type: "diabeto",
+  motif: "Titration basale",
+}
+
+const originalLocation = window.location
+
+beforeEach(() => {
+  Object.defineProperty(window, "location", {
+    writable: true,
+    configurable: true,
+    value: { href: "/appointments" },
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  Object.defineProperty(window, "location", {
+    writable: true,
+    configurable: true,
+    value: originalLocation,
+  })
+})
+
+describe("useCreateAppointment", () => {
+  it("happy path : POST 201 → retourne newId + loading=false", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ id: 42 }),
+    } as Response)
+
+    const { result } = renderHook(() => useCreateAppointment())
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBeNull()
+
+    let returned: number | null = null
+    await act(async () => {
+      returned = await result.current.submit(validInput)
+    })
+
+    expect(returned).toBe(42)
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBeNull()
+  })
+
+  it("400 validation → retourne null + error code stable", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: "validationFailed" }),
+    } as Response)
+
+    const { result } = renderHook(() => useCreateAppointment())
+    let returned: number | null = 999
+    await act(async () => {
+      returned = await result.current.submit(validInput)
+    })
+
+    expect(returned).toBeNull()
+    expect(result.current.error).toBe("validationFailed")
+  })
+
+  it("403 forbidden → retourne null + error code", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: "forbidden" }),
+    } as Response)
+
+    const { result } = renderHook(() => useCreateAppointment())
+    let returned: number | null = 999
+    await act(async () => {
+      returned = await result.current.submit(validInput)
+    })
+
+    expect(returned).toBeNull()
+    expect(result.current.error).toBe("forbidden")
+  })
+
+  it("409 conflict slot membre (EXCLUDE GiST) → retourne null + error code", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({ error: "slotConflict" }),
+    } as Response)
+
+    const { result } = renderHook(() => useCreateAppointment())
+    let returned: number | null = 999
+    await act(async () => {
+      returned = await result.current.submit(validInput)
+    })
+
+    expect(returned).toBeNull()
+    expect(result.current.error).toBe("slotConflict")
+  })
+
+  it("401 → redirect /login?expired=1 (auth perdue)", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: "tokenExpired" }),
+    } as Response)
+
+    const { result } = renderHook(() => useCreateAppointment())
+    await act(async () => {
+      await result.current.submit(validInput)
+    })
+
+    await waitFor(() => expect(window.location.href).toBe("/login?expired=1"))
+  })
+
+  it("network error → retourne null + 'networkError' code", async () => {
+    vi.spyOn(global, "fetch").mockRejectedValue(new Error("Failed to fetch"))
+
+    const { result } = renderHook(() => useCreateAppointment())
+    let returned: number | null = 999
+    await act(async () => {
+      returned = await result.current.submit(validInput)
+    })
+
+    expect(returned).toBeNull()
+    expect(result.current.error).toBe("Failed to fetch")
+  })
+
+  it("fetch options : credentials + cache:no-store + X-Requested-With + Content-Type", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 1 }),
+    } as Response)
+
+    const { result } = renderHook(() => useCreateAppointment())
+    await act(async () => {
+      await result.current.submit(validInput)
+    })
+
+    const init = fetchMock.mock.calls[0]![1] as RequestInit
+    expect(init.method).toBe("POST")
+    expect(init.credentials).toBe("include")
+    expect(init.cache).toBe("no-store")
+    const headers = init.headers as Record<string, string>
+    expect(headers["Content-Type"]).toBe("application/json")
+    expect(headers["X-Requested-With"]).toBe("XMLHttpRequest")
+    expect(JSON.parse(init.body as string)).toEqual(validInput)
+  })
+
+  it("reset() : reset error entre 2 submits", async () => {
+    vi.spyOn(global, "fetch")
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: "validationFailed" }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 99 }),
+      } as Response)
+
+    const { result } = renderHook(() => useCreateAppointment())
+    await act(async () => {
+      await result.current.submit(validInput)
+    })
+    expect(result.current.error).toBe("validationFailed")
+
+    act(() => result.current.reset())
+    expect(result.current.error).toBeNull()
+    expect(result.current.loading).toBe(false)
+
+    let returned: number | null = null
+    await act(async () => {
+      returned = await result.current.submit(validInput)
+    })
+    expect(returned).toBe(99)
+  })
+})

--- a/tests/unit/usePatientList.test.tsx
+++ b/tests/unit/usePatientList.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests unitaires pour le hook `usePatientList`.
+ *
+ * US-2500-UI iter 6 — couvre :
+ *   - enabled=false → idle (pas de fetch)
+ *   - enabled=true → fetch + items mapping user.firstname/lastname
+ *   - search → fetch avec query param
+ *   - 401 → redirect /login?expired=1
+ *   - 500 → error code
+ *   - AbortController cleanup au unmount
+ *   - fetch options : credentials + cache + X-Requested-With
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { usePatientList } from "@/components/diabeo/appointments/usePatientList"
+
+const mockResponse = {
+  items: [
+    { id: 1, user: { firstname: "Jean", lastname: "Durand" } },
+    { id: 2, user: { firstname: "Claire", lastname: "Bernard" } },
+  ],
+  nextCursor: null,
+}
+
+const originalLocation = window.location
+
+beforeEach(() => {
+  Object.defineProperty(window, "location", {
+    writable: true,
+    configurable: true,
+    value: { href: "/appointments" },
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  Object.defineProperty(window, "location", {
+    writable: true,
+    configurable: true,
+    value: originalLocation,
+  })
+})
+
+describe("usePatientList", () => {
+  it("enabled=false → idle (pas de fetch)", async () => {
+    const fetchMock = vi.spyOn(global, "fetch")
+    const { result } = renderHook(() =>
+      usePatientList({ enabled: false }),
+    )
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(result.current.items).toEqual([])
+    expect(result.current.error).toBeNull()
+  })
+
+  it("enabled=true → fetch + items mapping flat (id + firstname + lastname)", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    } as Response)
+
+    const { result } = renderHook(() => usePatientList({ enabled: true }))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.items).toHaveLength(2)
+    expect(result.current.items[0]).toEqual({
+      id: 1,
+      firstname: "Jean",
+      lastname: "Durand",
+    })
+    expect(result.current.items[1]).toEqual({
+      id: 2,
+      firstname: "Claire",
+      lastname: "Bernard",
+    })
+  })
+
+  it("search param → propagé dans URL fetch", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [], nextCursor: null }),
+    } as Response)
+
+    renderHook(() => usePatientList({ enabled: true, search: "Durand" }))
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+
+    const url = fetchMock.mock.calls[0]![0] as string
+    expect(url).toContain("limit=50")
+    expect(url).toContain("search=Durand")
+  })
+
+  it("search vide → pas de query param search dans l'URL", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [], nextCursor: null }),
+    } as Response)
+
+    renderHook(() => usePatientList({ enabled: true, search: "   " }))
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+
+    const url = fetchMock.mock.calls[0]![0] as string
+    expect(url).not.toContain("search=")
+  })
+
+  it("401 → redirect /login?expired=1", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: "tokenExpired" }),
+    } as Response)
+
+    renderHook(() => usePatientList({ enabled: true }))
+    await waitFor(() => expect(window.location.href).toBe("/login?expired=1"))
+  })
+
+  it("500 → error set + items vide", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "serverError" }),
+    } as Response)
+
+    const { result } = renderHook(() => usePatientList({ enabled: true }))
+    await waitFor(() => expect(result.current.error).toBe("serverError"))
+    expect(result.current.items).toEqual([])
+  })
+
+  it("fetch options : credentials + cache:no-store + X-Requested-With", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    } as Response)
+
+    renderHook(() => usePatientList({ enabled: true }))
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+
+    const init = fetchMock.mock.calls[0]![1] as RequestInit
+    expect(init.credentials).toBe("include")
+    expect(init.cache).toBe("no-store")
+    expect((init.headers as Record<string, string>)["X-Requested-With"]).toBe("XMLHttpRequest")
+  })
+
+  it("unmount → AbortController cleanup (pas de setState fantôme)", async () => {
+    let resolveFetch!: (v: Response) => void
+    const pendingResponse = new Promise<Response>((r) => { resolveFetch = r })
+    vi.spyOn(global, "fetch").mockReturnValue(pendingResponse)
+
+    const { result, unmount } = renderHook(() => usePatientList({ enabled: true }))
+    await waitFor(() => expect(result.current.loading).toBe(true))
+
+    unmount()
+
+    // Maintenant résoudre le fetch — ne doit pas crash ni warn React
+    resolveFetch({ ok: true, json: async () => mockResponse } as Response)
+    // Aucune assertion explicite : le test passe si pas de warn React
+    // dans la console (setState on unmounted component).
+  })
+})


### PR DESCRIPTION
## Summary
- Bouton **"+ Nouveau RDV"** dans le header du calendrier (disabled si scope membre non résolu)
- `<AppointmentCreateModal>` formulaire shadcn Dialog avec patient combobox / date / heure / durée / location / type / motif (chiffré AES-256-GCM côté backend)
- `<PatientCombobox>` autocomplete via `<datalist>` natif + debounce 250ms sur search HMAC backend
- 2 hooks : `useCreateAppointment` (POST `/api/appointments`) + `usePatientList` (GET `/api/patients/search?limit=50`)
- Fix régression headers ANSSI sur POST `/api/appointments` (oubli round 2 iter 5)
- **27 nouveaux tests**, 12 clés i18n FR/EN/AR

## Sécurité / HDS
- Headers ANSSI factorisés via `setAppointmentSecurityHeaders` (helper iter 5) sur la réponse 201 + 400 — la réponse contient `AppointmentDTO` complet avec motif déchiffré
- `motif` chiffré à l'insertion en base via `encryptField` (backend US-2500 existant)
- Audit `CREATE` ciblé côté backend (resource=APPOINTMENT, metadata.patientId, US-2268)
- `aria-live="assertive"` + `key={\`\${error}-\${errorNonce}\`}` sur alerte → re-annonce screen reader
- Render uniquement `t("createError")` générique, jamais code backend brut (HSA-3 defense-in-depth)

## Architecture (cohérent pattern iter 5)
- Mount-on-open + `key={\`create-\${effectiveMemberId}\`}` sur modal → state interne fresh à chaque ouverture
- `memberId` auto-résolu via `effectiveMemberId` (pattern iter 4)
- `handleClose` gate sur `loading` → Escape/backdrop pendant submit ignoré (mode contrôlé Base UI Dialog)
- `PatientCombobox` uncontrolled-mostly : pas de sync prop→state inputValue via useEffect (pattern React Compiler)

## Hors scope (V1.5 documenté dans spec)
- Validation client double-booking visuel (backend déjà enforce via EXCLUDE GiST + 409)
- `bookingMode=manual_validation` (requires HealthcareService.bookingMode schema)

## Test plan
- [x] 2377/2377 tests verts (vitest)
- [x] 0 lint / 0 typecheck errors
- [ ] Test manuel browser : créer RDV pour Jean Durand depuis Dr Sophie Martin → vérifier apparaît dans calendar
- [ ] Test 409 conflict si slot déjà pris
- [ ] Test 403 si patientId hors scope cabinet

## Spec
[`docs/UserStory/pro-user-stories/23-rdv/US-2500-UI-calendrier-rdv-pro.md`](docs/UserStory/pro-user-stories/23-rdv/US-2500-UI-calendrier-rdv-pro.md) §Création/édition — items cochés iter 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)