### PR TITLE
feat(admin): iter 2 — System Health + Backups UI (Plan B 2/5)

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1006,6 +1006,8 @@
     "documents": "المستندات",
     "settings": "الإعدادات",
     "adminDataBreaches": "انتهاكات اللائحة الأوروبية",
+    "adminSystemHealth": "صحة النظام",
+    "adminBackups": "نسخ احتياطية",
     "logout": "تسجيل الخروج"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1006,6 +1006,8 @@
     "documents": "Documents",
     "settings": "Settings",
     "adminDataBreaches": "GDPR breaches",
+    "adminSystemHealth": "System health",
+    "adminBackups": "DB backups",
     "logout": "Sign out"
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1006,6 +1006,8 @@
     "documents": "Documents",
     "settings": "Parametres",
     "adminDataBreaches": "Violations RGPD",
+    "adminSystemHealth": "Sante systeme",
+    "adminBackups": "Backups DB",
     "logout": "Se deconnecter"
   }
 }

--- a/src/app/(dashboard)/admin/backups/page.tsx
+++ b/src/app/(dashboard)/admin/backups/page.tsx
@@ -1,0 +1,28 @@
+/**
+ * US-2151 Admin gestion backups PostgreSQL (page conteneur).
+ *
+ * ADMIN-only. Liste des backups + filtres status + déclenchement nouveau backup.
+ * Backend : `backupService` (PR #409). Routes : GET/POST `/api/admin/backups`.
+ */
+import { headers } from "next/headers"
+import { redirect } from "next/navigation"
+import { BackupsListClient } from "@/components/diabeo/admin/BackupsListClient"
+
+export default async function BackupsPage() {
+  const headersList = await headers()
+  const role = headersList.get("x-user-role")
+  if (role !== "ADMIN") redirect("/")
+
+  return (
+    <main className="flex flex-col gap-6 p-4 lg:p-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Backups PostgreSQL</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Historique des backups DB + déclenchement manuel. Backup automatique
+          quotidien via cron (cf. <code>docs/runbook/postgres-backup.md</code>).
+        </p>
+      </header>
+      <BackupsListClient />
+    </main>
+  )
+}

--- a/src/app/(dashboard)/admin/system-health/page.tsx
+++ b/src/app/(dashboard)/admin/system-health/page.tsx
@@ -1,0 +1,30 @@
+/**
+ * US-2150 Dashboard santé système (page conteneur).
+ *
+ * ADMIN-only. Vue temps-réel : DB / Redis / CGM ingestion lag / backups
+ * freshness / active sessions / unauthorized attempts 24h.
+ *
+ * Backend : `systemHealthService.snapshot` (PR #409 Groupe 9 Admin/Ops).
+ */
+import { headers } from "next/headers"
+import { redirect } from "next/navigation"
+import { SystemHealthClient } from "@/components/diabeo/admin/SystemHealthClient"
+
+export default async function SystemHealthPage() {
+  const headersList = await headers()
+  const role = headersList.get("x-user-role")
+  if (role !== "ADMIN") redirect("/")
+
+  return (
+    <main className="flex flex-col gap-6 p-4 lg:p-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Santé système</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          État temps-réel des composants critiques (DB, Redis, CGM, backups).
+          Refresh automatique toutes les 60s.
+        </p>
+      </header>
+      <SystemHealthClient />
+    </main>
+  )
+}

