### PR TITLE
feat(messaging): Issue #450 — Cross-tab logout sync via BroadcastChannel

### DIFF
--- a/docs/compliance/dpia-messaging-scope-a.md
+++ b/docs/compliance/dpia-messaging-scope-a.md
@@ -271,3 +271,43 @@ Nouveau endpoint backend (PR #444) qui appelle `canMessage()` côté serveur pou
 - [ ] DPA Google Firebase signé (transfert hors-UE Art. 44+ — projet Firebase US-region)
 - [ ] CGU pro mention notifications push activées + permission flow `Notification.requestPermission()` UI
 - [ ] Test E2E Playwright : SW registration + push consume + BroadcastChannel callback (jsdom unsupported)
+
+## §11 — Cross-tab logout sync (Issue #450 PR #451)
+
+### 11.1 Contexte
+
+L'iter 4 (PR #444) + Issue #446 (PR #449) résolvent le bug FCM cleanup sur logout d'un onglet — mais sur poste partagé cabinet, si PS A laisse plusieurs onglets ouverts et logout dans un seul, les autres restent visuellement authentifiés. Risque : `useMessagingPush` mount cycle des autres tabs ré-register un token FCM (annulant cleanup tab 1) → PS B login derrière reçoit push PS A.
+
+### 11.2 Solution implémentée — `BroadcastChannel("diabeo:auth")`
+
+Cf. `docs/runbook/messaging-logout.md` section M2. Le tab initiateur du logout broadcast `{type, from, at}` après cleanup backend ; les autres tabs cleanup local (sessionStorage clear + replace `/login`) sans ré-émettre (anti-loop). `useState(() => crypto.randomUUID())[0]` comme tab identifier.
+
+### 11.3 Modèle de menace
+
+| Risque | Impact | Mitigation V1 | Statut |
+|---|---|---|---|
+| **XSS amplification** : attaquant XSS broadcast `{type: "logout"}` → DOS session tous tabs | XSS est game-over (cookie déjà exfiltrable via XHR) ; DOS empêche victime de noter l'attaque | Aucune mitigation pratique (un secret JS-accessible serait extractible par même XSS). Documenté DPIA, surveillance CSP `default-src 'self'` | ⏸ Acceptable V1 |
+| **Timing oracle sous-domaine** : si futur `cdn.diabeo.fr` partage origin (CSP relax) → attaquant observe quand PS logout | Information disclosure faible (timing patterns d'activité) | BroadcastChannel strictement same-origin (host+port+protocol). Sous-domaines hors-origin isolés | ✓ Spec-level |
+| **Forge tab id par XSS** : attaquant peut envoyer `{type, from: "fake-id"}` pour faire cleanup d'un autre tab | Cf. XSS amplification ci-dessus | `tabId` non secret, juste désambiguïsation runtime — pas une frontière sécurité | ⏸ Acceptable V1 |
+| **Cross-user logout DOS multi-account** : V2 multi-account UX → logout user A déclenche logout user B | Pas applicable V1 (cookie unique par origin = 1 user actif) | Documenté DPIA + Issue GH V2 (filter `userId` payload) | ⏸ V2 ([Issue #452](https://github.com/freecompub/Diabeo-BackOffice/issues/452)) |
+| **Cookie httpOnly tab 2 résiduel post-logout tab 1** : cookie reste jusqu'à expiration JWT (~15min) | Tab 2 peut tenter d'accéder à PHI cached avant prochain middleware refresh | Cleanup UI immédiat via cross-tab listener (replace `/login` < 100ms) | ✓ PR #451 |
+
+### 11.4 Décision audit `session.cross_tab_close`
+
+**Question HSA H2 round 2 PR #451** : faut-il émettre un audit log backend pour chaque tab fermé via broadcast cross-tab ?
+
+**Décision V1 (PR #451)** : **NON** — la révocation backend tab 1 (POST `/api/auth/logout`) fait foi pour démontrer "PS X a fini sa session à T". Audit cross-tab additionnel = bruit (N tabs × 1 audit = pollution + perf cron messagerie).
+
+**Démonstrabilité HDS Art. L.1111-8** : forensique "PS X a fini sa session à T sur tous ses tabs" reconstituable via :
+1. Audit `session.logout` (action="DELETE" resource="SESSION") tab initiateur — IP/UA + count tokens FCM cleared
+2. Audit `push.unregister.all` (PR #449 HSA H2) — IP/UA + count
+3. Middleware refuse cookie résiduel autres tabs au prochain refresh (≤15min) — implicite par modèle cookie unique
+
+**Validation DPO** : pending signature pre-prod patients réels (à demander avec PR #451 review).
+
+### 11.5 Bloqueurs pre-prod patients réels (iter 4 — addendum PR #451)
+
+- [ ] Décision DPO §11.4 — confirmation que révocation backend tab 1 + middleware refresh suffit pour démonstrabilité Art. L.1111-8 cross-tab
+- [ ] Surveillance CSP `default-src 'self'` + `script-src 'self'` strict (mitigation XSS amplification §11.3)
+- [ ] Issue GH V1.5 trackée pour filtre `userId` si multi-account UX V2
+

--- a/docs/runbook/messaging-logout.md
+++ b/docs/runbook/messaging-logout.md
@@ -103,22 +103,48 @@ ré-émettre (anti-loop : seul l'initiateur broadcast).
 **Pattern** :
 
 ```typescript
-// useAuth — listener au mount (toutes instances).
+// useAuth — channel ref persistant + listener au mount.
+// Fix H1 round 2 PR #451 — channel ref REUSE (vs éphémère post+close à chaque
+// logout) élimine race postMessage async / close sync immédiat.
+const channelRef = useRef<BroadcastChannel | null>(null)
+
+// Fix H3 + L1 round 2 — useState lazy + crypto.randomUUID() collision-proof
+// (vs Math.random + Date.now + useRef mutation render).
+const [tabId] = useState(() => crypto.randomUUID())
+
+// Fix H4 round 2 — routerRef stable + deps [tabId] (vs [router] qui re-mount
+// le channel à chaque navigation, fenêtre microscopique sans listener actif).
+const routerRef = useRef(router)
+useEffect(() => { routerRef.current = router }, [router])
+
 useEffect(() => {
   if (typeof BroadcastChannel === "undefined") return  // fallback IE/vieux Safari
   const channel = new BroadcastChannel("diabeo:auth")
+  channelRef.current = channel
   channel.onmessage = (event) => {
-    if (event.data?.type === "logout" && event.data?.from !== ownTabId) {
-      applyLogoutLocalCleanup(router.replace)
-    }
+    const data = event.data
+    if (data?.type !== "logout") return
+    // Fix M1 round 2 — guard runtime sur from typeof string (anti malformed msg).
+    if (typeof data.from !== "string") return
+    // Anti-loop : ignorer ses propres broadcasts.
+    if (data.from === tabId) return
+    applyLogoutLocalCleanup((path) => routerRef.current.replace(path))
   }
-  return () => channel.close()
-}, [router])
+  return () => {
+    channel.close()
+    channelRef.current = null
+  }
+}, [tabId])
 
-// logout() — broadcast après cleanup backend chain.
-const channel = new BroadcastChannel("diabeo:auth")
-channel.postMessage({ type: "logout", from: ownTabId, at: Date.now() })
-channel.close()
+// logout() — broadcast via ref persistant dans le finally.
+const channel = channelRef.current
+if (channel) {
+  try {
+    channel.postMessage({ type: "logout", from: tabId, at: Date.now() })
+  } catch (err) {
+    logHookError("logout.broadcast", err, { alwaysLog: true })
+  }
+}
 ```
 
 **Filtre `from === ownTabId`** : spec browser dit que sender ne reçoit pas,
@@ -129,6 +155,43 @@ renvoie au sender. Filtre défensif requis pour portabilité.
 des tabs DU MÊME profil/contexte navigateur. PS qui a ouvert tab 1 dans
 Chrome profil A et tab 2 dans Chrome profil B → pas de sync (sessions
 isolées de toute façon, pas un cas réel sur poste cabinet).
+
+### Modèle Session + cookie httpOnly tab 2 (résolution HSA H1 round 2 PR #451)
+
+**Investigation** : `src/lib/auth/session.ts` + `prisma/schema.prisma:478`
+montrent que le modèle Session est **1 row par login event** (createSession
+génère un sessionToken random à chaque appel). Cependant :
+
+- **Cookie httpOnly est unique par origin** : 2 tabs ouverts par PS A après
+  son login unique partagent le **même cookie** → **même session DB**.
+- Tab 1 POST `/api/auth/logout` invalide cette session (cookie Set-Cookie
+  max-age=0) → tab 2 hérite du cookie clear via storage event natif au
+  prochain navigateur reload.
+- Middleware Edge re-vérifie le JWT à chaque requête → si la session DB est
+  révoquée, refuse même si tab 2 garde encore le cookie en mémoire (≤15min
+  refresh).
+
+**Conséquence pour cross-tab sync** : tab 2 n'a PAS besoin d'émettre son
+propre POST `/api/auth/logout` (la session backend est déjà révoquée par
+tab 1). Le listener cross-tab fait uniquement le cleanup UI immédiat
+(replace `/login` + clear sessionStorage) pour **fermer la vue PHI sans
+attendre le prochain middleware refresh**.
+
+**Forensique HDS Art. L.1111-8** : la révocation backend tab 1 fait foi
+pour démontrer "PS X a fini sa session à T". Aucun audit cross-tab
+additionnel requis (cf. DPIA §11 décision documentée).
+
+### HSA H6 round 2 — Pas de filtre `userId` dans message (V1.5 follow-up)
+
+**Statut V1** : message broadcast contient uniquement `{type, from, at}`,
+pas d'`userId`. Acceptable car le modèle cookie unique par origin garantit
+"1 user actif par contexte navigateur" — pas de scénario multi-account
+same-origin en V1.
+
+**Risque V2 (multi-account UX)** : si à l'avenir le backoffice supporte
+plusieurs comptes simultanés dans le même navigateur (account switcher),
+un logout d'un compte cleanup actuellement TOUS les tabs (cross-user DOS).
+Issue GH #452 trackée V2 — ajouter `userId` au payload + filtrage listener.
 
 ### M4 — Race async cleanup window (~100-500ms)
 

--- a/docs/runbook/messaging-logout.md
+++ b/docs/runbook/messaging-logout.md
@@ -92,19 +92,43 @@ client sont **inopérantes** sur cookies httpOnly (par design).
 chaque requête → si la session DB a été révoquée par un autre canal (ex:
 admin force-logout), le cookie résiduel est rejeté au prochain refresh.
 
-### M2 — Multi-tab : tab2 conserve SW + tokens après logout tab1
+### M2 — Multi-tab : sync cross-tab via BroadcastChannel ✅ RÉSOLU (PR #451)
 
-Si PS ouvre 2 tabs `/messages` + `/patients` et logout dans tab1, le tab2 :
-- reste authentifié visuellement jusqu'au prochain refresh (cookie cleared
-  côté tab1 → tab2 voit aussi le cookie vide via storage event natif sur
-  reload)
-- garde son SW registered tant qu'il n'est pas naviqué vers `/login`
-- peut potentiellement ré-register un token FCM via `useMessagingPush`
-  (annulant le cleanup tab1)
+**Statut V1** : implémenté via `BroadcastChannel("diabeo:auth")` (Issue #450
+PR #451). Si PS A logout dans tab 1, tous les autres tabs ouverts sur la
+même origin Diabeo reçoivent un message `{type: "logout", from, at}` et
+cleanup local (sessionStorage clear + `router.replace("/login")`) SANS
+ré-émettre (anti-loop : seul l'initiateur broadcast).
 
-**Statut** : tracking GitHub Issue follow-up V1.5 — implémenter
-`BroadcastChannel("auth")` pour cross-tab logout sync (postMessage `logout`
-→ listener force redirect `/login` + cleanup local sur tous tabs).
+**Pattern** :
+
+```typescript
+// useAuth — listener au mount (toutes instances).
+useEffect(() => {
+  if (typeof BroadcastChannel === "undefined") return  // fallback IE/vieux Safari
+  const channel = new BroadcastChannel("diabeo:auth")
+  channel.onmessage = (event) => {
+    if (event.data?.type === "logout" && event.data?.from !== ownTabId) {
+      applyLogoutLocalCleanup(router.replace)
+    }
+  }
+  return () => channel.close()
+}, [router])
+
+// logout() — broadcast après cleanup backend chain.
+const channel = new BroadcastChannel("diabeo:auth")
+channel.postMessage({ type: "logout", from: ownTabId, at: Date.now() })
+channel.close()
+```
+
+**Filtre `from === ownTabId`** : spec browser dit que sender ne reçoit pas,
+mais Node `worker_threads.BroadcastChannel` (jsdom + Edge runtime futur)
+renvoie au sender. Filtre défensif requis pour portabilité.
+
+**Limite résiduelle** : BroadcastChannel ne fonctionne que SAME-ORIGIN dans
+des tabs DU MÊME profil/contexte navigateur. PS qui a ouvert tab 1 dans
+Chrome profil A et tab 2 dans Chrome profil B → pas de sync (sessions
+isolées de toute façon, pas un cas réel sur poste cabinet).
 
 ### M4 — Race async cleanup window (~100-500ms)
 
@@ -202,7 +226,9 @@ Inclut la régression HSA H2 : `unregisterAll` propage `ctx` + `metadata.count`
 - **`Notification.show()` futur** : si iter 6+ ajoute notifications visibles
   tray, vérifier que `getRegistrations()` cleanup au logout couvre TOUS les
   workers (pas juste `firebase-messaging-sw.js`).
-- **Cross-tab logout sync** : Issue follow-up V1.5 (BroadcastChannel("auth")).
+- ~~**Cross-tab logout sync** : Issue follow-up V1.5 (BroadcastChannel("auth")).~~
+  ✅ **Résolu** PR #451 (Issue #450) — cf. section "Limites connues — M2"
+  ci-dessus.
 - **Cookie httpOnly clear** : non clearable côté JS — fallback middleware
   re-check JWT à chaque requête (cf. limite M1 ci-dessus).
 
@@ -210,6 +236,8 @@ Inclut la régression HSA H2 : `unregisterAll` propage `ctx` + `metadata.count`
 
 - Issue GH #446 — Logout flow unregister SW + DELETE FCM token
 - PR #449 — Implémentation (reviews round 1 : 17 findings résolus)
+- Issue GH #450 — Cross-tab logout sync (follow-up HSA M2)
+- PR #451 — Implémentation cross-tab sync via `BroadcastChannel("diabeo:auth")`
 - US-2076-UI iter 4 PR #444 — `unregisterMessagingServiceWorker()` helper
 - US-2073 PR #340 — Backend `/api/push/register` DELETE endpoint
 - US-2268 — Convention `auditLog.resourceId` plat + `metadata.userId` pivot

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -18,7 +18,7 @@
  * calculate remaining session time without touching the httpOnly cookie.
  */
 
-import { useState, useCallback, useRef } from "react"
+import { useState, useCallback, useEffect, useRef } from "react"
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { LOGIN_TIMESTAMP_KEY } from "@/hooks/use-session-timeout"
@@ -43,6 +43,48 @@ async function safeCleanupStep(
   } catch (err) {
     logHookError(label, err, { alwaysLog: true })
   }
+}
+
+// ---------------------------------------------------------------------------
+// Cross-tab logout sync (Issue #450 — follow-up review HSA M2 PR #449)
+// ---------------------------------------------------------------------------
+
+/**
+ * Nom du `BroadcastChannel` partagé entre tous les tabs ouverts sur la même
+ * origin Diabeo. Toute instance `useAuth` mount un listener — quand le tab
+ * initiateur du logout finit sa chaîne cleanup, il post un message `"logout"`
+ * que les autres tabs consomment pour se déconnecter localement.
+ *
+ * Sans ce sync, sur poste partagé cabinet multi-PS (HDS Art. L.1111-8) :
+ *   - PS A logout tab 1 → tokens DELETE backend
+ *   - Tab 2 toujours actif → `useMessagingPush` mount cycle → ré-register
+ *     token FCM (annule cleanup tab 1)
+ *   - PS B login peu après → token PS A persiste sous identité PS A
+ *   - Cron messagerie push → arrive à device PS A (alors qu'il a logout)
+ */
+const AUTH_CHANNEL_NAME = "diabeo:auth"
+
+interface AuthBroadcastMessage {
+  type: "logout"
+  /** Identifiant unique du tab émetteur — permet au listener d'ignorer ses
+   * propres broadcasts. Spec `BroadcastChannel` dit que le sender ne reçoit
+   * pas, mais l'implémentation Node (`node:worker_threads`) renvoie au sender
+   * → filtrage défensif requis pour tests jsdom + portabilité Node future
+   * (Edge runtime). Browser : `BroadcastChannel` ne se renvoie pas, donc le
+   * filtre est un no-op runtime. */
+  from: string
+  /** Timestamp émission (debug / observability — pas utilisé pour logique). */
+  at: number
+}
+
+/**
+ * Cleanup LOCAL au tab courant — appelé soit par le `finally` du logout
+ * initiateur, soit par les listeners cross-tab. Ne broadcast PAS (sinon
+ * loop infini théorique, même si `BroadcastChannel` n'envoie pas au sender).
+ */
+function applyLogoutLocalCleanup(redirect: (path: string) => void): void {
+  sessionStorage.removeItem(LOGIN_TIMESTAMP_KEY)
+  redirect("/login")
 }
 
 // ---------------------------------------------------------------------------
@@ -219,6 +261,35 @@ export function useAuth() {
   // aligné HSA-3 inFlightRef iter 2).
   const isLoggingOutRef = useRef(false)
 
+  // Issue #450 — tab identity unique pour filtrer les broadcasts émis par
+  // soi-même (cf. doc `AuthBroadcastMessage.from`). Random suffit (pas
+  // sécurité, juste désambiguïsation runtime).
+  const tabIdRef = useRef<string>("")
+  if (tabIdRef.current === "") {
+    tabIdRef.current = Math.random().toString(36).slice(2) + Date.now().toString(36)
+  }
+
+  // Issue #450 follow-up review HSA M2 PR #449 — listener cross-tab logout.
+  // Si un AUTRE tab logout, on cleanup local (sessionStorage clear + redirect
+  // /login) SANS ré-émettre (anti-loop : seul l'initiateur broadcast).
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof BroadcastChannel === "undefined") {
+      // Vieux Safari/IE ou SSR : graceful fallback no-op.
+      return
+    }
+    const channel = new BroadcastChannel(AUTH_CHANNEL_NAME)
+    const ownTabId = tabIdRef.current
+    channel.onmessage = (event: MessageEvent<AuthBroadcastMessage>) => {
+      if (event.data?.type !== "logout") return
+      // Filtre défensif : ignorer ses propres broadcasts (cf. doc `from`).
+      if (event.data.from === ownTabId) return
+      applyLogoutLocalCleanup((path) => router.replace(path))
+    }
+    return () => {
+      channel.close()
+    }
+  }, [router])
+
   const logout = useCallback(async () => {
     // Fix Issue #446 (US-2076-UI iter 4 PR #444 follow-up) + reviews PR #449
     // — cleanup HDS Art. L.1111-8 gestion fin de session sur poste partagé
@@ -267,14 +338,33 @@ export function useAuth() {
         ),
       ])
     } finally {
+      // Issue #450 — broadcast aux autres tabs AVANT le cleanup local pour
+      // que tous les tabs cleanup en parallèle (latence cross-tab minimisée).
+      // Seul l'initiateur du logout broadcast → pas de loop (les listeners
+      // appellent `applyLogoutLocalCleanup` sans ré-émettre).
+      if (typeof window !== "undefined" && typeof BroadcastChannel !== "undefined") {
+        try {
+          const channel = new BroadcastChannel(AUTH_CHANNEL_NAME)
+          channel.postMessage({
+            type: "logout",
+            from: tabIdRef.current,
+            at: Date.now(),
+          } satisfies AuthBroadcastMessage)
+          channel.close()
+        } catch (err) {
+          // Fire-and-forget : si broadcast fail (browser quirk), le cleanup
+          // local du tab initiateur fonctionne toujours. Les autres tabs
+          // verront le 401 au prochain refresh middleware.
+          logHookError("logout.broadcast", err, { alwaysLog: true })
+        }
+      }
       // Fix FE M3 round 1 PR #449 — clear + redirect dans finally global,
       // même si un bug React 19 compiler edge case fait throw sur await.
-      sessionStorage.removeItem(LOGIN_TIMESTAMP_KEY)
       // Fix FE H6 round 1 PR #449 — `router.replace` au lieu de `router.push`.
       // Push conserve l'historique → back button → flash PHI dashboard cached
       // avant que middleware re-redirect. Sur poste partagé cabinet = leak
       // visuel. `replace` invalide le history entry courant.
-      router.replace("/login")
+      applyLogoutLocalCleanup((path) => router.replace(path))
       isLoggingOutRef.current = false
     }
   }, [router])

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -73,7 +73,8 @@ interface AuthBroadcastMessage {
    * (Edge runtime). Browser : `BroadcastChannel` ne se renvoie pas, donc le
    * filtre est un no-op runtime. */
   from: string
-  /** Timestamp émission (debug / observability — pas utilisé pour logique). */
+  /** Timestamp émission UTC. Utilisé uniquement pour observability (logs ops
+   * "tab X cleanup à T+50ms après broadcast tab Y") — pas de logique métier. */
   at: number
 }
 
@@ -261,13 +262,43 @@ export function useAuth() {
   // aligné HSA-3 inFlightRef iter 2).
   const isLoggingOutRef = useRef(false)
 
-  // Issue #450 — tab identity unique pour filtrer les broadcasts émis par
-  // soi-même (cf. doc `AuthBroadcastMessage.from`). Random suffit (pas
-  // sécurité, juste désambiguïsation runtime).
-  const tabIdRef = useRef<string>("")
-  if (tabIdRef.current === "") {
-    tabIdRef.current = Math.random().toString(36).slice(2) + Date.now().toString(36)
-  }
+  // Fix H3 round 2 review PR #451 — `useState(() => init)[0]` lazy init
+  // idiomatic React 19 (vs mutation `tabIdRef.current` pendant render body
+  // qui viole render purity + risque sous compiler/StrictMode double-invoke).
+  // Fix L1 round 2 — `crypto.randomUUID()` (RFC 4122 v4, ~122 bits entropy)
+  // élimine la collision théorique `Math.random + Date.now` 2 tabs même ms.
+  // Disponible browser ≥ 2022 + Node ≥ 19 + Edge runtime.
+  // Pas de valeur sécurité : tabId est un identifiant UI éphémère pour
+  // désambiguïser le sender côté listener BroadcastChannel — un attaquant
+  // XSS pourrait forger n'importe quel tabId, donc pas une frontière de
+  // confiance. `crypto.randomUUID()` choisi pour son caractère collision-proof
+  // (~1 chance sur 2^122 de collision même au pire moment).
+  const [tabId] = useState(() => {
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+      return crypto.randomUUID()
+    }
+    // Fallback test env (jsdom < 19 ou polyfill manquant) — Math.random OK car
+    // jamais sécurité, juste désambiguïsation runtime.
+    return Math.random().toString(36).slice(2) + Date.now().toString(36)
+  })
+
+  // Fix H4 round 2 review PR #451 — `routerRef` stable mis à jour dans un
+  // useEffect séparé (vs mutation render body). Le listener useEffect a
+  // désormais deps `[tabId]` (stable) au lieu de `[router]` — évite la
+  // fenêtre microscopique close→new à chaque changement d'instance router
+  // (Next.js 16 useRouter contrat non-stable garanti).
+  const routerRef = useRef(router)
+  useEffect(() => {
+    routerRef.current = router
+  }, [router])
+
+  // Fix H1 + FE L3 round 2 review PR #451 — channel ref PERSISTANT pour
+  // toute la durée de vie du hook (au lieu d'éphémère post + close à chaque
+  // logout). Élimine la race postMessage/close (postMessage async + close
+  // sync immédiat → Firefox a historiquement abandonné des messages). Le
+  // channel est créé au mount + posté via ref dans logout + closed au
+  // unmount du hook uniquement.
+  const channelRef = useRef<BroadcastChannel | null>(null)
 
   // Issue #450 follow-up review HSA M2 PR #449 — listener cross-tab logout.
   // Si un AUTRE tab logout, on cleanup local (sessionStorage clear + redirect
@@ -278,17 +309,23 @@ export function useAuth() {
       return
     }
     const channel = new BroadcastChannel(AUTH_CHANNEL_NAME)
-    const ownTabId = tabIdRef.current
+    channelRef.current = channel
     channel.onmessage = (event: MessageEvent<AuthBroadcastMessage>) => {
-      if (event.data?.type !== "logout") return
+      const data = event.data
+      if (data?.type !== "logout") return
+      // Fix M1 round 2 review PR #451 — validation runtime `from` typeof
+      // string. Sans ça, `{type: "logout", from: null}` passe filtre (null
+      // !== string ownTabId) → cleanup déclenché par message malformé.
+      if (typeof data.from !== "string") return
       // Filtre défensif : ignorer ses propres broadcasts (cf. doc `from`).
-      if (event.data.from === ownTabId) return
-      applyLogoutLocalCleanup((path) => router.replace(path))
+      if (data.from === tabId) return
+      applyLogoutLocalCleanup((path) => routerRef.current.replace(path))
     }
     return () => {
       channel.close()
+      channelRef.current = null
     }
-  }, [router])
+  }, [tabId])
 
   const logout = useCallback(async () => {
     // Fix Issue #446 (US-2076-UI iter 4 PR #444 follow-up) + reviews PR #449
@@ -342,15 +379,19 @@ export function useAuth() {
       // que tous les tabs cleanup en parallèle (latence cross-tab minimisée).
       // Seul l'initiateur du logout broadcast → pas de loop (les listeners
       // appellent `applyLogoutLocalCleanup` sans ré-émettre).
-      if (typeof window !== "undefined" && typeof BroadcastChannel !== "undefined") {
+      //
+      // Fix H1 round 2 review PR #451 — utilise `channelRef.current`
+      // persistant (créé au mount) au lieu d'un channel éphémère post+close.
+      // Élimine race postMessage async / close sync immédiat (Firefox a
+      // historiquement abandonné des messages avec ce pattern).
+      const channel = channelRef.current
+      if (channel) {
         try {
-          const channel = new BroadcastChannel(AUTH_CHANNEL_NAME)
           channel.postMessage({
             type: "logout",
-            from: tabIdRef.current,
+            from: tabId,
             at: Date.now(),
           } satisfies AuthBroadcastMessage)
-          channel.close()
         } catch (err) {
           // Fire-and-forget : si broadcast fail (browser quirk), le cleanup
           // local du tab initiateur fonctionne toujours. Les autres tabs
@@ -364,10 +405,10 @@ export function useAuth() {
       // Push conserve l'historique → back button → flash PHI dashboard cached
       // avant que middleware re-redirect. Sur poste partagé cabinet = leak
       // visuel. `replace` invalide le history entry courant.
-      applyLogoutLocalCleanup((path) => router.replace(path))
+      applyLogoutLocalCleanup((path) => routerRef.current.replace(path))
       isLoggingOutRef.current = false
     }
-  }, [router])
+  }, [tabId])
 
   return { login, logout, isLoading, error, setError }
 }

--- a/tests/unit/use-auth-broadcast.test.tsx
+++ b/tests/unit/use-auth-broadcast.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  *
  * Tests pour Issue #450 — cross-tab logout sync via `BroadcastChannel("diabeo:auth")`
- * (follow-up review HSA M2 PR #449).
+ * (follow-up review HSA M2 PR #449 + round 2 reviews PR #451).
  *
  * **Risque HDS Art. L.1111-8 résolu** : sur poste partagé cabinet multi-PS,
  * si PS A logout dans tab 1 mais laisse tab 2 ouvert, ce dernier peut
@@ -37,7 +37,7 @@ vi.mock("next-intl", () => ({
   useTranslations: () => (k: string) => k,
 }))
 
-describe("useAuth — cross-tab logout sync (Issue #450)", () => {
+describe("useAuth — cross-tab logout sync (Issue #450 + round 2 PR #451)", () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>
   let unregisterSpy: ReturnType<typeof vi.spyOn>
 
@@ -56,17 +56,14 @@ describe("useAuth — cross-tab logout sync (Issue #450)", () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   // -------------------------------------------------------------------------
-  // Broadcast émission lors du logout
+  // Broadcast émission lors du logout (Fix M2 round 2 : waitFor vs setTimeout)
   // -------------------------------------------------------------------------
 
   it("logout() broadcast un message {type: 'logout', from, at} après cleanup", async () => {
-    // On crée un listener SPY sur un channel distinct (simule "autre tab")
-    // monté AVANT le logout. BroadcastChannel jsdom envoie aussi à ses
-    // propres listeners — donc le `from` doit être DIFFÉRENT pour qu'on le
-    // capture comme "autre tab".
     const otherTabMessages: Array<{ type: string; from: string; at: number }> = []
     const otherTabChannel = new BroadcastChannel("diabeo:auth")
     otherTabChannel.onmessage = (event) => {
@@ -78,7 +75,8 @@ describe("useAuth — cross-tab logout sync (Issue #450)", () => {
       await result.current.logout()
     })
 
-    // Vérifier qu'un message logout a bien été broadcasté.
+    // Fix M2 round 2 : waitFor au lieu de `await new Promise(r => setTimeout(r, 20))`
+    // (flaky en CI sous charge). waitFor retry jusqu'à timeout par défaut 1s.
     await waitFor(() => expect(otherTabMessages.length).toBeGreaterThan(0))
     const msg = otherTabMessages.find((m) => m.type === "logout")
     expect(msg).toBeDefined()
@@ -95,11 +93,9 @@ describe("useAuth — cross-tab logout sync (Issue #450)", () => {
   // -------------------------------------------------------------------------
 
   it("tab 2 reçoit broadcast logout d'un autre tab → cleanup local (replace /login + clear sessionStorage)", async () => {
-    // Mount du hook "tab 2" → installe listener BroadcastChannel.
     sessionStorage.setItem("diabeo_session_start", "999")
     renderHook(() => useAuth())
 
-    // Simule un broadcast depuis un AUTRE tab (with different `from` id).
     const senderChannel = new BroadcastChannel("diabeo:auth")
     await act(async () => {
       senderChannel.postMessage({
@@ -107,12 +103,9 @@ describe("useAuth — cross-tab logout sync (Issue #450)", () => {
         from: "other-tab-id-xyz",
         at: Date.now(),
       })
-      // Petite attente pour propagation event loop BroadcastChannel.
-      await new Promise((r) => setTimeout(r, 20))
     })
 
-    // Tab 2 doit avoir cleanup local SANS appeler logout() complet
-    // (pas de POST /api/auth/logout, pas de DELETE FCM, pas de SW unregister).
+    // Fix M2 round 2 : waitFor robuste vs setTimeout arbitraire.
     await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/login"))
     expect(sessionStorage.getItem("diabeo_session_start")).toBeNull()
 
@@ -125,19 +118,67 @@ describe("useAuth — cross-tab logout sync (Issue #450)", () => {
 
   // -------------------------------------------------------------------------
   // Anti-loop : tab initiateur ignore son propre broadcast
+  // (Fix H2 round 2 : test efficace — capture le `from` réellement envoyé
+  // puis simule un message ENTRANT avec le MÊME `from` pour valider que le
+  // filtre `from === ownTabId` est réellement actif)
   // -------------------------------------------------------------------------
 
-  it("tab initiateur ignore son propre broadcast (anti-loop via from === ownTabId)", async () => {
-    const { result } = renderHook(() => useAuth())
+  it("Fix H2 — tab initiateur ignore son propre broadcast (anti-loop via from === ownTabId réellement filtré)", async () => {
+    // Capture le tabId réel via le broadcast émis lors du logout.
+    let capturedTabId: string | null = null
+    const spyChannel = new BroadcastChannel("diabeo:auth")
+    spyChannel.onmessage = (event) => {
+      if (event.data?.type === "logout" && typeof event.data.from === "string") {
+        capturedTabId = event.data.from
+      }
+    }
 
+    const { result } = renderHook(() => useAuth())
     await act(async () => {
       await result.current.logout()
     })
 
-    // logout() complet broadcast + cleanup local — DOIT appeler replace
-    // exactement 1 fois (sa propre exécution finally), pas 2 (si listener
-    // se déclenchait aussi sur son propre broadcast).
-    await waitFor(() => expect(mockReplace).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(capturedTabId).not.toBeNull())
+    const replaceCallsAfterLogout = mockReplace.mock.calls.length
+    expect(replaceCallsAfterLogout).toBe(1) // 1 appel via finally local
+
+    // Maintenant simule un message ENTRANT avec exactement le même tabId
+    // que celui que ce hook a émis → le listener DOIT l'ignorer (sinon
+    // replace serait appelé une 2e fois).
+    await act(async () => {
+      spyChannel.postMessage({
+        type: "logout",
+        from: capturedTabId,
+        at: Date.now() + 10,
+      })
+    })
+
+    // Attente robuste pour propagation — replace doit rester à 1 appel.
+    // On utilise waitFor avec un délai borné pour permettre à un éventuel
+    // listener bogué de déclencher (et faire échouer le test si filtre cassé).
+    await new Promise((r) => setTimeout(r, 50))
+    expect(mockReplace).toHaveBeenCalledTimes(replaceCallsAfterLogout)
+
+    spyChannel.close()
+  })
+
+  // -------------------------------------------------------------------------
+  // Validation runtime — message malformé (Fix M1 round 2)
+  // -------------------------------------------------------------------------
+
+  it("Fix M1 — message broadcast avec from null (malformé) → ignoré", async () => {
+    renderHook(() => useAuth())
+
+    const sender = new BroadcastChannel("diabeo:auth")
+    await act(async () => {
+      // `from: null` : passerait le filtre `from === ownTabId` (null !== string)
+      // sans la guard `typeof from !== "string"` introduite en round 2.
+      sender.postMessage({ type: "logout", from: null, at: Date.now() })
+    })
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(mockReplace).not.toHaveBeenCalled()
+    sender.close()
   })
 
   // -------------------------------------------------------------------------
@@ -151,10 +192,9 @@ describe("useAuth — cross-tab logout sync (Issue #450)", () => {
     const sender = new BroadcastChannel("diabeo:auth")
     await act(async () => {
       sender.postMessage({ type: "other-event", payload: 42 })
-      await new Promise((r) => setTimeout(r, 20))
     })
 
-    // Pas de cleanup local pour message non-logout.
+    await new Promise((r) => setTimeout(r, 50))
     expect(mockReplace).not.toHaveBeenCalled()
     expect(sessionStorage.getItem("diabeo_session_start")).toBe("555")
 
@@ -169,8 +209,6 @@ describe("useAuth — cross-tab logout sync (Issue #450)", () => {
     const { unmount } = renderHook(() => useAuth())
     unmount()
 
-    // Après unmount, un broadcast logout d'un autre tab ne doit PLUS
-    // déclencher de cleanup (channel closed, listener détaché).
     const sender = new BroadcastChannel("diabeo:auth")
     await act(async () => {
       sender.postMessage({
@@ -178,32 +216,63 @@ describe("useAuth — cross-tab logout sync (Issue #450)", () => {
         from: "other-tab-after-unmount",
         at: Date.now(),
       })
-      await new Promise((r) => setTimeout(r, 20))
     })
 
+    await new Promise((r) => setTimeout(r, 50))
     expect(mockReplace).not.toHaveBeenCalled()
     sender.close()
   })
 
   // -------------------------------------------------------------------------
   // Graceful fallback : BroadcastChannel non supporté
+  // (Fix L2 round 2 : vi.stubGlobal au lieu de delete global.X)
   // -------------------------------------------------------------------------
 
   it("BroadcastChannel non supporté → logout fonctionne quand même (graceful fallback)", async () => {
-    const originalBC = global.BroadcastChannel
-    // @ts-expect-error — simulate absence dans vieux navigateurs.
-    delete global.BroadcastChannel
+    // Fix L2 round 2 : `vi.stubGlobal` + `vi.unstubAllGlobals()` dans afterEach
+    // au lieu de `delete global.BroadcastChannel` (isolation test, restore
+    // garanti même si test throw).
+    vi.stubGlobal("BroadcastChannel", undefined)
 
-    try {
-      const { result } = renderHook(() => useAuth())
-      await act(async () => {
-        await result.current.logout()
-      })
+    const { result } = renderHook(() => useAuth())
+    await act(async () => {
+      await result.current.logout()
+    })
 
-      // Logout local doit fonctionner même sans BroadcastChannel.
-      await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/login"))
-    } finally {
-      global.BroadcastChannel = originalBC
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/login"))
+  })
+
+  // -------------------------------------------------------------------------
+  // Concurrent dual-logout 2 tabs simultanés (Fix M3 round 2)
+  // -------------------------------------------------------------------------
+
+  it("Fix M3 — 2 tabs logout simultanés → chaque tab cleanup exactement 1 fois (idempotent)", async () => {
+    // Simule 2 hooks distincts (= 2 tabs ouverts par le même PS).
+    const { result: tab1 } = renderHook(() => useAuth())
+    const { result: tab2 } = renderHook(() => useAuth())
+
+    // Les 2 tabs cliquent logout SIMULTANÉMENT.
+    await act(async () => {
+      await Promise.all([tab1.current.logout(), tab2.current.logout()])
+    })
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalled())
+    // Petite attente pour permettre aux broadcasts cross-tab de se propager.
+    await new Promise((r) => setTimeout(r, 50))
+
+    // Comportement attendu :
+    //   - tab1 broadcast → tab2 reçoit (autre from) → tab2 listener cleanup local
+    //     MAIS tab2 a déjà fait son cleanup local via son propre finally
+    //   - inverse pour tab2 → tab1
+    // Total replace : 2 calls minimum (1 par finally) ; cleanup local
+    // additionnel listener idempotent (sessionStorage déjà cleared, router.replace
+    // appelé sur même path = no-op visuel Next.js).
+    // Le test garantit qu'on n'a PAS de boucle infinie (sinon dépasserait 4).
+    expect(mockReplace.mock.calls.length).toBeGreaterThanOrEqual(2)
+    expect(mockReplace.mock.calls.length).toBeLessThanOrEqual(4)
+    // Tous les replace doivent cibler /login (pas de URL corruption).
+    for (const call of mockReplace.mock.calls) {
+      expect(call[0]).toBe("/login")
     }
   })
 })

--- a/tests/unit/use-auth-broadcast.test.tsx
+++ b/tests/unit/use-auth-broadcast.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests pour Issue #450 — cross-tab logout sync via `BroadcastChannel("diabeo:auth")`
+ * (follow-up review HSA M2 PR #449).
+ *
+ * **Risque HDS Art. L.1111-8 résolu** : sur poste partagé cabinet multi-PS,
+ * si PS A logout dans tab 1 mais laisse tab 2 ouvert, ce dernier peut
+ * ré-register un token FCM via `useMessagingPush` mount cycle (annulant le
+ * cleanup tab 1). PS B login peu après → tokens PS A persistent sous identité
+ * PS A → cron messagerie push arrive à device PS A après son logout.
+ *
+ * Solution : `BroadcastChannel("diabeo:auth")` partagé entre tous les tabs.
+ * Le tab initiateur du logout broadcast `{type: "logout", from: tabId, at}` ;
+ * les autres tabs cleanup local (sessionStorage clear + replace `/login`) sans
+ * ré-émettre (anti-loop : seul l'initiateur broadcast).
+ *
+ * **Filtrage `from === ownTabId`** : la spec browser dit que sender ne reçoit
+ * pas, mais Node `worker_threads.BroadcastChannel` (jsdom) renvoie au sender.
+ * Filtre défensif requis pour portabilité.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, act, waitFor } from "@testing-library/react"
+import { useAuth } from "@/hooks/use-auth"
+import * as swLifecycleModule from "@/lib/messaging/sw-lifecycle"
+
+// Mock next/navigation router — capture replace + push.
+const mockReplace = vi.fn()
+const mockPush = vi.fn()
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+}))
+
+// Mock next-intl translations.
+vi.mock("next-intl", () => ({
+  useTranslations: () => (k: string) => k,
+}))
+
+describe("useAuth — cross-tab logout sync (Issue #450)", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+  let unregisterSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    mockReplace.mockReset()
+    mockPush.mockReset()
+    unregisterSpy = vi
+      .spyOn(swLifecycleModule, "unregisterMessagingServiceWorker")
+      .mockResolvedValue({ unregistered: true })
+    fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as Response)
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // -------------------------------------------------------------------------
+  // Broadcast émission lors du logout
+  // -------------------------------------------------------------------------
+
+  it("logout() broadcast un message {type: 'logout', from, at} après cleanup", async () => {
+    // On crée un listener SPY sur un channel distinct (simule "autre tab")
+    // monté AVANT le logout. BroadcastChannel jsdom envoie aussi à ses
+    // propres listeners — donc le `from` doit être DIFFÉRENT pour qu'on le
+    // capture comme "autre tab".
+    const otherTabMessages: Array<{ type: string; from: string; at: number }> = []
+    const otherTabChannel = new BroadcastChannel("diabeo:auth")
+    otherTabChannel.onmessage = (event) => {
+      otherTabMessages.push(event.data)
+    }
+
+    const { result } = renderHook(() => useAuth())
+    await act(async () => {
+      await result.current.logout()
+    })
+
+    // Vérifier qu'un message logout a bien été broadcasté.
+    await waitFor(() => expect(otherTabMessages.length).toBeGreaterThan(0))
+    const msg = otherTabMessages.find((m) => m.type === "logout")
+    expect(msg).toBeDefined()
+    expect(msg?.from).toBeTypeOf("string")
+    expect(msg?.from.length).toBeGreaterThan(0)
+    expect(msg?.at).toBeTypeOf("number")
+    expect(msg?.at).toBeGreaterThan(0)
+
+    otherTabChannel.close()
+  })
+
+  // -------------------------------------------------------------------------
+  // Listener cross-tab — autre tab reçoit logout → cleanup local
+  // -------------------------------------------------------------------------
+
+  it("tab 2 reçoit broadcast logout d'un autre tab → cleanup local (replace /login + clear sessionStorage)", async () => {
+    // Mount du hook "tab 2" → installe listener BroadcastChannel.
+    sessionStorage.setItem("diabeo_session_start", "999")
+    renderHook(() => useAuth())
+
+    // Simule un broadcast depuis un AUTRE tab (with different `from` id).
+    const senderChannel = new BroadcastChannel("diabeo:auth")
+    await act(async () => {
+      senderChannel.postMessage({
+        type: "logout",
+        from: "other-tab-id-xyz",
+        at: Date.now(),
+      })
+      // Petite attente pour propagation event loop BroadcastChannel.
+      await new Promise((r) => setTimeout(r, 20))
+    })
+
+    // Tab 2 doit avoir cleanup local SANS appeler logout() complet
+    // (pas de POST /api/auth/logout, pas de DELETE FCM, pas de SW unregister).
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/login"))
+    expect(sessionStorage.getItem("diabeo_session_start")).toBeNull()
+
+    // Critique : pas d'appel logout() complet (pas de side-effect backend).
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(unregisterSpy).not.toHaveBeenCalled()
+
+    senderChannel.close()
+  })
+
+  // -------------------------------------------------------------------------
+  // Anti-loop : tab initiateur ignore son propre broadcast
+  // -------------------------------------------------------------------------
+
+  it("tab initiateur ignore son propre broadcast (anti-loop via from === ownTabId)", async () => {
+    const { result } = renderHook(() => useAuth())
+
+    await act(async () => {
+      await result.current.logout()
+    })
+
+    // logout() complet broadcast + cleanup local — DOIT appeler replace
+    // exactement 1 fois (sa propre exécution finally), pas 2 (si listener
+    // se déclenchait aussi sur son propre broadcast).
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledTimes(1))
+  })
+
+  // -------------------------------------------------------------------------
+  // Message non-logout ignoré
+  // -------------------------------------------------------------------------
+
+  it("message broadcast non-logout → ignoré (pas de side-effect)", async () => {
+    sessionStorage.setItem("diabeo_session_start", "555")
+    renderHook(() => useAuth())
+
+    const sender = new BroadcastChannel("diabeo:auth")
+    await act(async () => {
+      sender.postMessage({ type: "other-event", payload: 42 })
+      await new Promise((r) => setTimeout(r, 20))
+    })
+
+    // Pas de cleanup local pour message non-logout.
+    expect(mockReplace).not.toHaveBeenCalled()
+    expect(sessionStorage.getItem("diabeo_session_start")).toBe("555")
+
+    sender.close()
+  })
+
+  // -------------------------------------------------------------------------
+  // Cleanup channel au unmount
+  // -------------------------------------------------------------------------
+
+  it("listener BroadcastChannel close()é au unmount du hook (pas de fuite)", async () => {
+    const { unmount } = renderHook(() => useAuth())
+    unmount()
+
+    // Après unmount, un broadcast logout d'un autre tab ne doit PLUS
+    // déclencher de cleanup (channel closed, listener détaché).
+    const sender = new BroadcastChannel("diabeo:auth")
+    await act(async () => {
+      sender.postMessage({
+        type: "logout",
+        from: "other-tab-after-unmount",
+        at: Date.now(),
+      })
+      await new Promise((r) => setTimeout(r, 20))
+    })
+
+    expect(mockReplace).not.toHaveBeenCalled()
+    sender.close()
+  })
+
+  // -------------------------------------------------------------------------
+  // Graceful fallback : BroadcastChannel non supporté
+  // -------------------------------------------------------------------------
+
+  it("BroadcastChannel non supporté → logout fonctionne quand même (graceful fallback)", async () => {
+    const originalBC = global.BroadcastChannel
+    // @ts-expect-error — simulate absence dans vieux navigateurs.
+    delete global.BroadcastChannel
+
+    try {
+      const { result } = renderHook(() => useAuth())
+      await act(async () => {
+        await result.current.logout()
+      })
+
+      // Logout local doit fonctionner même sans BroadcastChannel.
+      await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/login"))
+    } finally {
+      global.BroadcastChannel = originalBC
+    }
+  })
+})


### PR DESCRIPTION
Closes #450 — follow-up review HSA M2 PR #449 (Issue #446 logout flow).

## Contexte

Sur poste partagé cabinet multi-PS (HDS Art. L.1111-8 gestion fin de session), si PS A logout dans tab 1 mais laisse tab 2 ouvert :
- tokens DELETE backend côté tab 1 → mais tab 2 toujours actif peut ré-register un token FCM via \`useMessagingPush\` mount cycle
- PS B login peu après → token PS A persiste sous identité PS A
- cron messagerie push arrive à device PS A après son logout

## Solution

\`BroadcastChannel("diabeo:auth")\` partagé entre tous les tabs. Le tab initiateur du logout post un message \`{type, from, at}\` après cleanup backend ; les autres tabs cleanup local (sessionStorage clear + replace \`/login\`) sans ré-émettre (anti-loop : seul l'initiateur broadcast).

## Implementation

- \`useAuth\` mount un listener \`BroadcastChannel("diabeo:auth")\` qui filtre les messages \`type === "logout"\` ET \`from !== ownTabId\`. Helper \`applyLogoutLocalCleanup\` factor le cleanup réutilisé entre listener cross-tab et finally du logout initiateur.
- \`logout()\` post le broadcast dans le \`finally\` (après la chaîne POST→[DELETE,SW]). Wrap dans try/catch + \`logHookError({alwaysLog: true})\` cohérent C1 PR #449.
- \`tabIdRef\` = random + Date.now base36 (pas sécurité, juste désambiguïsation). Filtre \`from === ownTabId\` défensif : spec browser dit que sender ne reçoit pas, mais Node \`worker_threads.BroadcastChannel\` (jsdom + Edge runtime futur) renvoie au sender → portabilité.
- Graceful fallback si \`BroadcastChannel === "undefined"\` (vieux Safari/IE ou SSR Node).

## Tests

2764/2764 verts (+6 nouveaux \`use-auth-broadcast.test.tsx\`) :
- Broadcast émis avec type/from/at après logout
- Tab 2 reçoit logout d'un autre tab → cleanup local SANS appel backend (assert pas de POST/DELETE/SW)
- Tab initiateur ignore son propre broadcast (anti-loop via from === ownTabId)
- Message non-logout ignoré (pas de side-effect)
- Listener close() au unmount du hook (pas de fuite)
- Graceful fallback si BroadcastChannel non supporté

## Test plan

- [x] Tests unit \`use-auth-broadcast.test.tsx\` × 6 + \`use-auth-logout.test.tsx\` × 9
- [x] Lint clean
- [x] \`tsc --noEmit\` clean
- [x] Full suite 2764/2764 verts
- [ ] Test manuel multi-tab cabinet (ouvrir 2 tabs \`/messages\` → logout dans 1 → vérifier que tab 2 redirige automatiquement vers \`/login\` en < 100ms)
- [ ] E2E Playwright cross-context (limité : BroadcastChannel ne traverse pas \`context.newContext()\` par défaut, à voir Issue #448)

## Runbook

Section M2 marquée RÉSOLU + pattern documenté + limite résiduelle (SAME-ORIGIN/same-profile uniquement, pas un cas réel sur poste cabinet).

## Références

- Issue #450 (créée PR #449 review HSA M2)
- PR #449 logout flow FCM cleanup
- Issue #446 + PR #449 contexte HDS Art. L.1111-8
- \`docs/runbook/messaging-logout.md\` section "Limites connues — M2"

🤖 Generated with [Claude Code](https://claude.com/claude-code)