### PR TITLE
feat(admin): iter 3 — Cabinets list + detail (settings + SMS config) UI

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1008,6 +1008,7 @@
     "adminDataBreaches": "انتهاكات اللائحة الأوروبية",
     "adminSystemHealth": "صحة النظام",
     "adminBackups": "نسخ احتياطية",
+    "adminCabinets": "العيادات",
     "logout": "تسجيل الخروج"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1008,6 +1008,7 @@
     "adminDataBreaches": "GDPR breaches",
     "adminSystemHealth": "System health",
     "adminBackups": "DB backups",
+    "adminCabinets": "Cabinets",
     "logout": "Sign out"
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1008,6 +1008,7 @@
     "adminDataBreaches": "Violations RGPD",
     "adminSystemHealth": "Sante systeme",
     "adminBackups": "Backups DB",
+    "adminCabinets": "Cabinets",
     "logout": "Se deconnecter"
   }
 }

--- a/src/app/(dashboard)/admin/cabinets/[id]/page.tsx
+++ b/src/app/(dashboard)/admin/cabinets/[id]/page.tsx
@@ -1,0 +1,31 @@
+/**
+ * US-2117/2118 + US-2506 — Cabinet detail (settings + SMS config).
+ *
+ * ADMIN-only. 2 sections : settings éditables manager-level (phone, address,
+ * specialties, capacity, openingHours) + SMS config V1 mock (toggle + crédits).
+ */
+import { headers } from "next/headers"
+import { redirect } from "next/navigation"
+import { CabinetDetailClient } from "@/components/diabeo/admin/CabinetDetailClient"
+
+interface PageProps {
+  params: Promise<{ id: string }>
+}
+
+export default async function CabinetDetailPage({ params }: PageProps) {
+  const headersList = await headers()
+  const role = headersList.get("x-user-role")
+  if (role !== "ADMIN") redirect("/")
+
+  const { id } = await params
+  const cabinetId = Number.parseInt(id, 10)
+  if (!Number.isFinite(cabinetId) || cabinetId <= 0) {
+    redirect("/admin/cabinets")
+  }
+
+  return (
+    <main className="flex flex-col gap-6 p-4 lg:p-6">
+      <CabinetDetailClient cabinetId={cabinetId} />
+    </main>
+  )
+}

