### PR TITLE
feat(rdv): US-2500-UI iter 10 — polish a11y (skip-link + landmark + aria-busy)

### DIFF
--- a/docs/UserStory/pro-user-stories/23-rdv/US-2500-UI-calendrier-rdv-pro.md
+++ b/docs/UserStory/pro-user-stories/23-rdv/US-2500-UI-calendrier-rdv-pro.md
@@ -114,11 +114,15 @@ Le backend RDV est livré et déployé en prod depuis **PR #392** (Groupe 8 RDV 
 
 ### Accessibilité
 
-- [ ] ARIA roles : `role="grid"` sur le calendrier mois, `role="gridcell"` sur chaque jour
-- [ ] Navigation clavier : flèches pour naviguer entre slots, Enter pour ouvrir détail
-- [ ] Focus rings 3-4px (cohérent design system Sérénité Active)
-- [ ] `aria-live="polite"` sur les changements de statut RDV (announce screen reader)
-- [ ] Touch targets ≥ 44px sur les boutons de navigation mois
+- [⚠️] ARIA roles `role="grid"` interne — Schedule-X v4 ne le fournit pas nativement (rendu DOM imperatif via preact-signals). Wrapper `<div role="region" aria-label>` ajouté iter 10 pour landmark SR. Migration cmdk/custom V1.5 si requis WCAG strict.
+- [⚠️] Navigation clavier flèches Schedule-X — Tab+Enter supportés natifs v4, flèches directionnelles non natives. Alternative bouton "Déplacer" iter 5 (WCAG 2.5.7) couvre le besoin déplacement clavier.
+- [x] Focus rings explicites `focus-visible:ring-2 ring-primary ring-offset-2` sur tous boutons custom (StatusFilter chips iter 8, region calendar iter 10, modal buttons via shadcn). ✅ iter 10
+- [x] `aria-live="polite"` sur successAnnounce + status bar / `aria-live="assertive"` sur erreurs (dndError, actionError modal, alertes). ✅ iter 6/7/8/9
+- [x] Touch targets ≥ 44px sur boutons interactifs custom (PatientFilter clear/close, StatusFilter chips, modal sub-mode actions). ✅ iter 5/6/7/8
+- [x] Skip-link "Aller au calendrier" visible au focus (WCAG 2.4.1 Bypass Blocks AA) ✅ iter 10
+- [x] Landmark region `role="region" aria-label` sur wrapper Schedule-X + scopeMissing path cohérent ✅ iter 10
+- [x] `aria-busy` synchronisé avec `isInitialLoading` du hook polling ✅ iter 10
+- [x] `aria-labelledby` main → h1 page pour landmark sémantique ✅ iter 10
 
 ### Performance
 

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -390,7 +390,8 @@
     "actionConfirmAcceptAlt": "تأكيد القبول",
     "resetFilters": "إعادة ضبط عوامل التصفية",
     "skipToCalendar": "تخطي إلى تقويم المواعيد",
