### PR TITLE
feat(admin): iter 4 — Invoices list + detail + PDF download UI (Plan B 4/5)

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1009,6 +1009,7 @@
     "adminSystemHealth": "صحة النظام",
     "adminBackups": "نسخ احتياطية",
     "adminCabinets": "العيادات",
+    "adminInvoices": "الفواتير",
     "logout": "تسجيل الخروج"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1009,6 +1009,7 @@
     "adminSystemHealth": "System health",
     "adminBackups": "DB backups",
     "adminCabinets": "Cabinets",
+    "adminInvoices": "Invoices",
     "logout": "Sign out"
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1009,6 +1009,7 @@
     "adminSystemHealth": "Sante systeme",
     "adminBackups": "Backups DB",
     "adminCabinets": "Cabinets",
+    "adminInvoices": "Factures",
     "logout": "Se deconnecter"
   }
 }

--- a/src/app/(dashboard)/admin/invoices/[id]/page.tsx
+++ b/src/app/(dashboard)/admin/invoices/[id]/page.tsx
@@ -1,0 +1,29 @@
+/**
+ * US-2102 — Invoice detail + PDF download (ADMIN).
+ */
+import { headers } from "next/headers"
+import { redirect } from "next/navigation"
+import { InvoiceDetailClient } from "@/components/diabeo/admin/InvoiceDetailClient"
+
+interface PageProps {
+  params: Promise<{ id: string }>
+}
+
+export default async function InvoiceDetailPage({ params }: PageProps) {
+  const headersList = await headers()
+  const role = headersList.get("x-user-role")
+  if (role !== "ADMIN") redirect("/")
+
+  const { id } = await params
+  // Regex stricte (cf. fix H5 PR #459) — anti audit pollution US-2268.
+  if (!/^[1-9]\d{0,9}$/.test(id)) {
+    redirect("/admin/invoices")
+  }
+  const invoiceId = Number.parseInt(id, 10)
+
+  return (
+    <main className="flex flex-col gap-6 p-4 lg:p-6">
+      <InvoiceDetailClient invoiceId={invoiceId} />
+    </main>
+  )
+}

--- a/src/app/(dashboard)/admin/invoices/page.tsx
+++ b/src/app/(dashboard)/admin/invoices/page.tsx
@@ -1,0 +1,28 @@
+/**
+ * US-2102/2108 — Admin gestion factures (page conteneur).
+ *
+ * ADMIN-only. Liste paginée des factures + filtres status/cabinet/patient.
+ * Backend : `GET /api/billing/invoices`.
+ */
+import { headers } from "next/headers"
+import { redirect } from "next/navigation"
+import { InvoicesListClient } from "@/components/diabeo/admin/InvoicesListClient"
+
+export default async function InvoicesPage() {
+  const headersList = await headers()
+  const role = headersList.get("x-user-role")
+  if (role !== "ADMIN") redirect("/")
+
+  return (
+    <main className="flex flex-col gap-6 p-4 lg:p-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Factures</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Historique des factures émises + brouillons. Cliquer pour détail
+          et téléchargement PDF.
+        </p>
+      </header>
+      <InvoicesListClient />
+    </main>
+  )
+}