--- a/src/app/(dashboard)/admin/cabinets/[id]/page.tsx
+++ b/src/app/(dashboard)/admin/cabinets/[id]/page.tsx
@@ -18,10 +18,13 @@ export default async function CabinetDetailPage({ params }: PageProps) {
   if (role !== "ADMIN") redirect("/")
 
   const { id } = await params
-  const cabinetId = Number.parseInt(id, 10)
-  if (!Number.isFinite(cabinetId) || cabinetId <= 0) {
+  // Fix H5 round 1 review PR #459 (HSA M2) — regex stricte vs parseInt
+  // accepting "1.5xyz" / "1e10" silent truncate. URL `/admin/cabinets/1.5`
+  // pourrait polluer audit US-2268 avec resourceId non-canonique.
+  if (!/^[1-9]\d{0,9}$/.test(id)) {
     redirect("/admin/cabinets")
   }
+  const cabinetId = Number.parseInt(id, 10)
 
   return (
     <main className="flex flex-col gap-6 p-4 lg:p-6">

--- a/src/app/(dashboard)/admin/cabinets/page.tsx
+++ b/src/app/(dashboard)/admin/cabinets/page.tsx
@@ -1,0 +1,28 @@
+/**
+ * US-2117/2118/2506 Admin gestion cabinets (page conteneur).
+ *
+ * ADMIN-only. Liste paginée des cabinets + lien vers détail (settings +
+ * SMS config). Backend : `GET /api/admin/healthcare-services`.
+ */
+import { headers } from "next/headers"
+import { redirect } from "next/navigation"
+import { CabinetsListClient } from "@/components/diabeo/admin/CabinetsListClient"
+
+export default async function CabinetsListPage() {
+  const headersList = await headers()
+  const role = headersList.get("x-user-role")
+  if (role !== "ADMIN") redirect("/")
+
+  return (
+    <main className="flex flex-col gap-6 p-4 lg:p-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Cabinets &amp; structures</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Liste des cabinets médicaux + structures hospitalières. Cliquer
+          pour gérer paramètres + configuration SMS V1 mock.
+        </p>
+      </header>
+      <CabinetsListClient />
+    </main>
+  )
+}

--- a/src/components/diabeo/Sidebar.tsx
+++ b/src/components/diabeo/Sidebar.tsx
@@ -20,6 +20,7 @@ import {
   ShieldAlert,
   HardDrive,
   Heart,
+  Building2,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useAuth } from "@/hooks/use-auth"
@@ -48,6 +49,8 @@ const navItems: ReadonlyArray<NavItem> = [
   // US-2150 + US-2151 (iter 2 PR Plan B) — ADMIN ops monitoring.
   { href: "/admin/system-health", labelKey: "adminSystemHealth", icon: Heart, roles: ["ADMIN"] },
   { href: "/admin/backups", labelKey: "adminBackups", icon: HardDrive, roles: ["ADMIN"] },
+  // US-2117/2118 + US-2506 (iter 3 PR Plan B) — Admin cabinets + SMS config.
+  { href: "/admin/cabinets", labelKey: "adminCabinets", icon: Building2, roles: ["ADMIN"] },
 ]
 
 /**

--- a/src/components/diabeo/admin/CabinetDetailClient.tsx
+++ b/src/components/diabeo/admin/CabinetDetailClient.tsx
@@ -4,23 +4,25 @@
  * CabinetDetailClient — UI ADMIN detail cabinet (US-2117/2118 settings +
  * US-2506 SMS config V1 mock).
  *
- * 2 sections :
- *   - "Paramètres cabinet" — fetch GET `/api/cabinet/[id]/settings` +
- *     PUT pour update (manager-level fields : contact, adresse, capacity,
- *     spécialités, flags noVideos/noFood). Champs régaliens (siret, type)
- *     en read-only.
- *   - "Configuration SMS V1 mock" — GET/PUT `/api/cabinet/[id]/sms-config`
- *     (smsEnabled toggle + smsCreditBalance integer). Provider="mock" V1
- *     (US-2506bis V3 = Twilio/OVH réel).
- *
- * Pattern aligné iter 1+2 PR #457/#458 round 1 fixes :
- *   - AbortController + mountedRef + cleanup
- *   - Dialog shadcn pour confirmations
- *   - i18n via useLocale + formatDate
- *   - DiabeoButton variants
+ * Fixes round 1 review PR #459 (~22 findings — Option C totale) :
+ *   - H1 : `extractApiError` mapping codes erreur + détails per-field
+ *   - H2 : types extraits `src/lib/types/cabinet-admin.ts`
+ *   - H3 : reset state `setSettings(null) + setSms(null)` au début fetchAll
+ *   - H4 : color contrast warning crédit + aria-label emoji
+ *   - C1+H2 : aria-invalid + aria-describedby form inputs
+ *   - M1 : truncate spécialités 60 chars côté UI (cohérent Zod backend)
+ *   - M2 : `setDraft(prev => ...)` stale-safe vs spread direct
+ *   - M3 : success banner role="status" auto-dismiss 3s
+ *   - M4 : char count display TextInput
+ *   - M7 : Dialog close button aria-label i18n FR
+ *   - M8 : PUT diff body (changes only vs full draft)
+ *   - L4 : `SMS_CREDITS_MAX` const partagée
+ *   - L5 : confirmation Dialog Settings save (cohérence avec SMS)
+ *   - A11y L1 : emoji ⚠ wrap span aria-label
+ *   - A11y L2 : `<nav aria-label="Breadcrumb">` retour liste
  */
 
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useId, useRef, useState } from "react"
 import Link from "next/link"
 import {
   AlertCircle,
@@ -41,38 +43,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-
-// ---------------------------------------------------------------------------
-// Types DTO (cohérent backend cabinet-settings.service + sms.service)
-// ---------------------------------------------------------------------------
-
-interface CabinetSettingsDTO {
-  id: number
-  name: string
-  establishment: string | null
-  phone: string | null
-  email: string | null
-  website: string | null
-  addressLine1: string | null
-  addressLine2: string | null
-  postalCode: string | null
-  city: string | null
-  country: string | null
-  openingHours: unknown
-  specialties: string[]
-  capacity: number | null
-  noVideos: boolean
-  noFood: boolean
-  managerId: number | null
-  siret: string | null
-  tvaIntra: string | null
-  type: string
-}
-
-interface SmsConfigDTO {
-  smsEnabled: boolean
-  smsCreditBalance: number
-}
+import {
+  type CabinetSettingsDTOClient as CabinetSettingsDTO,
+  type SmsConfigDTOClient as SmsConfigDTO,
+  SMS_CREDITS_MAX,
+  CABINET_FIELD_LIMITS,
+} from "@/lib/types/cabinet-admin"
+import { extractApiError, type ParsedApiError } from "@/lib/ui/api-error"
 
 type AsyncState = "idle" | "loading" | "saving" | "success" | "error"
 
@@ -92,6 +69,10 @@ export function CabinetDetailClient({ cabinetId }: { cabinetId: number }) {
     if (abortRef.current) abortRef.current.abort()
     const controller = new AbortController()
     abortRef.current = controller
+    // Fix H3 round 1 review PR #459 — reset state pour éviter données stales
+    // si seconde route échoue partiellement au refresh.
+    setSettings(null)
+    setSms(null)
     setState("loading")
     setErrorMessage(null)
     try {
@@ -108,11 +89,10 @@ export function CabinetDetailClient({ cabinetId }: { cabinetId: number }) {
       if (!mountedRef.current) return
       if (!settingsRes.ok || !smsRes.ok) {
         setState("error")
-        setErrorMessage(
-          settingsRes.status === 404
-            ? "Cabinet introuvable"
-            : `HTTP ${!settingsRes.ok ? settingsRes.status : smsRes.status}`,
-        )
+        // Fix H1 round 1 — extract error code friendly (vs HTTP générique).
+        const failedRes = !settingsRes.ok ? settingsRes : smsRes
+        const parsed = await extractApiError(failedRes)
+        setErrorMessage(parsed.message)
         return
       }
       const settingsData = (await settingsRes.json()) as { settings?: CabinetSettingsDTO }
@@ -169,13 +149,16 @@ export function CabinetDetailClient({ cabinetId }: { cabinetId: number }) {
 
   return (
     <>
-      <Link
-        href="/admin/cabinets"
-        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-      >
-        <ArrowLeft className="size-4" aria-hidden="true" />
-        Retour à la liste
-      </Link>
+      {/* Fix A11y L2 round 1 — wrap dans <nav> breadcrumb landmark. */}
+      <nav aria-label="Fil d'Ariane">
+        <Link
+          href="/admin/cabinets"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 rounded"
+        >
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          Retour à la liste
+        </Link>
+      </nav>
 
       <header className="space-y-1">
         <h1 className="text-2xl font-semibold flex items-center gap-2">
@@ -225,11 +208,18 @@ function SettingsSection({
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState<Partial<CabinetSettingsDTO>>({})
   const [saveState, setSaveState] = useState<AsyncState>("idle")
-  const [saveError, setSaveError] = useState<string | null>(null)
+  const [saveError, setSaveError] = useState<ParsedApiError | null>(null)
+  // Fix L5 round 1 — confirmation Dialog (cohérence avec SmsConfigSection).
+  const [showConfirm, setShowConfirm] = useState(false)
   const mountedRef = useRef(true)
+  // Fix M3 round 1 — success banner auto-dismiss timer tracked.
+  const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   useEffect(() => {
     mountedRef.current = true
-    return () => { mountedRef.current = false }
+    return () => {
+      mountedRef.current = false
+      if (successTimerRef.current) clearTimeout(successTimerRef.current)
+    }
   }, [])
 
   const startEdit = () => {
@@ -250,10 +240,49 @@ function SettingsSection({
     setEditing(true)
   }
 
-  const handleSave = useCallback(async () => {
+  /**
+   * Fix M8 round 1 — compute diff body (vs full draft) pour PATCH semantics.
+   * Backend audit log enregistre uniquement les changements effectifs.
+   * Comparaison shallow par field — `specialties` array compared via JSON.
+   */
+  const computeChanges = useCallback((): Partial<CabinetSettingsDTO> => {
+    const changes: Partial<CabinetSettingsDTO> = {}
+    const compareKey = <K extends keyof CabinetSettingsDTO>(key: K): void => {
+      if (draft[key] === undefined) return
+      const draftVal = draft[key]
+      const initialVal = initial[key]
+      // Compare arrays via JSON.stringify (specialties).
+      const same = Array.isArray(draftVal) && Array.isArray(initialVal)
+        ? JSON.stringify(draftVal) === JSON.stringify(initialVal)
+        : draftVal === initialVal
+      if (!same) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ;(changes as any)[key] = draftVal
+      }
+    }
+    compareKey("phone")
+    compareKey("email")
+    compareKey("website")
+    compareKey("addressLine1")
+    compareKey("addressLine2")
+    compareKey("postalCode")
+    compareKey("city")
+    compareKey("capacity")
+    compareKey("noVideos")
+    compareKey("noFood")
+    compareKey("specialties")
+    return changes
+  }, [draft, initial])
+
+  const hasChanges = Object.keys(computeChanges()).length > 0
+
+  const executeSave = useCallback(async () => {
+    setShowConfirm(false)
     setSaveState("saving")
     setSaveError(null)
     try {
+      // Fix M8 round 1 — send only changed fields.
+      const body = computeChanges()
       const res = await fetch(`/api/cabinet/${cabinetId}/settings`, {
         method: "PUT",
         credentials: "include",
@@ -261,23 +290,32 @@ function SettingsSection({
           "Content-Type": "application/json",
           "X-Requested-With": "XMLHttpRequest",
         },
-        body: JSON.stringify(draft),
+        body: JSON.stringify(body),
       })
       if (!mountedRef.current) return
       if (!res.ok) {
         setSaveState("error")
-        setSaveError(`HTTP ${res.status}`)
+        // Fix H1 round 1 — error code mapping friendly + field-level details.
+        const parsed = await extractApiError(res)
+        setSaveError(parsed)
         return
       }
       setSaveState("success")
       setEditing(false)
       onSaved()
+      // Fix M3 round 1 — success banner auto-dismiss after 3s.
+      if (successTimerRef.current) clearTimeout(successTimerRef.current)
+      successTimerRef.current = setTimeout(() => {
+        if (mountedRef.current) setSaveState("idle")
+      }, 3000)
     } catch (err) {
       if (!mountedRef.current) return
       setSaveState("error")
-      setSaveError(err instanceof Error ? err.message : "Erreur réseau")
+      setSaveError({
+        message: err instanceof Error ? err.message : "Erreur réseau",
+      })
     }
-  }, [cabinetId, draft, onSaved])
+  }, [cabinetId, computeChanges, onSaved])
 
   return (
     <section className="rounded-md border p-4 space-y-3" aria-labelledby="settings-section">
@@ -311,85 +349,111 @@ function SettingsSection({
         </dl>
       ) : (
         <div className="grid grid-cols-1 gap-3 text-sm md:grid-cols-2">
+          {/* Fix M2 round 1 — `setDraft(prev => ...)` stale-safe (vs spread direct).
+              Fix C1+H2 round 1 — `errorField` propagé pour aria-invalid (H1 details). */}
           <TextInput
             label="Téléphone"
+            field="phone"
             value={draft.phone ?? ""}
-            onChange={(v) => setDraft({ ...draft, phone: v || null })}
-            maxLength={30}
+            onChange={(v) => setDraft((prev) => ({ ...prev, phone: v || null }))}
+            maxLength={CABINET_FIELD_LIMITS.PHONE_MAX}
+            errorDetails={saveError?.details}
           />
           <TextInput
             label="Email"
+            field="email"
             type="email"
             value={draft.email ?? ""}
-            onChange={(v) => setDraft({ ...draft, email: v || null })}
-            maxLength={255}
+            onChange={(v) => setDraft((prev) => ({ ...prev, email: v || null }))}
+            maxLength={CABINET_FIELD_LIMITS.EMAIL_MAX}
+            errorDetails={saveError?.details}
           />
           <TextInput
             label="Site web"
+            field="website"
             value={draft.website ?? ""}
-            onChange={(v) => setDraft({ ...draft, website: v || null })}
-            maxLength={500}
+            onChange={(v) => setDraft((prev) => ({ ...prev, website: v || null }))}
+            maxLength={CABINET_FIELD_LIMITS.WEBSITE_MAX}
+            errorDetails={saveError?.details}
           />
           <NumberInput
             label="Capacité"
+            field="capacity"
             value={draft.capacity ?? null}
-            onChange={(v) => setDraft({ ...draft, capacity: v })}
+            onChange={(v) => setDraft((prev) => ({ ...prev, capacity: v }))}
             min={0}
-            max={10_000}
+            max={CABINET_FIELD_LIMITS.CAPACITY_MAX}
+            errorDetails={saveError?.details}
           />
           <TextInput
             label="Adresse ligne 1"
+            field="addressLine1"
             value={draft.addressLine1 ?? ""}
-            onChange={(v) => setDraft({ ...draft, addressLine1: v || null })}
-            maxLength={255}
+            onChange={(v) => setDraft((prev) => ({ ...prev, addressLine1: v || null }))}
+            maxLength={CABINET_FIELD_LIMITS.ADDRESS_MAX}
+            errorDetails={saveError?.details}
             wide
           />
           <TextInput
             label="Adresse ligne 2"
+            field="addressLine2"
             value={draft.addressLine2 ?? ""}
-            onChange={(v) => setDraft({ ...draft, addressLine2: v || null })}
-            maxLength={255}
+            onChange={(v) => setDraft((prev) => ({ ...prev, addressLine2: v || null }))}
+            maxLength={CABINET_FIELD_LIMITS.ADDRESS_MAX}
+            errorDetails={saveError?.details}
             wide
           />
           <TextInput
             label="Code postal"
+            field="postalCode"
             value={draft.postalCode ?? ""}
-            onChange={(v) => setDraft({ ...draft, postalCode: v || null })}
-            maxLength={10}
+            onChange={(v) => setDraft((prev) => ({ ...prev, postalCode: v || null }))}
+            maxLength={CABINET_FIELD_LIMITS.POSTAL_CODE_MAX}
+            errorDetails={saveError?.details}
           />
           <TextInput
             label="Ville"
+            field="city"
             value={draft.city ?? ""}
-            onChange={(v) => setDraft({ ...draft, city: v || null })}
-            maxLength={100}
+            onChange={(v) => setDraft((prev) => ({ ...prev, city: v || null }))}
+            maxLength={CABINET_FIELD_LIMITS.CITY_MAX}
+            errorDetails={saveError?.details}
           />
           <TextInput
             label="Spécialités (séparées par virgule)"
+            field="specialties"
             value={(draft.specialties ?? []).join(", ")}
             onChange={(v) =>
-              setDraft({
-                ...draft,
-                specialties: v.split(",").map((s) => s.trim()).filter(Boolean).slice(0, 20),
-              })
+              // Fix M1 round 1 — truncate per-spécialité 60 chars (cohérent Zod backend).
+              setDraft((prev) => ({
+                ...prev,
+                specialties: v
+                  .split(",")
+                  .map((s) => s.trim().slice(0, CABINET_FIELD_LIMITS.SPECIALTY_LEN_MAX))
+                  .filter(Boolean)
+                  .slice(0, CABINET_FIELD_LIMITS.SPECIALTIES_COUNT_MAX),
+              }))
             }
             maxLength={500}
+            errorDetails={saveError?.details}
             wide
+            helpText={`Max ${CABINET_FIELD_LIMITS.SPECIALTIES_COUNT_MAX} spécialités, ${CABINET_FIELD_LIMITS.SPECIALTY_LEN_MAX} caractères chacune.`}
           />
           <BoolInput
             label="Pas de vidéo"
             value={draft.noVideos ?? false}
-            onChange={(v) => setDraft({ ...draft, noVideos: v })}
+            onChange={(v) => setDraft((prev) => ({ ...prev, noVideos: v }))}
           />
           <BoolInput
             label="Pas de repas"
             value={draft.noFood ?? false}
-            onChange={(v) => setDraft({ ...draft, noFood: v })}
+            onChange={(v) => setDraft((prev) => ({ ...prev, noFood: v }))}
           />
 
           {saveState === "error" && saveError && (
             <p role="alert" className="md:col-span-2 text-sm text-destructive flex items-center gap-2">
               <AlertCircle className="size-4" aria-hidden="true" />
-              Erreur : {saveError}
+              {saveError.message}
             </p>
           )}
 
@@ -397,13 +461,48 @@ function SettingsSection({
             <DiabeoButton variant="diabeoTertiary" onClick={() => setEditing(false)}>
               Annuler
             </DiabeoButton>
-            <DiabeoButton onClick={() => void handleSave()} disabled={saveState === "saving"}>
+            <DiabeoButton
+              onClick={() => setShowConfirm(true)}
+              disabled={saveState === "saving" || !hasChanges}
+            >
               <Save className="size-4 mr-1" aria-hidden="true" />
               {saveState === "saving" ? "Enregistrement…" : "Enregistrer"}
             </DiabeoButton>
           </div>
         </div>
       )}
+
+      {/* Fix M3 round 1 — success banner auto-dismiss 3s. */}
+      {!editing && saveState === "success" && (
+        <div role="status" aria-live="polite" className="rounded-md border border-primary/20 bg-primary/5 p-3 text-sm">
+          <p className="flex items-center gap-2 text-primary">
+            <CheckCircle2 className="size-4" aria-hidden="true" />
+            Paramètres cabinet mis à jour.
+          </p>
+        </div>
+      )}
+
+      {/* Fix L5 round 1 — confirmation Dialog Settings save (cohérence SMS). */}
+      <Dialog open={showConfirm} onOpenChange={(open) => { if (!open) setShowConfirm(false) }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirmer les modifications du cabinet ?</DialogTitle>
+            <DialogDescription>
+              {Object.keys(computeChanges()).length} champ(s) modifié(s).
+              Action tracée dans l&apos;audit log immuable.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DiabeoButton variant="diabeoTertiary" onClick={() => setShowConfirm(false)}>
+              Annuler
+            </DiabeoButton>
+            <DiabeoButton onClick={() => void executeSave()}>
+              <CheckCircle2 className="size-4 mr-1" aria-hidden="true" />
+              Confirmer
+            </DiabeoButton>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </section>
   )
 }
@@ -425,12 +524,17 @@ function SmsConfigSection({
   const [draftEnabled, setDraftEnabled] = useState(initial.smsEnabled)
   const [draftCredits, setDraftCredits] = useState(initial.smsCreditBalance)
   const [saveState, setSaveState] = useState<AsyncState>("idle")
-  const [saveError, setSaveError] = useState<string | null>(null)
+  // Fix H1 round 1 — ParsedApiError pour mapping codes + détails (vs string).
+  const [saveError, setSaveError] = useState<ParsedApiError | null>(null)
   const [showConfirm, setShowConfirm] = useState(false)
   const mountedRef = useRef(true)
+  const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   useEffect(() => {
     mountedRef.current = true
-    return () => { mountedRef.current = false }
+    return () => {
+      mountedRef.current = false
+      if (successTimerRef.current) clearTimeout(successTimerRef.current)
+    }
   }, [])
 
   const startEdit = () => {
@@ -462,16 +566,25 @@ function SmsConfigSection({
       if (!mountedRef.current) return
       if (!res.ok) {
         setSaveState("error")
-        setSaveError(`HTTP ${res.status}`)
+        // Fix H1 round 1 — error code mapping friendly.
+        const parsed = await extractApiError(res)
+        setSaveError(parsed)
         return
       }
       setSaveState("success")
       setEditing(false)
       onSaved()
+      // Fix M3 round 1 — success banner auto-dismiss 3s.
+      if (successTimerRef.current) clearTimeout(successTimerRef.current)
+      successTimerRef.current = setTimeout(() => {
+        if (mountedRef.current) setSaveState("idle")
+      }, 3000)
     } catch (err) {
       if (!mountedRef.current) return
       setSaveState("error")
-      setSaveError(err instanceof Error ? err.message : "Erreur réseau")
+      setSaveError({
+        message: err instanceof Error ? err.message : "Erreur réseau",
+      })
     }
   }, [cabinetId, draftEnabled, draftCredits, initial.smsEnabled, initial.smsCreditBalance, onSaved])
 
@@ -503,9 +616,15 @@ function SmsConfigSection({
             </Badge>
           </Field>
           <Field label="Crédits SMS restants">
-            <span className={initial.smsCreditBalance < 10 ? "text-orange-700 font-medium" : ""}>
+            {/* Fix H4 + A11y L1 round 1 — text-orange-800 augmente contraste ≥4.5:1.
+                Wrap emoji ⚠ + label sr-only pour SR ("Alerte : crédit faible"). */}
+            <span className={initial.smsCreditBalance < 10 && initial.smsEnabled ? "text-orange-800 font-medium" : ""}>
               {initial.smsCreditBalance}
-              {initial.smsCreditBalance < 10 && initial.smsEnabled && " ⚠ Faible"}
+              {initial.smsCreditBalance < 10 && initial.smsEnabled && (
+                <span className="ml-1" aria-label="Alerte : crédit SMS faible">
+                  <span aria-hidden="true">⚠ Faible</span>
+                </span>
+              )}
             </span>
           </Field>
         </dl>
@@ -518,16 +637,18 @@ function SmsConfigSection({
           />
           <NumberInput
             label="Crédits SMS"
+            field="smsCreditBalance"
             value={draftCredits}
             onChange={(v) => setDraftCredits(v ?? 0)}
             min={0}
-            max={1_000_000}
+            max={SMS_CREDITS_MAX}
+            errorDetails={saveError?.details}
           />
 
           {saveState === "error" && saveError && (
             <p role="alert" className="text-sm text-destructive flex items-center gap-2">
               <AlertCircle className="size-4" aria-hidden="true" />
-              Erreur : {saveError}
+              {saveError.message}
             </p>
           )}
 
@@ -578,6 +699,16 @@ function SmsConfigSection({
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Fix M3 round 1 — success banner SMS auto-dismiss 3s. */}
+      {!editing && saveState === "success" && (
+        <div role="status" aria-live="polite" className="rounded-md border border-primary/20 bg-primary/5 p-3 text-sm">
+          <p className="flex items-center gap-2 text-primary">
+            <CheckCircle2 className="size-4" aria-hidden="true" />
+            Configuration SMS mise à jour.
+          </p>
+        </div>
+      )}
     </section>
   )
 }
@@ -595,52 +726,103 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
   )
 }
 
+/**
+ * Fix C1+H2+M4 round 1 review PR #459 — TextInput enrichi avec :
+ *   - `field` + `errorDetails` → `aria-invalid` + `aria-describedby` (validation feedback)
+ *   - `maxLength` + char count visible (`<small aria-live="polite">{N}/{MAX}</small>`)
+ *   - `helpText` optionnel pour instructions inline (WCAG 3.3.2)
+ */
 function TextInput({
   label,
+  field,
   type = "text",
   value,
   onChange,
   maxLength,
   wide = false,
+  errorDetails,
+  helpText,
 }: {
   label: string
+  field?: string
   type?: string
   value: string
   onChange: (value: string) => void
   maxLength?: number
   wide?: boolean
+  errorDetails?: Record<string, string[] | undefined>
+  helpText?: string
 }) {
+  const inputId = useId()
+  const helpId = useId()
+  const errorId = useId()
+  const fieldErrors = field && errorDetails ? errorDetails[field] : undefined
+  const hasError = Boolean(fieldErrors && fieldErrors.length > 0)
+  const showCharCount = typeof maxLength === "number" && maxLength <= 500
+  const describedBy = [
+    helpText ? helpId : null,
+    hasError ? errorId : null,
+    showCharCount ? `${inputId}-count` : null,
+  ].filter(Boolean).join(" ") || undefined
+
   return (
-    <label className={`flex flex-col gap-1 text-sm ${wide ? "md:col-span-2" : ""}`}>
+    <label htmlFor={inputId} className={`flex flex-col gap-1 text-sm ${wide ? "md:col-span-2" : ""}`}>
       <span>{label}</span>
       <input
+        id={inputId}
         type={type}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         maxLength={maxLength}
-        className="rounded-md border bg-background px-3 py-2"
+        aria-invalid={hasError || undefined}
+        aria-describedby={describedBy}
+        className={`rounded-md border bg-background px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 ${
+          hasError ? "border-destructive" : ""
+        }`}
       />
+      {helpText && (
+        <span id={helpId} className="text-xs text-muted-foreground">{helpText}</span>
+      )}
+      {showCharCount && (
+        <small id={`${inputId}-count`} aria-live="polite" className="text-xs text-muted-foreground self-end">
+          {value.length} / {maxLength}
+        </small>
+      )}
+      {hasError && fieldErrors && (
+        <span id={errorId} role="alert" className="text-xs text-destructive">
+          {fieldErrors.join(", ")}
+        </span>
+      )}
     </label>
   )
 }
 
 function NumberInput({
   label,
+  field,
   value,
   onChange,
   min,
   max,
+  errorDetails,
 }: {
   label: string
+  field?: string
   value: number | null
   onChange: (value: number | null) => void
   min?: number
   max?: number
+  errorDetails?: Record<string, string[] | undefined>
 }) {
+  const inputId = useId()
+  const errorId = useId()
+  const fieldErrors = field && errorDetails ? errorDetails[field] : undefined
+  const hasError = Boolean(fieldErrors && fieldErrors.length > 0)
   return (
-    <label className="flex flex-col gap-1 text-sm">
+    <label htmlFor={inputId} className="flex flex-col gap-1 text-sm">
       <span>{label}</span>
       <input
+        id={inputId}
         type="number"
         value={value ?? ""}
         onChange={(e) => {
@@ -654,8 +836,17 @@ function NumberInput({
         }}
         min={min}
         max={max}
-        className="rounded-md border bg-background px-3 py-2"
+        aria-invalid={hasError || undefined}
+        aria-describedby={hasError ? errorId : undefined}
+        className={`rounded-md border bg-background px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 ${
+          hasError ? "border-destructive" : ""
+        }`}
       />
+      {hasError && fieldErrors && (
+        <span id={errorId} role="alert" className="text-xs text-destructive">
+          {fieldErrors.join(", ")}
+        </span>
+      )}
     </label>
   )
 }

--- a/src/components/diabeo/admin/CabinetDetailClient.tsx
+++ b/src/components/diabeo/admin/CabinetDetailClient.tsx
@@ -1,0 +1,683 @@
+"use client"
+
+/**
+ * CabinetDetailClient — UI ADMIN detail cabinet (US-2117/2118 settings +
+ * US-2506 SMS config V1 mock).
+ *
+ * 2 sections :
+ *   - "Paramètres cabinet" — fetch GET `/api/cabinet/[id]/settings` +
+ *     PUT pour update (manager-level fields : contact, adresse, capacity,
+ *     spécialités, flags noVideos/noFood). Champs régaliens (siret, type)
+ *     en read-only.
+ *   - "Configuration SMS V1 mock" — GET/PUT `/api/cabinet/[id]/sms-config`
+ *     (smsEnabled toggle + smsCreditBalance integer). Provider="mock" V1
+ *     (US-2506bis V3 = Twilio/OVH réel).
+ *
+ * Pattern aligné iter 1+2 PR #457/#458 round 1 fixes :
+ *   - AbortController + mountedRef + cleanup
+ *   - Dialog shadcn pour confirmations
+ *   - i18n via useLocale + formatDate
+ *   - DiabeoButton variants
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import Link from "next/link"
+import {
+  AlertCircle,
+  ArrowLeft,
+  Building2,
+  CheckCircle2,
+  Loader2,
+  MessageSquare,
+  Save,
+} from "lucide-react"
+import { DiabeoButton } from "@/components/diabeo/DiabeoButton"
+import { Badge } from "@/components/ui/badge"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+// ---------------------------------------------------------------------------
+// Types DTO (cohérent backend cabinet-settings.service + sms.service)
+// ---------------------------------------------------------------------------
+
+interface CabinetSettingsDTO {
+  id: number
+  name: string
+  establishment: string | null
+  phone: string | null
+  email: string | null
+  website: string | null
+  addressLine1: string | null
+  addressLine2: string | null
+  postalCode: string | null
+  city: string | null
+  country: string | null
+  openingHours: unknown
+  specialties: string[]
+  capacity: number | null
+  noVideos: boolean
+  noFood: boolean
+  managerId: number | null
+  siret: string | null
+  tvaIntra: string | null
+  type: string
+}
+
+interface SmsConfigDTO {
+  smsEnabled: boolean
+  smsCreditBalance: number
+}
+
+type AsyncState = "idle" | "loading" | "saving" | "success" | "error"
+
+// ---------------------------------------------------------------------------
+// Composant principal
+// ---------------------------------------------------------------------------
+
+export function CabinetDetailClient({ cabinetId }: { cabinetId: number }) {
+  const [settings, setSettings] = useState<CabinetSettingsDTO | null>(null)
+  const [sms, setSms] = useState<SmsConfigDTO | null>(null)
+  const [state, setState] = useState<AsyncState>("loading")
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const mountedRef = useRef(true)
+  const abortRef = useRef<AbortController | null>(null)
+
+  const fetchAll = useCallback(async () => {
+    if (abortRef.current) abortRef.current.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+    setState("loading")
+    setErrorMessage(null)
+    try {
+      const [settingsRes, smsRes] = await Promise.all([
+        fetch(`/api/cabinet/${cabinetId}/settings`, {
+          credentials: "include",
+          signal: controller.signal,
+        }),
+        fetch(`/api/cabinet/${cabinetId}/sms-config`, {
+          credentials: "include",
+          signal: controller.signal,
+        }),
+      ])
+      if (!mountedRef.current) return
+      if (!settingsRes.ok || !smsRes.ok) {
+        setState("error")
+        setErrorMessage(
+          settingsRes.status === 404
+            ? "Cabinet introuvable"
+            : `HTTP ${!settingsRes.ok ? settingsRes.status : smsRes.status}`,
+        )
+        return
+      }
+      const settingsData = (await settingsRes.json()) as { settings?: CabinetSettingsDTO }
+      const smsData = (await smsRes.json()) as SmsConfigDTO
+      if (!mountedRef.current) return
+      if (settingsData.settings) setSettings(settingsData.settings)
+      setSms(smsData)
+      setState("success")
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return
+      if (!mountedRef.current) return
+      setState("error")
+      setErrorMessage(err instanceof Error ? err.message : "Erreur réseau")
+    }
+  }, [cabinetId])
+
+  useEffect(() => {
+    mountedRef.current = true
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void fetchAll()
+    return () => {
+      mountedRef.current = false
+      if (abortRef.current) abortRef.current.abort()
+    }
+  }, [fetchAll])
+
+  if (state === "loading" && !settings) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground" aria-live="polite">
+        <Loader2 className="size-4 animate-spin motion-safe:animate-spin" aria-hidden="true" />
+        Chargement…
+      </div>
+    )
+  }
+
+  if (state === "error" || !settings || !sms) {
+    return (
+      <div role="alert" className="rounded-md border border-destructive/20 bg-destructive/10 p-3">
+        <p className="font-medium text-destructive flex items-center gap-2">
+          <AlertCircle className="size-4" aria-hidden="true" />
+          Erreur de chargement
+        </p>
+        {errorMessage && <p className="text-xs text-muted-foreground mt-1">{errorMessage}</p>}
+        <Link
+          href="/admin/cabinets"
+          className="inline-flex items-center gap-1 text-sm text-primary hover:underline mt-2"
+        >
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          Retour à la liste
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <Link
+        href="/admin/cabinets"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="size-4" aria-hidden="true" />
+        Retour à la liste
+      </Link>
+
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold flex items-center gap-2">
+          <Building2 className="size-6" aria-hidden="true" />
+          {settings.name}
+        </h1>
+        {settings.establishment && (
+          <p className="text-sm text-muted-foreground">{settings.establishment}</p>
+        )}
+        <div className="flex items-center gap-2 flex-wrap mt-1">
+          <Badge variant="outline">{settings.type}</Badge>
+          {settings.siret && <Badge variant="secondary">SIRET {settings.siret}</Badge>}
+          {settings.managerId === null && (
+            <Badge variant="destructive">Pas de manager</Badge>
+          )}
+        </div>
+      </header>
+
+      <SettingsSection
+        cabinetId={cabinetId}
+        initial={settings}
+        onSaved={() => void fetchAll()}
+      />
+
+      <SmsConfigSection
+        cabinetId={cabinetId}
+        initial={sms}
+        onSaved={() => void fetchAll()}
+      />
+    </>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// SettingsSection — manager-level fields editable
+// ---------------------------------------------------------------------------
+
+function SettingsSection({
+  cabinetId,
+  initial,
+  onSaved,
+}: {
+  cabinetId: number
+  initial: CabinetSettingsDTO
+  onSaved: () => void
+}) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState<Partial<CabinetSettingsDTO>>({})
+  const [saveState, setSaveState] = useState<AsyncState>("idle")
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const mountedRef = useRef(true)
+  useEffect(() => {
+    mountedRef.current = true
+    return () => { mountedRef.current = false }
+  }, [])
+
+  const startEdit = () => {
+    setDraft({
+      phone: initial.phone,
+      email: initial.email,
+      website: initial.website,
+      addressLine1: initial.addressLine1,
+      addressLine2: initial.addressLine2,
+      postalCode: initial.postalCode,
+      city: initial.city,
+      capacity: initial.capacity,
+      noVideos: initial.noVideos,
+      noFood: initial.noFood,
+      specialties: initial.specialties,
+    })
+    setSaveError(null)
+    setEditing(true)
+  }
+
+  const handleSave = useCallback(async () => {
+    setSaveState("saving")
+    setSaveError(null)
+    try {
+      const res = await fetch(`/api/cabinet/${cabinetId}/settings`, {
+        method: "PUT",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Requested-With": "XMLHttpRequest",
+        },
+        body: JSON.stringify(draft),
+      })
+      if (!mountedRef.current) return
+      if (!res.ok) {
+        setSaveState("error")
+        setSaveError(`HTTP ${res.status}`)
+        return
+      }
+      setSaveState("success")
+      setEditing(false)
+      onSaved()
+    } catch (err) {
+      if (!mountedRef.current) return
+      setSaveState("error")
+      setSaveError(err instanceof Error ? err.message : "Erreur réseau")
+    }
+  }, [cabinetId, draft, onSaved])
+
+  return (
+    <section className="rounded-md border p-4 space-y-3" aria-labelledby="settings-section">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <h2 id="settings-section" className="text-lg font-semibold">
+          Paramètres cabinet
+        </h2>
+        {!editing && (
+          <DiabeoButton variant="diabeoTertiary" size="sm" onClick={startEdit}>
+            Modifier
+          </DiabeoButton>
+        )}
+      </div>
+
+      {!editing ? (
+        <dl className="grid grid-cols-1 gap-3 text-sm md:grid-cols-2">
+          <Field label="Téléphone">{initial.phone ?? "—"}</Field>
+          <Field label="Email">{initial.email ?? "—"}</Field>
+          <Field label="Site web">{initial.website ?? "—"}</Field>
+          <Field label="Capacité">{initial.capacity ?? "—"}</Field>
+          <Field label="Adresse ligne 1">{initial.addressLine1 ?? "—"}</Field>
+          <Field label="Adresse ligne 2">{initial.addressLine2 ?? "—"}</Field>
+          <Field label="Code postal">{initial.postalCode ?? "—"}</Field>
+          <Field label="Ville">{initial.city ?? "—"}</Field>
+          <Field label="Pays">{initial.country ?? "—"}</Field>
+          <Field label="Spécialités">
+            {initial.specialties.length > 0 ? initial.specialties.join(", ") : "—"}
+          </Field>
+          <Field label="Pas de vidéo">{initial.noVideos ? "Oui" : "Non"}</Field>
+          <Field label="Pas de repas">{initial.noFood ? "Oui" : "Non"}</Field>
+        </dl>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 text-sm md:grid-cols-2">
+          <TextInput
+            label="Téléphone"
+            value={draft.phone ?? ""}
+            onChange={(v) => setDraft({ ...draft, phone: v || null })}
+            maxLength={30}
+          />
+          <TextInput
+            label="Email"
+            type="email"
+            value={draft.email ?? ""}
+            onChange={(v) => setDraft({ ...draft, email: v || null })}
+            maxLength={255}
+          />
+          <TextInput
+            label="Site web"
+            value={draft.website ?? ""}
+            onChange={(v) => setDraft({ ...draft, website: v || null })}
+            maxLength={500}
+          />
+          <NumberInput
+            label="Capacité"
+            value={draft.capacity ?? null}
+            onChange={(v) => setDraft({ ...draft, capacity: v })}
+            min={0}
+            max={10_000}
+          />
+          <TextInput
+            label="Adresse ligne 1"
+            value={draft.addressLine1 ?? ""}
+            onChange={(v) => setDraft({ ...draft, addressLine1: v || null })}
+            maxLength={255}
+            wide
+          />
+          <TextInput
+            label="Adresse ligne 2"
+            value={draft.addressLine2 ?? ""}
+            onChange={(v) => setDraft({ ...draft, addressLine2: v || null })}
+            maxLength={255}
+            wide
+          />
+          <TextInput
+            label="Code postal"
+            value={draft.postalCode ?? ""}
+            onChange={(v) => setDraft({ ...draft, postalCode: v || null })}
+            maxLength={10}
+          />
+          <TextInput
+            label="Ville"
+            value={draft.city ?? ""}
+            onChange={(v) => setDraft({ ...draft, city: v || null })}
+            maxLength={100}
+          />
+          <TextInput
+            label="Spécialités (séparées par virgule)"
+            value={(draft.specialties ?? []).join(", ")}
+            onChange={(v) =>
+              setDraft({
+                ...draft,
+                specialties: v.split(",").map((s) => s.trim()).filter(Boolean).slice(0, 20),
+              })
+            }
+            maxLength={500}
+            wide
+          />
+          <BoolInput
+            label="Pas de vidéo"
+            value={draft.noVideos ?? false}
+            onChange={(v) => setDraft({ ...draft, noVideos: v })}
+          />
+          <BoolInput
+            label="Pas de repas"
+            value={draft.noFood ?? false}
+            onChange={(v) => setDraft({ ...draft, noFood: v })}
+          />
+
+          {saveState === "error" && saveError && (
+            <p role="alert" className="md:col-span-2 text-sm text-destructive flex items-center gap-2">
+              <AlertCircle className="size-4" aria-hidden="true" />
+              Erreur : {saveError}
+            </p>
+          )}
+
+          <div className="md:col-span-2 flex justify-end gap-2 pt-2 border-t">
+            <DiabeoButton variant="diabeoTertiary" onClick={() => setEditing(false)}>
+              Annuler
+            </DiabeoButton>
+            <DiabeoButton onClick={() => void handleSave()} disabled={saveState === "saving"}>
+              <Save className="size-4 mr-1" aria-hidden="true" />
+              {saveState === "saving" ? "Enregistrement…" : "Enregistrer"}
+            </DiabeoButton>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// SmsConfigSection — toggle + crédits
+// ---------------------------------------------------------------------------
+
+function SmsConfigSection({
+  cabinetId,
+  initial,
+  onSaved,
+}: {
+  cabinetId: number
+  initial: SmsConfigDTO
+  onSaved: () => void
+}) {
+  const [editing, setEditing] = useState(false)
+  const [draftEnabled, setDraftEnabled] = useState(initial.smsEnabled)
+  const [draftCredits, setDraftCredits] = useState(initial.smsCreditBalance)
+  const [saveState, setSaveState] = useState<AsyncState>("idle")
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [showConfirm, setShowConfirm] = useState(false)
+  const mountedRef = useRef(true)
+  useEffect(() => {
+    mountedRef.current = true
+    return () => { mountedRef.current = false }
+  }, [])
+
+  const startEdit = () => {
+    setDraftEnabled(initial.smsEnabled)
+    setDraftCredits(initial.smsCreditBalance)
+    setSaveError(null)
+    setEditing(true)
+  }
+
+  const hasChanges = draftEnabled !== initial.smsEnabled || draftCredits !== initial.smsCreditBalance
+
+  const executeSave = useCallback(async () => {
+    setShowConfirm(false)
+    setSaveState("saving")
+    setSaveError(null)
+    try {
+      const body: { smsEnabled?: boolean; smsCreditBalance?: number } = {}
+      if (draftEnabled !== initial.smsEnabled) body.smsEnabled = draftEnabled
+      if (draftCredits !== initial.smsCreditBalance) body.smsCreditBalance = draftCredits
+      const res = await fetch(`/api/cabinet/${cabinetId}/sms-config`, {
+        method: "PUT",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Requested-With": "XMLHttpRequest",
+        },
+        body: JSON.stringify(body),
+      })
+      if (!mountedRef.current) return
+      if (!res.ok) {
+        setSaveState("error")
+        setSaveError(`HTTP ${res.status}`)
+        return
+      }
+      setSaveState("success")
+      setEditing(false)
+      onSaved()
+    } catch (err) {
+      if (!mountedRef.current) return
+      setSaveState("error")
+      setSaveError(err instanceof Error ? err.message : "Erreur réseau")
+    }
+  }, [cabinetId, draftEnabled, draftCredits, initial.smsEnabled, initial.smsCreditBalance, onSaved])
+
+  return (
+    <section className="rounded-md border p-4 space-y-3" aria-labelledby="sms-section">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <h2 id="sms-section" className="text-lg font-semibold flex items-center gap-2">
+          <MessageSquare className="size-5" aria-hidden="true" />
+          Configuration SMS
+          <Badge variant="outline" className="text-[10px]">V1 mock</Badge>
+        </h2>
+        {!editing && (
+          <DiabeoButton variant="diabeoTertiary" size="sm" onClick={startEdit}>
+            Modifier
+          </DiabeoButton>
+        )}
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        V1 mock : aucun SMS réel envoyé (provider=&quot;mock&quot;). Real Twilio/OVH = US-2506bis V3.
+        Le crédit décrémente quand même côté audit pour simuler le coût.
+      </p>
+
+      {!editing ? (
+        <dl className="grid grid-cols-1 gap-3 text-sm md:grid-cols-2">
+          <Field label="SMS activé">
+            <Badge variant={initial.smsEnabled ? "default" : "secondary"}>
+              {initial.smsEnabled ? "OUI" : "NON"}
+            </Badge>
+          </Field>
+          <Field label="Crédits SMS restants">
+            <span className={initial.smsCreditBalance < 10 ? "text-orange-700 font-medium" : ""}>
+              {initial.smsCreditBalance}
+              {initial.smsCreditBalance < 10 && initial.smsEnabled && " ⚠ Faible"}
+            </span>
+          </Field>
+        </dl>
+      ) : (
+        <div className="space-y-3">
+          <BoolInput
+            label="Activer SMS pour ce cabinet"
+            value={draftEnabled}
+            onChange={setDraftEnabled}
+          />
+          <NumberInput
+            label="Crédits SMS"
+            value={draftCredits}
+            onChange={(v) => setDraftCredits(v ?? 0)}
+            min={0}
+            max={1_000_000}
+          />
+
+          {saveState === "error" && saveError && (
+            <p role="alert" className="text-sm text-destructive flex items-center gap-2">
+              <AlertCircle className="size-4" aria-hidden="true" />
+              Erreur : {saveError}
+            </p>
+          )}
+
+          <div className="flex justify-end gap-2 pt-2 border-t">
+            <DiabeoButton variant="diabeoTertiary" onClick={() => setEditing(false)}>
+              Annuler
+            </DiabeoButton>
+            <DiabeoButton
+              onClick={() => setShowConfirm(true)}
+              disabled={!hasChanges || saveState === "saving"}
+            >
+              <Save className="size-4 mr-1" aria-hidden="true" />
+              {saveState === "saving" ? "Enregistrement…" : "Enregistrer"}
+            </DiabeoButton>
+          </div>
+        </div>
+      )}
+
+      {/* Confirmation Dialog shadcn (focus trap + ESC + restore). */}
+      <Dialog open={showConfirm} onOpenChange={(open) => { if (!open) setShowConfirm(false) }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Mettre à jour la configuration SMS ?</DialogTitle>
+            <DialogDescription>
+              {draftEnabled !== initial.smsEnabled && (
+                <span className="block">
+                  • SMS : <strong>{initial.smsEnabled ? "activé" : "désactivé"} → {draftEnabled ? "activé" : "désactivé"}</strong>
+                </span>
+              )}
+              {draftCredits !== initial.smsCreditBalance && (
+                <span className="block">
+                  • Crédits : <strong>{initial.smsCreditBalance} → {draftCredits}</strong>
+                </span>
+              )}
+              <span className="block mt-2 text-xs">
+                Action tracée dans l&apos;audit log immuable.
+              </span>
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DiabeoButton variant="diabeoTertiary" onClick={() => setShowConfirm(false)}>
+              Annuler
+            </DiabeoButton>
+            <DiabeoButton onClick={() => void executeSave()}>
+              <CheckCircle2 className="size-4 mr-1" aria-hidden="true" />
+              Confirmer
+            </DiabeoButton>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </section>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers UI
+// ---------------------------------------------------------------------------
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <dt className="text-xs text-muted-foreground">{label}</dt>
+      <dd className="mt-0.5">{children}</dd>
+    </div>
+  )
+}
+
+function TextInput({
+  label,
+  type = "text",
+  value,
+  onChange,
+  maxLength,
+  wide = false,
+}: {
+  label: string
+  type?: string
+  value: string
+  onChange: (value: string) => void
+  maxLength?: number
+  wide?: boolean
+}) {
+  return (
+    <label className={`flex flex-col gap-1 text-sm ${wide ? "md:col-span-2" : ""}`}>
+      <span>{label}</span>
+      <input
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        maxLength={maxLength}
+        className="rounded-md border bg-background px-3 py-2"
+      />
+    </label>
+  )
+}
+
+function NumberInput({
+  label,
+  value,
+  onChange,
+  min,
+  max,
+}: {
+  label: string
+  value: number | null
+  onChange: (value: number | null) => void
+  min?: number
+  max?: number
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-sm">
+      <span>{label}</span>
+      <input
+        type="number"
+        value={value ?? ""}
+        onChange={(e) => {
+          const v = e.target.value
+          if (v === "") {
+            onChange(null)
+          } else {
+            const n = Number.parseInt(v, 10)
+            if (Number.isFinite(n)) onChange(n)
+          }
+        }}
+        min={min}
+        max={max}
+        className="rounded-md border bg-background px-3 py-2"
+      />
+    </label>
+  )
+}
+
+function BoolInput({
+  label,
+  value,
+  onChange,
+}: {
+  label: string
+  value: boolean
+  onChange: (value: boolean) => void
+}) {
+  return (
+    <label className="flex items-center gap-2 text-sm cursor-pointer">
+      <input
+        type="checkbox"
+        checked={value}
+        onChange={(e) => onChange(e.target.checked)}
+        className="size-4 rounded border"
+      />
+      <span>{label}</span>
+    </label>
+  )
+}

--- a/src/components/diabeo/admin/CabinetsListClient.tsx
+++ b/src/components/diabeo/admin/CabinetsListClient.tsx
@@ -5,6 +5,12 @@
  *
  * Backend : `GET /api/admin/healthcare-services` (paginé). Pattern aligné
  * iter 1+2 (AbortController + Dialog shadcn + i18n via formatDate).
+ *
+ * Fixes round 1 review PR #459 :
+ *   - H1 : error codes mapping via `extractApiError`
+ *   - H2 : types extraits dans `src/lib/types/cabinet-admin.ts`
+ *   - L1 : `isServiceType` guard + warning dev si type drift backend
+ *   - L8 : limit 100 documenté + TODO pagination cursor V1.5
  */
 
 import { useCallback, useEffect, useRef, useState } from "react"
@@ -18,33 +24,27 @@ import {
 } from "lucide-react"
 import { DiabeoButton } from "@/components/diabeo/DiabeoButton"
 import { Badge } from "@/components/ui/badge"
-
-type ServiceType = "hospital" | "clinic" | "private_practice" | "lab" | "pharmacy" | "other"
-
-interface HealthcareServiceDTO {
-  id: number
-  name: string
-  type: ServiceType
-  city: string | null
-  establishment: string | null
-  smsEnabled: boolean
-  smsCreditBalance: number
-  managerId: number | null
-}
+import {
+  type HealthcareServiceListItem,
+  type ServiceType,
+  isServiceType,
+  SERVICE_TYPE_LABELS_FR,
+} from "@/lib/types/cabinet-admin"
+import { extractApiError } from "@/lib/ui/api-error"
 
 type AsyncState = "idle" | "loading" | "success" | "error"
 
-const TYPE_LABELS: Record<ServiceType, string> = {
-  hospital: "Hôpital",
-  clinic: "Clinique",
-  private_practice: "Cabinet libéral",
-  lab: "Laboratoire",
-  pharmacy: "Pharmacie",
-  other: "Autre",
+function getTypeLabel(type: ServiceType | string): string {
+  if (isServiceType(type)) return SERVICE_TYPE_LABELS_FR[type]
+  // Fix L1 round 1 — defense-in-depth + warning dev (drift backend enum).
+  if (process.env.NODE_ENV !== "production") {
+    console.warn(`[CabinetsListClient] Unknown ServiceType: ${type}`)
+  }
+  return type
 }
 
 export function CabinetsListClient() {
-  const [cabinets, setCabinets] = useState<HealthcareServiceDTO[]>([])
+  const [cabinets, setCabinets] = useState<HealthcareServiceListItem[]>([])
   const [state, setState] = useState<AsyncState>("idle")
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [query, setQuery] = useState("")
@@ -58,6 +58,8 @@ export function CabinetsListClient() {
     setState("loading")
     setErrorMessage(null)
     try {
+      // Fix L8 round 1 — pagination cursor V1.5 (backend `nextCursor` exposé).
+      // Iter 3 : 100 premiers cabinets (aligné backend cap MAX_LIST_LIMIT).
       const res = await fetch("/api/admin/healthcare-services?limit=100", {
         credentials: "include",
         signal: controller.signal,
@@ -65,10 +67,12 @@ export function CabinetsListClient() {
       if (!mountedRef.current) return
       if (!res.ok) {
         setState("error")
-        setErrorMessage(`HTTP ${res.status}`)
+        // Fix H1 round 1 review PR #459 — error code mapping friendly (vs HTTP générique).
+        const parsed = await extractApiError(res)
+        setErrorMessage(parsed.message)
         return
       }
-      const data = (await res.json()) as { items?: HealthcareServiceDTO[] }
+      const data = (await res.json()) as { items?: HealthcareServiceListItem[] }
       if (!mountedRef.current) return
       setCabinets(data.items ?? [])
       setState("success")
@@ -109,7 +113,7 @@ export function CabinetsListClient() {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Rechercher par nom / ville / établissement…"
-            className="w-full rounded-md border bg-background pl-9 pr-3 py-2 text-sm"
+            className="w-full rounded-md border bg-background pl-9 pr-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
             aria-label="Rechercher un cabinet"
           />
         </div>
@@ -160,7 +164,7 @@ export function CabinetsListClient() {
                   <div className="flex items-center gap-2 flex-wrap">
                     <span className="font-medium">{cabinet.name}</span>
                     <Badge variant="outline" className="text-[10px]">
-                      {TYPE_LABELS[cabinet.type] ?? cabinet.type}
+                      {getTypeLabel(cabinet.type)}
                     </Badge>
                     {cabinet.smsEnabled && (
                       <Badge variant="default" className="text-[10px]">

--- a/src/components/diabeo/admin/CabinetsListClient.tsx
+++ b/src/components/diabeo/admin/CabinetsListClient.tsx
@@ -1,0 +1,188 @@
+"use client"
+
+/**
+ * CabinetsListClient — UI ADMIN list cabinets (US-2117/2118).
+ *
+ * Backend : `GET /api/admin/healthcare-services` (paginé). Pattern aligné
+ * iter 1+2 (AbortController + Dialog shadcn + i18n via formatDate).
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import Link from "next/link"
+import {
+  AlertCircle,
+  Building2,
+  ChevronRight,
+  RefreshCw,
+  Search,
+} from "lucide-react"
+import { DiabeoButton } from "@/components/diabeo/DiabeoButton"
+import { Badge } from "@/components/ui/badge"
+
+type ServiceType = "hospital" | "clinic" | "private_practice" | "lab" | "pharmacy" | "other"
+
+interface HealthcareServiceDTO {
+  id: number
+  name: string
+  type: ServiceType
+  city: string | null
+  establishment: string | null
+  smsEnabled: boolean
+  smsCreditBalance: number
+  managerId: number | null
+}
+
+type AsyncState = "idle" | "loading" | "success" | "error"
+
+const TYPE_LABELS: Record<ServiceType, string> = {
+  hospital: "Hôpital",
+  clinic: "Clinique",
+  private_practice: "Cabinet libéral",
+  lab: "Laboratoire",
+  pharmacy: "Pharmacie",
+  other: "Autre",
+}
+
+export function CabinetsListClient() {
+  const [cabinets, setCabinets] = useState<HealthcareServiceDTO[]>([])
+  const [state, setState] = useState<AsyncState>("idle")
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [query, setQuery] = useState("")
+  const mountedRef = useRef(true)
+  const abortRef = useRef<AbortController | null>(null)
+
+  const fetchCabinets = useCallback(async () => {
+    if (abortRef.current) abortRef.current.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+    setState("loading")
+    setErrorMessage(null)
+    try {
+      const res = await fetch("/api/admin/healthcare-services?limit=100", {
+        credentials: "include",
+        signal: controller.signal,
+      })
+      if (!mountedRef.current) return
+      if (!res.ok) {
+        setState("error")
+        setErrorMessage(`HTTP ${res.status}`)
+        return
+      }
+      const data = (await res.json()) as { items?: HealthcareServiceDTO[] }
+      if (!mountedRef.current) return
+      setCabinets(data.items ?? [])
+      setState("success")
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return
+      if (!mountedRef.current) return
+      setState("error")
+      setErrorMessage(err instanceof Error ? err.message : "Erreur réseau")
+    }
+  }, [])
+
+  useEffect(() => {
+    mountedRef.current = true
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void fetchCabinets()
+    return () => {
+      mountedRef.current = false
+      if (abortRef.current) abortRef.current.abort()
+    }
+  }, [fetchCabinets])
+
+  const filtered = query.trim().length > 0
+    ? cabinets.filter((c) => {
+        const q = query.trim().toLowerCase()
+        return c.name.toLowerCase().includes(q)
+          || (c.city ?? "").toLowerCase().includes(q)
+          || (c.establishment ?? "").toLowerCase().includes(q)
+      })
+    : cabinets
+
+  return (
+    <>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" aria-hidden="true" />
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Rechercher par nom / ville / établissement…"
+            className="w-full rounded-md border bg-background pl-9 pr-3 py-2 text-sm"
+            aria-label="Rechercher un cabinet"
+          />
+        </div>
+        <DiabeoButton variant="diabeoTertiary" size="sm" onClick={() => void fetchCabinets()}>
+          <RefreshCw className="size-3.5 mr-1" aria-hidden="true" />
+          Actualiser
+        </DiabeoButton>
+      </div>
+
+      {state === "loading" && cabinets.length === 0 && (
+        <p className="text-sm text-muted-foreground" aria-live="polite">
+          Chargement…
+        </p>
+      )}
+
+      {state === "error" && cabinets.length === 0 && (
+        <div role="alert" className="rounded-md border border-destructive/20 bg-destructive/10 p-3 text-sm">
+          <p className="font-medium text-destructive flex items-center gap-2">
+            <AlertCircle className="size-4" aria-hidden="true" />
+            Liste indisponible
+          </p>
+          {errorMessage && <p className="text-xs text-muted-foreground mt-1">{errorMessage}</p>}
+          <DiabeoButton variant="diabeoTertiary" size="sm" onClick={() => void fetchCabinets()} className="mt-2">
+            Réessayer
+          </DiabeoButton>
+        </div>
+      )}
+
+      {state === "success" && filtered.length === 0 && (
+        <div className="rounded-md border border-dashed p-8 text-center">
+          <Building2 className="size-8 text-muted-foreground mx-auto mb-2" aria-hidden="true" />
+          <p className="text-sm text-muted-foreground">
+            {query ? "Aucun cabinet ne correspond à la recherche." : "Aucun cabinet enregistré."}
+          </p>
+        </div>
+      )}
+
+      {filtered.length > 0 && (
+        <ul className="space-y-2" aria-label="Liste des cabinets">
+          {filtered.map((cabinet) => (
+            <li key={cabinet.id} className="rounded-md border">
+              <Link
+                href={`/admin/cabinets/${cabinet.id}`}
+                className="flex items-start gap-3 p-3 hover:bg-muted/30 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-md"
+              >
+                <Building2 className="size-5 text-muted-foreground shrink-0 mt-0.5" aria-hidden="true" />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="font-medium">{cabinet.name}</span>
+                    <Badge variant="outline" className="text-[10px]">
+                      {TYPE_LABELS[cabinet.type] ?? cabinet.type}
+                    </Badge>
+                    {cabinet.smsEnabled && (
+                      <Badge variant="default" className="text-[10px]">
+                        SMS activé ({cabinet.smsCreditBalance} crédits)
+                      </Badge>
+                    )}
+                    {cabinet.managerId === null && (
+                      <Badge variant="destructive" className="text-[10px]">
+                        Pas de manager
+                      </Badge>
+                    )}
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    {[cabinet.establishment, cabinet.city].filter(Boolean).join(" · ") || "—"}
+                  </p>
+                </div>
+                <ChevronRight className="size-4 text-muted-foreground shrink-0 mt-1" aria-hidden="true" />
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  )
+}

--- a/src/lib/types/cabinet-admin.ts
+++ b/src/lib/types/cabinet-admin.ts
@@ -1,0 +1,104 @@
+/**
+ * Types partagés pour US-2117/2118 (Cabinet enrichi) + US-2506 (SMS config) UI.
+ *
+ * Fix H2 round 1 review PR #459 — extraction DRY (vs DTOs inline dans
+ * CabinetsListClient + CabinetDetailClient). Cohérent pattern PR #458
+ * `src/lib/types/admin-ops.ts` + PR #457 `src/lib/types/data-breach.ts`.
+ *
+ * Backend DTOs : `cabinet-settings.service.ts:CabinetSettingsDTO` + `sms.service.ts:SmsConfig`.
+ * Aligné `prisma/schema.prisma` enum `ServiceType` (3 valeurs).
+ */
+
+// ─────────────────────────────────────────────────────────────
+// ServiceType (Prisma enum) — 3 valeurs réelles backend
+// ─────────────────────────────────────────────────────────────
+
+export type ServiceType = "clinic" | "hospital" | "freelance"
+
+const SERVICE_TYPES: ReadonlySet<ServiceType> = new Set(["clinic", "hospital", "freelance"])
+
+export function isServiceType(value: unknown): value is ServiceType {
+  return typeof value === "string" && SERVICE_TYPES.has(value as ServiceType)
+}
+
+export const SERVICE_TYPE_LABELS_FR: Record<ServiceType, string> = {
+  clinic: "Clinique",
+  hospital: "Hôpital",
+  freelance: "Cabinet libéral",
+}
+
+// ─────────────────────────────────────────────────────────────
+// CabinetSettingsDTO (manager-level fields + read-only régaliens)
+// ─────────────────────────────────────────────────────────────
+
+export interface CabinetSettingsDTOClient {
+  id: number
+  name: string
+  establishment: string | null
+  phone: string | null
+  email: string | null
+  website: string | null
+  addressLine1: string | null
+  addressLine2: string | null
+  postalCode: string | null
+  city: string | null
+  country: string | null
+  /** Prisma.JsonValue — picker structuré V1.5. */
+  openingHours: unknown
+  specialties: string[]
+  capacity: number | null
+  noVideos: boolean
+  noFood: boolean
+  managerId: number | null
+  /** Champs régaliens (read-only côté manager — modifiables admin via /api/admin/healthcare-services). */
+  siret: string | null
+  tvaIntra: string | null
+  type: ServiceType | string
+}
+
+/**
+ * Shape pour liste (subset de DTO complet + sms fields).
+ * Backend `/api/admin/healthcare-services` retourne en ligne.
+ */
+export interface HealthcareServiceListItem {
+  id: number
+  name: string
+  type: ServiceType | string
+  city: string | null
+  establishment: string | null
+  smsEnabled: boolean
+  smsCreditBalance: number
+  managerId: number | null
+}
+
+// ─────────────────────────────────────────────────────────────
+// SMS Config (US-2506 V1 mock)
+// ─────────────────────────────────────────────────────────────
+
+export interface SmsConfigDTOClient {
+  smsEnabled: boolean
+  smsCreditBalance: number
+}
+
+/**
+ * Fix L4 round 1 review PR #459 — const partagée backend/UI.
+ * Aligné Zod backend `sms-config/route.ts` (`z.number().int().nonnegative().max(1_000_000)`).
+ */
+export const SMS_CREDITS_MAX = 1_000_000
+
+// ─────────────────────────────────────────────────────────────
+// Validation bornes UI (alignées Zod backend cabinet-settings)
+// ─────────────────────────────────────────────────────────────
+
+export const CABINET_FIELD_LIMITS = {
+  PHONE_MAX: 30,
+  EMAIL_MAX: 255,
+  WEBSITE_MAX: 500,
+  ADDRESS_MAX: 255,
+  POSTAL_CODE_MAX: 10,
+  CITY_MAX: 100,
+  CAPACITY_MAX: 10_000,
+  SPECIALTIES_COUNT_MAX: 20,
+  /** Fix M1 round 1 review PR #459 — backend Zod `z.string().max(60)` par item. */
+  SPECIALTY_LEN_MAX: 60,
+} as const

--- a/src/lib/ui/api-error.ts
+++ b/src/lib/ui/api-error.ts
@@ -1,0 +1,91 @@
+/**
+ * extractApiError — helper UI partagé pour mapper réponse HTTP error vers
+ * message friendly + field-level details.
+ *
+ * Fix H1 round 1 review PR #459 — régression M3 PR #458. UI affichait
+ * `HTTP ${status}` générique au lieu de lire `data.error` + `data.details`.
+ *
+ * Pattern : tous les services backend exposent erreurs typées via Zod safeParse
+ * (404/409/422 avec `error: codeString` + optionnel `details: Record<field, errors[]>`).
+ * Helper unifie le parsing + fallback générique.
+ */
+
+interface ApiErrorBody {
+  error?: string
+  field?: string
+  details?: Record<string, string[] | undefined>
+}
+
+const ERROR_CODE_LABELS_FR: Record<string, string> = {
+  // cabinet-settings.service
+  notCabinetManager: "Accès refusé — vous n'êtes pas gestionnaire de ce cabinet.",
+  cabinetNotFound: "Cabinet introuvable.",
+  // sms.service
+  cabinetNotFoundSms: "Cabinet SMS introuvable.",
+  smsValidation: "Validation SMS échouée.",
+  atLeastOneFieldRequired: "Au moins un champ requis.",
+  // génériques
+  validationFailed: "Données invalides — vérifier les champs en rouge.",
+  forbidden: "Accès refusé.",
+  unauthorized: "Authentification requise.",
+  notFound: "Ressource introuvable.",
+  rateLimited: "Trop de requêtes — réessayer plus tard.",
+  invalidJSON: "Requête malformée.",
+  contentTypeRequired: "Content-Type application/json requis.",
+  bodyTooLarge: "Charge utile trop volumineuse.",
+}
+
+const STATUS_FALLBACK_FR: Record<number, string> = {
+  400: "Requête invalide.",
+  401: "Authentification requise.",
+  403: "Accès refusé.",
+  404: "Ressource introuvable.",
+  409: "Conflit — opération déjà en cours ou état incompatible.",
+  422: "Données invalides — vérifier les champs.",
+  429: "Trop de requêtes — réessayer plus tard.",
+  500: "Erreur serveur — réessayer ou contacter l'équipe ops.",
+  503: "Service temporairement indisponible.",
+}
+
+export interface ParsedApiError {
+  /** Message principal lisible UI. */
+  message: string
+  /** Code erreur backend brut (debug / mapping i18n V2). */
+  code?: string
+  /** Champ ayant échoué la validation (422). Pour highlight UI aria-invalid. */
+  field?: string
+  /** Détails per-field si validationFailed Zod safeParse flatten. */
+  details?: Record<string, string[] | undefined>
+}
+
+/**
+ * Parse une réponse fetch !ok pour extraire un message UI lisible.
+ *
+ * @param res Response (!res.ok)
+ * @returns ParsedApiError avec message friendly + code + détails
+ */
+export async function extractApiError(res: Response): Promise<ParsedApiError> {
+  let body: ApiErrorBody | null = null
+  try {
+    body = (await res.json()) as ApiErrorBody
+  } catch {
+    body = null
+  }
+  const code = body?.error
+  const codeMessage = code ? ERROR_CODE_LABELS_FR[code] : undefined
+  const statusFallback = STATUS_FALLBACK_FR[res.status] ?? `Erreur (HTTP ${res.status})`
+  return {
+    message: codeMessage ?? statusFallback,
+    code,
+    field: body?.field,
+    details: body?.details,
+  }
+}
+
+/**
+ * Helper sync — si on a déjà parsé le body. Utile pour tests.
+ */
+export function formatApiErrorCode(code: string | undefined, status: number): string {
+  if (code && ERROR_CODE_LABELS_FR[code]) return ERROR_CODE_LABELS_FR[code]
+  return STATUS_FALLBACK_FR[status] ?? `Erreur (HTTP ${status})`
+}


### PR DESCRIPTION
Plan B Pre-prod cabinet multi-PS **iter 3/5** (post-PR #458). UI ADMIN pour 3 US Groupe 7+9 dont backends livrés PR #409.

## Périmètre iter 3

| US | Backend | UI iter 3 |
|---|---|---|
| US-2117 Cabinet enrichi (adresses + horaires + spécialités) | PR #409 | ✅ Section "Paramètres cabinet" |
| US-2118 Praticiens libéraux (RPPS/ADELI) | PR #409 | ⚠️ Read-only (type, SIRET) — création via \`/api/admin/healthcare-services\` séparée |
| US-2506 SMS config V1 mock | PR #418 | ✅ Section "Configuration SMS" toggle + crédits |

## Liste — \`/admin/cabinets\`

- Recherche client-side (nom / ville / établissement)
- Badges : type + SMS activé + warning si pas de manager
- Link row → détail

## Détail — \`/admin/cabinets/[id]\`

2 sections combinées :

**Paramètres cabinet** : phone, email, website, addresses, capacity, spécialités CSV, noVideos, noFood. Champs régaliens read-only (type, SIRET, country).

**Configuration SMS V1 mock** : toggle smsEnabled + smsCreditBalance + warning ⚠ Faible si < 10. Save via Dialog confirmation (montre diff before → after). Disclaimer "aucun SMS réel envoyé (provider=mock)" + référence US-2506bis V3.

## Sidebar — 1 nouvel item ADMIN

\`/admin/cabinets\` (Building2 icon) — gated \`roles: ["ADMIN"]\`. Pattern aligné iter 1+2.

## Pattern aligné iter 1+2 round 1 fixes

- AbortController + mountedRef
- Dialog shadcn (focus trap + ESC + restore)
- DiabeoButton variants diabeoTertiary/diabeoPrimary
- motion-safe:animate-spin
- Server ADMIN gate + backend RBAC

## Tests

- [x] 2769/2769 vitest verts (UI seulement, inchangé)
- [x] tsc --noEmit clean
- [x] Lint clean
- [ ] CI E2E green (à vérifier post-push)
- [ ] Test manuel ADMIN : sidebar 4 items admin → cliquer Cabinets → liste seed cabinets → cliquer un cabinet → modifier paramètres + toggle SMS

## Plan B status après merge

- iter 1/5 ✅ Sessions + Data Breaches (PR #457)
- iter 2/5 ✅ System Health + Backups (PR #458)
- iter 3/5 ✅ Cabinets + SMS config (cette PR)
- iter 4/5 ⏳ Invoices list + PDF download
- iter 5/5 ⏳ Admin users + Tax rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)