--- a/src/components/diabeo/Sidebar.tsx
+++ b/src/components/diabeo/Sidebar.tsx
@@ -18,6 +18,8 @@ import {
   Activity,
   Pill,
   ShieldAlert,
+  HardDrive,
+  Heart,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useAuth } from "@/hooks/use-auth"
@@ -43,6 +45,9 @@ const navItems: ReadonlyArray<NavItem> = [
   // Le gate côté server "/admin/data-breaches/page.tsx" redirige vers "/"
   // pour non-ADMIN, donc cacher l'item côté Sidebar évite la confusion UX.
   { href: "/admin/data-breaches", labelKey: "adminDataBreaches", icon: ShieldAlert, roles: ["ADMIN"] },
+  // US-2150 + US-2151 (iter 2 PR Plan B) — ADMIN ops monitoring.
+  { href: "/admin/system-health", labelKey: "adminSystemHealth", icon: Heart, roles: ["ADMIN"] },
+  { href: "/admin/backups", labelKey: "adminBackups", icon: HardDrive, roles: ["ADMIN"] },
 ]
 
 /**

--- a/src/components/diabeo/admin/BackupsListClient.tsx
+++ b/src/components/diabeo/admin/BackupsListClient.tsx
@@ -1,0 +1,340 @@
+"use client"
+
+/**
+ * BackupsListClient — UI US-2151 Admin gestion backups (ADMIN-only).
+ *
+ * Liste backups + filtres status + bouton "Déclencher backup" (POST).
+ * Le worker externe (cron) consomme les rows pending. UI affiche state +
+ * permet de relancer si pending stuck.
+ *
+ * Backend : `backupService.list/trigger` (PR #409). Pas de restore exposé
+ * iter 2 (procédure ops manuelle documentée runbook).
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useLocale } from "next-intl"
+import {
+  AlertCircle,
+  CheckCircle2,
+  Clock,
+  Database,
+  HardDrive,
+  Loader2,
+  Plus,
+  RefreshCw,
+  XCircle,
+} from "lucide-react"
+import { DiabeoButton } from "@/components/diabeo/DiabeoButton"
+import { Badge } from "@/components/ui/badge"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { formatDate } from "@/lib/intl/formatters"
+import type { Locale } from "@/i18n/config"
+
+type BackupStatus = "pending" | "running" | "completed" | "failed"
+
+interface BackupLogDTO {
+  id: number
+  backupRef: string
+  status: BackupStatus
+  location: string | null
+  sizeBytes: number | null // BigInt sérialisé number
+  durationMs: number | null
+  triggeredBy: number | null
+  startedAt: string // ISO
+  completedAt: string | null
+  errorMessage: string | null
+}
+
+type AsyncState = "idle" | "loading" | "success" | "error"
+
+const STATUS_LABELS: Record<BackupStatus, string> = {
+  pending: "En attente",
+  running: "En cours",
+  completed: "Terminé",
+  failed: "Échoué",
+}
+
+const STATUS_VARIANT: Record<BackupStatus, "default" | "secondary" | "destructive" | "outline"> = {
+  pending: "secondary",
+  running: "outline",
+  completed: "default",
+  failed: "destructive",
+}
+
+function StatusIcon({ status, className }: { status: BackupStatus; className?: string }) {
+  if (status === "completed") return <CheckCircle2 className={className} aria-hidden="true" />
+  if (status === "running") return <Loader2 className={`${className ?? ""} animate-spin`} aria-hidden="true" />
+  if (status === "failed") return <XCircle className={className} aria-hidden="true" />
+  return <Clock className={className} aria-hidden="true" />
+}
+
+/**
+ * Formate sizeBytes en KB/MB/GB lisible.
+ */
+function formatBytes(bytes: number | null): string {
+  if (bytes === null || bytes === 0) return "—"
+  const units = ["B", "KB", "MB", "GB", "TB"]
+  let size = bytes
+  let unitIdx = 0
+  while (size >= 1024 && unitIdx < units.length - 1) {
+    size /= 1024
+    unitIdx++
+  }
+  return `${size.toFixed(unitIdx === 0 ? 0 : 1)} ${units[unitIdx]}`
+}
+
+/**
+ * Formate durationMs en secondes/minutes.
+ */
+function formatDuration(ms: number | null): string {
+  if (ms === null) return "—"
+  if (ms < 1000) return `${ms} ms`
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)} s`
+  return `${Math.floor(ms / 60_000)} min ${Math.floor((ms % 60_000) / 1000)} s`
+}
+
+export function BackupsListClient() {
+  const locale = useLocale() as Locale
+  const [backups, setBackups] = useState<BackupLogDTO[]>([])
+  const [state, setState] = useState<AsyncState>("idle")
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [filterStatus, setFilterStatus] = useState<BackupStatus | "all">("all")
+  const [showTriggerConfirm, setShowTriggerConfirm] = useState(false)
+  const [triggerState, setTriggerState] = useState<AsyncState>("idle")
+  const [triggerError, setTriggerError] = useState<string | null>(null)
+
+  const mountedRef = useRef(true)
+  const abortRef = useRef<AbortController | null>(null)
+  const fetchSeqRef = useRef(0)
+
+  const fetchBackups = useCallback(async () => {
+    if (abortRef.current) abortRef.current.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+    const seq = ++fetchSeqRef.current
+    setState("loading")
+    setErrorMessage(null)
+    try {
+      const params = new URLSearchParams()
+      if (filterStatus !== "all") params.set("status", filterStatus)
+      const url = `/api/admin/backups${params.toString() ? `?${params.toString()}` : ""}`
+      const res = await fetch(url, { credentials: "include", signal: controller.signal })
+      if (seq !== fetchSeqRef.current || !mountedRef.current) return
+      if (!res.ok) {
+        setState("error")
+        setErrorMessage(`HTTP ${res.status}`)
+        return
+      }
+      const data = (await res.json()) as { items?: BackupLogDTO[]; nextCursor?: number }
+      if (seq !== fetchSeqRef.current || !mountedRef.current) return
+      setBackups(data.items ?? [])
+      setState("success")
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return
+      if (seq !== fetchSeqRef.current || !mountedRef.current) return
+      setState("error")
+      setErrorMessage(err instanceof Error ? err.message : "Erreur réseau")
+    }
+  }, [filterStatus])
+
+  useEffect(() => {
+    mountedRef.current = true
+    // fetchBackups recapture filterStatus via useCallback — re-triggered au
+    // changement de filtre. AbortController + fetchSeq gèrent race condition.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void fetchBackups()
+    return () => {
+      mountedRef.current = false
+      if (abortRef.current) abortRef.current.abort()
+    }
+  }, [fetchBackups])
+
+  const executeTrigger = useCallback(async () => {
+    setShowTriggerConfirm(false)
+    setTriggerState("loading")
+    setTriggerError(null)
+    try {
+      const res = await fetch("/api/admin/backups", {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Requested-With": "XMLHttpRequest",
+        },
+      })
+      if (!mountedRef.current) return
+      if (res.status === 409) {
+        setTriggerState("error")
+        setTriggerError("Un backup est déjà en cours. Réessayer plus tard.")
+        return
+      }
+      if (!res.ok) {
+        setTriggerState("error")
+        setTriggerError(`HTTP ${res.status}`)
+        return
+      }
+      setTriggerState("success")
+      await fetchBackups()
+      // Reset state success après 3s.
+      setTimeout(() => {
+        if (mountedRef.current) setTriggerState("idle")
+      }, 3000)
+    } catch (err) {
+      if (!mountedRef.current) return
+      setTriggerState("error")
+      setTriggerError(err instanceof Error ? err.message : "Erreur réseau")
+    }
+  }, [fetchBackups])
+
+  return (
+    <>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <label className="flex items-center gap-1 text-sm">
+          <span className="text-muted-foreground">Statut :</span>
+          <select
+            value={filterStatus}
+            onChange={(e) => setFilterStatus(e.target.value as BackupStatus | "all")}
+            className="rounded-md border bg-background px-2 py-1 text-sm"
+            aria-label="Filtrer par statut backup"
+          >
+            <option value="all">Tous</option>
+            {Object.entries(STATUS_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div className="flex items-center gap-2">
+          <DiabeoButton variant="diabeoTertiary" size="sm" onClick={() => void fetchBackups()}>
+            <RefreshCw className="size-3.5 mr-1" aria-hidden="true" />
+            Actualiser
+          </DiabeoButton>
+          <DiabeoButton onClick={() => setShowTriggerConfirm(true)} disabled={triggerState === "loading"}>
+            <Plus className="size-4 mr-1" aria-hidden="true" />
+            Déclencher backup
+          </DiabeoButton>
+        </div>
+      </div>
+
+      {triggerState === "error" && triggerError && (
+        <div role="alert" className="rounded-md border border-destructive/20 bg-destructive/10 p-3 text-sm">
+          <p className="text-destructive flex items-center gap-2">
+            <AlertCircle className="size-4" aria-hidden="true" />
+            {triggerError}
+          </p>
+        </div>
+      )}
+
+      {triggerState === "success" && (
+        <div role="status" aria-live="polite" className="rounded-md border border-primary/20 bg-primary/5 p-3 text-sm">
+          <p className="flex items-center gap-2 text-primary">
+            <CheckCircle2 className="size-4" aria-hidden="true" />
+            Backup déclenché (status: pending). Le worker le consommera bientôt.
+          </p>
+        </div>
+      )}
+
+      {state === "loading" && backups.length === 0 && (
+        <p className="text-sm text-muted-foreground" aria-live="polite">
+          Chargement…
+        </p>
+      )}
+
+      {state === "error" && backups.length === 0 && (
+        <div role="alert" className="rounded-md border border-destructive/20 bg-destructive/10 p-3 text-sm">
+          <p className="font-medium text-destructive flex items-center gap-2">
+            <AlertCircle className="size-4" aria-hidden="true" />
+            Liste indisponible
+          </p>
+          {errorMessage && <p className="text-xs text-muted-foreground mt-1">{errorMessage}</p>}
+          <DiabeoButton variant="diabeoTertiary" size="sm" onClick={() => void fetchBackups()} className="mt-2">
+            Réessayer
+          </DiabeoButton>
+        </div>
+      )}
+
+      {state === "success" && backups.length === 0 && (
+        <div className="rounded-md border border-dashed p-8 text-center">
+          <HardDrive className="size-8 text-muted-foreground mx-auto mb-2" aria-hidden="true" />
+          <p className="text-sm text-muted-foreground">Aucun backup enregistré.</p>
+        </div>
+      )}
+
+      {backups.length > 0 && (
+        <ul className="space-y-2" aria-label="Liste des backups">
+          {backups.map((backup) => (
+            <li
+              key={backup.id}
+              className={`rounded-md border p-3 ${
+                backup.status === "failed" ? "border-destructive/40 bg-destructive/5" : "border-border"
+              }`}
+            >
+              <div className="flex items-start gap-3">
+                <StatusIcon status={backup.status} className="size-5 text-muted-foreground shrink-0 mt-0.5" />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <code className="text-xs font-mono">{backup.backupRef.slice(0, 12)}…</code>
+                    <Badge variant={STATUS_VARIANT[backup.status]} className="text-[10px]">
+                      {STATUS_LABELS[backup.status]}
+                    </Badge>
+                  </div>
+                  <div className="text-xs text-muted-foreground mt-1 flex flex-wrap gap-3">
+                    <span className="flex items-center gap-1">
+                      <Clock className="size-3" aria-hidden="true" />
+                      Démarré {formatDate(backup.startedAt, locale, { withTime: true })}
+                    </span>
+                    {backup.completedAt && (
+                      <span>Durée : {formatDuration(backup.durationMs)}</span>
+                    )}
+                    {backup.sizeBytes !== null && (
+                      <span className="flex items-center gap-1">
+                        <Database className="size-3" aria-hidden="true" />
+                        {formatBytes(backup.sizeBytes)}
+                      </span>
+                    )}
+                    {backup.triggeredBy !== null && (
+                      <span>Par User #{backup.triggeredBy}</span>
+                    )}
+                  </div>
+                  {backup.errorMessage && (
+                    <p className="text-xs text-destructive mt-1">⚠ {backup.errorMessage}</p>
+                  )}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Confirmation déclenchement backup (Dialog shadcn — focus trap + ESC). */}
+      <Dialog open={showTriggerConfirm} onOpenChange={(open) => { if (!open) setShowTriggerConfirm(false) }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Déclencher un backup PostgreSQL ?</DialogTitle>
+            <DialogDescription>
+              Le backup démarrera immédiatement (status: pending → running). Durée
+              estimée : 2-15 minutes selon taille DB. L&apos;opération est tracée
+              dans le journal d&apos;audit.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DiabeoButton variant="diabeoTertiary" onClick={() => setShowTriggerConfirm(false)}>
+              Annuler
+            </DiabeoButton>
+            <DiabeoButton onClick={() => void executeTrigger()}>
+              Déclencher
+            </DiabeoButton>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/components/diabeo/admin/BackupsListClient.tsx
+++ b/src/components/diabeo/admin/BackupsListClient.tsx
@@ -3,12 +3,22 @@
 /**
  * BackupsListClient — UI US-2151 Admin gestion backups (ADMIN-only).
  *
- * Liste backups + filtres status + bouton "Déclencher backup" (POST).
- * Le worker externe (cron) consomme les rows pending. UI affiche state +
- * permet de relancer si pending stuck.
- *
  * Backend : `backupService.list/trigger` (PR #409). Pas de restore exposé
- * iter 2 (procédure ops manuelle documentée runbook).
+ * iter 2 (procédure ops manuelle via runbook).
+ *
+ * Fixes round 1 review PR #458 :
+ *   - H1 : `setTimeout` reset success tracké via ref (régression M8 PR #457)
+ *   - M1 : types extraits dans `src/lib/types/admin-ops.ts`
+ *   - M2 : `<StatusIcon kind="backup">` partagé (admin/StatusIcon.tsx)
+ *   - M3 : mapping backend error codes UI (backup_already_in_progress / generic)
+ *   - M5 : DTO retire `location` (HSA) — `hasLocation` flag à la place
+ *   - M7 : `title={backup.backupRef}` tooltip full UUID (A11y M1)
+ *   - M8 : `Intl.NumberFormat` dynamic locale (dates via formatDate)
+ *   - L1 : helpers `formatBytes`/`formatDuration` documentés (Intl gigabyte
+ *     unit fallback navigateur < unit support → preserve custom helper)
+ *   - L7 : clear filter button si filterStatus ≠ all
+ *   - A11y M3 : errorMessage long via <details>/<summary> expandable
+ *   - A11y L1 : statut affiché Capitalize (Pending) vs UPPERCASE
  */
 
 import { useCallback, useEffect, useRef, useState } from "react"
@@ -19,10 +29,9 @@ import {
   Clock,
   Database,
   HardDrive,
-  Loader2,
   Plus,
   RefreshCw,
-  XCircle,
+  X,
 } from "lucide-react"
 import { DiabeoButton } from "@/components/diabeo/DiabeoButton"
 import { Badge } from "@/components/ui/badge"
@@ -36,49 +45,33 @@ import {
 } from "@/components/ui/dialog"
 import { formatDate } from "@/lib/intl/formatters"
 import type { Locale } from "@/i18n/config"
-
-type BackupStatus = "pending" | "running" | "completed" | "failed"
-
-interface BackupLogDTO {
-  id: number
-  backupRef: string
-  status: BackupStatus
-  location: string | null
-  sizeBytes: number | null // BigInt sérialisé number
-  durationMs: number | null
-  triggeredBy: number | null
-  startedAt: string // ISO
-  completedAt: string | null
-  errorMessage: string | null
-}
+import {
+  type BackupStatus,
+  type BackupLogDTOClient as BackupLogDTO,
+  BACKUP_STATUS_LABELS_FR,
+  BACKUP_STATUS_VARIANT,
+} from "@/lib/types/admin-ops"
+import { StatusIcon } from "./StatusIcon"
 
 type AsyncState = "idle" | "loading" | "success" | "error"
 
-const STATUS_LABELS: Record<BackupStatus, string> = {
-  pending: "En attente",
-  running: "En cours",
-  completed: "Terminé",
-  failed: "Échoué",
-}
-
-const STATUS_VARIANT: Record<BackupStatus, "default" | "secondary" | "destructive" | "outline"> = {
-  pending: "secondary",
-  running: "outline",
-  completed: "default",
-  failed: "destructive",
-}
-
-function StatusIcon({ status, className }: { status: BackupStatus; className?: string }) {
-  if (status === "completed") return <CheckCircle2 className={className} aria-hidden="true" />
-  if (status === "running") return <Loader2 className={`${className ?? ""} animate-spin`} aria-hidden="true" />
-  if (status === "failed") return <XCircle className={className} aria-hidden="true" />
-  return <Clock className={className} aria-hidden="true" />
+/**
+ * Fix M3 round 1 review PR #458 — mapping codes erreur backend → message
+ * UI lisible. Codes connus backendService.trigger (PR #409 + future).
+ */
+const BACKUP_TRIGGER_ERROR_LABELS: Record<string, string> = {
+  backup_already_in_progress: "Un backup est déjà en cours. Réessayer plus tard.",
+  worker_unreachable: "Worker backup indisponible. Contacter l'équipe ops.",
+  disk_full: "Espace disque insuffisant sur le serveur backup.",
 }
 
 /**
- * Formate sizeBytes en KB/MB/GB lisible.
+ * Fix L1 round 1 review PR #458 — formatBytes custom (Intl.NumberFormat
+ * `style: "unit", unit: "gigabyte"` n'est pas supporté de manière fiable
+ * sur tous les navigateurs pour les unités sub-GB). Locale-aware via
+ * Intl.NumberFormat pour le nombre, suffix unit en suffixe textuel.
  */
-function formatBytes(bytes: number | null): string {
+function formatBytes(bytes: number | null, locale: Locale): string {
   if (bytes === null || bytes === 0) return "—"
   const units = ["B", "KB", "MB", "GB", "TB"]
   let size = bytes
@@ -87,17 +80,25 @@ function formatBytes(bytes: number | null): string {
     size /= 1024
     unitIdx++
   }
-  return `${size.toFixed(unitIdx === 0 ? 0 : 1)} ${units[unitIdx]}`
+  const formatter = new Intl.NumberFormat(locale, {
+    maximumFractionDigits: unitIdx === 0 ? 0 : 1,
+  })
+  return `${formatter.format(size)} ${units[unitIdx]}`
 }
 
-/**
- * Formate durationMs en secondes/minutes.
- */
 function formatDuration(ms: number | null): string {
   if (ms === null) return "—"
   if (ms < 1000) return `${ms} ms`
   if (ms < 60_000) return `${(ms / 1000).toFixed(1)} s`
   return `${Math.floor(ms / 60_000)} min ${Math.floor((ms % 60_000) / 1000)} s`
+}
+
+/**
+ * Fix A11y L1 round 1 — Status badge Capitalize au lieu UPPERCASE
+ * (WCAG 1.4.8 AAA lisibilité — capitales plus dures à lire).
+ */
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase()
 }
 
 export function BackupsListClient() {
@@ -113,6 +114,9 @@ export function BackupsListClient() {
   const mountedRef = useRef(true)
   const abortRef = useRef<AbortController | null>(null)
   const fetchSeqRef = useRef(0)
+  // Fix H1 round 1 review PR #458 (régression M8 PR #457) — tracking ref
+  // pour setTimeout success reset + cleanup au unmount (anti memory leak).
+  const triggerResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const fetchBackups = useCallback(async () => {
     if (abortRef.current) abortRef.current.abort()
@@ -146,13 +150,13 @@ export function BackupsListClient() {
 
   useEffect(() => {
     mountedRef.current = true
-    // fetchBackups recapture filterStatus via useCallback — re-triggered au
-    // changement de filtre. AbortController + fetchSeq gèrent race condition.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     void fetchBackups()
     return () => {
       mountedRef.current = false
       if (abortRef.current) abortRef.current.abort()
+      // Fix H1 round 1 — cleanup timer reset au unmount.
+      if (triggerResetTimerRef.current) clearTimeout(triggerResetTimerRef.current)
     }
   }, [fetchBackups])
 
@@ -170,20 +174,20 @@ export function BackupsListClient() {
         },
       })
       if (!mountedRef.current) return
-      if (res.status === 409) {
-        setTriggerState("error")
-        setTriggerError("Un backup est déjà en cours. Réessayer plus tard.")
-        return
-      }
       if (!res.ok) {
         setTriggerState("error")
-        setTriggerError(`HTTP ${res.status}`)
+        // Fix M3 round 1 — parse body pour récupérer error code backend.
+        const data = (await res.json().catch(() => null)) as { error?: string } | null
+        const code = data?.error
+        const friendly = code ? BACKUP_TRIGGER_ERROR_LABELS[code] : undefined
+        setTriggerError(friendly ?? `Erreur backend (HTTP ${res.status})`)
         return
       }
       setTriggerState("success")
       await fetchBackups()
-      // Reset state success après 3s.
-      setTimeout(() => {
+      // Fix H1 round 1 — timer tracké pour cleanup au unmount.
+      if (triggerResetTimerRef.current) clearTimeout(triggerResetTimerRef.current)
+      triggerResetTimerRef.current = setTimeout(() => {
         if (mountedRef.current) setTriggerState("idle")
       }, 3000)
     } catch (err) {
@@ -196,22 +200,30 @@ export function BackupsListClient() {
   return (
     <>
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <label className="flex items-center gap-1 text-sm">
-          <span className="text-muted-foreground">Statut :</span>
-          <select
-            value={filterStatus}
-            onChange={(e) => setFilterStatus(e.target.value as BackupStatus | "all")}
-            className="rounded-md border bg-background px-2 py-1 text-sm"
-            aria-label="Filtrer par statut backup"
-          >
-            <option value="all">Tous</option>
-            {Object.entries(STATUS_LABELS).map(([value, label]) => (
-              <option key={value} value={value}>
-                {label}
-              </option>
-            ))}
-          </select>
-        </label>
+        <div className="flex items-center gap-2">
+          <label className="flex items-center gap-1 text-sm">
+            <span className="text-muted-foreground">Statut :</span>
+            <select
+              value={filterStatus}
+              onChange={(e) => setFilterStatus(e.target.value as BackupStatus | "all")}
+              className="rounded-md border bg-background px-2 py-1 text-sm"
+              aria-label="Filtrer par statut backup"
+            >
+              <option value="all">Tous</option>
+              {Object.entries(BACKUP_STATUS_LABELS_FR).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          {/* Fix L7 round 1 — bouton clear filter si actif. */}
+          {filterStatus !== "all" && (
+            <DiabeoButton variant="diabeoTertiary" size="sm" onClick={() => setFilterStatus("all")} aria-label="Effacer le filtre">
+              <X className="size-3.5" aria-hidden="true" />
+            </DiabeoButton>
+          )}
+        </div>
         <div className="flex items-center gap-2">
           <DiabeoButton variant="diabeoTertiary" size="sm" onClick={() => void fetchBackups()}>
             <RefreshCw className="size-3.5 mr-1" aria-hidden="true" />
@@ -278,12 +290,23 @@ export function BackupsListClient() {
               }`}
             >
               <div className="flex items-start gap-3">
