### PR TITLE
feat(admin): iter 5 — Users management + Tax rules UI (Plan B 5/5 FINAL)

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1010,6 +1010,8 @@
     "adminBackups": "نسخ احتياطية",
     "adminCabinets": "العيادات",
     "adminInvoices": "الفواتير",
+    "adminUsers": "المستخدمون",
+    "adminTaxRules": "القواعد الضريبية",
     "logout": "تسجيل الخروج"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1010,6 +1010,8 @@
     "adminBackups": "DB backups",
     "adminCabinets": "Cabinets",
     "adminInvoices": "Invoices",
+    "adminUsers": "Users",
+    "adminTaxRules": "Tax rules",
     "logout": "Sign out"
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1010,6 +1010,8 @@
     "adminBackups": "Backups DB",
     "adminCabinets": "Cabinets",
     "adminInvoices": "Factures",
+    "adminUsers": "Utilisateurs",
+    "adminTaxRules": "Regles fiscales",
     "logout": "Se deconnecter"
   }
 }

--- a/src/app/(dashboard)/admin/tax-rules/page.tsx
+++ b/src/app/(dashboard)/admin/tax-rules/page.tsx
@@ -1,0 +1,29 @@
+/**
+ * US-2110 — Tax rules admin (lecture seule).
+ *
+ * ADMIN-only. Résolution taux fiscal actif (countryCode + taxType + date).
+ * Backend : `GET /api/config/tax-rules/active`.
+ */
+import { headers } from "next/headers"
+import { redirect } from "next/navigation"
+import { TaxRulesClient } from "@/components/diabeo/admin/TaxRulesClient"
+
+export default async function TaxRulesPage() {
+  const headersList = await headers()
+  const role = headersList.get("x-user-role")
+  if (role !== "ADMIN") redirect("/")
+
+  return (
+    <main className="flex flex-col gap-6 p-4 lg:p-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Règles fiscales</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Résolution du taux fiscal actif pour un pays + type de taxe à une
+          date donnée. Lecture seule iter 5 — création/modification via
+          backend opérations (cf. <code>docs/runbook/tax-rules.md</code>).
+        </p>
+      </header>
+      <TaxRulesClient />
+    </main>
+  )
+}

--- a/src/app/(dashboard)/admin/users/[id]/page.tsx
+++ b/src/app/(dashboard)/admin/users/[id]/page.tsx
@@ -1,0 +1,28 @@
+/**
+ * US-2148 — User detail + actions admin.
+ */
+import { headers } from "next/headers"
+import { redirect } from "next/navigation"
+import { UserDetailClient } from "@/components/diabeo/admin/UserDetailClient"
+
+interface PageProps {
+  params: Promise<{ id: string }>
+}
+
+export default async function UserDetailPage({ params }: PageProps) {
+  const headersList = await headers()
+  const role = headersList.get("x-user-role")
+  if (role !== "ADMIN") redirect("/")
+
+  const { id } = await params
+  if (!/^[1-9]\d{0,9}$/.test(id)) {
+    redirect("/admin/users")
+  }
+  const userId = Number.parseInt(id, 10)
+
+  return (
+    <main className="flex flex-col gap-6 p-4 lg:p-6">
+      <UserDetailClient userId={userId} />
+    </main>
+  )
+}

--- a/src/app/(dashboard)/admin/users/page.tsx
+++ b/src/app/(dashboard)/admin/users/page.tsx
@@ -1,0 +1,28 @@
+/**
+ * US-2148 — Admin gestion utilisateurs (page conteneur).
+ *
+ * ADMIN-only. Liste paginée + filtres role/status.
+ * Backend : `GET /api/admin/users`.
+ */
+import { headers } from "next/headers"
+import { redirect } from "next/navigation"
+import { UsersListClient } from "@/components/diabeo/admin/UsersListClient"
+
+export default async function UsersPage() {
+  const headersList = await headers()
+  const role = headersList.get("x-user-role")
+  if (role !== "ADMIN") redirect("/")
+
+  return (
+    <main className="flex flex-col gap-6 p-4 lg:p-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Utilisateurs</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Gestion des comptes utilisateurs (admins, médecins, infirmier·ères, patients).
+          Cliquer pour détail + actions suspension/archivage.
+        </p>
+      </header>
+      <UsersListClient />
+    </main>
+  )
+}

--- a/src/components/diabeo/Sidebar.tsx
+++ b/src/components/diabeo/Sidebar.tsx
@@ -22,6 +22,8 @@ import {
   Heart,
   Building2,
   Receipt,
+  UserCog,
+  Percent,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useAuth } from "@/hooks/use-auth"
@@ -54,6 +56,9 @@ const navItems: ReadonlyArray<NavItem> = [
   { href: "/admin/cabinets", labelKey: "adminCabinets", icon: Building2, roles: ["ADMIN"] },
   // US-2102/2108 (iter 4 PR Plan B) — Admin invoices + PDF download.
   { href: "/admin/invoices", labelKey: "adminInvoices", icon: Receipt, roles: ["ADMIN"] },
+  // US-2148 + US-2110 (iter 5 PR Plan B FINAL) — Admin users + tax rules.
+  { href: "/admin/users", labelKey: "adminUsers", icon: UserCog, roles: ["ADMIN"] },
+  { href: "/admin/tax-rules", labelKey: "adminTaxRules", icon: Percent, roles: ["ADMIN"] },
 ]
 
 /**

--- a/src/components/diabeo/admin/AdminPhiBanner.tsx
+++ b/src/components/diabeo/admin/AdminPhiBanner.tsx
@@ -1,0 +1,29 @@
+/**
+ * AdminPhiBanner — bandeau persistant rappel données personnelles ADMIN.
+ *
+ * Fix M4 round 1 review PR #461 (HSA M3) — sur écrans ADMIN affichant
+ * PHI/PII patient déchiffré (email, firstname, lastname, NIRPP via futur
+ * iter), rappel visuel "ne pas screenshoter / screen-share". Conformité
+ * DPIA US-2148 (mesure organisationnelle RGPD Art. 32).
+ *
+ * Léger, peu intrusif (border + bg jaune doux), accessible (role="note"
+ * + aria-label explicite).
+ */
+import { ShieldAlert } from "lucide-react"
+
+export function AdminPhiBanner({
+  message = "Données personnelles utilisateur — usage strictement administratif. Ne pas capturer ni partager l'écran.",
+}: {
+  message?: string
+}) {
+  return (
+    <div
+      role="note"
+      aria-label="Avertissement confidentialité"
+      className="rounded-md border border-amber-300 bg-amber-50 p-2 text-xs flex items-start gap-2"
+    >
+      <ShieldAlert className="size-4 text-amber-700 shrink-0 mt-0.5" aria-hidden="true" />
+      <p className="text-amber-900">{message}</p>
+    </div>
+  )
+}