-    "calendarMainLabel": "تقويم المواعيد"
+    "calendarMainLabel": "تقويم المواعيد",
+    "todayDateAnnouncement": "اليوم: {date}"
   },
   "weekly": {
     "title": "العرض الأسبوعي",

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -388,7 +388,9 @@
     "acceptAltNewSlot": "الموعد الجديد",
     "acceptAltConfirmHint": "القبول نهائي: سيعود الموعد إلى حالة \"مجدول\" في هذا التاريخ الجديد.",
     "actionConfirmAcceptAlt": "تأكيد القبول",
-    "resetFilters": "إعادة ضبط عوامل التصفية"
+    "resetFilters": "إعادة ضبط عوامل التصفية",
+    "skipToCalendar": "تخطي إلى تقويم المواعيد",
+    "calendarMainLabel": "تقويم المواعيد"
   },
   "weekly": {
     "title": "العرض الأسبوعي",

--- a/messages/en.json
+++ b/messages/en.json
@@ -388,7 +388,9 @@
     "acceptAltNewSlot": "New slot",
     "acceptAltConfirmHint": "Acceptance is final: the appointment will go back to \"scheduled\" at this new date.",
     "actionConfirmAcceptAlt": "Confirm acceptance",
-    "resetFilters": "Reset filters"
+    "resetFilters": "Reset filters",
+    "skipToCalendar": "Skip to appointments calendar",
+    "calendarMainLabel": "Appointments calendar"
   },
   "weekly": {
     "title": "Weekly View",

--- a/messages/en.json
+++ b/messages/en.json
@@ -390,7 +390,8 @@
     "actionConfirmAcceptAlt": "Confirm acceptance",
     "resetFilters": "Reset filters",
     "skipToCalendar": "Skip to appointments calendar",
-    "calendarMainLabel": "Appointments calendar"
+    "calendarMainLabel": "Appointments calendar",
+    "todayDateAnnouncement": "Today: {date}"
   },
   "weekly": {
     "title": "Weekly View",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -388,7 +388,9 @@
     "acceptAltNewSlot": "Nouveau créneau",
     "acceptAltConfirmHint": "L'acceptation est définitive : le RDV repassera en \"planifié\" à cette nouvelle date.",
     "actionConfirmAcceptAlt": "Confirmer l'acceptation",
-    "resetFilters": "Réinitialiser les filtres"
+    "resetFilters": "Réinitialiser les filtres",
+    "skipToCalendar": "Passer au calendrier des rendez-vous",
+    "calendarMainLabel": "Calendrier des rendez-vous"
   },
   "weekly": {
     "title": "Vue hebdomadaire",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -390,7 +390,8 @@
     "actionConfirmAcceptAlt": "Confirmer l'acceptation",
     "resetFilters": "Réinitialiser les filtres",
     "skipToCalendar": "Passer au calendrier des rendez-vous",
-    "calendarMainLabel": "Calendrier des rendez-vous"
+    "calendarMainLabel": "Calendrier des rendez-vous",
+    "todayDateAnnouncement": "Aujourd'hui : {date}"
   },
   "weekly": {
     "title": "Vue hebdomadaire",

--- a/src/app/(dashboard)/appointments/page.tsx
+++ b/src/app/(dashboard)/appointments/page.tsx
@@ -35,10 +35,27 @@ export default async function AppointmentsPage() {
   const t = await getTranslations("appointments")
 
   return (
-    <main className="flex flex-col gap-6 p-4 lg:p-6">
+    <main
+      className="flex flex-col gap-6 p-4 lg:p-6"
+      // Fix US-2500-UI iter 10 a11y polish — landmark main lié au h1 page.
+      aria-labelledby="appointments-page-title"
+    >
+      {/* US-2500-UI iter 10 a11y polish — skip-link visible only on focus
+          (WCAG 2.4.1 Bypass Blocks AA). Permet à un user clavier-only ou
+          SR de sauter le header + filtres pour aller direct au calendrier
+          (qui peut contenir 200+ RDV). Le link reste invisible sauf focus
+          via la classe `sr-only focus:not-sr-only`. */}
+      <a
+        href="#appointment-calendar-main"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:rounded focus:bg-primary focus:px-3 focus:py-2 focus:text-primary-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+      >
+        {t("skipToCalendar")}
+      </a>
       <header className="flex items-baseline justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-semibold">{t("pageTitle")}</h1>
+          <h1 id="appointments-page-title" className="text-2xl font-semibold">
+            {t("pageTitle")}
+          </h1>
           <p className="mt-1 text-sm text-muted-foreground">{t("pageSubtitle")}</p>
         </div>
       </header>

--- a/src/app/(dashboard)/appointments/page.tsx
+++ b/src/app/(dashboard)/appointments/page.tsx
@@ -44,10 +44,22 @@ export default async function AppointmentsPage() {
           (WCAG 2.4.1 Bypass Blocks AA). Permet à un user clavier-only ou
           SR de sauter le header + filtres pour aller direct au calendrier
           (qui peut contenir 200+ RDV). Le link reste invisible sauf focus
-          via la classe `sr-only focus:not-sr-only`. */}
+          via la classe `sr-only focus:not-sr-only`.
+
+          Fix A11Y-1 round 1 review PR #437 — `bg-teal-800` (#115E59) sur
+          white = contraste 7.1:1 (WCAG AAA). L'ancien `bg-primary` teal-600
+          (#0D9488) donnait 3.74:1 (FAIL WCAG AA 4.5:1).
+
+          Fix A11Y-2 round 1 — `focus:start-2` (vs `focus:left-2`) Tailwind
+          logical property → respecte automatiquement `dir="rtl"` arabe :
+          skip-link à droite en RTL, à gauche en LTR.
+
+          Fix CR-5 round 1 — `focus-visible:outline-none` (vs `focus:`)
+          cohérent avec wrapper calendar pour éviter outline natif sur clic
+          souris involontaire. */}
       <a
         href="#appointment-calendar-main"
-        className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:rounded focus:bg-primary focus:px-3 focus:py-2 focus:text-primary-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:start-2 focus:z-50 focus:rounded focus:bg-teal-800 focus:px-3 focus:py-2 focus:text-white focus-visible:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
       >
         {t("skipToCalendar")}
       </a>

--- a/src/components/diabeo/appointments/AppointmentCalendar.tsx
+++ b/src/components/diabeo/appointments/AppointmentCalendar.tsx
@@ -190,6 +190,20 @@ export function AppointmentCalendar({
   const [selectedDate, setSelectedDate] = useState<Date>(() => new Date())
   const range = useMemo(() => computeRange(selectedDate), [selectedDate])
 
+  // Fix A11Y-5 round 1 review PR #437 — date du jour stable au mount via
+  // useState lazy init (anti React-Compiler `Date.now()` au render +
+  // anti drift visible si polling à minuit). Format Intl.DateTimeFormat
+  // locale-aware pour SR users (workaround Schedule-X v4 pas de
+  // `aria-current="date"` natif).
+  const [todayLabel] = useState(() =>
+    new Intl.DateTimeFormat(undefined, {
+      weekday: "long",
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    }).format(new Date()),
+  )
+
   // US-2500-UI iter 4 — état du filtre membre cabinet.
   // Fix CR-1 + H-4 round 2 review PR #432 — `useMyMemberships` est appelé
   // dans le parent (vs auparavant dans `<MemberFilter>`) pour éviter le
@@ -580,12 +594,20 @@ export function AppointmentCalendar({
           {newApptButton}
         </div>
         {/* US-2500-UI iter 10 a11y polish — id target skip-link cohérent même
-            en scopeMissing path. role=region + aria-label pour landmark SR. */}
+            en scopeMissing path. role=region + aria-label pour landmark SR.
+            Fix CR-1/A11Y-3/HSA-6 round 1 — id distinct `-empty` (vs `-main`)
+            pour éviter risque duplicate id si futur refactor casse l'exclusion
+            mutuelle des 2 branches. Skip-link cible `-main` ; en scopeMissing
+            on accepte qu'il n'atteigne pas la zone (calendar absent de toute
+            façon, le filtre membre cabinet est juste au-dessus). Fix CR-2
+            round 1 — tabIndex={-1} + focus-visible:ring symétrique au path
+            normal pour cohérence visuelle si futur skip-link cible `-empty`. */}
         <div
-          id="appointment-calendar-main"
+          id="appointment-calendar-empty"
           role="region"
           aria-label={t("calendarMainLabel")}
-          className="rounded-lg border border-border bg-card p-12 text-center"
+          tabIndex={-1}
+          className="rounded-lg border border-border bg-card p-12 text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
         >
           <h2 className="text-lg font-medium text-foreground">
             {t(scopeMissingTitleKey)}
@@ -699,6 +721,11 @@ export function AppointmentCalendar({
        *     fournit pas de landmark natif sur son outer wrapper)
        *   - `aria-busy` synchronisé avec `isInitialLoading` du hook polling
        *     (SR users informés que le contenu est en cours de chargement)
+       *   - Fix CR-4 round 1 — `aria-busy={isInitialLoading}` boolean direct
+       *     (React sérialise correctement en string "true"/"false")
+       *   - Fix A11Y-4 round 1 — `aria-label` contextuel "Calendrier des
+       *     rendez-vous — Chargement..." pendant isInitialLoading (vs
+       *     annonce vague "Calendrier occupé" sans contexte).
        *
        * **Schedule-X v4 a11y limitations connues** (V1.5 follow-up V2 — issue
        * GH à créer si besoin) :
@@ -706,7 +733,8 @@ export function AppointmentCalendar({
        *     (rendu DOM Schedule-X imperatif via preact-signals)
        *   - Navigation clavier flèches : Schedule-X v4 supporte Tab + Enter
        *     mais pas flèches directionnelles natives sur la grille
-       *   - aria-current="date" sur la cellule "today" : à vérifier QA visuel
+       *   - aria-current="date" sur la cellule "today" : workaround
+       *     SR-only "Aujourd'hui : <date>" rendu en dessous (A11Y-5 fix).
        *
        * Pour V1, l'alternative a11y du drag&drop est le bouton "Déplacer"
        * dans le modal détail iter 5 (Fix FE-2 PR #435 WCAG 2.5.7).
@@ -714,13 +742,25 @@ export function AppointmentCalendar({
       <div
         id="appointment-calendar-main"
         role="region"
-        aria-label={t("calendarMainLabel")}
-        aria-busy={isInitialLoading ? "true" : "false"}
+        aria-label={
+          isInitialLoading
+            ? `${t("calendarMainLabel")} — ${t("loading")}`
+            : t("calendarMainLabel")
+        }
+        aria-busy={isInitialLoading}
         className="rounded-lg border border-border bg-card overflow-hidden min-h-[640px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
         tabIndex={-1}
       >
         <ScheduleXCalendar calendarApp={calendar} />
       </div>
+
+      {/* Fix A11Y-5 round 1 review PR #437 — workaround Schedule-X v4 ne
+          fournit pas `aria-current="date"` sur la cellule today. SR users
+          peuvent identifier la date du jour via cette annonce SR-only
+          (invisible visuellement, ne perturbe pas le rendu).
+          aria-live="off" par défaut — pas d'annonce dynamique (la date du
+          jour ne change pas pendant la session). */}
+      <p className="sr-only">{t("todayDateAnnouncement", { date: todayLabel })}</p>
 
       {detailModal}
       {createModal}

--- a/src/components/diabeo/appointments/AppointmentCalendar.tsx
+++ b/src/components/diabeo/appointments/AppointmentCalendar.tsx
@@ -579,7 +579,14 @@ export function AppointmentCalendar({
           {filterEl}
           {newApptButton}
         </div>
-        <div className="rounded-lg border border-border bg-card p-12 text-center">
+        {/* US-2500-UI iter 10 a11y polish — id target skip-link cohérent même
+            en scopeMissing path. role=region + aria-label pour landmark SR. */}
+        <div
+          id="appointment-calendar-main"
+          role="region"
+          aria-label={t("calendarMainLabel")}
+          className="rounded-lg border border-border bg-card p-12 text-center"
+        >
           <h2 className="text-lg font-medium text-foreground">
             {t(scopeMissingTitleKey)}
           </h2>
@@ -684,8 +691,34 @@ export function AppointmentCalendar({
       {successAnnounce}
       {dndErrorAnnounce}
 
-      {/* Fix L-1 — Tailwind class au lieu de magic inline style. */}
-      <div className="rounded-lg border border-border bg-card overflow-hidden min-h-[640px]">
+      {/* Fix L-1 — Tailwind class au lieu de magic inline style.
+       *
+       * US-2500-UI iter 10 a11y polish :
+       *   - `id="appointment-calendar-main"` cible du skip-link page (WCAG 2.4.1)
+       *   - `role="region"` + `aria-label` landmark explicite (Schedule-X v4 ne
+       *     fournit pas de landmark natif sur son outer wrapper)
+       *   - `aria-busy` synchronisé avec `isInitialLoading` du hook polling
+       *     (SR users informés que le contenu est en cours de chargement)
+       *
+       * **Schedule-X v4 a11y limitations connues** (V1.5 follow-up V2 — issue
+       * GH à créer si besoin) :
+       *   - Pas de `role="grid"` interne sur les vues mois/semaine/jour
+       *     (rendu DOM Schedule-X imperatif via preact-signals)
+       *   - Navigation clavier flèches : Schedule-X v4 supporte Tab + Enter
+       *     mais pas flèches directionnelles natives sur la grille
+       *   - aria-current="date" sur la cellule "today" : à vérifier QA visuel
+       *
+       * Pour V1, l'alternative a11y du drag&drop est le bouton "Déplacer"
+       * dans le modal détail iter 5 (Fix FE-2 PR #435 WCAG 2.5.7).
+       */}
+      <div
+        id="appointment-calendar-main"
+        role="region"
+        aria-label={t("calendarMainLabel")}
+        aria-busy={isInitialLoading ? "true" : "false"}
+        className="rounded-lg border border-border bg-card overflow-hidden min-h-[640px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+        tabIndex={-1}
+      >
         <ScheduleXCalendar calendarApp={calendar} />
       </div>
 

--- a/tests/unit/appointments-a11y.test.tsx
+++ b/tests/unit/appointments-a11y.test.tsx
@@ -17,7 +17,11 @@ import { describe, it, expect, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
 
 vi.mock("next-intl", () => ({
-  useTranslations: () => (k: string) => k,
+  useTranslations: () => (k: string, v?: Record<string, unknown>) => {
+    // Mock interpolate {date} param pour test A11Y-5 todayDateAnnouncement.
+    if (v && "date" in v) return `${k}:${v.date}`
+    return k
+  },
   useLocale: () => "fr-FR",
 }))
 
@@ -121,14 +125,14 @@ describe("US-2500-UI iter 10 a11y polish", () => {
     expect(region!.className).toContain("focus-visible:ring-2")
   })
 
-  it("scopeMissing path : id+role region cohérent pour skip-link", () => {
+  it("scopeMissing path : region cohérente (id renommé `-empty` par CR-1 fix round 1)", () => {
     setUpMocks({ scopeMissing: true })
     const { container } = render(<AppointmentCalendar userRole="DOCTOR" />)
-    const region = container.querySelector("#appointment-calendar-main")
+    // Fix CR-1 round 1 — id distinct `-empty` (vs `-main`) pour éviter
+    // duplicate id si futur refactor casse l'exclusion mutuelle des branches.
+    const region = container.querySelector("#appointment-calendar-empty")
     expect(region).not.toBeNull()
     expect(region!.getAttribute("role")).toBe("region")
-    // En scopeMissing, on garde l'id pour que le skip-link page atteigne
-    // la zone "Sélectionnez un membre" cohérent UX.
     // Mock memberships=[] → scopeMissingTitleKey="scopeMissingTitle"
     // (vs "scopeChooseTitle" si >= 2 memberships).
     expect(screen.getByText("scopeMissingTitle")).toBeTruthy()
@@ -148,5 +152,78 @@ describe("US-2500-UI iter 10 a11y polish", () => {
     // tabIndex=-1 = pas dans le Tab order naturel MAIS focusable
     // programmatiquement (skip-link.focus() ou href="#id" déplace focus).
     expect(region!.getAttribute("tabindex")).toBe("-1")
+  })
+
+  /**
+   * Fix CR-1/A11Y-3/HSA-6 round 1 review PR #437 — id distinct entre les 2
+   * paths (scopeMissing vs normal) pour éviter risque duplicate id si futur
+   * refactor casse l'exclusion mutuelle des branches conditionnelles.
+   */
+  it("Fix CR-1/A11Y-3 round 1 — id distinct '-empty' sur scopeMissing path (vs '-main' normal)", () => {
+    setUpMocks({ scopeMissing: true })
+    const { container } = render(<AppointmentCalendar userRole="DOCTOR" />)
+    expect(container.querySelector("#appointment-calendar-empty")).not.toBeNull()
+    expect(container.querySelector("#appointment-calendar-main")).toBeNull()
+  })
+
+  /**
+   * Fix CR-2 round 1 review PR #437 — symétrie scopeMissing path
+   * (tabIndex={-1} + focus-visible:ring) cohérent path normal.
+   */
+  it("Fix CR-2 round 1 — scopeMissing path : tabIndex=-1 + focus-visible:ring symétrique", () => {
+    setUpMocks({ scopeMissing: true })
+    const { container } = render(<AppointmentCalendar userRole="DOCTOR" />)
+    const region = container.querySelector("#appointment-calendar-empty")
+    expect(region!.getAttribute("tabindex")).toBe("-1")
+    expect(region!.className).toContain("focus-visible:ring-2")
+  })
+
+  /**
+   * Fix CR-4 round 1 review PR #437 — `aria-busy={isInitialLoading}` boolean
+   * direct (React sérialise correctement). Pas de conversion manuelle.
+   */
+  it("Fix CR-4 round 1 — aria-busy boolean direct (React sérialise en 'true'/'false')", () => {
+    setUpMocks({ isInitialLoading: true })
+    const { container } = render(<AppointmentCalendar userRole="DOCTOR" />)
+    const region = container.querySelector("#appointment-calendar-main")
+    // React sérialise boolean en string DOM "true"/"false"
+    expect(region!.getAttribute("aria-busy")).toBe("true")
+  })
+
+  /**
+   * Fix A11Y-4 round 1 review PR #437 — aria-label contextuel pendant
+   * isInitialLoading pour SR feedback informatif (vs annonce vague
+   * "Calendrier occupé" sans contexte).
+   */
+  it("Fix A11Y-4 round 1 — aria-label inclut 'loading' pendant isInitialLoading", () => {
+    setUpMocks({ isInitialLoading: true })
+    const { container } = render(<AppointmentCalendar userRole="DOCTOR" />)
+    const region = container.querySelector("#appointment-calendar-main")
+    // Format: "{calendarMainLabel} — {loading}" → "calendarMainLabel — loading"
+    expect(region!.getAttribute("aria-label")).toContain("loading")
+    expect(region!.getAttribute("aria-label")).toContain("calendarMainLabel")
+  })
+
+  it("Fix A11Y-4 round 1 — aria-label revient à label simple après chargement", () => {
+    setUpMocks({ isInitialLoading: false })
+    const { container } = render(<AppointmentCalendar userRole="DOCTOR" />)
+    const region = container.querySelector("#appointment-calendar-main")
+    // Pas de "loading" suffix après le 1er fetch.
+    expect(region!.getAttribute("aria-label")).toBe("calendarMainLabel")
+  })
+
+  /**
+   * Fix A11Y-5 round 1 review PR #437 — SR-only annonce date du jour
+   * (workaround Schedule-X v4 pas de `aria-current="date"` natif).
+   */
+  it("Fix A11Y-5 round 1 — annonce SR-only 'todayDateAnnouncement' avec date locale", () => {
+    setUpMocks()
+    const { container } = render(<AppointmentCalendar userRole="DOCTOR" />)
+    const srOnly = container.querySelector("p.sr-only")
+    expect(srOnly).not.toBeNull()
+    // Mock i18n returns key name; le formatage Intl.DateTimeFormat est appliqué
+    // sur la date réelle au mount → la chaîne contient au moins l'année courante.
+    const year = new Date().getFullYear()
+    expect(srOnly!.textContent).toContain(String(year))
   })
 })

--- a/tests/unit/appointments-a11y.test.tsx
+++ b/tests/unit/appointments-a11y.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests a11y US-2500-UI iter 10 polish — vérifications des landmarks
+ * ARIA, skip-link, aria-busy + heading hierarchy sur la page calendar.
+ *
+ * Couvre :
+ *   - skip-link visible au focus (WCAG 2.4.1 Bypass Blocks AA)
+ *   - landmark region calendar avec aria-label (Schedule-X v4 ne fournit
+ *     pas de landmark natif sur son outer wrapper)
+ *   - aria-busy lié à isInitialLoading du hook
+ *   - heading hierarchy h1 page + h2 sections
+ *   - id="appointment-calendar-main" cible du skip-link
+ */
+
+import { describe, it, expect, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (k: string) => k,
+  useLocale: () => "fr-FR",
+}))
+
+// Mock Schedule-X — on teste le wrapper a11y, pas le rendu Schedule-X
+vi.mock("@schedule-x/react", () => ({
+  ScheduleXCalendar: () => <div data-testid="schedule-x-mock" />,
+  useNextCalendarApp: () => ({}),
+}))
+vi.mock("@schedule-x/calendar", () => ({
+  createViewMonthGrid: () => ({}),
+  createViewWeek: () => ({}),
+  createViewDay: () => ({}),
+}))
+vi.mock("@schedule-x/events-service", () => ({
+  createEventsServicePlugin: () => ({ set: vi.fn() }),
+}))
+vi.mock("@schedule-x/drag-and-drop", () => ({
+  createDragAndDropPlugin: () => ({}),
+}))
+
+// Mock hooks pour contrôler isInitialLoading
+const mockUseAppointments = vi.fn()
+vi.mock("@/components/diabeo/appointments/useAppointments", () => ({
+  useAppointments: (...args: unknown[]) => mockUseAppointments(...args),
+}))
+const mockUseMyMemberships = vi.fn()
+vi.mock("@/components/diabeo/appointments/useMyMemberships", () => ({
+  useMyMemberships: () => mockUseMyMemberships(),
+}))
+vi.mock("@/components/diabeo/appointments/useAppointmentDetail", () => ({
+  useAppointmentDetail: () => ({ detail: null, loading: false, error: null, refetch: vi.fn() }),
+}))
+vi.mock("@/components/diabeo/appointments/AppointmentDetailModal", () => ({
+  AppointmentDetailModal: () => null,
+}))
+vi.mock("@/components/diabeo/appointments/AppointmentCreateModal", () => ({
+  AppointmentCreateModal: () => null,
+}))
+vi.mock("@/components/diabeo/appointments/useUpdateAppointment", () => ({
+  useUpdateAppointment: () => ({
+    loading: false, error: null, submit: vi.fn(), reset: vi.fn(),
+  }),
+}))
+
+const { AppointmentCalendar } = await import(
+  "@/components/diabeo/appointments/AppointmentCalendar"
+)
+
+function setUpMocks(opts: {
+  isInitialLoading?: boolean
+  scopeMissing?: boolean
+} = {}) {
+  mockUseMyMemberships.mockReturnValue({
+    items: opts.scopeMissing ? [] : [{
+      memberId: 1, memberName: "Dr Test", serviceId: 1,
+      serviceName: "Test Service", establishment: "CHU",
+    }],
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  })
+  mockUseAppointments.mockReturnValue({
+    items: [],
+    truncated: false,
+    loading: false,
+    isInitialLoading: opts.isInitialLoading ?? false,
+    error: null,
+    lastFetchedAt: new Date(),
+    refetch: vi.fn(),
+  })
+}
+
+describe("US-2500-UI iter 10 a11y polish", () => {
+  it("landmark region calendar avec id et aria-label", () => {
+    setUpMocks()
+    const { container } = render(<AppointmentCalendar userRole="DOCTOR" />)
+    const region = container.querySelector("#appointment-calendar-main")
+    expect(region).not.toBeNull()
+    expect(region!.getAttribute("role")).toBe("region")
+    expect(region!.getAttribute("aria-label")).toBe("calendarMainLabel")
+  })
+
+  it("aria-busy='true' pendant isInitialLoading", () => {
+    setUpMocks({ isInitialLoading: true })
+    const { container } = render(<AppointmentCalendar userRole="DOCTOR" />)
+    const region = container.querySelector("#appointment-calendar-main")
+    expect(region!.getAttribute("aria-busy")).toBe("true")
+  })
+
+  it("aria-busy='false' après chargement initial", () => {
+    setUpMocks({ isInitialLoading: false })
+    const { container } = render(<AppointmentCalendar userRole="DOCTOR" />)
+    const region = container.querySelector("#appointment-calendar-main")
+    expect(region!.getAttribute("aria-busy")).toBe("false")
+  })
+
+  it("focus-visible:ring sur le wrapper calendar (WCAG 2.4.7)", () => {
+    setUpMocks()
+    const { container } = render(<AppointmentCalendar userRole="DOCTOR" />)
+    const region = container.querySelector("#appointment-calendar-main")
+    expect(region!.className).toContain("focus-visible:ring-2")
+  })
+
+  it("scopeMissing path : id+role region cohérent pour skip-link", () => {
+    setUpMocks({ scopeMissing: true })
+    const { container } = render(<AppointmentCalendar userRole="DOCTOR" />)
+    const region = container.querySelector("#appointment-calendar-main")
+    expect(region).not.toBeNull()
+    expect(region!.getAttribute("role")).toBe("region")
+    // En scopeMissing, on garde l'id pour que le skip-link page atteigne
+    // la zone "Sélectionnez un membre" cohérent UX.
+    // Mock memberships=[] → scopeMissingTitleKey="scopeMissingTitle"
+    // (vs "scopeChooseTitle" si >= 2 memberships).
+    expect(screen.getByText("scopeMissingTitle")).toBeTruthy()
+  })
+
+  it("h2 heading dans scopeMissing path (hierarchy correcte)", () => {
+    setUpMocks({ scopeMissing: true })
+    const { container } = render(<AppointmentCalendar userRole="DOCTOR" />)
+    const h2 = container.querySelector("h2")
+    expect(h2).not.toBeNull()
+  })
+
+  it("tabIndex=-1 sur la région calendar (programmatically focusable pour skip-link)", () => {
+    setUpMocks()
+    const { container } = render(<AppointmentCalendar userRole="DOCTOR" />)
+    const region = container.querySelector("#appointment-calendar-main")
+    // tabIndex=-1 = pas dans le Tab order naturel MAIS focusable
+    // programmatiquement (skip-link.focus() ou href="#id" déplace focus).
+    expect(region!.getAttribute("tabindex")).toBe("-1")
+  })
+})


### PR DESCRIPTION
## Summary
Clôt l'US-2500-UI calendrier RDV (10/10 itérations) — polish a11y final WCAG 2.1 AA.

- **Skip-link** "Passer au calendrier" visible au focus (WCAG 2.4.1 Bypass Blocks AA)
- **Landmark region** `role="region" aria-label` sur wrapper Schedule-X (v4 ne fournit pas de landmark natif)
- **`aria-busy`** synchronisé avec `isInitialLoading` (SR feedback chargement)
- **`aria-labelledby`** main → h1 page pour landmark sémantique
- **`focus-visible:ring-2`** + `tabIndex={-1}` sur région calendar (cible skip-link)
- **Documentation** Schedule-X v4 a11y limitations + alternatives fournies

## Schedule-X v4 limitations documentées
| Critère WCAG | Status | Alternative |
|---|---|---|
| `role="grid"` interne | ⚠️ Pas natif | Wrapper `role="region"` ajouté iter 10 |
| Navigation flèches | ⚠️ Pas natif (Tab+Enter OK) | Bouton "Déplacer" modal détail (WCAG 2.5.7 iter 5/7) |
| Focus visible cellules | ⚠️ Schedule-X interne | `focus-visible:ring` sur wrapper iter 10 |

V1.5 follow-up : audit cmdk migration si requis WCAG strict.

## État final US-2500-UI (10/10)
| Iter | Fonction | PR | Status |
|---|---|---|---|
| 1-3 | Scaffold + range fetch + adapter | #431 | ✅ |
| 4 | Filtre membre cabinet | #432 | ✅ |
| 5 | Modal détail RDV | #433 | ✅ |
| 6 | Modal création RDV | #434 | ✅ |
| 7 | Drag & drop | #435 | ✅ |
| 8+9 | Filtres statut/patient + workflow alternatives | #436 | ✅ |
| 10 | **Polish a11y** | **#437** | ✅ |

## i18n
2 nouvelles clés FR/EN/AR : `skipToCalendar`, `calendarMainLabel`

## Tests (+7)
`tests/unit/appointments-a11y.test.tsx` (NEW) :
- landmark region id/role/aria-label
- aria-busy true/false selon isInitialLoading
- focus-visible:ring sur wrapper
- tabIndex=-1 (cible skip-link sans Tab order)
- scopeMissing path cohérent
- h2 hierarchy

## Test plan
- [x] 2509/2509 tests verts (vitest)
- [x] 0 lint errors / 0 typecheck errors
- [ ] Test manuel SR (NVDA/VoiceOver) : skip-link audible au Tab, main annonce title, calendar annoncé "region"
- [ ] Test manuel clavier-only : Tab → skip-link → Enter → focus sur calendar ; Tab → header → filtres

## Spec
[`docs/UserStory/pro-user-stories/23-rdv/US-2500-UI-calendrier-rdv-pro.md`](docs/UserStory/pro-user-stories/23-rdv/US-2500-UI-calendrier-rdv-pro.md) §Accessibilité — items mis à jour avec status final + limitations Schedule-X documentées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)