-                <StatusIcon status={backup.status} className="size-5 text-muted-foreground shrink-0 mt-0.5" />
+                <StatusIcon
+                  kind="backup"
+                  status={backup.status}
+                  className="size-5 text-muted-foreground shrink-0 mt-0.5"
+                />
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 flex-wrap">
-                    <code className="text-xs font-mono">{backup.backupRef.slice(0, 12)}…</code>
-                    <Badge variant={STATUS_VARIANT[backup.status]} className="text-[10px]">
-                      {STATUS_LABELS[backup.status]}
+                    {/* Fix M7 + A11y M1 round 1 — title tooltip full backupRef. */}
+                    <code
+                      className="text-xs font-mono"
+                      title={`Référence backup : ${backup.backupRef}`}
+                    >
+                      {backup.backupRef.slice(0, 12)}…
+                    </code>
+                    {/* Fix A11y L1 round 1 — Capitalize au lieu de UPPERCASE. */}
+                    <Badge variant={BACKUP_STATUS_VARIANT[backup.status]} className="text-[10px]">
+                      {capitalize(BACKUP_STATUS_LABELS_FR[backup.status])}
                     </Badge>
                   </div>
                   <div className="text-xs text-muted-foreground mt-1 flex flex-wrap gap-3">
@@ -297,15 +320,23 @@ export function BackupsListClient() {
                     {backup.sizeBytes !== null && (
                       <span className="flex items-center gap-1">
                         <Database className="size-3" aria-hidden="true" />
-                        {formatBytes(backup.sizeBytes)}
+                        {formatBytes(backup.sizeBytes, locale)}
                       </span>
                     )}
                     {backup.triggeredBy !== null && (
+                      // TODO V2 (Issue #456) — remplacer User #ID séquentiel par
+                      // staff.publicRef UUID opaque (anti-énumération).
                       <span>Par User #{backup.triggeredBy}</span>
                     )}
                   </div>
                   {backup.errorMessage && (
-                    <p className="text-xs text-destructive mt-1">⚠ {backup.errorMessage}</p>
+                    // Fix A11y M3 round 1 — expandable details (vs overflow horizontal).
+                    <details className="text-xs text-destructive mt-1.5">
+                      <summary className="cursor-pointer font-medium">⚠ Voir l&apos;erreur</summary>
+                      <pre className="mt-1 whitespace-pre-wrap break-words rounded bg-destructive/5 p-2 max-h-32 overflow-auto">
+                        {backup.errorMessage}
+                      </pre>
+                    </details>
                   )}
                 </div>
               </div>

--- a/src/components/diabeo/admin/StatusIcon.tsx
+++ b/src/components/diabeo/admin/StatusIcon.tsx
@@ -1,0 +1,65 @@
+/**
+ * StatusIcon — composant partagé entre admin clients (SystemHealth, Backups).
+ *
+ * Fix M2 round 1 review PR #458 — DRY (vs 2 implémentations dupliquées avec
+ * mappings différents). Map sur 2 unions disjointes : `ComponentStatus`
+ * (system health) + `BackupStatus`.
+ *
+ * Fix H3 round 1 review PR #458 — `motion-safe:animate-spin` pour Loader2
+ * (status backup `running`) respecte `prefers-reduced-motion` user
+ * (WCAG 2.3.3 Animation from Interactions).
+ */
+
+import {
+  AlertCircle,
+  CheckCircle2,
+  Clock,
+  HelpCircle,
+  Loader2,
+  XCircle,
+  type LucideIcon,
+} from "lucide-react"
+import type { ComponentStatus, BackupStatus } from "@/lib/types/admin-ops"
+
+interface StatusIconBaseProps {
+  className?: string
+}
+
+interface ComponentStatusIconProps extends StatusIconBaseProps {
+  kind: "component"
+  status: ComponentStatus
+}
+
+interface BackupStatusIconProps extends StatusIconBaseProps {
+  kind: "backup"
+  status: BackupStatus
+}
+
+type StatusIconProps = ComponentStatusIconProps | BackupStatusIconProps
+
+const COMPONENT_ICONS: Record<ComponentStatus, LucideIcon> = {
+  ok: CheckCircle2,
+  degraded: AlertCircle,
+  down: XCircle,
+  unknown: HelpCircle,
+}
+
+const BACKUP_ICONS: Record<BackupStatus, LucideIcon> = {
+  completed: CheckCircle2,
+  running: Loader2,
+  failed: XCircle,
+  pending: Clock,
+}
+
+export function StatusIcon(props: StatusIconProps) {
+  const Icon = props.kind === "component"
+    ? COMPONENT_ICONS[props.status]
+    : BACKUP_ICONS[props.status]
+  const isSpinning = props.kind === "backup" && props.status === "running"
+  return (
+    <Icon
+      className={`${props.className ?? ""} ${isSpinning ? "motion-safe:animate-spin" : ""}`.trim()}
+      aria-hidden="true"
+    />
+  )
+}

--- a/src/components/diabeo/admin/SystemHealthClient.tsx
+++ b/src/components/diabeo/admin/SystemHealthClient.tsx
@@ -3,80 +3,53 @@
 /**
  * SystemHealthClient — UI US-2150 Dashboard santé système (ADMIN-only).
  *
- * Affiche : statut global + 4 composants (DB, Redis, CGM lag, Backups) +
- * métriques (sessions actives, tentatives non-autorisées 24h, CGM lag, age
- * dernier backup).
+ * Backend : `GET /api/admin/system-health` (PR #409). Auto-refresh 60s
+ * (toggle pause utilisateur — Fix C1 round 1 review PR #458 WCAG 2.2.1).
  *
- * Backend : `GET /api/admin/system-health` (PR #409). Refresh auto 60s.
- *
- * Pattern aligné PR #457 iter 1 (Sessions/DataBreaches) : AbortController +
- * mountedRef + error feedback + i18n via next-intl.
+ * Fixes round 1 review PR #458 :
+ *   - C1 : bouton pause/reprendre auto-refresh (WCAG 2.2.1 Timing Adjustable)
+ *   - C2 : warning text "⚠ Seuil dépassé" + icône (WCAG 1.4.1 color-only)
+ *   - H4 : `<h2>` explicite par section (WCAG 1.3.1 hierarchy)
+ *   - M1 : types extraits dans `src/lib/types/admin-ops.ts`
+ *   - M2 : `<StatusIcon>` partagé (admin/StatusIcon.tsx)
+ *   - M6 : `setTimeout` récursif post-fetch (auto-throttle si DB rame)
+ *   - M8 : `Intl.NumberFormat(locale)` dynamic (vs toLocaleString("fr-FR"))
+ *   - L3 : `OVERALL_STATUS_LABELS_FR[status]` map (vs chained ternary)
+ *   - L5 : icône `Heart` conservée (sémantique discussion — Activity alt rejetée)
  */
 
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useLocale } from "next-intl"
 import {
-  AlertCircle,
   Activity,
-  CheckCircle2,
+  AlertCircle,
+  AlertTriangle,
   Clock,
   Database,
   HardDrive,
-  HelpCircle,
+  Pause,
+  Play,
   RefreshCw,
   ShieldAlert,
   Users,
-  XCircle,
   Zap,
 } from "lucide-react"
 import { DiabeoButton } from "@/components/diabeo/DiabeoButton"
 import { Badge } from "@/components/ui/badge"
 import { formatRelativeTime } from "@/lib/intl/formatters"
 import type { Locale } from "@/i18n/config"