--- a/src/components/diabeo/admin/TaxRulesClient.tsx
+++ b/src/components/diabeo/admin/TaxRulesClient.tsx
@@ -1,0 +1,221 @@
+"use client"
+
+/**
+ * TaxRulesClient — UI ADMIN résolution taux fiscal actif (US-2110).
+ *
+ * Backend : `GET /api/config/tax-rules/active?countryCode=&taxType=&date=`.
+ * Pattern aligné iter 1-4 (AbortController + extractApiError).
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useLocale } from "next-intl"
+import {
+  AlertCircle,
+  CheckCircle2,
+  Loader2,
+  Percent,
+  Search,
+} from "lucide-react"
+import { DiabeoButton } from "@/components/diabeo/DiabeoButton"
+import { Badge } from "@/components/ui/badge"
+import { formatDate } from "@/lib/intl/formatters"
+import type { Locale } from "@/i18n/config"
+import {
+  type TaxRuleDTOClient,
+  type TaxType,
+  TAX_TYPES,
+  TAX_TYPE_LABELS_FR,
+  formatTaxRate,
+} from "@/lib/types/user-admin"
+import { extractApiError } from "@/lib/ui/api-error"
+
+type AsyncState = "idle" | "loading" | "success" | "error" | "not_found"
+
+// ISO 3166-1 alpha-2 codes — extension V1.5 si besoin.
+const COUNTRY_OPTIONS: ReadonlyArray<{ code: string; label: string }> = [
+  { code: "FR", label: "France" },
+  { code: "DZ", label: "Algérie" },
+  { code: "BE", label: "Belgique" },
+  { code: "CH", label: "Suisse" },
+  { code: "MA", label: "Maroc" },
+  { code: "TN", label: "Tunisie" },
+]
+
+export function TaxRulesClient() {
+  const locale = useLocale() as Locale
+  const [countryCode, setCountryCode] = useState<string>("FR")
+  const [taxType, setTaxType] = useState<TaxType>("VAT")
+  const [date, setDate] = useState<string>(new Date().toISOString().slice(0, 10))
+  const [result, setResult] = useState<TaxRuleDTOClient | null>(null)
+  const [state, setState] = useState<AsyncState>("idle")
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const mountedRef = useRef(true)
+  const abortRef = useRef<AbortController | null>(null)
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      if (abortRef.current) abortRef.current.abort()
+    }
+  }, [])
+
+  const fetchRule = useCallback(async () => {
+    if (abortRef.current) abortRef.current.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+    setState("loading")
+    setErrorMessage(null)
+    setResult(null)
+    try {
+      const params = new URLSearchParams({ countryCode, taxType, date })
+      const res = await fetch(`/api/config/tax-rules/active?${params.toString()}`, {
+        credentials: "include",
+        signal: controller.signal,
+      })
+      if (!mountedRef.current) return
+      if (res.status === 404) {
+        setState("not_found")
+        return
+      }
+      if (!res.ok) {
+        setState("error")
+        const parsed = await extractApiError(res)
+        setErrorMessage(parsed.message)
+        return
+      }
+      const data = (await res.json()) as { rule?: TaxRuleDTOClient } | TaxRuleDTOClient
+      if (!mountedRef.current) return
+      const rule = "rule" in data ? data.rule : (data as TaxRuleDTOClient)
+      if (rule) setResult(rule)
+      setState("success")
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return
+      if (!mountedRef.current) return
+      setState("error")
+      setErrorMessage(err instanceof Error ? err.message : "Erreur réseau")
+    }
+  }, [countryCode, taxType, date])
+
+  return (
+    <>
+      {/* Form recherche */}
+      <section className="rounded-md border p-4 space-y-3" aria-labelledby="search-section">
+        <h2 id="search-section" className="text-lg font-semibold">Rechercher un taux actif</h2>
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Pays</span>
+            <select
+              value={countryCode}
+              onChange={(e) => setCountryCode(e.target.value)}
+              className="rounded-md border bg-background px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            >
+              {COUNTRY_OPTIONS.map((c) => (
+                <option key={c.code} value={c.code}>{c.label} ({c.code})</option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Type de taxe</span>
+            <select
+              value={taxType}
+              onChange={(e) => setTaxType(e.target.value as TaxType)}
+              className="rounded-md border bg-background px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            >
+              {TAX_TYPES.map((t) => (
+                <option key={t} value={t}>{TAX_TYPE_LABELS_FR[t]}</option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Date</span>
+            <input
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              className="rounded-md border bg-background px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            />
+          </label>
+          <div className="flex items-end">
+            <DiabeoButton onClick={() => void fetchRule()} disabled={state === "loading"} className="w-full">
+              <Search className="size-4 mr-1" aria-hidden="true" />
+              {state === "loading" ? "Recherche…" : "Rechercher"}
+            </DiabeoButton>
+          </div>
+        </div>
+      </section>
+
+      {/* Résultats */}
+      {state === "loading" && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground" aria-live="polite">
+          <Loader2 className="size-4 motion-safe:animate-spin" aria-hidden="true" />
+          Chargement…
+        </div>
+      )}
+
+      {state === "error" && errorMessage && (
+        <div role="alert" tabIndex={-1} ref={(el) => { el?.focus() }} className="rounded-md border border-destructive/20 bg-destructive/10 p-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive">
+          <p className="font-medium text-destructive flex items-center gap-2">
+            <AlertCircle className="size-4" aria-hidden="true" />
+            Erreur
+          </p>
+          <p className="text-xs text-muted-foreground mt-1">{errorMessage}</p>
+        </div>
+      )}
+
+      {state === "not_found" && (
+        <div role="status" aria-live="polite" className="rounded-md border border-dashed p-6 text-center text-sm">
+          <p className="text-muted-foreground">
+            Aucun taux actif pour <strong>{countryCode}</strong> / <strong>{TAX_TYPE_LABELS_FR[taxType]}</strong> au {date}.
+          </p>
+        </div>
+      )}
+
+      {state === "success" && result && (
+        <section className="rounded-md border p-4 space-y-3" aria-labelledby="result-section">
+          <h2 id="result-section" className="text-lg font-semibold flex items-center gap-2">
+            <CheckCircle2 className="size-5 text-primary" aria-hidden="true" />
+            Taux actif trouvé
+          </h2>
+          <div className="flex items-center gap-3 mb-2">
+            <Percent className="size-8 text-primary" aria-hidden="true" />
+            <div>
+              <p className="text-3xl font-bold">{formatTaxRate(result.baseRate, locale)}</p>
+              <p className="text-sm text-muted-foreground">{TAX_TYPE_LABELS_FR[result.taxType]} · {result.countryCode}</p>
+            </div>
+          </div>
+          <dl className="grid grid-cols-1 gap-3 text-sm md:grid-cols-2">
+            <Field label="Pays">{result.countryCode}</Field>
+            <Field label="Type">
+              {TAX_TYPE_LABELS_FR[result.taxType]}
+              <Badge variant="outline" className="ml-1 text-[10px]">{result.taxType}</Badge>
+            </Field>
+            <Field label="Taux">{formatTaxRate(result.baseRate, locale)}</Field>
+            <Field label="Statut">
+              <Badge variant={result.isActive ? "default" : "secondary"}>
+                {result.isActive ? "Actif" : "Inactif"}
+              </Badge>
+            </Field>
+            <Field label="Effet depuis">{formatDate(result.appliesFrom, locale, { withTime: false })}</Field>
+            <Field label="Effet jusqu'au">
+              {result.appliesUntil ? formatDate(result.appliesUntil, locale, { withTime: false }) : "Pas de fin programmée"}
+            </Field>
+            {result.description && (
+              <Field label="Description">
+                <span className="text-sm">{result.description}</span>
+              </Field>
+            )}
+          </dl>
+        </section>
+      )}
+    </>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <dt className="text-xs text-muted-foreground">{label}</dt>
+      <dd className="mt-0.5">{children}</dd>
+    </div>
+  )
+}

--- a/src/components/diabeo/admin/TaxRulesClient.tsx
+++ b/src/components/diabeo/admin/TaxRulesClient.tsx
@@ -26,31 +26,42 @@ import {
   TAX_TYPES,
   TAX_TYPE_LABELS_FR,
   formatTaxRate,
+  getLocalIsoDate,
 } from "@/lib/types/user-admin"
 import { extractApiError } from "@/lib/ui/api-error"
 
 type AsyncState = "idle" | "loading" | "success" | "error" | "not_found"
 
-// ISO 3166-1 alpha-2 codes — extension V1.5 si besoin.
-const COUNTRY_OPTIONS: ReadonlyArray<{ code: string; label: string }> = [
+// Fix M5 round 1 review PR #461 — `<datalist>` suggestions + `<input type="text">`
+// libre (vs `<select>` qui figeait 6 codes et bloquait cabinets US/UK/DE).
+// Backend `countryTaxRuleService` accepte tout ISO 3166-1 alpha-2.
+const COUNTRY_SUGGESTIONS: ReadonlyArray<{ code: string; label: string }> = [
   { code: "FR", label: "France" },
   { code: "DZ", label: "Algérie" },
   { code: "BE", label: "Belgique" },
   { code: "CH", label: "Suisse" },
   { code: "MA", label: "Maroc" },
   { code: "TN", label: "Tunisie" },
+  { code: "DE", label: "Allemagne" },
+  { code: "US", label: "États-Unis" },
+  { code: "GB", label: "Royaume-Uni" },
 ]
+
+const COUNTRY_CODE_RE = /^[A-Z]{2}$/
 
 export function TaxRulesClient() {
   const locale = useLocale() as Locale
   const [countryCode, setCountryCode] = useState<string>("FR")
   const [taxType, setTaxType] = useState<TaxType>("VAT")
-  const [date, setDate] = useState<string>(new Date().toISOString().slice(0, 10))
+  // Fix M6 round 1 — getLocalIsoDate (vs new Date().toISOString() UTC).
+  const [date, setDate] = useState<string>(getLocalIsoDate())
   const [result, setResult] = useState<TaxRuleDTOClient | null>(null)
   const [state, setState] = useState<AsyncState>("idle")
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const mountedRef = useRef(true)
   const abortRef = useRef<AbortController | null>(null)
+  // Fix L1 round 1 — useRef + useEffect focus error state.
+  const errorRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     mountedRef.current = true
     return () => {
@@ -58,6 +69,10 @@ export function TaxRulesClient() {
       if (abortRef.current) abortRef.current.abort()
     }
   }, [])
+  useEffect(() => {
+    if (state === "error") errorRef.current?.focus()
+  }, [state])
+  const isCountryValid = COUNTRY_CODE_RE.test(countryCode)
 
   const fetchRule = useCallback(async () => {
     if (abortRef.current) abortRef.current.abort()
@@ -103,16 +118,25 @@ export function TaxRulesClient() {
         <h2 id="search-section" className="text-lg font-semibold">Rechercher un taux actif</h2>
         <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
           <label className="flex flex-col gap-1 text-sm">
-            <span>Pays</span>
-            <select
+            <span>Pays (ISO 3166-1 alpha-2)</span>
+            {/* Fix M5 round 1 — input libre + datalist suggestions. */}
+            <input
+              type="text"
               value={countryCode}
-              onChange={(e) => setCountryCode(e.target.value)}
-              className="rounded-md border bg-background px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-            >
-              {COUNTRY_OPTIONS.map((c) => (
+              onChange={(e) => setCountryCode(e.target.value.toUpperCase())}
+              list="country-suggestions"
+              pattern="[A-Z]{2}"
+              maxLength={2}
+              required
+              placeholder="FR"
+              aria-invalid={countryCode.length > 0 && !COUNTRY_CODE_RE.test(countryCode) ? "true" : undefined}
+              className="rounded-md border bg-background px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary uppercase"
+            />
+            <datalist id="country-suggestions">
+              {COUNTRY_SUGGESTIONS.map((c) => (
                 <option key={c.code} value={c.code}>{c.label} ({c.code})</option>
               ))}
-            </select>
+            </datalist>
           </label>
           <label className="flex flex-col gap-1 text-sm">
             <span>Type de taxe</span>
@@ -136,7 +160,7 @@ export function TaxRulesClient() {
             />
           </label>
           <div className="flex items-end">
-            <DiabeoButton onClick={() => void fetchRule()} disabled={state === "loading"} className="w-full">
+            <DiabeoButton onClick={() => void fetchRule()} disabled={state === "loading" || !isCountryValid} className="w-full">
               <Search className="size-4 mr-1" aria-hidden="true" />
               {state === "loading" ? "Recherche…" : "Rechercher"}
             </DiabeoButton>
@@ -153,7 +177,7 @@ export function TaxRulesClient() {
       )}
 
       {state === "error" && errorMessage && (
-        <div role="alert" tabIndex={-1} ref={(el) => { el?.focus() }} className="rounded-md border border-destructive/20 bg-destructive/10 p-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive">
+        <div role="alert" tabIndex={-1} ref={errorRef} className="rounded-md border border-destructive/20 bg-destructive/10 p-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive">
           <p className="font-medium text-destructive flex items-center gap-2">
             <AlertCircle className="size-4" aria-hidden="true" />
             Erreur

--- a/src/components/diabeo/admin/UserDetailClient.tsx
+++ b/src/components/diabeo/admin/UserDetailClient.tsx
@@ -1,0 +1,352 @@
+"use client"
+
+/**
+ * UserDetailClient — UI ADMIN détail utilisateur + actions PATCH (US-2148).
+ *
+ * Backend :
+ *   - GET `/api/admin/users/[id]` → AdminUserView
+ *   - PATCH `/api/admin/users/[id]` { role? } OU { status? } (anti-lockout
+ *     Serializable + JWT revocation atomique côté backend PR #409)
+ *
+ * Actions :
+ *   - Changer rôle (ADMIN/DOCTOR/NURSE/VIEWER) — Dialog confirmation
+ *   - Changer status (active/suspended/archived) — Dialog confirmation
+ *
+ * Pattern aligné iter 1-4 round 1 fixes.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import Link from "next/link"
+import { useLocale } from "next-intl"
+import {
+  AlertCircle,
+  ArrowLeft,
+  CheckCircle2,
+  Loader2,
+  ShieldCheck,
+  UserCircle2,
+} from "lucide-react"
+import { DiabeoButton } from "@/components/diabeo/DiabeoButton"
+import { Badge } from "@/components/ui/badge"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { formatDate } from "@/lib/intl/formatters"
+import type { Locale } from "@/i18n/config"
+import {
+  type AdminUserDTOClient,
+  type Role,
+  type UserStatus,
+  ROLE_LABELS_FR,
+  USER_STATUS_LABELS_FR,
+  getRoleLabel,
+  getRoleVariant,
+  getUserStatusLabel,
+  getUserStatusVariant,
+  getUserDisplayName,
+} from "@/lib/types/user-admin"
+import { extractApiError, type ParsedApiError } from "@/lib/ui/api-error"
+
+type AsyncState = "idle" | "loading" | "saving" | "success" | "error"
+
+type PendingAction =
+  | { type: "role"; newRole: Role }
+  | { type: "status"; newStatus: UserStatus }
+  | null
+
+export function UserDetailClient({ userId }: { userId: number }) {
+  const locale = useLocale() as Locale
+  const [user, setUser] = useState<AdminUserDTOClient | null>(null)
+  const [state, setState] = useState<AsyncState>("loading")
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [actionState, setActionState] = useState<AsyncState>("idle")
+  const [actionError, setActionError] = useState<ParsedApiError | null>(null)
+  const [pending, setPending] = useState<PendingAction>(null)
+  const mountedRef = useRef(true)
+  const abortRef = useRef<AbortController | null>(null)
+  const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      if (successTimerRef.current) clearTimeout(successTimerRef.current)
+      if (abortRef.current) abortRef.current.abort()
+    }
+  }, [])
+
+  const fetchUser = useCallback(async () => {
+    if (abortRef.current) abortRef.current.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+    setUser(null)
+    setState("loading")
+    setErrorMessage(null)
+    try {
+      const res = await fetch(`/api/admin/users/${userId}`, {
+        credentials: "include",
+        signal: controller.signal,
+      })
+      if (!mountedRef.current) return
+      if (!res.ok) {
+        setState("error")
+        const parsed = await extractApiError(res)
+        setErrorMessage(parsed.message)
+        return
+      }
+      const data = (await res.json()) as { user?: AdminUserDTOClient } | AdminUserDTOClient
+      if (!mountedRef.current) return
+      // Backend peut renvoyer { user } ou directement le DTO — accept both.
+      const u = "user" in data ? data.user : (data as AdminUserDTOClient)
+      if (u) setUser(u)
+      setState("success")
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return
+      if (!mountedRef.current) return
+      setState("error")
+      setErrorMessage(err instanceof Error ? err.message : "Erreur réseau")
+    }
+  }, [userId])
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void fetchUser()
+  }, [fetchUser])
+
+  const executeAction = useCallback(async () => {
+    if (!pending) return
+    setActionState("saving")
+    setActionError(null)
+    const body = pending.type === "role"
+      ? { role: pending.newRole }
+      : { status: pending.newStatus }
+    setPending(null)
+    try {
+      const res = await fetch(`/api/admin/users/${userId}`, {
+        method: "PATCH",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Requested-With": "XMLHttpRequest",
+        },
+        body: JSON.stringify(body),
+      })
+      if (!mountedRef.current) return
+      if (!res.ok) {
+        setActionState("error")
+        const parsed = await extractApiError(res)
+        setActionError(parsed)
+        return
+      }
+      setActionState("success")
+      await fetchUser()
+      if (successTimerRef.current) clearTimeout(successTimerRef.current)
+      successTimerRef.current = setTimeout(() => {
+        if (mountedRef.current) setActionState("idle")
+      }, 3000)
+    } catch (err) {
+      if (!mountedRef.current) return
+      setActionState("error")
+      setActionError({
+        message: err instanceof Error ? err.message : "Erreur réseau",
+      })
+    }
+  }, [userId, pending, fetchUser])
+
+  if (state === "loading" && !user) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground" aria-live="polite">
+        <Loader2 className="size-4 motion-safe:animate-spin" aria-hidden="true" />
+        Chargement…
+      </div>
+    )
+  }
+
+  if (state === "error" || !user) {
+    return (
+      <div
+        role="alert"
+        tabIndex={-1}
+        ref={(el) => { el?.focus() }}
+        className="rounded-md border border-destructive/20 bg-destructive/10 p-3"
+      >
+        <p className="font-medium text-destructive flex items-center gap-2">
+          <AlertCircle className="size-4" aria-hidden="true" />
+          Erreur de chargement
+        </p>
+        {errorMessage && <p className="text-xs text-muted-foreground mt-1">{errorMessage}</p>}
+        <Link
+          href="/admin/users"
+          className="inline-flex items-center gap-1 text-sm text-primary hover:underline mt-2"
+        >
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          Retour à la liste
+        </Link>
+      </div>
+    )
+  }
+
+  const otherRoles: Role[] = (["ADMIN", "DOCTOR", "NURSE", "VIEWER"] as Role[]).filter((r) => r !== user.role)
+  const otherStatuses: UserStatus[] = (["active", "suspended", "archived"] as UserStatus[]).filter((s) => s !== user.status)
+
+  return (
+    <>
+      <nav aria-label="Fil d'Ariane">
+        <Link
+          href="/admin/users"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 rounded"
+        >
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          Retour à la liste
+        </Link>
+      </nav>
+
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold flex items-center gap-2">
+          <UserCircle2 className="size-6" aria-hidden="true" />
+          {getUserDisplayName(user)}
+        </h1>
+        <div className="flex items-center gap-2 flex-wrap">
+          <Badge variant={getRoleVariant(user.role)}>{getRoleLabel(user.role)}</Badge>
+          <Badge variant={getUserStatusVariant(user.status)}>{getUserStatusLabel(user.status)}</Badge>
+          {user.mfaEnabled && (
+            <Badge variant="secondary">
+              <ShieldCheck className="size-3 mr-0.5" aria-hidden="true" />
+              MFA activé
+            </Badge>
+          )}
+        </div>
+      </header>
+
+      {/* Détails */}
+      <section className="rounded-md border p-4 space-y-3" aria-labelledby="detail-section">
+        <h2 id="detail-section" className="text-lg font-semibold">Détails</h2>
+        <dl className="grid grid-cols-1 gap-3 text-sm md:grid-cols-2">
+          <Field label="Email">{user.email ?? "—"}</Field>
+          <Field label="Prénom">{user.firstname ?? "—"}</Field>
+          <Field label="Nom">{user.lastname ?? "—"}</Field>
+          <Field label="Langue">{user.language ?? "—"}</Field>
+          <Field label="Créé le">{formatDate(user.createdAt, locale, { withTime: true })}</Field>
+          {user.statusChangedAt && (
+            <Field label="Statut modifié le">{formatDate(user.statusChangedAt, locale, { withTime: true })}</Field>
+          )}
+          <Field label="Mis à jour le">{formatDate(user.updatedAt, locale, { withTime: true })}</Field>
+        </dl>
+      </section>
+
+      {/* Actions */}
+      <section className="rounded-md border p-4 space-y-3" aria-labelledby="actions-section">
+        <h2 id="actions-section" className="text-lg font-semibold">Actions</h2>
+        <p className="text-xs text-muted-foreground">
+          Modification du rôle ou du statut tracée dans l&apos;audit log immuable.
+          Anti-lockout : impossible de retirer le dernier ADMIN (backend Serializable).
+        </p>
+
+        {/* Rôle */}
+        <div className="space-y-2">
+          <h3 className="text-sm font-medium">Changer le rôle</h3>
+          <div className="flex flex-wrap gap-2">
+            {otherRoles.map((r) => (
+              <DiabeoButton
+                key={r}
+                variant="diabeoTertiary"
+                size="sm"
+                onClick={() => setPending({ type: "role", newRole: r })}
+                disabled={actionState === "saving"}
+              >
+                Promouvoir / Rétrograder en {ROLE_LABELS_FR[r]}
+              </DiabeoButton>
+            ))}
+          </div>
+        </div>
+
+        {/* Status */}
+        <div className="space-y-2">
+          <h3 className="text-sm font-medium">Changer le statut</h3>
+          <div className="flex flex-wrap gap-2">
+            {otherStatuses.map((s) => (
+              <DiabeoButton
+                key={s}
+                variant={s === "archived" ? "diabeoDestructive" : "diabeoTertiary"}
+                size="sm"
+                onClick={() => setPending({ type: "status", newStatus: s })}
+                disabled={actionState === "saving"}
+              >
+                {USER_STATUS_LABELS_FR[s]}
+              </DiabeoButton>
+            ))}
+          </div>
+        </div>
+
+        {actionState === "error" && actionError && (
+          <p role="alert" className="text-sm text-destructive flex items-center gap-2">
+            <AlertCircle className="size-4" aria-hidden="true" />
+            {actionError.message}
+          </p>
+        )}
+
+        {actionState === "success" && (
+          <div role="status" aria-live="polite" className="rounded-md border border-primary/20 bg-primary/5 p-2 text-sm">
+            <p className="flex items-center gap-2 text-primary">
+              <CheckCircle2 className="size-4" aria-hidden="true" />
+              Action effectuée.
+            </p>
+          </div>
+        )}
+      </section>
+
+      {/* Dialog confirmation */}
+      <Dialog open={pending !== null} onOpenChange={(open) => { if (!open) setPending(null) }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {pending?.type === "role" && `Changer le rôle vers ${ROLE_LABELS_FR[pending.newRole]} ?`}
+              {pending?.type === "status" && `Changer le statut vers ${USER_STATUS_LABELS_FR[pending.newStatus]} ?`}
+            </DialogTitle>
+            <DialogDescription>
+              {pending?.type === "status" && pending.newStatus === "archived" && (
+                <span className="block font-semibold text-destructive">
+                  ⚠ L&apos;archivage révoque tous les tokens JWT — l&apos;utilisateur sera déconnecté immédiatement.
+                </span>
+              )}
+              {pending?.type === "role" && pending.newRole === "ADMIN" && (
+                <span className="block">
+                  ⚠ Promotion vers ADMIN = accès complet plateforme.
+                </span>
+              )}
+              <span className="block mt-2 text-xs">
+                Action tracée dans l&apos;audit log immuable.
+              </span>
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DiabeoButton variant="diabeoTertiary" onClick={() => setPending(null)}>
+              Annuler
+            </DiabeoButton>
+            <DiabeoButton
+              variant={pending?.type === "status" && pending.newStatus === "archived" ? "diabeoDestructive" : "diabeoPrimary"}
+              onClick={() => void executeAction()}
+            >
+              <CheckCircle2 className="size-4 mr-1" aria-hidden="true" />
+              Confirmer
+            </DiabeoButton>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <dt className="text-xs text-muted-foreground">{label}</dt>
+      <dd className="mt-0.5">{children}</dd>
+    </div>
+  )
+}

--- a/src/components/diabeo/admin/UserDetailClient.tsx
+++ b/src/components/diabeo/admin/UserDetailClient.tsx
@@ -20,6 +20,7 @@ import Link from "next/link"
 import { useLocale } from "next-intl"
 import {
   AlertCircle,
+  AlertTriangle,
   ArrowLeft,
   CheckCircle2,
   Loader2,
@@ -43,7 +44,9 @@ import {
   type Role,
   type UserStatus,
   ROLE_LABELS_FR,
+  ROLES_ORDERED,
   USER_STATUS_LABELS_FR,
+  USER_STATUSES_ORDERED,
   getRoleLabel,
   getRoleVariant,
   getUserStatusLabel,
@@ -51,6 +54,7 @@ import {
   getUserDisplayName,
 } from "@/lib/types/user-admin"
 import { extractApiError, type ParsedApiError } from "@/lib/ui/api-error"
+import { AdminPhiBanner } from "./AdminPhiBanner"
 
 type AsyncState = "idle" | "loading" | "saving" | "success" | "error"
 
@@ -70,6 +74,12 @@ export function UserDetailClient({ userId }: { userId: number }) {
   const mountedRef = useRef(true)
   const abortRef = useRef<AbortController | null>(null)
   const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Fix L1 round 1 — useRef + useEffect pour focus error state (vs inline
+  // `ref={(el) => el?.focus()}` qui re-focus à chaque re-render → focus volé).
+  const errorRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (state === "error") errorRef.current?.focus()
+  }, [state])
 
   useEffect(() => {
     mountedRef.current = true
@@ -84,7 +94,10 @@ export function UserDetailClient({ userId }: { userId: number }) {
     if (abortRef.current) abortRef.current.abort()
     const controller = new AbortController()
     abortRef.current = controller
-    setUser(null)
+    // Fix M7 round 1 review PR #461 — reset conditionnel (vs blank flash après
+    // refetch action PATCH). On garde l'UI affichée si user déjà en mémoire,
+    // jusqu'au prochain success/error. Pattern via setter functional (stale-safe).
+    setUser((prev) => prev) // no-op : on conserve l'ancien snapshot.
     setState("loading")
     setErrorMessage(null)
     try {
@@ -119,12 +132,15 @@ export function UserDetailClient({ userId }: { userId: number }) {
   }, [fetchUser])
 
   const executeAction = useCallback(async () => {
-    if (!pending) return
+    // Fix L2 round 1 — capture pending dans var locale AVANT reset state
+    // (sinon perte du contexte action si erreur affichée plus tard).
+    const action = pending
+    if (!action) return
     setActionState("saving")
     setActionError(null)
-    const body = pending.type === "role"
-      ? { role: pending.newRole }
-      : { status: pending.newStatus }
+    const body = action.type === "role"
+      ? { role: action.newRole }
+      : { status: action.newStatus }
     setPending(null)
     try {
       const res = await fetch(`/api/admin/users/${userId}`, {
@@ -133,6 +149,9 @@ export function UserDetailClient({ userId }: { userId: number }) {
         headers: {
           "Content-Type": "application/json",
           "X-Requested-With": "XMLHttpRequest",
+          // Fix L6 round 1 (HSA L2) — Idempotency-Key pour dedup audit
+          // backend si double-click. Random UUID v4 unique par action.
+          "Idempotency-Key": crypto.randomUUID(),
         },
         body: JSON.stringify(body),
       })
@@ -172,8 +191,8 @@ export function UserDetailClient({ userId }: { userId: number }) {
       <div
         role="alert"
         tabIndex={-1}
-        ref={(el) => { el?.focus() }}
-        className="rounded-md border border-destructive/20 bg-destructive/10 p-3"
+        ref={errorRef}
+        className="rounded-md border border-destructive/20 bg-destructive/10 p-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive"
       >
         <p className="font-medium text-destructive flex items-center gap-2">
           <AlertCircle className="size-4" aria-hidden="true" />
@@ -191,11 +210,17 @@ export function UserDetailClient({ userId }: { userId: number }) {
     )
   }
 
-  const otherRoles: Role[] = (["ADMIN", "DOCTOR", "NURSE", "VIEWER"] as Role[]).filter((r) => r !== user.role)
-  const otherStatuses: UserStatus[] = (["active", "suspended", "archived"] as UserStatus[]).filter((s) => s !== user.status)
+  // Fix H4 round 1 — utilise ROLES_ORDERED + USER_STATUSES_ORDERED (hiérarchique stable).
+  const otherRoles: Role[] = ROLES_ORDERED.filter((r) => r !== user.role)
+  const otherStatuses: UserStatus[] = USER_STATUSES_ORDERED.filter((s) => s !== user.status)
+  // Fix H2 round 1 (HSA) — gate dur sur promotion ADMIN si MFA non activée.
+  // HDS ANS référentiel : comptes à privilèges DOIVENT avoir MFA.
+  const canPromoteToAdmin = user.mfaEnabled
 
   return (
     <>
+      {/* Fix M4 round 1 (HSA M3) — bandeau PHI rappel utilisation strictement admin. */}
+      <AdminPhiBanner />
       <nav aria-label="Fil d'Ariane">
         <Link
           href="/admin/users"
@@ -235,7 +260,10 @@ export function UserDetailClient({ userId }: { userId: number }) {
           {user.statusChangedAt && (
             <Field label="Statut modifié le">{formatDate(user.statusChangedAt, locale, { withTime: true })}</Field>
           )}
-          <Field label="Mis à jour le">{formatDate(user.updatedAt, locale, { withTime: true })}</Field>
+          {/* Fix H6 round 1 — null-guard updatedAt cohérent statusChangedAt. */}
+          {user.updatedAt && (
+            <Field label="Mis à jour le">{formatDate(user.updatedAt, locale, { withTime: true })}</Field>
+          )}
         </dl>
       </section>
 
@@ -249,26 +277,50 @@ export function UserDetailClient({ userId }: { userId: number }) {
 
         {/* Rôle */}
         <div className="space-y-2">
-          <h3 className="text-sm font-medium">Changer le rôle</h3>
-          <div className="flex flex-wrap gap-2">
-            {otherRoles.map((r) => (
-              <DiabeoButton
-                key={r}
-                variant="diabeoTertiary"
-                size="sm"
-                onClick={() => setPending({ type: "role", newRole: r })}
-                disabled={actionState === "saving"}
-              >
-                Promouvoir / Rétrograder en {ROLE_LABELS_FR[r]}
-              </DiabeoButton>
-            ))}
+          <h3 className="text-sm font-medium" id="role-section-heading">Changer le rôle</h3>
+          {/* Fix H2 round 1 (HSA) — warning visible MFA required ADMIN. */}
+          {!canPromoteToAdmin && (
+            <p
+              id="admin-mfa-warning"
+              role="note"
+              className="text-xs text-amber-900 bg-amber-50 border border-amber-300 rounded p-2 flex items-start gap-1"
+            >
+              <AlertTriangle className="size-3.5 text-amber-700 shrink-0 mt-0.5" aria-hidden="true" />
+              <span>
+                Promotion vers ADMIN désactivée : MFA requise pour les comptes à privilèges (HDS ANS référentiel).
+                L&apos;utilisateur doit d&apos;abord activer MFA dans ses paramètres.
+              </span>
+            </p>
+          )}
+          <div className="flex flex-wrap gap-2" role="group" aria-labelledby="role-section-heading">
+            {otherRoles.map((r) => {
+              const isAdminPromote = r === "ADMIN"
+              const disabled = actionState === "saving" || (isAdminPromote && !canPromoteToAdmin)
+              return (
+                <DiabeoButton
+                  key={r}
+                  variant="diabeoTertiary"
+                  size="sm"
+                  onClick={() => setPending({ type: "role", newRole: r })}
+                  disabled={disabled}
+                  // Fix M1 + L5 round 1 — libellé explicite + aria-describedby warning.
+                  aria-describedby={isAdminPromote && !canPromoteToAdmin ? "admin-mfa-warning" : undefined}
+                >
+                  Définir le rôle : {ROLE_LABELS_FR[user.role]} → {ROLE_LABELS_FR[r]}
+                </DiabeoButton>
+              )
+            })}
           </div>
         </div>
 
         {/* Status */}
         <div className="space-y-2">
-          <h3 className="text-sm font-medium">Changer le statut</h3>
-          <div className="flex flex-wrap gap-2">
+          <h3 className="text-sm font-medium" id="status-section-heading">Changer le statut</h3>
+          {/* Fix M1 round 1 — aria-describedby pointe vers warning archivage. */}
+          <p id="archive-warning" className="sr-only">
+            L&apos;archivage révoque tous les tokens JWT et déconnecte l&apos;utilisateur immédiatement.
+          </p>
+          <div className="flex flex-wrap gap-2" role="group" aria-labelledby="status-section-heading">
             {otherStatuses.map((s) => (
               <DiabeoButton
                 key={s}
@@ -276,8 +328,9 @@ export function UserDetailClient({ userId }: { userId: number }) {
                 size="sm"
                 onClick={() => setPending({ type: "status", newStatus: s })}
                 disabled={actionState === "saving"}
+                aria-describedby={s === "archived" ? "archive-warning" : undefined}
               >
-                {USER_STATUS_LABELS_FR[s]}
+                Statut : {USER_STATUS_LABELS_FR[user.status]} → {USER_STATUS_LABELS_FR[s]}
               </DiabeoButton>
             ))}
           </div>
@@ -310,13 +363,17 @@ export function UserDetailClient({ userId }: { userId: number }) {
             </DialogTitle>
             <DialogDescription>
               {pending?.type === "status" && pending.newStatus === "archived" && (
+                // Fix H3 round 1 (A11y HIGH 1) — wrap emoji ⚠ avec aria-label
+                // (vs raw emoji que SR rendent inconsistant entre lecteurs).
                 <span className="block font-semibold text-destructive">
-                  ⚠ L&apos;archivage révoque tous les tokens JWT — l&apos;utilisateur sera déconnecté immédiatement.
+                  <span aria-label="Attention" role="img" className="mr-1">⚠</span>
+                  L&apos;archivage révoque tous les tokens JWT — l&apos;utilisateur sera déconnecté immédiatement.
                 </span>
               )}
               {pending?.type === "role" && pending.newRole === "ADMIN" && (
                 <span className="block">
-                  ⚠ Promotion vers ADMIN = accès complet plateforme.
+                  <span aria-label="Attention" role="img" className="mr-1">⚠</span>
+                  Promotion vers ADMIN = accès complet plateforme.
                 </span>
               )}
               <span className="block mt-2 text-xs">

--- a/src/components/diabeo/admin/UsersListClient.tsx
+++ b/src/components/diabeo/admin/UsersListClient.tsx
@@ -26,7 +26,9 @@ import {
   type Role,
   type UserStatus,
   ROLE_LABELS_FR,
+  ROLES_ORDERED,
   USER_STATUS_LABELS_FR,
+  USER_STATUSES_ORDERED,
   getRoleLabel,
   getRoleVariant,
   getUserStatusLabel,
@@ -34,6 +36,7 @@ import {
   getUserDisplayName,
 } from "@/lib/types/user-admin"
 import { extractApiError } from "@/lib/ui/api-error"
+import { AdminPhiBanner } from "./AdminPhiBanner"
 
 type AsyncState = "idle" | "loading" | "success" | "error"
 
@@ -107,6 +110,8 @@ export function UsersListClient() {
 
   return (
     <>
+      {/* Fix M4 round 1 (HSA M3) — bandeau PHI rappel utilisation strictement admin. */}
+      <AdminPhiBanner />
       <div className="flex flex-wrap items-center gap-3">
         <div className="relative flex-1 max-w-md">
           <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" aria-hidden="true" />
@@ -117,6 +122,11 @@ export function UsersListClient() {
             placeholder="Rechercher par nom / email…"
             className="w-full rounded-md border bg-background pl-9 pr-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
             aria-label="Rechercher un utilisateur"
+            // Fix M2 round 1 review PR #461 (HSA M1) — autocomplete OFF :
+            // évite que le navigateur conserve historique emails partiels
+            // (poste cabinet partagé multi-PS).
+            autoComplete="off"
+            spellCheck={false}
           />
         </div>
         <label className="flex items-center gap-1 text-sm">
@@ -128,8 +138,9 @@ export function UsersListClient() {
             aria-label="Filtrer par rôle"
           >
             <option value="all">Tous les rôles</option>
-            {Object.entries(ROLE_LABELS_FR).map(([value, label]) => (
-              <option key={value} value={value}>{label}</option>
+            {/* Fix H4 round 1 — ROLES_ORDERED iter stable (hiérarchique). */}
+            {ROLES_ORDERED.map((r) => (
+              <option key={r} value={r}>{ROLE_LABELS_FR[r]}</option>
             ))}
           </select>
         </label>
@@ -142,8 +153,8 @@ export function UsersListClient() {
             aria-label="Filtrer par statut"
           >
             <option value="all">Tous les statuts</option>
-            {Object.entries(USER_STATUS_LABELS_FR).map(([value, label]) => (
-              <option key={value} value={value}>{label}</option>
+            {USER_STATUSES_ORDERED.map((s) => (
+              <option key={s} value={s}>{USER_STATUS_LABELS_FR[s]}</option>
             ))}
           </select>
         </label>
@@ -155,6 +166,15 @@ export function UsersListClient() {
 
       {state === "loading" && users.length === 0 && (
         <p className="text-sm text-muted-foreground" aria-live="polite">Chargement…</p>
+      )}
+
+      {/* Fix H5 round 1 — indicateur loading même si liste déjà affichée
+          (sinon user croit voir données filtrées). */}
+      {state === "loading" && users.length > 0 && (
+        <p className="text-xs text-muted-foreground flex items-center gap-1" aria-live="polite">
+          <RefreshCw className="size-3 motion-safe:animate-spin" aria-hidden="true" />
+          Mise à jour des résultats…
+        </p>
       )}
 
       {state === "error" && users.length === 0 && (
@@ -216,7 +236,8 @@ export function UsersListClient() {
       )}
 
       {hasMore && (
-        <div role="note" className="rounded-md border border-orange-300 bg-orange-50 p-3 text-sm flex items-start gap-2">
+        // Fix H4 round 1 (A11y HIGH 2) — role="status" + aria-live (vs non-standard "note").
+        <div role="status" aria-live="polite" className="rounded-md border border-orange-300 bg-orange-50 p-3 text-sm flex items-start gap-2">
           <AlertCircle className="size-4 text-orange-700 shrink-0 mt-0.5" aria-hidden="true" />
           <p className="text-orange-800">
             Plus de 100 utilisateurs correspondent. Affiner les filtres pour réduire la liste.

--- a/src/components/diabeo/admin/UsersListClient.tsx
+++ b/src/components/diabeo/admin/UsersListClient.tsx
@@ -1,0 +1,231 @@
+"use client"
+
+/**
+ * UsersListClient — UI ADMIN list users (US-2148).
+ *
+ * Backend : `GET /api/admin/users` (paginé cursor). Pattern aligné iter 1-4.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import Link from "next/link"
+import { useLocale } from "next-intl"
+import {
+  AlertCircle,
+  ChevronRight,
+  RefreshCw,
+  Search,
+  ShieldCheck,
+  UserCircle2,
+} from "lucide-react"
+import { DiabeoButton } from "@/components/diabeo/DiabeoButton"
+import { Badge } from "@/components/ui/badge"
+import { formatDate } from "@/lib/intl/formatters"
+import type { Locale } from "@/i18n/config"
+import {
+  type AdminUserDTOClient,
+  type Role,
+  type UserStatus,
+  ROLE_LABELS_FR,
+  USER_STATUS_LABELS_FR,
+  getRoleLabel,
+  getRoleVariant,
+  getUserStatusLabel,
+  getUserStatusVariant,
+  getUserDisplayName,
+} from "@/lib/types/user-admin"
+import { extractApiError } from "@/lib/ui/api-error"
+
+type AsyncState = "idle" | "loading" | "success" | "error"
+
+export function UsersListClient() {
+  const locale = useLocale() as Locale
+  const [users, setUsers] = useState<AdminUserDTOClient[]>([])
+  const [state, setState] = useState<AsyncState>("idle")
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [filterRole, setFilterRole] = useState<Role | "all">("all")
+  const [filterStatus, setFilterStatus] = useState<UserStatus | "all">("all")
+  const [query, setQuery] = useState("")
+  const [hasMore, setHasMore] = useState(false)
+  const mountedRef = useRef(true)
+  const abortRef = useRef<AbortController | null>(null)
+  const fetchSeqRef = useRef(0)
+
+  const fetchUsers = useCallback(async () => {
+    if (abortRef.current) abortRef.current.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+    const seq = ++fetchSeqRef.current
+    setState("loading")
+    setErrorMessage(null)
+    try {
+      const params = new URLSearchParams()
+      if (filterRole !== "all") params.set("role", filterRole)
+      if (filterStatus !== "all") params.set("status", filterStatus)
+      params.set("limit", "100")
+      const res = await fetch(`/api/admin/users?${params.toString()}`, {
+        credentials: "include",
+        signal: controller.signal,
+      })
+      if (seq !== fetchSeqRef.current || !mountedRef.current) return
+      if (!res.ok) {
+        setState("error")
+        const parsed = await extractApiError(res)
+        setErrorMessage(parsed.message)
+        return
+      }
+      const data = (await res.json()) as { items?: AdminUserDTOClient[]; nextCursor?: number }
+      if (seq !== fetchSeqRef.current || !mountedRef.current) return
+      setUsers(data.items ?? [])
+      setHasMore(data.nextCursor !== undefined && data.nextCursor !== null)
+      setState("success")
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return
+      if (seq !== fetchSeqRef.current || !mountedRef.current) return
+      setState("error")
+      setErrorMessage(err instanceof Error ? err.message : "Erreur réseau")
+    }
+  }, [filterRole, filterStatus])
+
+  useEffect(() => {
+    mountedRef.current = true
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void fetchUsers()
+    return () => {
+      mountedRef.current = false
+      if (abortRef.current) abortRef.current.abort()
+    }
+  }, [fetchUsers])
+
+  const filtered = query.trim().length > 0
+    ? users.filter((u) => {
+        const q = query.trim().toLowerCase()
+        return (u.email ?? "").toLowerCase().includes(q)
+          || (u.firstname ?? "").toLowerCase().includes(q)
+          || (u.lastname ?? "").toLowerCase().includes(q)
+      })
+    : users
+
+  return (
+    <>
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" aria-hidden="true" />
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Rechercher par nom / email…"
+            className="w-full rounded-md border bg-background pl-9 pr-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
+            aria-label="Rechercher un utilisateur"
+          />
+        </div>
+        <label className="flex items-center gap-1 text-sm">
+          <span className="text-muted-foreground">Rôle :</span>
+          <select
+            value={filterRole}
+            onChange={(e) => setFilterRole(e.target.value as Role | "all")}
+            className="rounded-md border bg-background px-2 py-1 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            aria-label="Filtrer par rôle"
+          >
+            <option value="all">Tous les rôles</option>
+            {Object.entries(ROLE_LABELS_FR).map(([value, label]) => (
+              <option key={value} value={value}>{label}</option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-1 text-sm">
+          <span className="text-muted-foreground">Statut :</span>
+          <select
+            value={filterStatus}
+            onChange={(e) => setFilterStatus(e.target.value as UserStatus | "all")}
+            className="rounded-md border bg-background px-2 py-1 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            aria-label="Filtrer par statut"
+          >
+            <option value="all">Tous les statuts</option>
+            {Object.entries(USER_STATUS_LABELS_FR).map(([value, label]) => (
+              <option key={value} value={value}>{label}</option>
+            ))}
+          </select>
+        </label>
+        <DiabeoButton variant="diabeoTertiary" size="sm" onClick={() => void fetchUsers()}>
+          <RefreshCw className="size-3.5 mr-1" aria-hidden="true" />
+          Actualiser
+        </DiabeoButton>
+      </div>
+
+      {state === "loading" && users.length === 0 && (
+        <p className="text-sm text-muted-foreground" aria-live="polite">Chargement…</p>
+      )}
+
+      {state === "error" && users.length === 0 && (
+        <div role="alert" className="rounded-md border border-destructive/20 bg-destructive/10 p-3 text-sm">
+          <p className="font-medium text-destructive flex items-center gap-2">
+            <AlertCircle className="size-4" aria-hidden="true" />
+            Liste indisponible
+          </p>
+          {errorMessage && <p className="text-xs text-muted-foreground mt-1">{errorMessage}</p>}
+          <DiabeoButton variant="diabeoTertiary" size="sm" onClick={() => void fetchUsers()} className="mt-2">
+            Réessayer
+          </DiabeoButton>
+        </div>
+      )}
+
+      {state === "success" && filtered.length === 0 && (
+        <div className="rounded-md border border-dashed p-8 text-center">
+          <UserCircle2 className="size-8 text-muted-foreground mx-auto mb-2" aria-hidden="true" />
+          <p className="text-sm text-muted-foreground">
+            {query ? "Aucun utilisateur ne correspond à la recherche." : "Aucun utilisateur."}
+          </p>
+        </div>
+      )}
+
+      {filtered.length > 0 && (
+        <ul className="space-y-2" aria-label="Liste des utilisateurs">
+          {filtered.map((user) => (
+            <li key={user.id} className="rounded-md border">
+              <Link
+                href={`/admin/users/${user.id}`}
+                className="flex items-start gap-3 p-3 hover:bg-muted/30 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-md"
+              >
+                <UserCircle2 className="size-5 text-muted-foreground shrink-0 mt-0.5" aria-hidden="true" />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="font-medium">{getUserDisplayName(user)}</span>
+                    <Badge variant={getRoleVariant(user.role)} className="text-[10px]">
+                      {getRoleLabel(user.role)}
+                    </Badge>
+                    <Badge variant={getUserStatusVariant(user.status)} className="text-[10px]">
+                      {getUserStatusLabel(user.status)}
+                    </Badge>
+                    {user.mfaEnabled && (
+                      <Badge variant="secondary" className="text-[10px]">
+                        <ShieldCheck className="size-3 mr-0.5" aria-hidden="true" />
+                        MFA
+                      </Badge>
+                    )}
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1 truncate">
+                    {user.email ?? "—"} · Créé le {formatDate(user.createdAt, locale, { withTime: false })}
+                  </p>
+                </div>
+                <ChevronRight className="size-4 text-muted-foreground shrink-0 mt-1" aria-hidden="true" />
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {hasMore && (
+        <div role="note" className="rounded-md border border-orange-300 bg-orange-50 p-3 text-sm flex items-start gap-2">
+          <AlertCircle className="size-4 text-orange-700 shrink-0 mt-0.5" aria-hidden="true" />
+          <p className="text-orange-800">
+            Plus de 100 utilisateurs correspondent. Affiner les filtres pour réduire la liste.
+            <span className="block text-xs opacity-80 mt-0.5">
+              Pagination cursor V1.5 — affichage tronqué.
+            </span>
+          </p>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/lib/types/user-admin.ts
+++ b/src/lib/types/user-admin.ts
@@ -1,0 +1,138 @@
+/**
+ * Types partagés pour US-2148 (Admin users) UI.
+ *
+ * Pattern aligné PR #457-#460 (`src/lib/types/*-admin.ts`).
+ * Backend DTO : `user-management.service.ts:AdminUserView`.
+ */
+
+export type Role = "ADMIN" | "DOCTOR" | "NURSE" | "VIEWER"
+export type UserStatus = "active" | "suspended" | "archived"
+
+const ROLES: ReadonlySet<Role> = new Set(["ADMIN", "DOCTOR", "NURSE", "VIEWER"])
+const STATUSES: ReadonlySet<UserStatus> = new Set(["active", "suspended", "archived"])
+
+export function isRole(value: unknown): value is Role {
+  return typeof value === "string" && ROLES.has(value as Role)
+}
+
+export function isUserStatus(value: unknown): value is UserStatus {
+  return typeof value === "string" && STATUSES.has(value as UserStatus)
+}
+
+/**
+ * AdminUserView côté client — Dates Prisma → ISO string via JSON serialize.
+ * Email + firstname + lastname déchiffrés côté backend AVANT envoi
+ * (cf. PR #409 `toAdminView`). UI affiche en clair (ADMIN screen).
+ */
+export interface AdminUserDTOClient {
+  id: number
+  email: string | null
+  firstname: string | null
+  lastname: string | null
+  role: Role
+  status: UserStatus
+  statusChangedAt: string | null
+  mfaEnabled: boolean
+  language: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export const ROLE_LABELS_FR: Record<Role, string> = {
+  ADMIN: "Administrateur",
+  DOCTOR: "Médecin",
+  NURSE: "Infirmier·ère",
+  VIEWER: "Patient",
+}
+
+export const USER_STATUS_LABELS_FR: Record<UserStatus, string> = {
+  active: "Actif",
+  suspended: "Suspendu",
+  archived: "Archivé",
+}
+
+export type BadgeVariant = "default" | "secondary" | "destructive" | "outline"
+
+export const ROLE_VARIANT: Record<Role, BadgeVariant> = {
+  ADMIN: "destructive",
+  DOCTOR: "default",
+  NURSE: "secondary",
+  VIEWER: "outline",
+}
+
+export const USER_STATUS_VARIANT: Record<UserStatus, BadgeVariant> = {
+  active: "default",
+  suspended: "outline",
+  archived: "secondary",
+}
+
+export function getRoleLabel(role: Role | string): string {
+  if (isRole(role)) return ROLE_LABELS_FR[role]
+  if (process.env.NODE_ENV !== "production") console.warn(`[user-admin] Unknown Role: ${role}`)
+  return role
+}
+
+export function getUserStatusLabel(status: UserStatus | string): string {
+  if (isUserStatus(status)) return USER_STATUS_LABELS_FR[status]
+  if (process.env.NODE_ENV !== "production") console.warn(`[user-admin] Unknown UserStatus: ${status}`)
+  return status
+}
+
+export function getRoleVariant(role: Role | string): BadgeVariant {
+  if (isRole(role)) return ROLE_VARIANT[role]
+  return "outline"
+}
+
+export function getUserStatusVariant(status: UserStatus | string): BadgeVariant {
+  if (isUserStatus(status)) return USER_STATUS_VARIANT[status]
+  return "outline"
+}
+
+/**
+ * Affichage nom complet — fallback email si nom non saisi.
+ * Format "Lastname Firstname" (français formel).
+ */
+export function getUserDisplayName(user: Pick<AdminUserDTOClient, "firstname" | "lastname" | "email" | "id">): string {
+  const parts: string[] = []
+  if (user.lastname) parts.push(user.lastname)
+  if (user.firstname) parts.push(user.firstname)
+  if (parts.length > 0) return parts.join(" ")
+  return user.email ?? `User #${user.id}`
+}
+
+// ─────────────────────────────────────────────────────────────
+// Tax Rules (US-2110 — config tax-rules)
+// ─────────────────────────────────────────────────────────────
+
+export const TAX_TYPES = ["VAT", "INCOME_TAX", "CORPORATE_TAX", "SOCIAL_CONTRIBUTION"] as const
+export type TaxType = (typeof TAX_TYPES)[number]
+
+export const TAX_TYPE_LABELS_FR: Record<TaxType, string> = {
+  VAT: "TVA",
+  INCOME_TAX: "Impôt sur le revenu",
+  CORPORATE_TAX: "Impôt sur les sociétés",
+  SOCIAL_CONTRIBUTION: "Cotisation sociale",
+}
+
+export interface TaxRuleDTOClient {
+  id: number
+  countryCode: string
+  taxType: TaxType
+  baseRate: number // 0..1
+  description: string | null
+  appliesFrom: string
+  appliesUntil: string | null
+  isActive: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * Formate baseRate 0..1 en pourcentage locale-aware (0.20 → "20 %").
+ */
+export function formatTaxRate(rate: number, locale: string): string {
+  return new Intl.NumberFormat(locale, {
+    style: "percent",
+    maximumFractionDigits: 2,
+  }).format(rate)
+}

--- a/src/lib/types/user-admin.ts
+++ b/src/lib/types/user-admin.ts
@@ -8,8 +8,16 @@
 export type Role = "ADMIN" | "DOCTOR" | "NURSE" | "VIEWER"
 export type UserStatus = "active" | "suspended" | "archived"
 
-const ROLES: ReadonlySet<Role> = new Set(["ADMIN", "DOCTOR", "NURSE", "VIEWER"])
-const STATUSES: ReadonlySet<UserStatus> = new Set(["active", "suspended", "archived"])
+/**
+ * Fix H4 round 1 review PR #461 — ordre stable (hiérarchique) pour itération
+ * UI (vs `Object.entries(ROLE_LABELS_FR)` qui dépend ordre d'insertion JS).
+ * Régression-proof : si refactor passe par Map/serializer, ordre cassé.
+ */
+export const ROLES_ORDERED: ReadonlyArray<Role> = ["ADMIN", "DOCTOR", "NURSE", "VIEWER"]
+export const USER_STATUSES_ORDERED: ReadonlyArray<UserStatus> = ["active", "suspended", "archived"]
+
+const ROLES: ReadonlySet<Role> = new Set(ROLES_ORDERED)
+const STATUSES: ReadonlySet<UserStatus> = new Set(USER_STATUSES_ORDERED)
 
 export function isRole(value: unknown): value is Role {
   return typeof value === "string" && ROLES.has(value as Role)
@@ -135,4 +143,16 @@ export function formatTaxRate(rate: number, locale: string): string {
     style: "percent",
     maximumFractionDigits: 2,
   }).format(rate)
+}
+
+/**
+ * Fix M6 round 1 review PR #461 — date locale-aware (vs `new Date().toISOString()`
+ * qui force UTC). Évite "demain" par défaut si client après minuit UTC mais
+ * avant minuit local (Paris CEST 01h30).
+ */
+export function getLocalIsoDate(date: Date = new Date()): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, "0")
+  const d = String(date.getDate()).padStart(2, "0")
+  return `${y}-${m}-${d}`
 }


### PR DESCRIPTION
Plan B Pre-prod cabinet multi-PS **iter 5/5 FINAL** (post-PR #460). UI ADMIN pour US-2148 + US-2110.

## US-2148 Users

### Liste — \`/admin/users\`
- Filtres recherche client + rôle + statut
- Rows : nom complet / email + role/status/MFA Badges
- hasMore indicator

### Détail — \`/admin/users/[id]\`
- Actions changer rôle + changer statut
- Dialog confirmation avec warnings ⚠ promotion ADMIN / archivage (révocation JWT)
- Backend anti-lockout Serializable + JWT revocation atomique (PR #409)

## US-2110 Tax Rules — \`/admin/tax-rules\`
- Form 4 colonnes : pays/type/date/bouton
- Résultat : grande card taux \`Intl.NumberFormat({style:"percent"})\` + détails
- 404 not found gracieux
- Lecture seule (création/modif = ops manuel)

## Sidebar — 2 nouveaux items ADMIN
\`/admin/users\` (UserCog) + \`/admin/tax-rules\` (Percent)

## Plan B status après merge — COMPLET ✅
- iter 1/5 ✅ Sessions + Data Breaches (PR #457)
- iter 2/5 ✅ System Health + Backups (PR #458)
- iter 3/5 ✅ Cabinets + SMS config (PR #459)
- iter 4/5 ✅ Invoices + PDF download (PR #460)
- iter 5/5 ✅ Users + Tax rules (cette PR — FINAL)

## Tests
- [x] 2769/2769 vitest verts
- [x] tsc + lint clean
- [ ] CI E2E (à vérifier)
- [ ] Test manuel ADMIN : Sidebar 12 items → Users list → user detail → changer rôle/statut + Tax rules lookup

🤖 Generated with [Claude Code](https://claude.com/claude-code)