--- a/src/components/diabeo/Sidebar.tsx
+++ b/src/components/diabeo/Sidebar.tsx
@@ -21,6 +21,7 @@ import {
   HardDrive,
   Heart,
   Building2,
+  Receipt,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useAuth } from "@/hooks/use-auth"
@@ -51,6 +52,8 @@ const navItems: ReadonlyArray<NavItem> = [
   { href: "/admin/backups", labelKey: "adminBackups", icon: HardDrive, roles: ["ADMIN"] },
   // US-2117/2118 + US-2506 (iter 3 PR Plan B) — Admin cabinets + SMS config.
   { href: "/admin/cabinets", labelKey: "adminCabinets", icon: Building2, roles: ["ADMIN"] },
+  // US-2102/2108 (iter 4 PR Plan B) — Admin invoices + PDF download.
+  { href: "/admin/invoices", labelKey: "adminInvoices", icon: Receipt, roles: ["ADMIN"] },
 ]
 
 /**

--- a/src/components/diabeo/admin/InvoiceDetailClient.tsx
+++ b/src/components/diabeo/admin/InvoiceDetailClient.tsx
@@ -1,0 +1,325 @@
+"use client"
+
+/**
+ * InvoiceDetailClient — UI ADMIN détail facture + génération/téléchargement PDF.
+ *
+ * Backend :
+ *   - GET `/api/billing/invoices/[id]` → InvoiceWithItemsDTO
+ *   - POST `/api/billing/invoices/[id]/pdf` → génère + retourne pdfUrl/pdfHash
+ *   - GET `/api/billing/invoices/[id]/pdf` → stream PDF (application/pdf)
+ *
+ * Pattern aligné iter 1-3 PR #457-#459 round 1 fixes.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import Link from "next/link"
+import { useLocale } from "next-intl"
+import {
+  AlertCircle,
+  ArrowLeft,
+  CheckCircle2,
+  Download,
+  FileText,
+  Loader2,
+  RefreshCw,
+} from "lucide-react"
+import { DiabeoButton } from "@/components/diabeo/DiabeoButton"
+import { Badge } from "@/components/ui/badge"
+import { formatDate } from "@/lib/intl/formatters"
+import type { Locale } from "@/i18n/config"
+import {
+  type InvoiceWithItemsDTOClient,
+  INVOICE_STATUS_LABELS_FR,
+  INVOICE_STATUS_VARIANT,
+  PAYMENT_METHOD_LABELS_FR,
+  formatAmount,
+} from "@/lib/types/invoice-admin"
+import { extractApiError } from "@/lib/ui/api-error"
+
+type AsyncState = "idle" | "loading" | "saving" | "success" | "error"
+
+export function InvoiceDetailClient({ invoiceId }: { invoiceId: number }) {
+  const locale = useLocale() as Locale
+  const [invoice, setInvoice] = useState<InvoiceWithItemsDTOClient | null>(null)
+  const [state, setState] = useState<AsyncState>("loading")
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [pdfGenState, setPdfGenState] = useState<AsyncState>("idle")
+  const [pdfError, setPdfError] = useState<string | null>(null)
+  const mountedRef = useRef(true)
+  const abortRef = useRef<AbortController | null>(null)
+
+  const fetchInvoice = useCallback(async () => {
+    if (abortRef.current) abortRef.current.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+    setInvoice(null)
+    setState("loading")
+    setErrorMessage(null)
+    try {
+      const res = await fetch(`/api/billing/invoices/${invoiceId}`, {
+        credentials: "include",
+        signal: controller.signal,
+      })
+      if (!mountedRef.current) return
+      if (!res.ok) {
+        setState("error")
+        const parsed = await extractApiError(res)
+        setErrorMessage(parsed.message)
+        return
+      }
+      const data = (await res.json()) as { invoice?: InvoiceWithItemsDTOClient }
+      if (!mountedRef.current) return
+      if (data.invoice) setInvoice(data.invoice)
+      setState("success")
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return
+      if (!mountedRef.current) return
+      setState("error")
+      setErrorMessage(err instanceof Error ? err.message : "Erreur réseau")
+    }
+  }, [invoiceId])
+
+  useEffect(() => {
+    mountedRef.current = true
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void fetchInvoice()
+    return () => {
+      mountedRef.current = false
+      if (abortRef.current) abortRef.current.abort()
+    }
+  }, [fetchInvoice])
+
+  /**
+   * Génère le PDF côté backend (idempotent si déjà généré). Sur succès,
+   * l'utilisateur peut télécharger via le lien GET stream.
+   */
+  const generatePdf = useCallback(async () => {
+    setPdfGenState("saving")
+    setPdfError(null)
+    try {
+      const res = await fetch(`/api/billing/invoices/${invoiceId}/pdf`, {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          "X-Requested-With": "XMLHttpRequest",
+        },
+      })
+      if (!mountedRef.current) return
+      if (!res.ok) {
+        setPdfGenState("error")
+        const parsed = await extractApiError(res)
+        setPdfError(parsed.message)
+        return
+      }
+      setPdfGenState("success")
+    } catch (err) {
+      if (!mountedRef.current) return
+      setPdfGenState("error")
+      setPdfError(err instanceof Error ? err.message : "Erreur réseau")
+    }
+  }, [invoiceId])
+
+  if (state === "loading" && !invoice) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground" aria-live="polite">
+        <Loader2 className="size-4 motion-safe:animate-spin" aria-hidden="true" />
+        Chargement…
+      </div>
+    )
+  }
+
+  if (state === "error" || !invoice) {
+    return (
+      <div role="alert" className="rounded-md border border-destructive/20 bg-destructive/10 p-3">
+        <p className="font-medium text-destructive flex items-center gap-2">
+          <AlertCircle className="size-4" aria-hidden="true" />
+          Erreur de chargement
+        </p>
+        {errorMessage && <p className="text-xs text-muted-foreground mt-1">{errorMessage}</p>}
+        <Link
+          href="/admin/invoices"
+          className="inline-flex items-center gap-1 text-sm text-primary hover:underline mt-2"
+        >
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          Retour à la liste
+        </Link>
+      </div>
+    )
+  }
+
+  const canDownload = invoice.status !== "draft"
+  const subtotalCents = invoice.totalCents - invoice.taxCents
+
+  return (
+    <>
+      <nav aria-label="Fil d'Ariane">
+        <Link
+          href="/admin/invoices"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 rounded"
+        >
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          Retour à la liste
+        </Link>
+      </nav>
+
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold flex items-center gap-2">
+          <FileText className="size-6" aria-hidden="true" />
+          {invoice.number ?? `Brouillon #${invoice.id}`}
+        </h1>
+        <div className="flex items-center gap-2 flex-wrap mt-1">
+          <Badge variant={INVOICE_STATUS_VARIANT[invoice.status]}>
+            {INVOICE_STATUS_LABELS_FR[invoice.status]}
+          </Badge>
+          <Badge variant="outline">{invoice.countryCode}</Badge>
+        </div>
+      </header>
+
+      {/* PDF action */}
+      <section className="rounded-md border p-4 space-y-3" aria-labelledby="pdf-section">
+        <h2 id="pdf-section" className="text-lg font-semibold">PDF</h2>
+        {!canDownload ? (
+          <p className="text-sm text-muted-foreground">
+            Le PDF n&apos;est disponible que pour les factures émises. Émettre la facture pour générer.
+          </p>
+        ) : (
+          <div className="flex items-center flex-wrap gap-3">
+            <DiabeoButton variant="diabeoTertiary" onClick={() => void generatePdf()} disabled={pdfGenState === "saving"}>
+              <RefreshCw className="size-4 mr-1" aria-hidden="true" />
+              {pdfGenState === "saving" ? "Génération…" : "Régénérer PDF"}
+            </DiabeoButton>
+            <a
+              href={`/api/billing/invoices/${invoice.id}/pdf`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 rounded-md bg-primary text-primary-foreground px-3 py-2 text-sm font-medium hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
+            >
+              <Download className="size-4" aria-hidden="true" />
+              Télécharger PDF
+            </a>
+          </div>
+        )}
+        {pdfGenState === "success" && (
+          <div role="status" aria-live="polite" className="rounded-md border border-primary/20 bg-primary/5 p-2 text-sm">
+            <p className="flex items-center gap-2 text-primary">
+              <CheckCircle2 className="size-4" aria-hidden="true" />
+              PDF généré. Cliquer Télécharger.
+            </p>
+          </div>
+        )}
+        {pdfGenState === "error" && pdfError && (
+          <p role="alert" className="text-sm text-destructive flex items-center gap-2">
+            <AlertCircle className="size-4" aria-hidden="true" />
+            {pdfError}
+          </p>
+        )}
+      </section>
+
+      {/* Détails */}
+      <section className="rounded-md border p-4 space-y-3" aria-labelledby="detail-section">
+        <h2 id="detail-section" className="text-lg font-semibold">Détails</h2>
+        <dl className="grid grid-cols-1 gap-3 text-sm md:grid-cols-2">
+          <Field label="Cabinet">#{invoice.cabinetId}</Field>
+          {invoice.patientId !== null && (
+            <Field label="Patient">#{invoice.patientId}</Field>
+          )}
+          <Field label="Devise">{invoice.currency}</Field>
+          <Field label="Pays">{invoice.countryCode}</Field>
+          {invoice.paymentMethod && (
+            <Field label="Mode de paiement">
+              {PAYMENT_METHOD_LABELS_FR[invoice.paymentMethod]}
+            </Field>
+          )}
+          {invoice.issuedAt && (
+            <Field label="Émise le">{formatDate(invoice.issuedAt, locale, { withTime: true })}</Field>
+          )}
+          {invoice.paidAt && (
+            <Field label="Payée le">{formatDate(invoice.paidAt, locale, { withTime: true })}</Field>
+          )}
+          {invoice.cancelledAt && (
+            <Field label="Annulée le">{formatDate(invoice.cancelledAt, locale, { withTime: true })}</Field>
+          )}
+          {invoice.refundedAt && (
+            <Field label="Remboursée le">{formatDate(invoice.refundedAt, locale, { withTime: true })}</Field>
+          )}
+          <Field label="Créée par">User #{invoice.createdBy}</Field>
+          <Field label="Créée le">{formatDate(invoice.createdAt, locale, { withTime: true })}</Field>
+        </dl>
+      </section>
+
+      {/* Lignes facture */}
+      <section className="rounded-md border p-4 space-y-3" aria-labelledby="items-section">
+        <h2 id="items-section" className="text-lg font-semibold">Lignes</h2>
+        {invoice.items.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Aucune ligne enregistrée.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left text-xs text-muted-foreground">
+                  <th className="py-2 pr-3 font-medium">Description</th>
+                  <th className="py-2 px-3 font-medium text-right">Qté</th>
+                  <th className="py-2 px-3 font-medium text-right">Prix unit. HT</th>
+                  <th className="py-2 px-3 font-medium text-right">TVA</th>
+                  <th className="py-2 pl-3 font-medium text-right">Total TTC</th>
+                </tr>
+              </thead>
+              <tbody>
+                {invoice.items.map((item) => (
+                  <tr key={item.id} className="border-b last:border-0">
+                    <td className="py-2 pr-3">{item.description}</td>
+                    <td className="py-2 px-3 text-right tabular-nums">{item.quantity}</td>
+                    <td className="py-2 px-3 text-right tabular-nums">
+                      {formatAmount(item.unitPriceCents, invoice.currency, locale)}
+                    </td>
+                    <td className="py-2 px-3 text-right tabular-nums">
+                      {(item.taxRate * 100).toFixed(1)}%
+                    </td>
+                    <td className="py-2 pl-3 text-right tabular-nums font-medium">
+                      {formatAmount(item.lineTotalCents, invoice.currency, locale)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot>
+                <tr className="border-t-2">
+                  <td colSpan={3} className="py-2 pr-3 text-right font-medium text-muted-foreground">
+                    Sous-total HT
+                  </td>
+                  <td colSpan={2} className="py-2 pl-3 text-right tabular-nums">
+                    {formatAmount(subtotalCents, invoice.currency, locale)}
+                  </td>
+                </tr>
+                <tr>
+                  <td colSpan={3} className="py-2 pr-3 text-right font-medium text-muted-foreground">
+                    TVA
+                  </td>
+                  <td colSpan={2} className="py-2 pl-3 text-right tabular-nums">
+                    {formatAmount(invoice.taxCents, invoice.currency, locale)}
+                  </td>
+                </tr>
+                <tr className="border-t">
+                  <td colSpan={3} className="py-2 pr-3 text-right font-semibold">
+                    Total TTC
+                  </td>
+                  <td colSpan={2} className="py-2 pl-3 text-right tabular-nums font-semibold">
+                    {formatAmount(invoice.totalCents, invoice.currency, locale)}
+                  </td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        )}
+      </section>
+    </>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <dt className="text-xs text-muted-foreground">{label}</dt>
+      <dd className="mt-0.5">{children}</dd>
+    </div>
+  )
+}

--- a/src/components/diabeo/admin/InvoiceDetailClient.tsx
+++ b/src/components/diabeo/admin/InvoiceDetailClient.tsx
@@ -29,9 +29,9 @@ import { formatDate } from "@/lib/intl/formatters"
 import type { Locale } from "@/i18n/config"
 import {
   type InvoiceWithItemsDTOClient,
-  INVOICE_STATUS_LABELS_FR,
-  INVOICE_STATUS_VARIANT,
-  PAYMENT_METHOD_LABELS_FR,
+  getInvoiceStatusLabel,
+  getInvoiceStatusVariant,
+  getPaymentMethodLabel,
   formatAmount,
 } from "@/lib/types/invoice-admin"
 import { extractApiError } from "@/lib/ui/api-error"
@@ -129,8 +129,15 @@ export function InvoiceDetailClient({ invoiceId }: { invoiceId: number }) {
   }
 
   if (state === "error" || !invoice) {
+    // Fix M4 round 1 review PR #460 — focus management role=alert via
+    // tabindex=-1 + ref autofocus pour SR / clavier ne rate pas le message.
     return (
-      <div role="alert" className="rounded-md border border-destructive/20 bg-destructive/10 p-3">
+      <div
+        role="alert"
+        tabIndex={-1}
+        ref={(el) => { el?.focus() }}
+        className="rounded-md border border-destructive/20 bg-destructive/10 p-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive"
+      >
         <p className="font-medium text-destructive flex items-center gap-2">
           <AlertCircle className="size-4" aria-hidden="true" />
           Erreur de chargement
@@ -148,7 +155,9 @@ export function InvoiceDetailClient({ invoiceId }: { invoiceId: number }) {
   }
 
   const canDownload = invoice.status !== "draft"
-  const subtotalCents = invoice.totalCents - invoice.taxCents
+  // Fix M1 round 1 — utilise subtotalCents canonique backend (vs recalcul
+  // client `totalCents - taxCents` qui dérivait si remises ligne).
+  const subtotalCents = invoice.subtotalCents
 
   return (
     <>
@@ -168,18 +177,23 @@ export function InvoiceDetailClient({ invoiceId }: { invoiceId: number }) {
           {invoice.number ?? `Brouillon #${invoice.id}`}
         </h1>
         <div className="flex items-center gap-2 flex-wrap mt-1">
-          <Badge variant={INVOICE_STATUS_VARIANT[invoice.status]}>
-            {INVOICE_STATUS_LABELS_FR[invoice.status]}
+          <Badge variant={getInvoiceStatusVariant(invoice.status)}>
+            {getInvoiceStatusLabel(invoice.status)}
           </Badge>
           <Badge variant="outline">{invoice.countryCode}</Badge>
         </div>
       </header>
 
       {/* PDF action */}
-      <section className="rounded-md border p-4 space-y-3" aria-labelledby="pdf-section">
+      <section
+        className="rounded-md border p-4 space-y-3"
+        aria-labelledby="pdf-section"
+        aria-describedby={!canDownload ? "pdf-disabled-help" : undefined}
+      >
         <h2 id="pdf-section" className="text-lg font-semibold">PDF</h2>
         {!canDownload ? (
-          <p className="text-sm text-muted-foreground">
+          // Fix M6 round 1 — aria-describedby pointe vers explication state disabled.
+          <p id="pdf-disabled-help" className="text-sm text-muted-foreground">
             Le PDF n&apos;est disponible que pour les factures émises. Émettre la facture pour générer.
           </p>
         ) : (
@@ -188,14 +202,21 @@ export function InvoiceDetailClient({ invoiceId }: { invoiceId: number }) {
               <RefreshCw className="size-4 mr-1" aria-hidden="true" />
               {pdfGenState === "saving" ? "Génération…" : "Régénérer PDF"}
             </DiabeoButton>
+            {/* Fix H1 + H4 round 1 review PR #460 :
+                - `referrerPolicy="no-referrer"` : pas de leak ID séquentiel via Referer
+                - `aria-label` : indique "nouvel onglet" WCAG 3.2.5 Change on Request
+                Backend (PR #414) renvoie déjà Cache-Control: no-store + Content-Disposition. */}
             <a
               href={`/api/billing/invoices/${invoice.id}/pdf`}
               target="_blank"
               rel="noopener noreferrer"
+              referrerPolicy="no-referrer"
+              aria-label={`Télécharger PDF de la facture ${invoice.number ?? `brouillon ${invoice.id}`} (nouvel onglet)`}
               className="inline-flex items-center gap-1 rounded-md bg-primary text-primary-foreground px-3 py-2 text-sm font-medium hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
             >
               <Download className="size-4" aria-hidden="true" />
               Télécharger PDF
+              <span aria-hidden="true" className="text-xs opacity-75 ml-0.5">(nouvel onglet)</span>
             </a>
           </div>
         )}
@@ -227,7 +248,7 @@ export function InvoiceDetailClient({ invoiceId }: { invoiceId: number }) {
           <Field label="Pays">{invoice.countryCode}</Field>
           {invoice.paymentMethod && (
             <Field label="Mode de paiement">
-              {PAYMENT_METHOD_LABELS_FR[invoice.paymentMethod]}
+              {getPaymentMethodLabel(invoice.paymentMethod)}
             </Field>
           )}
           {invoice.issuedAt && (
@@ -256,12 +277,14 @@ export function InvoiceDetailClient({ invoiceId }: { invoiceId: number }) {
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
+                {/* Fix C1 + A11y CRITICAL round 1 review PR #460 — scope="col"
+                    pour mapping screen-reader headers→cellules (WCAG 1.3.1). */}
                 <tr className="border-b text-left text-xs text-muted-foreground">
-                  <th className="py-2 pr-3 font-medium">Description</th>
-                  <th className="py-2 px-3 font-medium text-right">Qté</th>
-                  <th className="py-2 px-3 font-medium text-right">Prix unit. HT</th>
-                  <th className="py-2 px-3 font-medium text-right">TVA</th>
-                  <th className="py-2 pl-3 font-medium text-right">Total TTC</th>
+                  <th scope="col" className="py-2 pr-3 font-medium">Description</th>
+                  <th scope="col" className="py-2 px-3 font-medium text-right">Qté</th>
+                  <th scope="col" className="py-2 px-3 font-medium text-right">Prix unit. HT</th>
+                  <th scope="col" className="py-2 px-3 font-medium text-right">TVA</th>
+                  <th scope="col" className="py-2 pl-3 font-medium text-right">Total TTC</th>
                 </tr>
               </thead>
               <tbody>
@@ -282,26 +305,28 @@ export function InvoiceDetailClient({ invoiceId }: { invoiceId: number }) {
                 ))}
               </tbody>
               <tfoot>
+                {/* Fix C1 round 1 — <th scope="row"> sur labels totaux pour
+                    SR mapping (les chiffres totaux sont la ligne associée). */}
                 <tr className="border-t-2">
-                  <td colSpan={3} className="py-2 pr-3 text-right font-medium text-muted-foreground">
+                  <th scope="row" colSpan={3} className="py-2 pr-3 text-right font-medium text-muted-foreground">
                     Sous-total HT
-                  </td>
+                  </th>
                   <td colSpan={2} className="py-2 pl-3 text-right tabular-nums">
                     {formatAmount(subtotalCents, invoice.currency, locale)}
                   </td>
                 </tr>
                 <tr>
-                  <td colSpan={3} className="py-2 pr-3 text-right font-medium text-muted-foreground">
+                  <th scope="row" colSpan={3} className="py-2 pr-3 text-right font-medium text-muted-foreground">
                     TVA
-                  </td>
+                  </th>
                   <td colSpan={2} className="py-2 pl-3 text-right tabular-nums">
                     {formatAmount(invoice.taxCents, invoice.currency, locale)}
                   </td>
                 </tr>
                 <tr className="border-t">
-                  <td colSpan={3} className="py-2 pr-3 text-right font-semibold">
+                  <th scope="row" colSpan={3} className="py-2 pr-3 text-right font-semibold">
                     Total TTC
-                  </td>
+                  </th>
                   <td colSpan={2} className="py-2 pl-3 text-right tabular-nums font-semibold">
                     {formatAmount(invoice.totalCents, invoice.currency, locale)}
                   </td>

--- a/src/components/diabeo/admin/InvoicesListClient.tsx
+++ b/src/components/diabeo/admin/InvoicesListClient.tsx
@@ -25,7 +25,8 @@ import {
   type InvoiceDTOClient,
   type InvoiceStatus,
   INVOICE_STATUS_LABELS_FR,
-  INVOICE_STATUS_VARIANT,
+  getInvoiceStatusLabel,
+  getInvoiceStatusVariant,
   formatAmount,
 } from "@/lib/types/invoice-admin"
 import { extractApiError } from "@/lib/ui/api-error"
@@ -38,6 +39,9 @@ export function InvoicesListClient() {
   const [state, setState] = useState<AsyncState>("idle")
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [filterStatus, setFilterStatus] = useState<InvoiceStatus | "all">("all")
+  // Fix H5 round 1 review PR #460 — track nextCursor pour indiquer si la
+  // liste est tronquée (affiche "100+ factures, affiner le filtre").
+  const [hasMore, setHasMore] = useState(false)
   const mountedRef = useRef(true)
   const abortRef = useRef<AbortController | null>(null)
   const fetchSeqRef = useRef(0)
@@ -68,6 +72,7 @@ export function InvoicesListClient() {
       const data = (await res.json()) as { items?: InvoiceDTOClient[]; nextCursor?: number }
       if (seq !== fetchSeqRef.current || !mountedRef.current) return
       setInvoices(data.items ?? [])
+      setHasMore(data.nextCursor !== undefined && data.nextCursor !== null)
       setState("success")
     } catch (err) {
       if (err instanceof Error && err.name === "AbortError") return
@@ -98,12 +103,16 @@ export function InvoicesListClient() {
             onChange={(e) => setFilterStatus(e.target.value as InvoiceStatus | "all")}
             className="rounded-md border bg-background px-2 py-1 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
             aria-label="Filtrer par statut"
+            aria-describedby="filter-status-help"
           >
-            <option value="all">Tous</option>
+            <option value="all">Tous les statuts</option>
             {Object.entries(INVOICE_STATUS_LABELS_FR).map(([value, label]) => (
               <option key={value} value={value}>{label}</option>
             ))}
           </select>
+          <span id="filter-status-help" className="sr-only">
+            Sélectionnez un statut pour filtrer la liste des factures.
+          </span>
         </label>
         <DiabeoButton variant="diabeoTertiary" size="sm" onClick={() => void fetchInvoices()}>
           <RefreshCw className="size-3.5 mr-1" aria-hidden="true" />
@@ -149,8 +158,8 @@ export function InvoicesListClient() {
                     <span className="font-medium">
                       {invoice.number ?? `Brouillon #${invoice.id}`}
                     </span>
-                    <Badge variant={INVOICE_STATUS_VARIANT[invoice.status]} className="text-[10px]">
-                      {INVOICE_STATUS_LABELS_FR[invoice.status]}
+                    <Badge variant={getInvoiceStatusVariant(invoice.status)} className="text-[10px]">
+                      {getInvoiceStatusLabel(invoice.status)}
                     </Badge>
                     <span className="text-sm font-medium ml-auto">
                       {formatAmount(invoice.totalCents, invoice.currency, locale)}
@@ -171,6 +180,19 @@ export function InvoicesListClient() {
             </li>
           ))}
         </ul>
+      )}
+
+      {/* Fix H5 round 1 — indicateur liste tronquée (pagination V1.5). */}
+      {hasMore && (
+        <div role="note" className="rounded-md border border-orange-300 bg-orange-50 p-3 text-sm flex items-start gap-2">
+          <AlertCircle className="size-4 text-orange-700 shrink-0 mt-0.5" aria-hidden="true" />
+          <p className="text-orange-800">
+            Plus de 100 factures correspondent. Affiner le filtre statut pour réduire la liste.
+            <span className="block text-xs opacity-80 mt-0.5">
+              Pagination cursor V1.5 — affichage tronqué aux 100 plus récentes.
+            </span>
+          </p>
+        </div>
       )}
     </>
   )

--- a/src/components/diabeo/admin/InvoicesListClient.tsx
+++ b/src/components/diabeo/admin/InvoicesListClient.tsx
@@ -1,0 +1,177 @@
+"use client"
+
+/**
+ * InvoicesListClient — UI ADMIN list factures (US-2102/2108).
+ *
+ * Backend : `GET /api/billing/invoices` (paginé cursor). Pattern aligné
+ * iter 1-3 (AbortController + extractApiError + i18n via useLocale).
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import Link from "next/link"
+import { useLocale } from "next-intl"
+import {
+  AlertCircle,
+  ChevronRight,
+  FileText,
+  Filter,
+  RefreshCw,
+} from "lucide-react"
+import { DiabeoButton } from "@/components/diabeo/DiabeoButton"
+import { Badge } from "@/components/ui/badge"
+import { formatDate } from "@/lib/intl/formatters"
+import type { Locale } from "@/i18n/config"
+import {
+  type InvoiceDTOClient,
+  type InvoiceStatus,
+  INVOICE_STATUS_LABELS_FR,
+  INVOICE_STATUS_VARIANT,
+  formatAmount,
+} from "@/lib/types/invoice-admin"
+import { extractApiError } from "@/lib/ui/api-error"
+
+type AsyncState = "idle" | "loading" | "success" | "error"
+
+export function InvoicesListClient() {
+  const locale = useLocale() as Locale
+  const [invoices, setInvoices] = useState<InvoiceDTOClient[]>([])
+  const [state, setState] = useState<AsyncState>("idle")
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [filterStatus, setFilterStatus] = useState<InvoiceStatus | "all">("all")
+  const mountedRef = useRef(true)
+  const abortRef = useRef<AbortController | null>(null)
+  const fetchSeqRef = useRef(0)
+
+  const fetchInvoices = useCallback(async () => {
+    if (abortRef.current) abortRef.current.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+    const seq = ++fetchSeqRef.current
+    setState("loading")
+    setErrorMessage(null)
+    try {
+      const params = new URLSearchParams()
+      if (filterStatus !== "all") params.set("status", filterStatus)
+      params.set("limit", "100")
+      const url = `/api/billing/invoices?${params.toString()}`
+      const res = await fetch(url, {
+        credentials: "include",
+        signal: controller.signal,
+      })
+      if (seq !== fetchSeqRef.current || !mountedRef.current) return
+      if (!res.ok) {
+        setState("error")
+        const parsed = await extractApiError(res)
+        setErrorMessage(parsed.message)
+        return
+      }
+      const data = (await res.json()) as { items?: InvoiceDTOClient[]; nextCursor?: number }
+      if (seq !== fetchSeqRef.current || !mountedRef.current) return
+      setInvoices(data.items ?? [])
+      setState("success")
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return
+      if (seq !== fetchSeqRef.current || !mountedRef.current) return
+      setState("error")
+      setErrorMessage(err instanceof Error ? err.message : "Erreur réseau")
+    }
+  }, [filterStatus])
+
+  useEffect(() => {
+    mountedRef.current = true
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void fetchInvoices()
+    return () => {
+      mountedRef.current = false
+      if (abortRef.current) abortRef.current.abort()
+    }
+  }, [fetchInvoices])
+
+  return (
+    <>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <label className="flex items-center gap-1 text-sm">
+          <Filter className="size-4 text-muted-foreground" aria-hidden="true" />
+          <span className="text-muted-foreground">Statut :</span>
+          <select
+            value={filterStatus}
+            onChange={(e) => setFilterStatus(e.target.value as InvoiceStatus | "all")}
+            className="rounded-md border bg-background px-2 py-1 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
+            aria-label="Filtrer par statut"
+          >
+            <option value="all">Tous</option>
+            {Object.entries(INVOICE_STATUS_LABELS_FR).map(([value, label]) => (
+              <option key={value} value={value}>{label}</option>
+            ))}
+          </select>
+        </label>
+        <DiabeoButton variant="diabeoTertiary" size="sm" onClick={() => void fetchInvoices()}>
+          <RefreshCw className="size-3.5 mr-1" aria-hidden="true" />
+          Actualiser
+        </DiabeoButton>
+      </div>
+
+      {state === "loading" && invoices.length === 0 && (
+        <p className="text-sm text-muted-foreground" aria-live="polite">Chargement…</p>
+      )}
+
+      {state === "error" && invoices.length === 0 && (
+        <div role="alert" className="rounded-md border border-destructive/20 bg-destructive/10 p-3 text-sm">
+          <p className="font-medium text-destructive flex items-center gap-2">
+            <AlertCircle className="size-4" aria-hidden="true" />
+            Liste indisponible
+          </p>
+          {errorMessage && <p className="text-xs text-muted-foreground mt-1">{errorMessage}</p>}
+          <DiabeoButton variant="diabeoTertiary" size="sm" onClick={() => void fetchInvoices()} className="mt-2">
+            Réessayer
+          </DiabeoButton>
+        </div>
+      )}
+
+      {state === "success" && invoices.length === 0 && (
+        <div className="rounded-md border border-dashed p-8 text-center">
+          <FileText className="size-8 text-muted-foreground mx-auto mb-2" aria-hidden="true" />
+          <p className="text-sm text-muted-foreground">Aucune facture enregistrée.</p>
+        </div>
+      )}
+
+      {invoices.length > 0 && (
+        <ul className="space-y-2" aria-label="Liste des factures">
+          {invoices.map((invoice) => (
+            <li key={invoice.id} className="rounded-md border">
+              <Link
+                href={`/admin/invoices/${invoice.id}`}
+                className="flex items-start gap-3 p-3 hover:bg-muted/30 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-md"
+              >
+                <FileText className="size-5 text-muted-foreground shrink-0 mt-0.5" aria-hidden="true" />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="font-medium">
+                      {invoice.number ?? `Brouillon #${invoice.id}`}
+                    </span>
+                    <Badge variant={INVOICE_STATUS_VARIANT[invoice.status]} className="text-[10px]">
+                      {INVOICE_STATUS_LABELS_FR[invoice.status]}
+                    </Badge>
+                    <span className="text-sm font-medium ml-auto">
+                      {formatAmount(invoice.totalCents, invoice.currency, locale)}
+                    </span>
+                  </div>
+                  <div className="text-xs text-muted-foreground mt-1 flex flex-wrap gap-3">
+                    {invoice.issuedAt && (
+                      <span>Émise le {formatDate(invoice.issuedAt, locale, { withTime: false })}</span>
+                    )}
+                    {invoice.patientId !== null && (
+                      <span>Patient #{invoice.patientId}</span>
+                    )}
+                    <span>Cabinet #{invoice.cabinetId}</span>
+                  </div>
+                </div>
+                <ChevronRight className="size-4 text-muted-foreground shrink-0 mt-1" aria-hidden="true" />
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  )
+}

--- a/src/lib/services/invoice.service.ts
+++ b/src/lib/services/invoice.service.ts
@@ -193,6 +193,13 @@ export interface InvoiceWithItemsDTO extends InvoiceDTO {
     teleconsultActeId: number | null
     position: number
   }>
+  /**
+   * Fix M1 round 1 review PR #460 — exposé serveur-side pour cohérence
+   * avec le PDF officiel généré (DGFiP). UI ne recalcule plus
+   * `totalCents - taxCents` (risque drift si remises ligne futures).
+   * = Somme `lineTotalCents` HT (avant TVA).
+   */
+  subtotalCents: number
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -654,21 +661,30 @@ function toDTO(inv: Invoice): InvoiceDTO {
 function toDetailDTO(
   inv: Invoice & { items: InvoiceItem[] },
 ): InvoiceWithItemsDTO {
+  const items = inv.items
+    .sort((a, b) => a.position - b.position)
+    .map((it) => ({
+      id: it.id,
+      description: it.description,
+      quantity: Number(it.quantity),
+      unitPriceCents: it.unitPriceCents,
+      taxRate: Number(it.taxRate),
+      taxCents: it.taxCents,
+      lineTotalCents: it.lineTotalCents,
+      teleconsultActeId: it.teleconsultActeId,
+      position: it.position,
+    }))
+  // Fix M1 round 1 review PR #460 — subtotalCents canonique côté serveur
+  // (UI ne recalcule plus, risque drift remises ligne futures DGFiP).
+  // = somme `lineTotalCents` (HT, avant TVA appliquée per row).
+  const subtotalCents = items.reduce(
+    (acc, it) => acc + (it.lineTotalCents - it.taxCents),
+    0,
+  )
   return {
     ...toDTO(inv),
-    items: inv.items
-      .sort((a, b) => a.position - b.position)
-      .map((it) => ({
-        id: it.id,
-        description: it.description,
-        quantity: Number(it.quantity),
-        unitPriceCents: it.unitPriceCents,
-        taxRate: Number(it.taxRate),
-        taxCents: it.taxCents,
-        lineTotalCents: it.lineTotalCents,
-        teleconsultActeId: it.teleconsultActeId,
-        position: it.position,
-      })),
+    items,
+    subtotalCents,
   }
 }
 

--- a/src/lib/types/invoice-admin.ts
+++ b/src/lib/types/invoice-admin.ts
@@ -3,10 +3,34 @@
  *
  * Pattern aligné PR #457/#458/#459 (`src/lib/types/*-admin.ts`).
  * Backend DTOs : `invoice.service.ts:InvoiceDTO/InvoiceWithItemsDTO`.
+ *
+ * Fixes round 1 review PR #460 :
+ *   - M1 : `subtotalCents` exposé serveur (UI ne recalcule plus)
+ *   - H2 : `formatAmount` currency minor units via Intl.NumberFormat
+ *     `resolvedOptions().maximumFractionDigits` (gère JPY/KRW 0 décimale,
+ *     TND/BHD 3 décimales — pas hardcoded /100)
+ *   - M2 : `getInvoiceStatusLabel` + `getPaymentMethodLabel` helpers avec
+ *     warning dev si drift backend (cohérent fix L1 PR #459 ServiceType)
  */
 
 export type InvoiceStatus = "draft" | "issued" | "paid" | "cancelled" | "refunded"
 export type PaymentMethod = "stripe" | "bank_transfer" | "cash" | "other"
+
+const INVOICE_STATUSES: ReadonlySet<InvoiceStatus> = new Set([
+  "draft", "issued", "paid", "cancelled", "refunded",
+])
+
+const PAYMENT_METHODS: ReadonlySet<PaymentMethod> = new Set([
+  "stripe", "bank_transfer", "cash", "other",
+])
+
+export function isInvoiceStatus(value: unknown): value is InvoiceStatus {
+  return typeof value === "string" && INVOICE_STATUSES.has(value as InvoiceStatus)
+}
+
+export function isPaymentMethod(value: unknown): value is PaymentMethod {
+  return typeof value === "string" && PAYMENT_METHODS.has(value as PaymentMethod)
+}
 
 export interface InvoiceDTOClient {
   id: number
@@ -41,7 +65,13 @@ export interface InvoiceItemDTOClient {
 
 export interface InvoiceWithItemsDTOClient extends InvoiceDTOClient {
   items: InvoiceItemDTOClient[]
+  /** Fix M1 round 1 — serveur-canonique (DGFiP). */
+  subtotalCents: number
 }
+
+// ─────────────────────────────────────────────────────────────
+// Labels FR + variants
+// ─────────────────────────────────────────────────────────────
 
 export const INVOICE_STATUS_LABELS_FR: Record<InvoiceStatus, string> = {
   draft: "Brouillon",
@@ -69,17 +99,61 @@ export const PAYMENT_METHOD_LABELS_FR: Record<PaymentMethod, string> = {
 }
 
 /**
- * Formate cents → euros lisible (1234 cents → "12,34 €").
- * Cents-only stocké backend pour éviter floating point. Locale-aware
- * via `Intl.NumberFormat` côté caller.
+ * Fix M2 round 1 — defense-in-depth + warning dev si backend ajoute
+ * un statut sans mise à jour UI (cohérent pattern PR #459 ServiceType).
+ */
+export function getInvoiceStatusLabel(status: InvoiceStatus | string): string {
+  if (isInvoiceStatus(status)) return INVOICE_STATUS_LABELS_FR[status]
+  if (process.env.NODE_ENV !== "production") {
+    console.warn(`[invoice-admin] Unknown InvoiceStatus: ${status}`)
+  }
+  return status
+}
+
+export function getPaymentMethodLabel(method: PaymentMethod | string): string {
+  if (isPaymentMethod(method)) return PAYMENT_METHOD_LABELS_FR[method]
+  if (process.env.NODE_ENV !== "production") {
+    console.warn(`[invoice-admin] Unknown PaymentMethod: ${method}`)
+  }
+  return method
+}
+
+export function getInvoiceStatusVariant(status: InvoiceStatus | string): BadgeVariant {
+  if (isInvoiceStatus(status)) return INVOICE_STATUS_VARIANT[status]
+  return "outline" // safe fallback
+}
+
+// ─────────────────────────────────────────────────────────────
+// formatAmount — currency-aware minor units
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Fix H2 round 1 review PR #460 — `Intl.NumberFormat` avec
+ * `resolvedOptions().minimumFractionDigits` détecte automatiquement le
+ * nombre de chiffres après la virgule pour la devise (0 pour JPY/KRW,
+ * 2 pour EUR/USD, 3 pour TND/BHD).
+ *
+ * Backend stocke en unité minimale de la devise (EUR cents, JPY yen,
+ * TND millicents) — diviseur calculé dynamiquement.
+ *
+ * Fix L7 round 1 — try/catch fallback si devise inconnue (sinon
+ * Intl.NumberFormat throw RangeError crash UI).
  */
 export function formatAmount(
-  cents: number,
+  minorUnits: number,
   currency: string,
   locale: string,
 ): string {
-  return new Intl.NumberFormat(locale, {
-    style: "currency",
-    currency,
-  }).format(cents / 100)
+  try {
+    const formatter = new Intl.NumberFormat(locale, {
+      style: "currency",
+      currency,
+    })
+    const fractionDigits = formatter.resolvedOptions().minimumFractionDigits ?? 2
+    const divisor = Math.pow(10, fractionDigits)
+    return formatter.format(minorUnits / divisor)
+  } catch {
+    // Devise invalide / non supportée par Intl → fallback affichage brut.
+    return `${minorUnits} ${currency}`
+  }
 }

--- a/src/lib/types/invoice-admin.ts
+++ b/src/lib/types/invoice-admin.ts
@@ -1,0 +1,85 @@
+/**
+ * Types partagés pour US-2102 (Invoice PDF) + US-2108 (Invoice reminders) UI.
+ *
+ * Pattern aligné PR #457/#458/#459 (`src/lib/types/*-admin.ts`).
+ * Backend DTOs : `invoice.service.ts:InvoiceDTO/InvoiceWithItemsDTO`.
+ */
+
+export type InvoiceStatus = "draft" | "issued" | "paid" | "cancelled" | "refunded"
+export type PaymentMethod = "stripe" | "bank_transfer" | "cash" | "other"
+
+export interface InvoiceDTOClient {
+  id: number
+  number: string | null
+  countryCode: string
+  cabinetId: number
+  patientId: number | null
+  totalCents: number
+  taxCents: number
+  currency: string
+  status: InvoiceStatus
+  paymentMethod: PaymentMethod | null
+  issuedAt: string | null // ISO 8601 from JSON
+  paidAt: string | null
+  cancelledAt: string | null
+  refundedAt: string | null
+  createdBy: number
+  createdAt: string
+}
+
+export interface InvoiceItemDTOClient {
+  id: number
+  description: string
+  quantity: number
+  unitPriceCents: number
+  taxRate: number
+  taxCents: number
+  lineTotalCents: number
+  teleconsultActeId: number | null
+  position: number
+}
+
+export interface InvoiceWithItemsDTOClient extends InvoiceDTOClient {
+  items: InvoiceItemDTOClient[]
+}
+
+export const INVOICE_STATUS_LABELS_FR: Record<InvoiceStatus, string> = {
+  draft: "Brouillon",
+  issued: "Émise",
+  paid: "Payée",
+  cancelled: "Annulée",
+  refunded: "Remboursée",
+}
+
+export type BadgeVariant = "default" | "secondary" | "destructive" | "outline"
+
+export const INVOICE_STATUS_VARIANT: Record<InvoiceStatus, BadgeVariant> = {
+  draft: "secondary",
+  issued: "outline",
+  paid: "default",
+  cancelled: "destructive",
+  refunded: "destructive",
+}
+
+export const PAYMENT_METHOD_LABELS_FR: Record<PaymentMethod, string> = {
+  stripe: "Carte (Stripe)",
+  bank_transfer: "Virement bancaire",
+  cash: "Espèces",
+  other: "Autre",
+}
+
+/**
+ * Formate cents → euros lisible (1234 cents → "12,34 €").
+ * Cents-only stocké backend pour éviter floating point. Locale-aware
+ * via `Intl.NumberFormat` côté caller.
+ */
+export function formatAmount(
+  cents: number,
+  currency: string,
+  locale: string,
+): string {
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency,
+  }).format(cents / 100)
+}

--- a/src/lib/ui/api-error.ts
+++ b/src/lib/ui/api-error.ts
@@ -24,6 +24,14 @@ const ERROR_CODE_LABELS_FR: Record<string, string> = {
   cabinetNotFoundSms: "Cabinet SMS introuvable.",
   smsValidation: "Validation SMS échouée.",
   atLeastOneFieldRequired: "Au moins un champ requis.",
+  // invoice.service (Fix PR #460 — codes US-2102/2108)
+  invoiceNotFound: "Facture introuvable.",
+  invoiceAccessDenied: "Accès facture refusé.",
+  invoiceInvalidState: "État de la facture incompatible avec cette action.",
+  invoiceConcurrency: "Conflit de modification — recharger la facture.",
+  invoiceSequenceOverflow: "Séquence de facturation saturée — contacter l'équipe ops.",
+  pdfNotGenerated: "PDF pas encore généré — émettre la facture d'abord.",
+  pdfRenderFailed: "Erreur génération PDF — réessayer ou contacter l'équipe ops.",
   // génériques
   validationFailed: "Données invalides — vérifier les champs en rouge.",
   forbidden: "Accès refusé.",


### PR DESCRIPTION
Plan B Pre-prod cabinet multi-PS **iter 4/5** (post-PR #459). UI ADMIN pour US-2102 (Facture PDF) + US-2108 (Relances factures auto). Backend livré PR #414/#417.

## Liste — \`/admin/invoices\`
- Filtre status (draft/issued/paid/cancelled/refunded)
- Rows : number, status badge, montant formaté Intl.NumberFormat locale, dates, cabinet/patient
- Pattern AbortController + fetchSeq + extractApiError

## Détail — \`/admin/invoices/[id]\`
- **Breadcrumb** \`<nav aria-label>\`
- **Section PDF** : bouton Régénérer (POST idempotent) + lien Télécharger (GET stream)
- **Détails** : cabinet, patient, devise, dates, paymentMethod
- **Lignes** : table avec footer Sous-total/TVA/Total TTC tabular-nums

## Sidebar
\`/admin/invoices\` (Receipt) — gated ADMIN, i18n FR/EN/AR

## Tests
- [x] 2769/2769 vitest verts
- [x] tsc + lint clean
- [ ] CI E2E (à vérifier post-push)
- [ ] Test manuel : ADMIN → Factures → liste → détail → générer + télécharger PDF

## Plan B status après merge
- iter 1/5 ✅ PR #457
- iter 2/5 ✅ PR #458
- iter 3/5 ✅ PR #459
- iter 4/5 ✅ cette PR
- iter 5/5 ⏳ Admin users + Tax rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)