-
-type ComponentStatus = "ok" | "degraded" | "down" | "unknown"
-type OverallStatus = "ok" | "degraded" | "down"
-
-interface SystemHealthDTO {
-  status: OverallStatus
-  components: {
-    db: ComponentStatus
-    redis: ComponentStatus
-    cgmIngestion: ComponentStatus
-    backups: ComponentStatus
-  }
-  metrics: {
-    activeSessions: number
-    unauthorizedAttempts24h: number
-    cgmLagMinutes: number | null
-    lastBackupAgeHours: number | null
-  }
-  checkedAt: string // ISO
-}
+import {
+  type ComponentStatus,
+  type SystemHealthDTOClient as SystemHealthDTO,
+  COMPONENT_STATUS_LABELS_FR,
+  COMPONENT_STATUS_VARIANT,
+  OVERALL_STATUS_LABELS_FR,
+  OVERALL_STATUS_VARIANT,
+} from "@/lib/types/admin-ops"
+import { StatusIcon } from "./StatusIcon"
 
 type AsyncState = "idle" | "loading" | "success" | "error"
 const REFRESH_INTERVAL_MS = 60_000
-
-const STATUS_LABELS: Record<ComponentStatus, string> = {
-  ok: "OK",
-  degraded: "Dégradé",
-  down: "HS",
-  unknown: "Inconnu",
-}
-
-const STATUS_VARIANT: Record<ComponentStatus, "default" | "secondary" | "destructive" | "outline"> = {
-  ok: "default",
-  degraded: "outline",
-  down: "destructive",
-  unknown: "secondary",
-}
-
-function StatusIcon({ status, className }: { status: ComponentStatus; className?: string }) {
-  if (status === "ok") return <CheckCircle2 className={className} aria-hidden="true" />
-  if (status === "degraded") return <AlertCircle className={className} aria-hidden="true" />
-  if (status === "down") return <XCircle className={className} aria-hidden="true" />
-  return <HelpCircle className={className} aria-hidden="true" />
-}
 
 const COMPONENT_META: Record<
   keyof SystemHealthDTO["components"],
@@ -109,9 +82,19 @@ export function SystemHealthClient() {
   const [snapshot, setSnapshot] = useState<SystemHealthDTO | null>(null)
   const [state, setState] = useState<AsyncState>("idle")
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  // Fix C1 round 1 — pause toggle auto-refresh (WCAG 2.2.1).
+  const [isPaused, setIsPaused] = useState(false)
+  // Ref miroir pour que `scheduleNextFetch` lise toujours la valeur
+  // courante sans recréation au toggle (pattern stable callback React 19).
+  const isPausedRef = useRef(false)
+  useEffect(() => { isPausedRef.current = isPaused }, [isPaused])
   const mountedRef = useRef(true)
   const abortRef = useRef<AbortController | null>(null)
-  const refreshTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  // Fix M6 round 1 — setTimeout récursif (vs setInterval qui overlap si fetch > 60s).
+  const nextFetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Fix M8 round 1 — Intl.NumberFormat dynamic locale (vs toLocaleString FR hardcoded).
+  const numberFormatter = useMemo(() => new Intl.NumberFormat(locale), [locale])
 
   const fetchSnapshot = useCallback(async () => {
     if (abortRef.current) abortRef.current.abort()
@@ -142,17 +125,46 @@ export function SystemHealthClient() {
     }
   }, [])
 
+  // Fix M6 round 1 — boucle setTimeout récursive interne au useEffect (vs
+  // setInterval qui overlap si fetch > 60s + vs useCallback récursif que
+  // React 19 lint flag immutability). La boucle vit dans le scope du
+  // useEffect ; deps [isPaused, fetchSnapshot] re-monte la loop à chaque
+  // pause toggle (acceptable car rare action user).
+  //
+  // Au mount : initial fetch + loop scheduled si !isPaused.
+  // À pause toggle : cleanup + re-mount loop si reprend.
   useEffect(() => {
     mountedRef.current = true
-    // Initial fetch + auto-refresh 60s. Pattern aligné PR #457 iter 1.
+    let cancelled = false
+
+    const loop = (): void => {
+      if (nextFetchTimerRef.current) clearTimeout(nextFetchTimerRef.current)
+      if (cancelled || isPausedRef.current) return
+      nextFetchTimerRef.current = setTimeout(async () => {
+        if (cancelled || !mountedRef.current || isPausedRef.current) return
+        await fetchSnapshot()
+        loop()
+      }, REFRESH_INTERVAL_MS)
+    }
+
+    // Initial mount only — fetch + loop. Pause toggle : juste re-schedule.
+    if (!isPaused) {
+      loop()
+    }
+
+    return () => {
+      cancelled = true
+      if (nextFetchTimerRef.current) clearTimeout(nextFetchTimerRef.current)
+    }
+  }, [isPaused, fetchSnapshot])
+
+  // Initial mount fetch (séparé du loop pour éviter re-fetch à chaque pause toggle).
+  useEffect(() => {
+    mountedRef.current = true
     // eslint-disable-next-line react-hooks/set-state-in-effect
     void fetchSnapshot()
-    refreshTimerRef.current = setInterval(() => {
-      void fetchSnapshot()
-    }, REFRESH_INTERVAL_MS)
     return () => {
       mountedRef.current = false
-      if (refreshTimerRef.current) clearInterval(refreshTimerRef.current)
       if (abortRef.current) abortRef.current.abort()
     }
   }, [fetchSnapshot])
@@ -182,15 +194,14 @@ export function SystemHealthClient() {
 
   if (!snapshot) return null
 
-  const overallVariant: "default" | "outline" | "destructive" =
-    snapshot.status === "ok" ? "default" : snapshot.status === "degraded" ? "outline" : "destructive"
-
   return (
     <>
-      {/* Statut global + refresh manuel */}
-      <section className="flex flex-wrap items-center justify-between gap-3 rounded-md border p-4">
+      {/* Statut global + refresh manuel + pause toggle */}
+      <section className="flex flex-wrap items-center justify-between gap-3 rounded-md border p-4" aria-labelledby="health-overall">
+        <h2 id="health-overall" className="sr-only">Statut global</h2>
         <div className="flex items-center gap-3">
           <StatusIcon
+            kind="component"
             status={snapshot.status === "ok" ? "ok" : snapshot.status === "degraded" ? "degraded" : "down"}
             className="size-8"
           />
@@ -198,9 +209,11 @@ export function SystemHealthClient() {
             <p className="text-sm text-muted-foreground">Statut global</p>
             <div className="flex items-center gap-2">
               <span className="text-xl font-semibold">
-                {snapshot.status === "ok" ? "Opérationnel" : snapshot.status === "degraded" ? "Dégradé" : "Hors service"}
+                {OVERALL_STATUS_LABELS_FR[snapshot.status]}
               </span>
-              <Badge variant={overallVariant}>{snapshot.status.toUpperCase()}</Badge>
+              <Badge variant={OVERALL_STATUS_VARIANT[snapshot.status]}>
+                {snapshot.status.toUpperCase()}
+              </Badge>
             </div>
           </div>
         </div>
@@ -208,6 +221,17 @@ export function SystemHealthClient() {
           <p className="text-xs text-muted-foreground">
             Dernière vérification {formatRelativeTime(snapshot.checkedAt, locale)}
           </p>
+          {/* Fix C1 round 1 — bouton pause/reprendre auto-refresh (WCAG 2.2.1). */}
+          <DiabeoButton
+            variant="diabeoTertiary"
+            size="sm"
+            onClick={() => setIsPaused((p) => !p)}
+            aria-pressed={isPaused}
+            aria-label={isPaused ? "Reprendre l'actualisation automatique" : "Mettre en pause l'actualisation automatique"}
+          >
+            {isPaused ? <Play className="size-3.5 mr-1" aria-hidden="true" /> : <Pause className="size-3.5 mr-1" aria-hidden="true" />}
+            {isPaused ? "Reprendre auto" : "Pause auto"}
+          </DiabeoButton>
           <DiabeoButton variant="diabeoTertiary" size="sm" onClick={() => void fetchSnapshot()}>
             <RefreshCw className="size-3.5 mr-1" aria-hidden="true" />
             Actualiser
@@ -216,64 +240,73 @@ export function SystemHealthClient() {
       </section>
 
       {/* Composants */}
-      <section className="grid grid-cols-1 gap-3 md:grid-cols-2" aria-label="Composants système">
-        {(Object.entries(snapshot.components) as Array<[keyof SystemHealthDTO["components"], ComponentStatus]>).map(
-          ([key, status]) => {
-            const meta = COMPONENT_META[key]
-            return (
-              <div
-                key={key}
-                className={`rounded-md border p-3 ${
-                  status === "down" ? "border-destructive/40 bg-destructive/5" : "border-border"
-                }`}
-              >
-                <div className="flex items-start gap-3">
-                  <meta.Icon className="size-5 text-muted-foreground shrink-0 mt-0.5" aria-hidden="true" />
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span className="font-medium">{meta.label}</span>
-                      <Badge variant={STATUS_VARIANT[status]} className="text-[10px]">
-                        {STATUS_LABELS[status]}
-                      </Badge>
+      <section aria-labelledby="health-components" className="space-y-2">
+        <h2 id="health-components" className="text-lg font-semibold">Composants</h2>
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          {(Object.entries(snapshot.components) as Array<[keyof SystemHealthDTO["components"], ComponentStatus]>).map(
+            ([key, status]) => {
+              const meta = COMPONENT_META[key]
+              return (
+                <div
+                  key={key}
+                  className={`rounded-md border p-3 ${
+                    status === "down" ? "border-destructive/40 bg-destructive/5" : "border-border"
+                  }`}
+                >
+                  <div className="flex items-start gap-3">
+                    <meta.Icon className="size-5 text-muted-foreground shrink-0 mt-0.5" aria-hidden="true" />
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="font-medium">{meta.label}</span>
+                        <Badge variant={COMPONENT_STATUS_VARIANT[status]} className="text-[10px]">
+                          {COMPONENT_STATUS_LABELS_FR[status]}
+                        </Badge>
+                      </div>
+                      <p className="text-xs text-muted-foreground mt-1">{meta.description}</p>
                     </div>
-                    <p className="text-xs text-muted-foreground mt-1">{meta.description}</p>
                   </div>
                 </div>
-              </div>
-            )
-          },
-        )}
+              )
+            },
+          )}
+        </div>
       </section>
 
       {/* Métriques */}
-      <section className="grid grid-cols-2 gap-3 md:grid-cols-4" aria-label="Métriques">
-        <MetricCard
-          icon={Users}
-          label="Sessions actives"
-          value={snapshot.metrics.activeSessions.toLocaleString("fr-FR")}
-        />
-        <MetricCard
-          icon={ShieldAlert}
-          label="Tentatives non-autorisées 24h"
-          value={snapshot.metrics.unauthorizedAttempts24h.toLocaleString("fr-FR")}
-          highlight={snapshot.metrics.unauthorizedAttempts24h > 100}
-        />
-        <MetricCard
-          icon={Activity}
-          label="CGM lag (minutes)"
-          value={snapshot.metrics.cgmLagMinutes !== null ? `${snapshot.metrics.cgmLagMinutes} min` : "—"}
-          highlight={(snapshot.metrics.cgmLagMinutes ?? 0) > 30}
-        />
-        <MetricCard
-          icon={Clock}
-          label="Dernier backup"
-          value={
-            snapshot.metrics.lastBackupAgeHours !== null
-              ? `il y a ${snapshot.metrics.lastBackupAgeHours}h`
-              : "—"
-          }
-          highlight={(snapshot.metrics.lastBackupAgeHours ?? 0) > 36}
-        />
+      <section aria-labelledby="health-metrics" className="space-y-2">
+        <h2 id="health-metrics" className="text-lg font-semibold">Métriques</h2>
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+          <MetricCard
+            icon={Users}
+            label="Sessions actives"
+            value={numberFormatter.format(snapshot.metrics.activeSessions)}
+          />
+          <MetricCard
+            icon={ShieldAlert}
+            label="Tentatives non-autorisées 24h"
+            value={numberFormatter.format(snapshot.metrics.unauthorizedAttempts24h)}
+            highlight={snapshot.metrics.unauthorizedAttempts24h > 100}
+            highlightReason="Plus de 100 tentatives non-autorisées sur 24h — risque attaque active."
+          />
+          <MetricCard
+            icon={Activity}
+            label="CGM lag (minutes)"
+            value={snapshot.metrics.cgmLagMinutes !== null ? `${snapshot.metrics.cgmLagMinutes} min` : "—"}
+            highlight={(snapshot.metrics.cgmLagMinutes ?? 0) > 30}
+            highlightReason="Retard d'ingestion CGM > 30 min — vérifier worker MyDiabby."
+          />
+          <MetricCard
+            icon={Clock}
+            label="Dernier backup"
+            value={
+              snapshot.metrics.lastBackupAgeHours !== null
+                ? `il y a ${snapshot.metrics.lastBackupAgeHours}h`
+                : "—"
+            }
+            highlight={(snapshot.metrics.lastBackupAgeHours ?? 0) > 36}
+            highlightReason="Dernier backup > 36h — vérifier cron postgres-backup."
+          />
+        </div>
       </section>
     </>
   )
@@ -284,23 +317,37 @@ function MetricCard({
   label,
   value,
   highlight = false,
+  highlightReason,
 }: {
   icon: typeof Database
   label: string
   value: string
   highlight?: boolean
+  highlightReason?: string
 }) {
   return (
     <div
       className={`rounded-md border p-3 ${
         highlight ? "border-orange-300 bg-orange-50" : "border-border"
       }`}
+      role={highlight ? "alert" : undefined}
     >
       <div className="flex items-center gap-2 text-muted-foreground mb-1">
         <Icon className="size-4" aria-hidden="true" />
         <span className="text-xs">{label}</span>
       </div>
       <p className="text-xl font-semibold">{value}</p>
+      {/* Fix C2 round 1 — warning text+icon explicite (vs color-only WCAG 1.4.1). */}
+      {highlight && (
+        <p className="mt-1.5 text-xs text-orange-700 flex items-start gap-1">
+          <AlertTriangle className="size-3.5 shrink-0 mt-0.5" aria-hidden="true" />
+          <span>
+            <span className="sr-only">Alerte : </span>
+            Seuil dépassé.
+            {highlightReason && <span className="block opacity-80">{highlightReason}</span>}
+          </span>
+        </p>
+      )}
     </div>
   )
 }

--- a/src/components/diabeo/admin/SystemHealthClient.tsx
+++ b/src/components/diabeo/admin/SystemHealthClient.tsx
@@ -1,0 +1,306 @@
+"use client"
+
+/**
+ * SystemHealthClient — UI US-2150 Dashboard santé système (ADMIN-only).
+ *
+ * Affiche : statut global + 4 composants (DB, Redis, CGM lag, Backups) +
+ * métriques (sessions actives, tentatives non-autorisées 24h, CGM lag, age
+ * dernier backup).
+ *
+ * Backend : `GET /api/admin/system-health` (PR #409). Refresh auto 60s.
+ *
+ * Pattern aligné PR #457 iter 1 (Sessions/DataBreaches) : AbortController +
+ * mountedRef + error feedback + i18n via next-intl.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useLocale } from "next-intl"
+import {
+  AlertCircle,
+  Activity,
+  CheckCircle2,
+  Clock,
+  Database,
+  HardDrive,
+  HelpCircle,
+  RefreshCw,
+  ShieldAlert,
+  Users,
+  XCircle,
+  Zap,
+} from "lucide-react"
+import { DiabeoButton } from "@/components/diabeo/DiabeoButton"
+import { Badge } from "@/components/ui/badge"
+import { formatRelativeTime } from "@/lib/intl/formatters"
+import type { Locale } from "@/i18n/config"
+
+type ComponentStatus = "ok" | "degraded" | "down" | "unknown"
+type OverallStatus = "ok" | "degraded" | "down"
+
+interface SystemHealthDTO {
+  status: OverallStatus
+  components: {
+    db: ComponentStatus
+    redis: ComponentStatus
+    cgmIngestion: ComponentStatus
+    backups: ComponentStatus
+  }
+  metrics: {
+    activeSessions: number
+    unauthorizedAttempts24h: number
+    cgmLagMinutes: number | null
+    lastBackupAgeHours: number | null
+  }
+  checkedAt: string // ISO
+}
+
+type AsyncState = "idle" | "loading" | "success" | "error"
+const REFRESH_INTERVAL_MS = 60_000
+
+const STATUS_LABELS: Record<ComponentStatus, string> = {
+  ok: "OK",
+  degraded: "Dégradé",
+  down: "HS",
+  unknown: "Inconnu",
+}
+
+const STATUS_VARIANT: Record<ComponentStatus, "default" | "secondary" | "destructive" | "outline"> = {
+  ok: "default",
+  degraded: "outline",
+  down: "destructive",
+  unknown: "secondary",
+}
+
+function StatusIcon({ status, className }: { status: ComponentStatus; className?: string }) {
+  if (status === "ok") return <CheckCircle2 className={className} aria-hidden="true" />
+  if (status === "degraded") return <AlertCircle className={className} aria-hidden="true" />
+  if (status === "down") return <XCircle className={className} aria-hidden="true" />
+  return <HelpCircle className={className} aria-hidden="true" />
+}
+
+const COMPONENT_META: Record<
+  keyof SystemHealthDTO["components"],
+  { label: string; description: string; Icon: typeof Database }
+> = {
+  db: {
+    label: "Base de données",
+    description: "PostgreSQL — connexion + ping < 2s",
+    Icon: Database,
+  },
+  redis: {
+    label: "Redis (cache)",
+    description: "Upstash — disponibilité ping",
+    Icon: Zap,
+  },
+  cgmIngestion: {
+    label: "Ingestion CGM",
+    description: "Délai dernière donnée capteur reçue",
+    Icon: Activity,
+  },
+  backups: {
+    label: "Backups",
+    description: "Fraîcheur dernier backup PostgreSQL (< 36h)",
+    Icon: HardDrive,
+  },
+}
+
+export function SystemHealthClient() {
+  const locale = useLocale() as Locale
+  const [snapshot, setSnapshot] = useState<SystemHealthDTO | null>(null)
+  const [state, setState] = useState<AsyncState>("idle")
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const mountedRef = useRef(true)
+  const abortRef = useRef<AbortController | null>(null)
+  const refreshTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const fetchSnapshot = useCallback(async () => {
+    if (abortRef.current) abortRef.current.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+    setState("loading")
+    setErrorMessage(null)
+    try {
+      const res = await fetch("/api/admin/system-health", {
+        credentials: "include",
+        signal: controller.signal,
+      })
+      if (!mountedRef.current) return
+      if (!res.ok) {
+        setState("error")
+        setErrorMessage(`HTTP ${res.status}`)
+        return
+      }
+      const data = (await res.json()) as SystemHealthDTO
+      if (!mountedRef.current) return
+      setSnapshot(data)
+      setState("success")
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return
+      if (!mountedRef.current) return
+      setState("error")
+      setErrorMessage(err instanceof Error ? err.message : "Erreur réseau")
+    }
+  }, [])
+
+  useEffect(() => {
+    mountedRef.current = true
+    // Initial fetch + auto-refresh 60s. Pattern aligné PR #457 iter 1.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void fetchSnapshot()
+    refreshTimerRef.current = setInterval(() => {
+      void fetchSnapshot()
+    }, REFRESH_INTERVAL_MS)
+    return () => {
+      mountedRef.current = false
+      if (refreshTimerRef.current) clearInterval(refreshTimerRef.current)
+      if (abortRef.current) abortRef.current.abort()
+    }
+  }, [fetchSnapshot])
+
+  if (state === "loading" && !snapshot) {
+    return (
+      <p className="text-sm text-muted-foreground" aria-live="polite">
+        Chargement du snapshot santé système…
+      </p>
+    )
+  }
+
+  if (state === "error" && !snapshot) {
+    return (
+      <div role="alert" className="rounded-md border border-destructive/20 bg-destructive/10 p-3">
+        <p className="font-medium text-destructive flex items-center gap-2">
+          <AlertCircle className="size-4" aria-hidden="true" />
+          Snapshot indisponible
+        </p>
+        {errorMessage && <p className="text-xs text-muted-foreground mt-1">{errorMessage}</p>}
+        <DiabeoButton variant="diabeoTertiary" size="sm" onClick={() => void fetchSnapshot()} className="mt-2">
+          Réessayer
+        </DiabeoButton>
+      </div>
+    )
+  }
+
+  if (!snapshot) return null
+
+  const overallVariant: "default" | "outline" | "destructive" =
+    snapshot.status === "ok" ? "default" : snapshot.status === "degraded" ? "outline" : "destructive"
+
+  return (
+    <>
+      {/* Statut global + refresh manuel */}
+      <section className="flex flex-wrap items-center justify-between gap-3 rounded-md border p-4">
+        <div className="flex items-center gap-3">
+          <StatusIcon
+            status={snapshot.status === "ok" ? "ok" : snapshot.status === "degraded" ? "degraded" : "down"}
+            className="size-8"
+          />
+          <div>
+            <p className="text-sm text-muted-foreground">Statut global</p>
+            <div className="flex items-center gap-2">
+              <span className="text-xl font-semibold">
+                {snapshot.status === "ok" ? "Opérationnel" : snapshot.status === "degraded" ? "Dégradé" : "Hors service"}
+              </span>
+              <Badge variant={overallVariant}>{snapshot.status.toUpperCase()}</Badge>
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <p className="text-xs text-muted-foreground">
+            Dernière vérification {formatRelativeTime(snapshot.checkedAt, locale)}
+          </p>
+          <DiabeoButton variant="diabeoTertiary" size="sm" onClick={() => void fetchSnapshot()}>
+            <RefreshCw className="size-3.5 mr-1" aria-hidden="true" />
+            Actualiser
+          </DiabeoButton>
+        </div>
+      </section>
+
+      {/* Composants */}
+      <section className="grid grid-cols-1 gap-3 md:grid-cols-2" aria-label="Composants système">
+        {(Object.entries(snapshot.components) as Array<[keyof SystemHealthDTO["components"], ComponentStatus]>).map(
+          ([key, status]) => {
+            const meta = COMPONENT_META[key]
+            return (
+              <div
+                key={key}
+                className={`rounded-md border p-3 ${
+                  status === "down" ? "border-destructive/40 bg-destructive/5" : "border-border"
+                }`}
+              >
+                <div className="flex items-start gap-3">
+                  <meta.Icon className="size-5 text-muted-foreground shrink-0 mt-0.5" aria-hidden="true" />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="font-medium">{meta.label}</span>
+                      <Badge variant={STATUS_VARIANT[status]} className="text-[10px]">
+                        {STATUS_LABELS[status]}
+                      </Badge>
+                    </div>
+                    <p className="text-xs text-muted-foreground mt-1">{meta.description}</p>
+                  </div>
+                </div>
+              </div>
+            )
+          },
+        )}
+      </section>
+
+      {/* Métriques */}
+      <section className="grid grid-cols-2 gap-3 md:grid-cols-4" aria-label="Métriques">
+        <MetricCard
+          icon={Users}
+          label="Sessions actives"
+          value={snapshot.metrics.activeSessions.toLocaleString("fr-FR")}
+        />
+        <MetricCard
+          icon={ShieldAlert}
+          label="Tentatives non-autorisées 24h"
+          value={snapshot.metrics.unauthorizedAttempts24h.toLocaleString("fr-FR")}
+          highlight={snapshot.metrics.unauthorizedAttempts24h > 100}
+        />
+        <MetricCard
+          icon={Activity}
+          label="CGM lag (minutes)"
+          value={snapshot.metrics.cgmLagMinutes !== null ? `${snapshot.metrics.cgmLagMinutes} min` : "—"}
+          highlight={(snapshot.metrics.cgmLagMinutes ?? 0) > 30}
+        />
+        <MetricCard
+          icon={Clock}
+          label="Dernier backup"
+          value={
+            snapshot.metrics.lastBackupAgeHours !== null
+              ? `il y a ${snapshot.metrics.lastBackupAgeHours}h`
+              : "—"
+          }
+          highlight={(snapshot.metrics.lastBackupAgeHours ?? 0) > 36}
+        />
+      </section>
+    </>
+  )
+}
+
+function MetricCard({
+  icon: Icon,
+  label,
+  value,
+  highlight = false,
+}: {
+  icon: typeof Database
+  label: string
+  value: string
+  highlight?: boolean
+}) {
+  return (
+    <div
+      className={`rounded-md border p-3 ${
+        highlight ? "border-orange-300 bg-orange-50" : "border-border"
+      }`}
+    >
+      <div className="flex items-center gap-2 text-muted-foreground mb-1">
+        <Icon className="size-4" aria-hidden="true" />
+        <span className="text-xs">{label}</span>
+      </div>
+      <p className="text-xl font-semibold">{value}</p>
+    </div>
+  )
+}

--- a/src/lib/services/backup.service.ts
+++ b/src/lib/services/backup.service.ts
@@ -77,10 +77,16 @@ export const backupService = {
     })
 
     // BigInt n'est pas JSON-sérialisable. Cast en number côté API DTO.
+    // Fix M5 round 1 review PR #458 (HSA MEDIUM-3) — retire `location` du
+    // DTO API (URI S3 `s3://bucket/path/dump.sql.gz` = leak bucket name +
+    // path enumeration). Remplacé par `hasLocation: boolean` pour UI savoir
+    // si backup est restorable sans exposer le path. Le `location` reste
+    // côté backend pour les ops restore (cf. `runbook/postgres-backup.md`).
     return {
-      items: page.map((b) => ({
-        ...b,
-        sizeBytes: bigIntToJson(b.sizeBytes),
+      items: page.map(({ location, ...rest }) => ({
+        ...rest,
+        sizeBytes: bigIntToJson(rest.sizeBytes),
+        hasLocation: location !== null,
       })),
       nextCursor,
     }

--- a/src/lib/types/admin-ops.ts
+++ b/src/lib/types/admin-ops.ts
@@ -1,0 +1,106 @@
+/**
+ * Types partagés pour US-2150 (System Health) + US-2151 (Backups) UI.
+ *
+ * Fix M1 round 1 review PR #458 — extraction DRY (vs DTOs inline dans
+ * SystemHealthClient + BackupsListClient). Cohérent pattern PR #457
+ * `src/lib/types/data-breach.ts`.
+ *
+ * Backend DTOs : `system-health.service.ts:SystemHealthDTO` +
+ * `backup.service.ts:list()` return type.
+ */
+
+// ─────────────────────────────────────────────────────────────
+// US-2150 System Health
+// ─────────────────────────────────────────────────────────────
+
+export type ComponentStatus = "ok" | "degraded" | "down" | "unknown"
+export type OverallStatus = "ok" | "degraded" | "down"
+
+export interface SystemHealthDTOClient {
+  status: OverallStatus
+  components: {
+    db: ComponentStatus
+    redis: ComponentStatus
+    cgmIngestion: ComponentStatus
+    backups: ComponentStatus
+  }
+  metrics: {
+    activeSessions: number
+    /** M4 (review re-1 PR #409) — comptage AuditLog UNAUTHORIZED 24h. */
+    unauthorizedAttempts24h: number
+    cgmLagMinutes: number | null
+    lastBackupAgeHours: number | null
+  }
+  checkedAt: string // ISO 8601 (Date sérialisé via JSON)
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2151 Backups
+// ─────────────────────────────────────────────────────────────
+
+export type BackupStatus = "pending" | "running" | "completed" | "failed"
+
+/**
+ * Fix M5 round 1 review PR #458 (HSA MEDIUM-3) — `location` (URI S3)
+ * retiré du DTO API. Remplacé par `hasLocation: boolean` pour UI savoir
+ * si backup est restorable sans exposer le path S3 (anti bucket
+ * enumeration + path discovery).
+ */
+export interface BackupLogDTOClient {
+  id: number
+  backupRef: string
+  status: BackupStatus
+  hasLocation: boolean
+  sizeBytes: number | null // BigInt → number via bigIntToJson (≤ TB OK)
+  durationMs: number | null
+  triggeredBy: number | null
+  startedAt: string // ISO
+  completedAt: string | null
+  errorMessage: string | null // Sanitized backend via sanitizeErrorMessage
+}
+
+// ─────────────────────────────────────────────────────────────
+// Labels FR (i18n complet V2 via messages/{fr,en,ar}.json)
+// ─────────────────────────────────────────────────────────────
+
+export const COMPONENT_STATUS_LABELS_FR: Record<ComponentStatus, string> = {
+  ok: "OK",
+  degraded: "Dégradé",
+  down: "HS",
+  unknown: "Inconnu",
+}
+
+export const BACKUP_STATUS_LABELS_FR: Record<BackupStatus, string> = {
+  pending: "En attente",
+  running: "En cours",
+  completed: "Terminé",
+  failed: "Échoué",
+}
+
+export type BadgeVariant = "default" | "secondary" | "destructive" | "outline"
+
+export const COMPONENT_STATUS_VARIANT: Record<ComponentStatus, BadgeVariant> = {
+  ok: "default",
+  degraded: "outline",
+  down: "destructive",
+  unknown: "secondary",
+}
+
+export const BACKUP_STATUS_VARIANT: Record<BackupStatus, BadgeVariant> = {
+  pending: "secondary",
+  running: "outline",
+  completed: "default",
+  failed: "destructive",
+}
+
+export const OVERALL_STATUS_LABELS_FR: Record<OverallStatus, string> = {
+  ok: "Opérationnel",
+  degraded: "Dégradé",
+  down: "Hors service",
+}
+
+export const OVERALL_STATUS_VARIANT: Record<OverallStatus, BadgeVariant> = {
+  ok: "default",
+  degraded: "outline",
+  down: "destructive",
+}


### PR DESCRIPTION
Plan B Pre-prod cabinet multi-PS **iter 2/5** (post-PR #457). UI pour 2 US Groupe 9 Admin/Ops dont le backend a été livré PR #409.

## Périmètre iter 2

| US | Backend | UI iter 2 |
|---|---|---|
| US-2150 Dashboard santé système | PR #409 | ✅ \`/admin/system-health\` (auto-refresh 60s) |
| US-2151 Backups PostgreSQL | PR #409 | ✅ \`/admin/backups\` (list + filtre + trigger) |

## US-2150 System Health

- Statut global + 4 composants (DB, Redis, CGM, Backups) avec icônes/badges
- 4 métriques (sessions actives, tentatives non-autorisées 24h, CGM lag, age dernier backup) avec highlight si seuils dépassés
- Auto-refresh 60s + bouton "Actualiser" + timestamp relatif i18n
- AbortController + mountedRef + cleanup interval

## US-2151 Backups

- Filtre status + bouton "Déclencher backup" avec Dialog confirm
- Liste : backupRef court + status badge + dates + durée + size formatée + triggeredBy
- Handle 409 conflict ("déjà en cours") + success toast 3s
- AbortController + fetchSeq race protection

## Sidebar — 2 nouveaux items ADMIN

\`/admin/system-health\` (Heart) + \`/admin/backups\` (HardDrive). Gated \`roles: ["ADMIN"]\`, pattern aligné PR #457.

## Pattern aligné iter 1 round 1 fixes

- AbortController + fetchSeqRef + mountedRef
- Dialog shadcn (vs confirm/alert natif)
- formatDate + formatRelativeTime next-intl
- DiabeoButton variants diabeoTertiary/diabeoPrimary

## Tests

- [x] 2769/2769 vitest verts (UI seulement, inchangé)
- [x] \`tsc --noEmit\` clean
- [x] Lint clean (2 eslint-disable inline justifiés)
- [ ] CI E2E green (à vérifier post-push)
- [ ] Test manuel ADMIN : sidebar 3 items admin → cliquer chaque → vérifier auto-refresh + déclencher backup

## Plan B status après merge

- iter 1/5 ✅ Sessions + Data Breaches (PR #457)
- iter 2/5 ✅ System Health + Backups (cette PR)
- iter 3/5 ⏳ Cabinet settings + SMS config
- iter 4/5 ⏳ Invoices list + PDF download
- iter 5/5 ⏳ Admin users + Tax rules

## Références

- PR #409 backend Groupe 9 Admin/Ops
- PR #457 iter 1 pattern
- US-2150 \`docs/UserStory/.../US-2150.md\`
- US-2151 \`docs/UserStory/.../US-2151.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)