### PR TITLE
feat(auth): A2 Step-up MFA for sensitive ADMIN actions (Plan B follow-up)

### DIFF
--- a/docs/runbook/step-up-mfa.md
+++ b/docs/runbook/step-up-mfa.md
@@ -1,0 +1,249 @@
+# Runbook — Step-up MFA
+
+**Owner** : Backend platform / Security
+**Statut** : Production (Plan B follow-up A2, 2026-05-28)
+**Scope** : Actions sensibles ADMIN (role/status, FSM data-breach, financier)
+
+---
+
+## 1. Pourquoi
+
+L'auth Diabeo actuelle (US-2002 MFA login) prouve MFA **une seule fois** au
+login. Pendant les 24h suivantes (durée session), un attacker qui vole la
+session (cookie httpOnly via attaque MITM, exfiltration via XSS pré-existant,
+etc.) peut exécuter n'importe quelle action ADMIN sans seconde preuve.
+
+Le step-up MFA force l'utilisateur à re-prouver MFA dans les 5 dernières
+minutes **avant** chaque action sensible :
+- Changement de rôle (`PATCH /api/admin/users/[id] { role }`)
+- Suspension de compte (`PATCH /api/admin/users/[id] { status }`)
+- Transition FSM data-breach (`POST /api/admin/data-breaches/[id]/transition`)
+- (Futur) Toggle SMS config cabinet, génération factures critiques, etc.
+
+Pattern aligné UX banking apps (Stripe Dashboard, AWS Console, etc.).
+
+---
+
+## 2. Architecture
+
+### Schéma
+
+`Session.mfaLastVerifiedAt DateTime?` (migration `20260528150000_a2_step_up_mfa`).
+NULL = jamais MFA-verified. Bumped à :
+- Login via `POST /api/auth/mfa/challenge` (cohérence — éviter step-up immédiat).
+- Step-up via `POST /api/auth/mfa/step-up`.
+
+### Fenêtre de fraîcheur
+
+`STEP_UP_WINDOW_SECONDS = 5 * 60` (5 min). Constante exportée depuis
+`src/lib/auth/step-up.ts` — modifiable centralement.
+
+### Helper `checkFreshMfa(userId, sessionId)`
+
+Retourne `{ ok: true, verifiedAt }` ou `{ ok: false, reason }` :
+- `mfaEnrollmentRequired` — l'utilisateur n'a pas MFA activée.
+- `stepUpRequired` — MFA activée mais pas fresh (ou jamais verified, ou session inconnue).
+
+### Helper `stepUpErrorResponse(reason, userId, sessionId, ctx, { route })`
+
+Construit la 401 + headers :
+- `WWW-Authenticate: stepup reason="<reason>", realm="diabeo"` (RFC 7235).
+- `Cache-Control: no-store, no-cache, must-revalidate, private` (ANSSI RGS §4.5).
+
+Émet audit `MFA_STEP_UP_REQUIRED` avec `metadata.route` + `metadata.reason`
+(US-2265 burst detection sur sondage répété).
+
+---
+
+## 3. Contrat client
+
+### 3.1 Action sensible — 1ère tentative
+
+```http
+PATCH /api/admin/users/42
+Cookie: diabeo_token=<JWT>
+Content-Type: application/json
+
+{ "role": "DOCTOR" }
+```
+
+Si MFA pas fresh, le serveur répond :
+
+```http
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: stepup reason="stepUpRequired", realm="diabeo"
+Cache-Control: no-store, no-cache, must-revalidate, private
+Content-Type: application/json
+
+{ "error": "stepUpRequired" }
+```
+
+### 3.2 UI prompt OTP → step-up
+
+```http
+POST /api/auth/mfa/step-up
+Cookie: diabeo_token=<JWT>
+Content-Type: application/json
+
+{ "otp": "123456" }
+```
+
+Réponse succès :
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "verifiedAt": "2026-05-28T15:00:00.000Z",
+  "expiresAt": "2026-05-28T15:05:00.000Z"
+}
+```
+
+### 3.3 Action sensible — retry après step-up
+
+Le client retry la même requête (même `Idempotency-Key` si présent — le
+wrapper idempotency considère le 1er échec 401 comme non-caché → handler
+ré-exécute proprement).
+
+### 3.4 Cas `mfaEnrollmentRequired`
+
+```http
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: stepup reason="mfaEnrollmentRequired", realm="diabeo"
+
+{ "error": "mfaEnrollmentRequired" }
+```
+
+L'UI doit rediriger vers `/account/security` (page d'enrôlement) plutôt
+que prompter l'OTP (pas de secret partagé encore).
+
+### 3.5 Best practice frontend
+
+```ts
+async function patchAdminUser(id: number, body: Record<string, unknown>) {
+  const res = await fetch(`/api/admin/users/${id}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Requested-With": "XMLHttpRequest", // CSRF
+      "Idempotency-Key": crypto.randomUUID(),
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (res.status === 401) {
+    const wwwAuth = res.headers.get("WWW-Authenticate") ?? ""
+    if (wwwAuth.startsWith("stepup ")) {
+      const json = await res.json()
+      if (json.error === "mfaEnrollmentRequired") {
+        // Redirect to setup page
+        location.href = "/account/security?reason=stepup-required"
+        return
+      }
+      // Prompt OTP modal → on submit:
+      const otp = await promptStepUpOtp()
+      const stepUp = await fetch("/api/auth/mfa/step-up", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ otp }),
+      })
+      if (!stepUp.ok) throw new Error("step-up failed")
+      // Retry la requête originale
+      return patchAdminUser(id, body)
+    }
+  }
+  return res.json()
+}
+```
+
+---
+
+## 4. Audit & forensique HDS
+
+3 nouveaux events `AuditAction` :
+
+- `MFA_STEP_UP_VERIFIED` — succès step-up. `resourceId = sessionId`,
+  `metadata.verifiedAt`.
+- `MFA_STEP_UP_REQUIRED` — action sensible refusée. `resourceId = sessionId`,
+  `metadata.route` + `metadata.reason`. Compté par US-2265 burst detection.
+- `MFA_CHALLENGE_FAILED` (existant US-2002) — réutilisé sur OTP invalide
+  step-up avec `metadata.phase = "step-up"` (distinguish login vs step-up).
+
+Forensique CNIL/ANS "qui a fait quoi quand" — toute action sensible ADMIN
+est désormais corrélable à un step-up event 0-5 min avant.
+
+---
+
+## 5. Sécurité
+
+### 5.1 Anti-replay TOTP
+
+Repose entièrement sur `mfaService.verifyOtp` (compare-and-set
+`mfaLastUsedStep`). Un OTP rejoué dans la même fenêtre 30s est rejeté.
+Pas de risque "même OTP réutilisé pour 2 step-ups".
+
+### 5.2 Cross-user spoof
+
+`mfaService.stepUp(userId, sessionId, otp)` utilise `updateMany WHERE id =
+sessionId AND userId = userId` — race-safe + cross-user safe. Si un attacker
+forge un JWT avec `sub=42` mais `sid` d'un autre user → `updateMany count=0`
+→ step-up échoue.
+
+### 5.3 Rate-limit
+
+`mfa-step-up:<userId>` bucket — 5 attempts / 5 min via
+`@/lib/auth/rate-limit` (cohérent avec MFA challenge login). Bloque
+brute-force online des codes 6 digits (avec MFA standard 30s/code, c'est
+défense en profondeur).
+
+### 5.4 Burst detection (US-2265)
+
+`MFA_STEP_UP_REQUIRED` répété ≥ 50 fois / 60s par même userId →
+`RBAC_BREACH_BURST` audit + alerte SOC. Indique :
+- Bug UI en boucle (probable).
+- Tentative bot / attacker sondant le perimètre.
+
+---
+
+## 6. Anti-patterns
+
+- ❌ Ne PAS utiliser pour des actions transactionnelles haute fréquence
+  (UX dégradée — OTP toutes les 5 min insupportable). Réservé aux actions
+  rares + à fort impact (role change, CNIL notif, etc.).
+- ❌ Ne PAS étendre la fenêtre à 30+ min sans review sécurité (anéantit le
+  bénéfice anti-MITM).
+- ❌ Ne PAS exiger sur les routes GET (lectures = pas de side-effect → step-up
+  inutile).
+- ❌ Ne PAS skipper sur les routes "qui ont déjà confirmation UI" (les
+  confirmations UI sont contournables côté JS — la défense backend reste
+  obligatoire).
+
+---
+
+## 7. DPIA — Impact RGPD
+
+**Données traitées** : timestamp MFA verification (`Session.mfaLastVerifiedAt`)
++ audit events `MFA_STEP_UP_*`. Pas de PHI. Pas de transfert hors-UE
+(PostgreSQL HDS-certifié OVH France).
+
+**Base légale** : intérêt légitime du responsable de traitement (RGPD Art.
+6.1.f) — sécurité des accès aux données de santé HDS Art. L.1111-8.
+
+**Risques résiduels** : aucun nouveau. Hérite des mesures MFA US-2002
+(secret chiffré AES-256-GCM, anti-replay TOTP, rate-limit).
+
+---
+
+## 8. Adoption ultérieure
+
+Routes candidates à wrapper avec `checkFreshMfa` (à arbitrer par security/UX) :
+
+- `PATCH /api/admin/data-breaches/[id]` (declare/update)
+- `PUT /api/cabinet/[id]/sms-config` (financier — provisioning SMS)
+- `POST /api/admin/users/[id]/jwt-revoke` (kick session forcé)
+- `POST /api/admin/exports/data-breach` (export PHI massif)
+- Tout endpoint qui appelle `invalidateAllUserSessions`
+
+Le helper `checkFreshMfa(user.id, user.sessionId)` + `stepUpErrorResponse(...)`
+est designé pour être inséré en 4 lignes en début de handler.

--- a/docs/runbook/step-up-mfa.md
+++ b/docs/runbook/step-up-mfa.md
@@ -1,7 +1,7 @@
 # Runbook — Step-up MFA
 
 **Owner** : Backend platform / Security
-**Statut** : Production (Plan B follow-up A2, 2026-05-28)
+**Statut** : Production (Plan B follow-up A2 round 2, 2026-05-28)
 **Scope** : Actions sensibles ADMIN (role/status, FSM data-breach, financier)
 
 ---
@@ -9,18 +9,23 @@
 ## 1. Pourquoi
 
 L'auth Diabeo actuelle (US-2002 MFA login) prouve MFA **une seule fois** au
-login. Pendant les 24h suivantes (durée session), un attacker qui vole la
-session (cookie httpOnly via attaque MITM, exfiltration via XSS pré-existant,
-etc.) peut exécuter n'importe quelle action ADMIN sans seconde preuve.
+login. Pendant les 24h de session, un attacker qui vole la session peut
+exécuter n'importe quelle action ADMIN sans seconde preuve.
 
-Le step-up MFA force l'utilisateur à re-prouver MFA dans les 5 dernières
-minutes **avant** chaque action sensible :
-- Changement de rôle (`PATCH /api/admin/users/[id] { role }`)
-- Suspension de compte (`PATCH /api/admin/users/[id] { status }`)
-- Transition FSM data-breach (`POST /api/admin/data-breaches/[id]/transition`)
-- (Futur) Toggle SMS config cabinet, génération factures critiques, etc.
+Le step-up MFA force re-prouver MFA dans les **5 dernières minutes** (par
+défaut) ou **60 dernières secondes** (mode CRITICAL) avant chaque action
+sensible :
 
-Pattern aligné UX banking apps (Stripe Dashboard, AWS Console, etc.).
+- Changement de rôle / suspension (`PATCH /api/admin/users/[id]`)  — fenêtre 5 min
+- Transition FSM data-breach (`POST /api/admin/data-breaches/[id]/transition`) —
+  **fenêtre 60 s CRITICAL** (RGPD Art. 33 — notif CNIL irréversible)
+
+Pattern aligné UX banking apps (Stripe Dashboard `live mode`, AWS Console).
+
+> ⚠️ **Note rollout — A2 round 2 M-3** : Au déploiement, toutes les sessions
+> live (~24h TTL max) auront `mfaLastVerifiedAt = NULL` → forcent step-up dès
+> la prochaine action sensible. **Email aux ADMIN 48h avant** + monitoring
+> `MFA_STEP_UP_REQUIRED` count J0 (Grafana dashboard à provisionner).
 
 ---
 
@@ -28,30 +33,54 @@ Pattern aligné UX banking apps (Stripe Dashboard, AWS Console, etc.).
 
 ### Schéma
 
-`Session.mfaLastVerifiedAt DateTime?` (migration `20260528150000_a2_step_up_mfa`).
-NULL = jamais MFA-verified. Bumped à :
+`Session.mfaLastVerifiedAt DateTime?` (migration `20260528150000_a2_step_up_mfa`,
+PG 11+ catalog-only ADD COLUMN). NULL = jamais MFA-verified. Bumped à :
+
 - Login via `POST /api/auth/mfa/challenge` (cohérence — éviter step-up immédiat).
 - Step-up via `POST /api/auth/mfa/step-up`.
 
-### Fenêtre de fraîcheur
+> ⚠️ **A2 round 2 M-6 warning** : `createSession({ mfaVerified: true })` bumpe
+> aussi `mfaLastVerifiedAt`. Conséquence : **les 5 premières minutes après
+> login MFA sont considérées "fresh"**. Un attacker qui vole le cookie d'un
+> user qui vient de login MFA a 5 min de fenêtre fresh sur toutes les routes
+> wrappées (defaut). Pour FSM data-breach (CRITICAL 60s), la fenêtre tombe à
+> 60s. Trade-off UX assumé — documenté DPIA §3.
 
-`STEP_UP_WINDOW_SECONDS = 5 * 60` (5 min). Constante exportée depuis
-`src/lib/auth/step-up.ts` — modifiable centralement.
+### Fenêtres de fraîcheur
 
-### Helper `checkFreshMfa(userId, sessionId)`
+- `STEP_UP_WINDOW_SECONDS = 5 * 60` (default — actions ADMIN réversibles)
+- `STEP_UP_WINDOW_SECONDS_CRITICAL = 60` (FSM data-breach, exports PHI massifs,
+  JWT revoke forcé — actions à impact externe irréversible)
+
+Constantes exportées depuis `src/lib/auth/step-up.ts`. **A2 round 2 M-7** —
+non-configurable runtime en V1. V1.5 prévu : env var `STEP_UP_WINDOW_SECONDS_OVERRIDE`
+avec validation `env.ts` (60 ≤ value ≤ 600).
+
+### Helper `checkFreshMfa(userId, sessionId, options?)`
 
 Retourne `{ ok: true, verifiedAt }` ou `{ ok: false, reason }` :
+
 - `mfaEnrollmentRequired` — l'utilisateur n'a pas MFA activée.
 - `stepUpRequired` — MFA activée mais pas fresh (ou jamais verified, ou session inconnue).
+
+`options.windowSeconds` (default `STEP_UP_WINDOW_SECONDS`) permet le mode
+CRITICAL via `STEP_UP_WINDOW_SECONDS_CRITICAL`.
 
 ### Helper `stepUpErrorResponse(reason, userId, sessionId, ctx, { route })`
 
 Construit la 401 + headers :
-- `WWW-Authenticate: stepup reason="<reason>", realm="diabeo"` (RFC 7235).
-- `Cache-Control: no-store, no-cache, must-revalidate, private` (ANSSI RGS §4.5).
 
-Émet audit `MFA_STEP_UP_REQUIRED` avec `metadata.route` + `metadata.reason`
-(US-2265 burst detection sur sondage répété).
+- `WWW-Authenticate: stepup reason="<reason>", realm="diabeo"` (RFC 7235 — custom scheme).
+- **`X-Step-Up-Required: <reason>`** — header custom pour clients qui ne
+  parsent pas RFC 7235 (interceptors fetch génériques, OkHttp Android natif).
+- `Cache-Control: no-store, no-cache, must-revalidate, private` (ANSSI RGS §4.5)
+- `Pragma: no-cache`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`
+
+Émet **`auditService.requireStepUp(...)`** (A2 round 2 C-2) qui :
+
+- Crée 1 row `MFA_STEP_UP_REQUIRED` audit.
+- Si même userId dépasse `BURST_THRESHOLD = 50` events / 60s → émet aussi
+  `RBAC_BREACH_BURST` row atomique dans la même TX. Cooldown 60s.
 
 ---
 
@@ -62,6 +91,7 @@ Construit la 401 + headers :
 ```http
 PATCH /api/admin/users/42
 Cookie: diabeo_token=<JWT>
+X-Requested-With: XMLHttpRequest    ← REQUIS sur 1ère tentative (CSRF middleware)
 Content-Type: application/json
 
 { "role": "DOCTOR" }
@@ -72,7 +102,9 @@ Si MFA pas fresh, le serveur répond :
 ```http
 HTTP/1.1 401 Unauthorized
 WWW-Authenticate: stepup reason="stepUpRequired", realm="diabeo"
+X-Step-Up-Required: stepUpRequired
 Cache-Control: no-store, no-cache, must-revalidate, private
+Referrer-Policy: no-referrer
 Content-Type: application/json
 
 { "error": "stepUpRequired" }
@@ -92,6 +124,7 @@ Réponse succès :
 
 ```http
 HTTP/1.1 200 OK
+Cache-Control: no-store, no-cache, must-revalidate, private
 Content-Type: application/json
 
 {
@@ -100,48 +133,66 @@ Content-Type: application/json
 }
 ```
 
+> ⚠️ Note : `expiresAt` est le horizon **default** (5 min). Pour FSM
+> data-breach (CRITICAL 60s), le client doit considérer `verifiedAt + 60s`.
+
 ### 3.3 Action sensible — retry après step-up
 
-Le client retry la même requête (même `Idempotency-Key` si présent — le
-wrapper idempotency considère le 1er échec 401 comme non-caché → handler
-ré-exécute proprement).
+**A2 round 2 C-1 CRITICAL fix** : le wrapper `withIdempotency` détecte
+`WWW-Authenticate: stepup` sur le 1er 401 et **NE cache PAS** cette response.
+Le client peut donc retry avec **le même Idempotency-Key** après step-up
+réussi → le handler re-évalue freshness et exécute normalement.
+
+```ts
+// Pattern client validé A2 round 2 C-1
+const idemKey = crypto.randomUUID()
+let res = await fetch(endpoint, { /* ... */, headers: { "Idempotency-Key": idemKey, ... } })
+if (res.status === 401 && res.headers.get("X-Step-Up-Required")) {
+  await stepUp() // POST /api/auth/mfa/step-up
+  res = await fetch(endpoint, { /* ... */, headers: { "Idempotency-Key": idemKey, ... } }) // même clé
+}
+```
 
 ### 3.4 Cas `mfaEnrollmentRequired`
+
+**A2 round 2 LOW-4 fix** — réponse alignée 401 + `WWW-Authenticate`
+(antérieurement 403 sans header sur le endpoint step-up direct, incohérent
+avec `stepUpErrorResponse`).
 
 ```http
 HTTP/1.1 401 Unauthorized
 WWW-Authenticate: stepup reason="mfaEnrollmentRequired", realm="diabeo"
+X-Step-Up-Required: mfaEnrollmentRequired
 
 { "error": "mfaEnrollmentRequired" }
 ```
 
-L'UI doit rediriger vers `/account/security` (page d'enrôlement) plutôt
-que prompter l'OTP (pas de secret partagé encore).
+L'UI doit rediriger vers `/account/security` (page d'enrôlement).
 
 ### 3.5 Best practice frontend
 
 ```ts
-async function patchAdminUser(id: number, body: Record<string, unknown>) {
+const MAX_STEP_UP_RETRIES = 1 // A2 round 2 LOW-L4 — anti boucle infinie
+
+async function patchAdminUser(id: number, body: Record<string, unknown>, _retried = false) {
+  const idemKey = crypto.randomUUID()
   const res = await fetch(`/api/admin/users/${id}`, {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
-      "X-Requested-With": "XMLHttpRequest", // CSRF
-      "Idempotency-Key": crypto.randomUUID(),
+      "X-Requested-With": "XMLHttpRequest",
+      "Idempotency-Key": idemKey,
     },
     body: JSON.stringify(body),
   })
 
   if (res.status === 401) {
-    const wwwAuth = res.headers.get("WWW-Authenticate") ?? ""
-    if (wwwAuth.startsWith("stepup ")) {
-      const json = await res.json()
-      if (json.error === "mfaEnrollmentRequired") {
-        // Redirect to setup page
-        location.href = "/account/security?reason=stepup-required"
-        return
-      }
-      // Prompt OTP modal → on submit:
+    const reason = res.headers.get("X-Step-Up-Required")
+    if (reason === "mfaEnrollmentRequired") {
+      location.href = "/account/security?reason=stepup-required"
+      return
+    }
+    if (reason === "stepUpRequired" && !_retried) {
       const otp = await promptStepUpOtp()
       const stepUp = await fetch("/api/auth/mfa/step-up", {
         method: "POST",
@@ -149,26 +200,37 @@ async function patchAdminUser(id: number, body: Record<string, unknown>) {
         body: JSON.stringify({ otp }),
       })
       if (!stepUp.ok) throw new Error("step-up failed")
-      // Retry la requête originale
-      return patchAdminUser(id, body)
+      // Retry — _retried=true empêche récursion infinie si server bug.
+      return patchAdminUser(id, body, true)
     }
   }
   return res.json()
 }
 ```
 
+> ⚠️ **A2 round 2 LO-L4 anti-pattern** : ne PAS retry plus de 1 fois (le
+> serveur ne doit pas renvoyer stepUpRequired après step-up réussi — si ça
+> arrive c'est un bug serveur, pas un retry à faire).
+
 ---
 
 ## 4. Audit & forensique HDS
 
-3 nouveaux events `AuditAction` :
+3 actions `AuditAction` :
 
 - `MFA_STEP_UP_VERIFIED` — succès step-up. `resourceId = sessionId`,
-  `metadata.verifiedAt`.
-- `MFA_STEP_UP_REQUIRED` — action sensible refusée. `resourceId = sessionId`,
-  `metadata.route` + `metadata.reason`. Compté par US-2265 burst detection.
+  `metadata.verifiedAt`. **Émis AVANT clearAttempts** (A2 round 2 H-T3) pour
+  garantir trace forensique HDS même si Redis rate-limit clear throw.
+- `MFA_STEP_UP_REQUIRED` — action sensible refusée. `resourceId = sessionId`
+  (ou `"jwt-legacy-no-sid"` + `metadata.legacyJwt: true`), `metadata.route` +
+  `metadata.reason`. **Émis via `auditService.requireStepUp(...)`** qui câble
+  US-2265 `recordAndCheckBurst` (A2 round 2 C-2 fix).
 - `MFA_CHALLENGE_FAILED` (existant US-2002) — réutilisé sur OTP invalide
   step-up avec `metadata.phase = "step-up"` (distinguish login vs step-up).
+
+**Burst detection US-2265 vraiment câblée** : 50 events `MFA_STEP_UP_REQUIRED`
+en 60s / userId → row additionnel `RBAC_BREACH_BURST` atomique +
+`metadata.kind: "step_up_required_burst"`. Alerte SOC.
 
 Forensique CNIL/ANS "qui a fait quoi quand" — toute action sensible ADMIN
 est désormais corrélable à un step-up event 0-5 min avant.
@@ -179,45 +241,70 @@ est désormais corrélable à un step-up event 0-5 min avant.
 
 ### 5.1 Anti-replay TOTP
 
-Repose entièrement sur `mfaService.verifyOtp` (compare-and-set
-`mfaLastUsedStep`). Un OTP rejoué dans la même fenêtre 30s est rejeté.
-Pas de risque "même OTP réutilisé pour 2 step-ups".
+`mfaService.verifyOtp` (compare-and-set `User.mfaLastUsedStep`). OTP rejoué
+dans la même fenêtre 30s rejeté. Pas de risque "même OTP réutilisé".
 
-### 5.2 Cross-user spoof
+### 5.2 Defense-in-depth `mfaEnabled` côté service (A2 round 2 H-2 + H-5)
 
-`mfaService.stepUp(userId, sessionId, otp)` utilise `updateMany WHERE id =
-sessionId AND userId = userId` — race-safe + cross-user safe. Si un attacker
-forge un JWT avec `sub=42` mais `sid` d'un autre user → `updateMany count=0`
-→ step-up échoue.
+`mfaService.stepUp` :
+
+1. Check `mfaEnabled = true` AVANT verifyOtp (defense même si caller skip).
+2. `updateMany WHERE id=sid AND userId=uid AND user.mfaEnabled=true` —
+   TOCTOU defense : si `disable` concurrent flippe `mfaEnabled` entre
+   verifyOtp et updateMany → count=0 → no bump.
 
 ### 5.3 Rate-limit
 
-`mfa-step-up:<userId>` bucket — 5 attempts / 5 min via
-`@/lib/auth/rate-limit` (cohérent avec MFA challenge login). Bloque
-brute-force online des codes 6 digits (avec MFA standard 30s/code, c'est
-défense en profondeur).
+`mfa-step-up:<userId>` bucket — pattern `LOCKOUT_SECONDS = [0, 0, 0, 300, 900, 3600]`
+(A2 round 2 M-9 doc fix) : 3 essais sans lockout puis 5 min / 15 min / 1h
+progressifs.
+
+**Recovery break-glass (A2 round 2 LO-5)** — si un ADMIN se lockout après 3
+fat-finger :
+
+```bash
+# Ops Redis CLI (Upstash)
+curl https://<your-redis>.upstash.io/del/diabeo:prod:ratelimit:mfa-step-up:<userId> \
+  -H "Authorization: Bearer <REDIS_TOKEN>"
+
+# Audit manuel (forensique HDS) — créer row MFA_BREAK_GLASS_GRANTED dans audit_logs
+# via psql avec userId + ops-userId + raison
+```
+
+V1.5 envisagé : auto-clear sur `POST /api/auth/mfa/challenge` succès (re-login
+clear le lockout step-up — login est lui-même rate-limited).
 
 ### 5.4 Burst detection (US-2265)
 
-`MFA_STEP_UP_REQUIRED` répété ≥ 50 fois / 60s par même userId →
-`RBAC_BREACH_BURST` audit + alerte SOC. Indique :
-- Bug UI en boucle (probable).
-- Tentative bot / attacker sondant le perimètre.
+**A2 round 2 C-2 fix CONFIRMÉ** : `auditService.requireStepUp` câble
+`recordAndCheckBurst`. ≥ 50 events / 60s par userId → `RBAC_BREACH_BURST`
+audit + alerte SOC. Cas usuels :
+
+1. **Bug UI en boucle** — frontend qui ne respecte pas `MAX_STEP_UP_RETRIES`.
+2. **Bot/attacker** sondant le périmètre step-up.
+
+Cooldown 60s entre 2 burst rows pour éviter log flood.
+
+### 5.5 Anti CRLF injection (A2 round 2 LO-1)
+
+`stepUpErrorResponse` whitelist explicite des `reason` autorisées avant
+interpolation dans `WWW-Authenticate`. Typage TS `StepUpReason` est déjà
+restrictif mais defense-in-depth si futur refactor ouvre le type.
 
 ---
 
 ## 6. Anti-patterns
 
-- ❌ Ne PAS utiliser pour des actions transactionnelles haute fréquence
-  (UX dégradée — OTP toutes les 5 min insupportable). Réservé aux actions
-  rares + à fort impact (role change, CNIL notif, etc.).
-- ❌ Ne PAS étendre la fenêtre à 30+ min sans review sécurité (anéantit le
-  bénéfice anti-MITM).
-- ❌ Ne PAS exiger sur les routes GET (lectures = pas de side-effect → step-up
-  inutile).
-- ❌ Ne PAS skipper sur les routes "qui ont déjà confirmation UI" (les
-  confirmations UI sont contournables côté JS — la défense backend reste
-  obligatoire).
+- ❌ Ne PAS utiliser pour actions transactionnelles haute fréquence
+  (UX dégradée — OTP toutes les 5 min insupportable).
+- ❌ Ne PAS étendre la fenêtre à 30+ min sans review sécurité.
+- ❌ Ne PAS exiger sur routes GET (lectures = pas de side-effect).
+- ❌ Ne PAS placer le step-up check à l'intérieur d'un handler wrappé
+  `withIdempotency` SANS s'assurer que le wrapper skip le cache si
+  `WWW-Authenticate: stepup` (A2 round 2 C-1 — déjà câblé).
+- ❌ Ne PAS hardcoder `5 * 60_000` côté UI countdown — utiliser `expiresAt`
+  retourné par le step-up endpoint.
+- ❌ Ne PAS retry > 1 fois côté frontend (boucle infinie si bug serveur).
 
 ---
 
@@ -230,20 +317,112 @@ défense en profondeur).
 **Base légale** : intérêt légitime du responsable de traitement (RGPD Art.
 6.1.f) — sécurité des accès aux données de santé HDS Art. L.1111-8.
 
-**Risques résiduels** : aucun nouveau. Hérite des mesures MFA US-2002
-(secret chiffré AES-256-GCM, anti-replay TOTP, rate-limit).
+**Risques résiduels documentés** :
+
+1. **A2 round 2 M-5 — `Session.mfaLastVerifiedAt` persisté en clair**.
+   Combiné avec `lastSeenAt`/`ipAddress`/`userAgent` (US-2007), un dump SQL
+   exfiltré permet profilage horaire ADMIN. Cohérent avec pattern existant
+   `Session.lastSeenAt` (non-chiffré). Décision DPO : argument minimisation
+   "horodatage non-corrélable à PHI direct" — pas de chiffrement supplémentaire.
+
+2. **A2 round 2 M-6 — 5 min de bypass step-up post-login**. `createSession({
+   mfaVerified: true })` bumpe `mfaLastVerifiedAt`. Trade-off UX assumé. Pour
+   FSM data-breach (CRITICAL 60s), le risque est ramené à 60s post-login.
+
+3. **A2 round 2 H-3 — `WWW-Authenticate: stepup` non-RFC standard**.
+   Mitigation : header custom `X-Step-Up-Required` ajouté en complément pour
+   clients qui ne parsent pas RFC 7235.
 
 ---
 
-## 8. Adoption ultérieure
+## 8. Adoption ultérieure (V1.5)
 
-Routes candidates à wrapper avec `checkFreshMfa` (à arbitrer par security/UX) :
+PR A2 round 2 livre **scope minimum** :
 
-- `PATCH /api/admin/data-breaches/[id]` (declare/update)
-- `PUT /api/cabinet/[id]/sms-config` (financier — provisioning SMS)
+- ✅ `PATCH /api/admin/users/[id]` (5 min default)
+- ✅ `POST /api/admin/data-breaches/[id]/transition` (60s CRITICAL — FSM CNIL)
+
+**Routes candidates V1.5** (suivi via Issue GH à créer) :
+
+- `PATCH /api/admin/data-breaches/[id]` (declare/update — 60s CRITICAL)
+- `PUT /api/cabinet/[id]/sms-config` (financier — voir US-2506)
 - `POST /api/admin/users/[id]/jwt-revoke` (kick session forcé)
-- `POST /api/admin/exports/data-breach` (export PHI massif)
+- `POST /api/admin/exports/data-breach` (export PHI massif — 60s CRITICAL)
 - Tout endpoint qui appelle `invalidateAllUserSessions`
 
-Le helper `checkFreshMfa(user.id, user.sessionId)` + `stepUpErrorResponse(...)`
-est designé pour être inséré en 4 lignes en début de handler.
+Pattern d'adoption :
+
+```typescript
+const stepUp = await checkFreshMfa(user.id, user.sessionId, {
+  windowSeconds: STEP_UP_WINDOW_SECONDS_CRITICAL, // pour FSM/exports
+})
+if (!stepUp.ok) {
+  return stepUpErrorResponse(stepUp.reason, user.id, user.sessionId, ctx, {
+    route: "<endpoint identifier>",
+  })
+}
+```
+
+---
+
+## 9. Procédure recovery / break-glass
+
+### 9.1 ADMIN locked out par rate-limit
+
+Voir §5.3 — ops Redis CLI `DEL diabeo:prod:ratelimit:mfa-step-up:<userId>`.
+
+### 9.2 ADMIN refuse d'enrôler MFA (perte phone, opposition, etc.)
+
+**Pas de bypass code-level**. Procédure ANS manuelle :
+
+1. Direction Médicale autorise l'override en écrit (email + signature).
+2. Ops Direction Diabeo exécute via psql :
+   ```sql
+   UPDATE users SET "mfaEnabled" = false WHERE id = <userId>;
+   INSERT INTO audit_logs (user_id, action, resource, resource_id, metadata, created_at)
+   VALUES (<ops-userId>, 'MFA_BREAK_GLASS_GRANTED', 'USER', '<target-userId>',
+           '{"reason":"<justification>","authorizedBy":"<direction-médicale>"}', NOW());
+   ```
+3. L'utilisateur peut alors agir sans MFA pendant 24h (session TTL) — devra
+   ré-enroller après. Risque opérationnel = visible en audit.
+
+### 9.3 Clock skew NTP désync
+
+Si `mfaLastVerifiedAt` se retrouve dans le futur (NTP désync arrière), le
+calcul `ageSec` est négatif → toujours `< windowSeconds` → ok. Tolérance
+documentée + testée (A2 round 2 unit test "clock skew").
+
+---
+
+## 10. Métriques / alertes (V1.5)
+
+À ajouter dans le dashboard observabilité quand US-2153 (Loki) sera livrée :
+
+- `MFA_STEP_UP_VERIFIED` count / 1h (succès)
+- `MFA_STEP_UP_REQUIRED` count / 1h (échecs / sondages)
+- `MFA_CHALLENGE_FAILED metadata.phase=step-up` count
+- `RBAC_BREACH_BURST metadata.kind=step_up_required_burst` count (ALERTE)
+- Ratio `verified / required` (faible = UX dégradée, à investiguer)
+- Latency p99 `POST /api/auth/mfa/step-up`
+
+---
+
+## 11. Procédure rollout production
+
+1. **J-48h** — Email aux ADMIN : "À partir de <date>, les actions sensibles
+   (changement rôle, FSM data-breach) demanderont une re-prove MFA toutes
+   les 5 min (60s pour les notifications CNIL). Prévoir 30s de plus par action."
+2. **J-24h** — Notification slack ops + DPO confirmation rollout
+3. **J0 heure creuse** — Deploy migration `20260528150000_a2_step_up_mfa`
+   (catalog-only, < 100ms PG 16) + code A2
+4. **J0 + 1h** — Monitoring `MFA_STEP_UP_REQUIRED` count via psql :
+   ```sql
+   SELECT COUNT(*) FROM audit_logs
+   WHERE action = 'MFA_STEP_UP_REQUIRED'
+   AND created_at > NOW() - INTERVAL '1 hour';
+   ```
+   Attendu : ~1 event / ADMIN actif (1ère action sensible post-deploy).
+5. **J0 + 24h** — Review tickets support + ajustement comm si > 10 tickets.
+
+Rollback : `ALTER TABLE sessions DROP COLUMN mfa_last_verified_at;` + revert
+code A2. Aucune perte de données (bump ré-acquérable via step-up).

--- a/prisma/migrations/20260528150000_a2_step_up_mfa/migration.sql
+++ b/prisma/migrations/20260528150000_a2_step_up_mfa/migration.sql
@@ -2,14 +2,27 @@
 --
 -- Ajoute `Session.mfa_last_verified_at` (nullable timestamptz). Bumped à chaque
 -- MFA challenge (login OU step-up). `requireFreshMfa` helper exige que ce
--- timestamp soit < STEP_UP_WINDOW_SECONDS (5min default) pour les actions
--- sensibles ADMIN.
+-- timestamp soit < STEP_UP_WINDOW_SECONDS (5min default, 60s pour FSM CRITICAL)
+-- pour les actions sensibles ADMIN.
 --
--- Migration zero-downtime :
---  - ADD COLUMN nullable (pas de write lock long sur sessions).
---  - Pas d'index (queries triviales par PK Session).
+-- Migration zero-downtime (Requires PostgreSQL 11+ — L1) :
+--  - ADD COLUMN nullable sans DEFAULT = catalog-only metadata update (PG ≥ 11).
+--    Pas de table rewrite, AccessExclusiveLock acquis brièvement uniquement
+--    pour update pg_attribute. Sur PG 9.x/10.x → réécriture complète table.
+--    Diabeo cible PG 16 (CLAUDE.md).
+--  - Pas d'index (queries triviales par PK Session sur les paths actuels).
 --  - Backfill non requis : NULL = "jamais MFA-verified" (interprétation par
 --    `requireFreshMfa` = forcer step-up sur les sessions actuelles).
+--
+-- Rollout (cf. docs/runbook/step-up-mfa.md §11) :
+--  - Au déploiement, toutes les sessions live (~24h TTL max) auront NULL →
+--    forcent step-up dès la prochaine action sensible. Email aux ADMIN 48h
+--    avant deploy (procédure runbook §11).
+--
+-- Index futur (V1.5 si cron purge ou forensique 7j ajouté) :
+--   CREATE INDEX CONCURRENTLY sessions_mfa_last_verified_at_idx
+--     ON sessions (mfa_last_verified_at)
+--     WHERE mfa_last_verified_at IS NOT NULL;
 --
 -- Rollback : ALTER TABLE sessions DROP COLUMN mfa_last_verified_at.
 -- Aucune perte de données (le bump est ré-acquérable via step-up).

--- a/prisma/migrations/20260528150000_a2_step_up_mfa/migration.sql
+++ b/prisma/migrations/20260528150000_a2_step_up_mfa/migration.sql
@@ -1,0 +1,17 @@
+-- Plan B follow-up A2 — Step-up MFA freshness timestamp.
+--
+-- Ajoute `Session.mfa_last_verified_at` (nullable timestamptz). Bumped à chaque
+-- MFA challenge (login OU step-up). `requireFreshMfa` helper exige que ce
+-- timestamp soit < STEP_UP_WINDOW_SECONDS (5min default) pour les actions
+-- sensibles ADMIN.
+--
+-- Migration zero-downtime :
+--  - ADD COLUMN nullable (pas de write lock long sur sessions).
+--  - Pas d'index (queries triviales par PK Session).
+--  - Backfill non requis : NULL = "jamais MFA-verified" (interprétation par
+--    `requireFreshMfa` = forcer step-up sur les sessions actuelles).
+--
+-- Rollback : ALTER TABLE sessions DROP COLUMN mfa_last_verified_at.
+-- Aucune perte de données (le bump est ré-acquérable via step-up).
+
+ALTER TABLE "sessions" ADD COLUMN "mfa_last_verified_at" TIMESTAMPTZ;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -483,6 +483,12 @@ model Session {
   /// True if this session was created via MFA challenge. HDS forensics:
   /// "which live sessions were second-factor-verified vs password-only".
   mfaVerified  Boolean  @default(false) @map("mfa_verified")
+  /// Plan B follow-up A2 — Step-up MFA freshness timestamp. Bumped à chaque
+  /// MFA challenge réussi (login OU step-up). `requireFreshMfa` exige que ce
+  /// timestamp soit < `STEP_UP_WINDOW_SECONDS` (5min) pour les actions
+  /// sensibles ADMIN (role/status changes, FSM data-breach transitions, etc.).
+  /// Null = jamais MFA-verified (login password-only).
+  mfaLastVerifiedAt DateTime? @map("mfa_last_verified_at") @db.Timestamptz()
   /// US-2007 (Groupe 9) — metadata pour la vue "Sessions multiples" UI :
   /// le user identifie chaque session par device/localisation et peut
   /// la révoquer. Pas de PHI — IP et UA déjà persistés en AuditLog.

--- a/src/app/api/admin/data-breaches/[id]/transition/route.ts
+++ b/src/app/api/admin/data-breaches/[id]/transition/route.ts
@@ -6,7 +6,7 @@
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
 import { DataBreachStatus } from "@prisma/client"
-import { AuthError } from "@/lib/auth"
+import { AuthError, checkFreshMfa, stepUpErrorResponse } from "@/lib/auth"
 import { extractRequestContext } from "@/lib/services/audit.service"
 import {
   auditedRequireRole,
@@ -54,6 +54,16 @@ async function postHandler(
     const user = await auditedRequireRole(
       req, "ADMIN", ctx, "DATA_BREACH", String(parsedParams.data.id),
     )
+
+    // Plan B follow-up A2 — Step-up MFA exigé sur les FSM transitions
+    // data-breach (CNIL notification, user notification — actions à risque
+    // élevé d'erreur humaine + impact externe).
+    const stepUp = await checkFreshMfa(user.id, user.sessionId)
+    if (!stepUp.ok) {
+      return stepUpErrorResponse(stepUp.reason, user.id, user.sessionId, ctx, {
+        route: "admin/data-breaches/[id]/transition POST",
+      })
+    }
 
     const body = await req.json().catch(() => null)
     if (!body) return NextResponse.json({ error: "invalidJSON" }, { status: 400 })

--- a/src/app/api/admin/data-breaches/[id]/transition/route.ts
+++ b/src/app/api/admin/data-breaches/[id]/transition/route.ts
@@ -6,7 +6,12 @@
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
 import { DataBreachStatus } from "@prisma/client"
-import { AuthError, checkFreshMfa, stepUpErrorResponse } from "@/lib/auth"
+import {
+  AuthError,
+  checkFreshMfa,
+  stepUpErrorResponse,
+  STEP_UP_WINDOW_SECONDS_CRITICAL,
+} from "@/lib/auth"
 import { extractRequestContext } from "@/lib/services/audit.service"
 import {
   auditedRequireRole,
@@ -55,10 +60,14 @@ async function postHandler(
       req, "ADMIN", ctx, "DATA_BREACH", String(parsedParams.data.id),
     )
 
-    // Plan B follow-up A2 — Step-up MFA exigé sur les FSM transitions
-    // data-breach (CNIL notification, user notification — actions à risque
-    // élevé d'erreur humaine + impact externe).
-    const stepUp = await checkFreshMfa(user.id, user.sessionId)
+    // Plan B follow-up A2 round 2 H-4 — Step-up MFA exigé avec fenêtre
+    // durcie 1 min (CRITICAL) sur les FSM transitions data-breach :
+    // notification CNIL externe irréversible (RGPD Art. 33), email patients,
+    // sévérité gonflée potentielle si session compromise. Banking apps "live
+    // mode" Stripe = pattern équivalent.
+    const stepUp = await checkFreshMfa(user.id, user.sessionId, {
+      windowSeconds: STEP_UP_WINDOW_SECONDS_CRITICAL,
+    })
     if (!stepUp.ok) {
       return stepUpErrorResponse(stepUp.reason, user.id, user.sessionId, ctx, {
         route: "admin/data-breaches/[id]/transition POST",

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -6,7 +6,12 @@
  */
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
-import { requireRole, AuthError } from "@/lib/auth"
+import {
+  requireRole,
+  AuthError,
+  checkFreshMfa,
+  stepUpErrorResponse,
+} from "@/lib/auth"
 import { extractRequestContext } from "@/lib/services/audit.service"
 import { userManagementService } from "@/lib/services/user-management.service"
 import { logger } from "@/lib/logger"
@@ -76,12 +81,22 @@ const USER_ERROR_CODES = new Map<string, number>([
  * (zéro side-effect : pas de re-PATCH, pas de re-audit, pas de re-JWT-revoke).
  */
 async function patchHandler(req: NextRequest, { params }: RouteParams) {
+  const ctx = extractRequestContext(req)
   try {
     const user = requireRole(req, "ADMIN")
     const { id: rawId } = await params
     const id = parseId(rawId)
     if (id === null) {
       return NextResponse.json({ error: "invalidUserId" }, { status: 400 })
+    }
+
+    // Plan B follow-up A2 — Step-up MFA exigé sur les changements de rôle /
+    // suspension. Cohérent avec UX banking apps : freshness 5 min.
+    const stepUp = await checkFreshMfa(user.id, user.sessionId)
+    if (!stepUp.ok) {
+      return stepUpErrorResponse(stepUp.reason, user.id, user.sessionId, ctx, {
+        route: "admin/users/[id] PATCH",
+      })
     }
 
     const body = await req.json()
@@ -93,7 +108,6 @@ async function patchHandler(req: NextRequest, { params }: RouteParams) {
       )
     }
 
-    const ctx = extractRequestContext(req)
     try {
       // Type guard explicite : la `.refine` garantit qu'exactement UN champ
       // est défini, mais TS ne narrow pas. Branche switch lisible et sans `!`.

--- a/src/app/api/auth/mfa/step-up/route.ts
+++ b/src/app/api/auth/mfa/step-up/route.ts
@@ -1,0 +1,118 @@
+/**
+ * POST /api/auth/mfa/step-up — Plan B follow-up A2.
+ *
+ * Re-prove MFA pour les actions sensibles ADMIN. Bumpé `Session.mfaLastVerifiedAt`
+ * → `requireFreshMfa` helper considère la session "fresh" pendant
+ * `STEP_UP_WINDOW_SECONDS` (5 min).
+ *
+ * Pré-requis :
+ *   - JWT valide (middleware injecte `x-user-id` + `x-session-id`).
+ *   - User a `mfaEnabled = true` (sinon 403 `mfaEnrollmentRequired`).
+ *
+ * Body : `{ otp: "123456" }`.
+ *
+ * Rate-limit : 5 attempts / 5 min via `mfa-step-up:<userId>` bucket (cohérent
+ * avec MFA challenge login).
+ *
+ * Audit :
+ *   - succès : `MFA_STEP_UP_VERIFIED` (resourceId = sessionId).
+ *   - échec OTP : `MFA_CHALLENGE_FAILED` (réutilise l'action existante US-2002).
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { prisma } from "@/lib/db/client"
+import {
+  requireAuth,
+  AuthError,
+  checkRateLimit,
+  recordFailedAttempt,
+  clearAttempts,
+} from "@/lib/auth"
+import { mfaService } from "@/lib/services/mfa.service"
+import { auditService, extractRequestContext } from "@/lib/services/audit.service"
+import { logger } from "@/lib/logger"
+import { mfaStepUpBodySchema } from "@/lib/schemas/auth"
+
+export async function POST(req: NextRequest) {
+  const ctx = extractRequestContext(req)
+  try {
+    const user = requireAuth(req)
+    if (!user.sessionId) {
+      // JWT sans `sid` — flow legacy avant US-2007. Refuse plutôt que de
+      // bumper sur une session inexistante.
+      return NextResponse.json({ error: "sessionRequired" }, { status: 401 })
+    }
+
+    const body = await req.json().catch(() => ({}))
+    const parsed = mfaStepUpBodySchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+
+    // Rate-limit AVANT le verify pour ne pas exposer le timing (un attacker
+    // pourrait sinon différencier "userId existe" vs "userId inexistant").
+    const rateLimitKey = `mfa-step-up:${user.id}`
+    const rl = await checkRateLimit(rateLimitKey)
+    if (rl.blocked) {
+      return NextResponse.json(
+        { error: "rateLimitExceeded" },
+        { status: 429, headers: { "Retry-After": String(rl.retryAfterSeconds ?? 300) } },
+      )
+    }
+
+    const dbUser = await prisma.user.findUnique({
+      where: { id: user.id },
+      select: { mfaEnabled: true },
+    })
+    if (!dbUser?.mfaEnabled) {
+      // MFA non-enrôlée → l'utilisateur doit setup d'abord. Erreur dédiée
+      // (vs 401 invalidOtp) pour que l'UI prompt l'enrôlement plutôt que
+      // de redemander le code.
+      return NextResponse.json({ error: "mfaEnrollmentRequired" }, { status: 403 })
+    }
+
+    const verifiedAt = await mfaService.stepUp(user.id, user.sessionId, parsed.data.otp)
+    if (!verifiedAt) {
+      await recordFailedAttempt(rateLimitKey)
+      await auditService.log({
+        userId: user.id,
+        action: "MFA_CHALLENGE_FAILED",
+        resource: "SESSION",
+        resourceId: user.sessionId,
+        ipAddress: ctx.ipAddress,
+        userAgent: ctx.userAgent,
+        requestId: ctx.requestId,
+        metadata: { phase: "step-up" },
+      })
+      return NextResponse.json({ error: "invalidOtp" }, { status: 401 })
+    }
+
+    await clearAttempts(rateLimitKey)
+    await auditService.log({
+      userId: user.id,
+      action: "MFA_STEP_UP_VERIFIED",
+      resource: "SESSION",
+      resourceId: user.sessionId,
+      ipAddress: ctx.ipAddress,
+      userAgent: ctx.userAgent,
+      requestId: ctx.requestId,
+      metadata: { verifiedAt: verifiedAt.toISOString() },
+    })
+
+    return NextResponse.json({
+      verifiedAt: verifiedAt.toISOString(),
+      // expiresAt = window 5 min (cohérent avec helper requireFreshMfa).
+      // Le client peut afficher un countdown UX "MFA valide jusqu'à HH:MM".
+      expiresAt: new Date(verifiedAt.getTime() + 5 * 60_000).toISOString(),
+    })
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error("auth/mfa/step-up", "step-up failed", { requestId: ctx.requestId }, error)
+    return NextResponse.json({ error: "serverUnavailable" }, { status: 503 })
+  }
+}

--- a/src/app/api/auth/mfa/step-up/route.ts
+++ b/src/app/api/auth/mfa/step-up/route.ts
@@ -3,20 +3,28 @@
  *
  * Re-prove MFA pour les actions sensibles ADMIN. Bumpé `Session.mfaLastVerifiedAt`
  * → `requireFreshMfa` helper considère la session "fresh" pendant
- * `STEP_UP_WINDOW_SECONDS` (5 min).
+ * `STEP_UP_WINDOW_SECONDS` (5 min) ou `STEP_UP_WINDOW_SECONDS_CRITICAL`
+ * (1 min pour FSM data-breach).
  *
  * Pré-requis :
  *   - JWT valide (middleware injecte `x-user-id` + `x-session-id`).
- *   - User a `mfaEnabled = true` (sinon 403 `mfaEnrollmentRequired`).
+ *   - User a `mfaEnabled = true` (sinon 401 `mfaEnrollmentRequired` + WWW-Authenticate).
  *
  * Body : `{ otp: "123456" }`.
  *
- * Rate-limit : 5 attempts / 5 min via `mfa-step-up:<userId>` bucket (cohérent
- * avec MFA challenge login).
+ * Rate-limit : 3 attempts puis lockout 5/15/60 min progressif via
+ * `mfa-step-up:<userId>` bucket (cohérent avec MFA challenge login).
+ *
+ * **A2 round 2 modifs** :
+ *   - H-1 : `Cache-Control: no-store` + headers ANSSI sur TOUTES les responses.
+ *   - L9 : `assertJsonContentType` (415) + `assertBodySize` (413).
+ *   - M-1 : `expiresAt` calculé via `STEP_UP_WINDOW_SECONDS` (vs magic `5*60_000`).
+ *   - LOW-4 : `mfaEnrollmentRequired` retourne 401 + `WWW-Authenticate` (vs 403)
+ *     pour alignement avec `stepUpErrorResponse` (cohérence UI parsing).
  *
  * Audit :
  *   - succès : `MFA_STEP_UP_VERIFIED` (resourceId = sessionId).
- *   - échec OTP : `MFA_CHALLENGE_FAILED` (réutilise l'action existante US-2002).
+ *   - échec OTP : `MFA_CHALLENGE_FAILED` (réutilise action existante US-2002).
  */
 
 import { NextResponse, type NextRequest } from "next/server"
@@ -27,39 +35,80 @@ import {
   checkRateLimit,
   recordFailedAttempt,
   clearAttempts,
+  STEP_UP_WINDOW_SECONDS,
 } from "@/lib/auth"
 import { mfaService } from "@/lib/services/mfa.service"
 import { auditService, extractRequestContext } from "@/lib/services/audit.service"
 import { logger } from "@/lib/logger"
 import { mfaStepUpBodySchema } from "@/lib/schemas/auth"
+import { assertJsonContentType, assertBodySize } from "@/lib/team-route-helpers"
+
+/**
+ * Headers ANSSI RGS §4.5 + Diabeo baseline. Appliqué à TOUTES les responses
+ * (succès et erreurs) pour éviter qu'un proxy/CDN mal configuré cache un
+ * 200 OK contenant `verifiedAt` (donnée de session sensible).
+ */
+const ANSSI_HEADERS: Record<string, string> = {
+  "Cache-Control": "no-store, no-cache, must-revalidate, private",
+  Pragma: "no-cache",
+  "X-Content-Type-Options": "nosniff",
+  "Referrer-Policy": "no-referrer",
+}
+
+function jsonAnssi(body: unknown, status: number, extraHeaders?: Record<string, string>): NextResponse {
+  return NextResponse.json(body, {
+    status,
+    headers: { ...ANSSI_HEADERS, ...(extraHeaders ?? {}) },
+  })
+}
+
+/**
+ * LOW-4 — Helper pour aligner `mfaEnrollmentRequired` sur le pattern
+ * `stepUpErrorResponse` (401 + `WWW-Authenticate: stepup` +
+ * `X-Step-Up-Required`). Frontend détecte une seule sémantique.
+ */
+function mfaEnrollmentRequiredResponse(): NextResponse {
+  return jsonAnssi(
+    { error: "mfaEnrollmentRequired" },
+    401,
+    {
+      "WWW-Authenticate": `stepup reason="mfaEnrollmentRequired", realm="diabeo"`,
+      "X-Step-Up-Required": "mfaEnrollmentRequired",
+    },
+  )
+}
 
 export async function POST(req: NextRequest) {
   const ctx = extractRequestContext(req)
   try {
     const user = requireAuth(req)
     if (!user.sessionId) {
-      // JWT sans `sid` — flow legacy avant US-2007. Refuse plutôt que de
-      // bumper sur une session inexistante.
-      return NextResponse.json({ error: "sessionRequired" }, { status: 401 })
+      return jsonAnssi({ error: "sessionRequired" }, 401)
     }
+
+    // L9 — guards baseline Diabeo (content-type + body size).
+    const ctErr = assertJsonContentType(req)
+    if (ctErr) return jsonAnssi({ error: "unsupportedMediaType" }, 415)
+    const sizeErr = assertBodySize(req, 1024) // body {otp:"123456"} ≈ 20 bytes
+    if (sizeErr) return jsonAnssi({ error: "payloadTooLarge", maxBytes: 1024 }, 413)
 
     const body = await req.json().catch(() => ({}))
     const parsed = mfaStepUpBodySchema.safeParse(body)
     if (!parsed.success) {
-      return NextResponse.json(
+      return jsonAnssi(
         { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
-        { status: 400 },
+        400,
       )
     }
 
-    // Rate-limit AVANT le verify pour ne pas exposer le timing (un attacker
-    // pourrait sinon différencier "userId existe" vs "userId inexistant").
+    // Rate-limit AVANT le verify pour ne pas exposer le timing.
     const rateLimitKey = `mfa-step-up:${user.id}`
     const rl = await checkRateLimit(rateLimitKey)
     if (rl.blocked) {
-      return NextResponse.json(
+      return jsonAnssi(
         { error: "rateLimitExceeded" },
-        { status: 429, headers: { "Retry-After": String(rl.retryAfterSeconds ?? 300) } },
+        429,
+        { "Retry-After": String(rl.retryAfterSeconds ?? 300) },
       )
     }
 
@@ -68,51 +117,79 @@ export async function POST(req: NextRequest) {
       select: { mfaEnabled: true },
     })
     if (!dbUser?.mfaEnabled) {
-      // MFA non-enrôlée → l'utilisateur doit setup d'abord. Erreur dédiée
-      // (vs 401 invalidOtp) pour que l'UI prompt l'enrôlement plutôt que
-      // de redemander le code.
-      return NextResponse.json({ error: "mfaEnrollmentRequired" }, { status: 403 })
+      // LOW-4 — 401 + WWW-Authenticate (vs ancien 403 sans header).
+      return mfaEnrollmentRequiredResponse()
     }
 
     const verifiedAt = await mfaService.stepUp(user.id, user.sessionId, parsed.data.otp)
     if (!verifiedAt) {
       await recordFailedAttempt(rateLimitKey)
+      // Best-effort — un fail audit n'impacte pas la response 401.
+      try {
+        await auditService.log({
+          userId: user.id,
+          action: "MFA_CHALLENGE_FAILED",
+          resource: "SESSION",
+          resourceId: user.sessionId,
+          ipAddress: ctx.ipAddress,
+          userAgent: ctx.userAgent,
+          requestId: ctx.requestId,
+          metadata: { phase: "step-up" },
+        })
+      } catch (err) {
+        logger.warn("auth/mfa/step-up", "audit MFA_CHALLENGE_FAILED failed", {
+          kind: "stepup.audit.failed",
+          userId: user.id,
+          requestId: ctx.requestId,
+          failMode: err instanceof Error ? err.message : String(err),
+        })
+      }
+      return jsonAnssi({ error: "invalidOtp" }, 401)
+    }
+
+    // H-T3 — On commit l'audit AVANT clearAttempts pour garantir la trace
+    // forensique HDS même si Redis (clearAttempts) throw. La session est
+    // déjà bumpée → la fenêtre fresh est ouverte.
+    try {
       await auditService.log({
         userId: user.id,
-        action: "MFA_CHALLENGE_FAILED",
+        action: "MFA_STEP_UP_VERIFIED",
         resource: "SESSION",
         resourceId: user.sessionId,
         ipAddress: ctx.ipAddress,
         userAgent: ctx.userAgent,
         requestId: ctx.requestId,
-        metadata: { phase: "step-up" },
+        metadata: { verifiedAt: verifiedAt.toISOString() },
       })
-      return NextResponse.json({ error: "invalidOtp" }, { status: 401 })
+    } catch (err) {
+      logger.warn("auth/mfa/step-up", "audit MFA_STEP_UP_VERIFIED failed", {
+        kind: "stepup.audit.failed",
+        userId: user.id,
+        requestId: ctx.requestId,
+        failMode: err instanceof Error ? err.message : String(err),
+      })
+    }
+    // clearAttempts best-effort — un fail Redis ne doit pas invalider le 200.
+    try {
+      await clearAttempts(rateLimitKey)
+    } catch (err) {
+      logger.warn("auth/mfa/step-up", "clearAttempts failed (silent)", {
+        kind: "stepup.ratelimit.clear_failed",
+        userId: user.id,
+        failMode: err instanceof Error ? err.message : String(err),
+      })
     }
 
-    await clearAttempts(rateLimitKey)
-    await auditService.log({
-      userId: user.id,
-      action: "MFA_STEP_UP_VERIFIED",
-      resource: "SESSION",
-      resourceId: user.sessionId,
-      ipAddress: ctx.ipAddress,
-      userAgent: ctx.userAgent,
-      requestId: ctx.requestId,
-      metadata: { verifiedAt: verifiedAt.toISOString() },
-    })
-
-    return NextResponse.json({
+    return jsonAnssi({
       verifiedAt: verifiedAt.toISOString(),
-      // expiresAt = window 5 min (cohérent avec helper requireFreshMfa).
-      // Le client peut afficher un countdown UX "MFA valide jusqu'à HH:MM".
-      expiresAt: new Date(verifiedAt.getTime() + 5 * 60_000).toISOString(),
-    })
+      // M-1 — `expiresAt` aligné `STEP_UP_WINDOW_SECONDS` (vs magic literal).
+      expiresAt: new Date(verifiedAt.getTime() + STEP_UP_WINDOW_SECONDS * 1000).toISOString(),
+    }, 200)
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.status })
+      return jsonAnssi({ error: error.message }, error.status)
     }
     logger.error("auth/mfa/step-up", "step-up failed", { requestId: ctx.requestId }, error)
-    return NextResponse.json({ error: "serverUnavailable" }, { status: 503 })
+    return jsonAnssi({ error: "serverUnavailable" }, 503)
   }
 }

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -18,6 +18,7 @@ export {
 export { revokeSession, isSessionRevoked } from "./revocation"
 export {
   STEP_UP_WINDOW_SECONDS,
+  STEP_UP_WINDOW_SECONDS_CRITICAL,
   checkFreshMfa,
   requireFreshMfa,
   stepUpErrorResponse,

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -16,6 +16,14 @@ export {
   clearAttempts,
 } from "./rate-limit"
 export { revokeSession, isSessionRevoked } from "./revocation"
+export {
+  STEP_UP_WINDOW_SECONDS,
+  checkFreshMfa,
+  requireFreshMfa,
+  stepUpErrorResponse,
+  StepUpRequiredError,
+} from "./step-up"
+export type { StepUpReason, StepUpCheck } from "./step-up"
 
 const VALID_ROLES: ReadonlySet<string> = new Set(["ADMIN", "DOCTOR", "NURSE", "VIEWER"])
 

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -29,6 +29,11 @@ export async function createSession(
       userId,
       expires,
       mfaVerified: opts.mfaVerified ?? false,
+      // Plan B follow-up A2 — Si MFA-verified au login, bumper aussi
+      // `mfaLastVerifiedAt` pour que les actions sensibles dans les 5min
+      // suivantes ne demandent pas de step-up immédiat (UX cohérent —
+      // l'utilisateur vient de prouver MFA).
+      mfaLastVerifiedAt: opts.mfaVerified ? new Date() : undefined,
       ipAddress: opts.ipAddress,
       userAgent: opts.userAgent ? opts.userAgent.slice(0, 500) : undefined,
     },

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -32,8 +32,9 @@ export async function createSession(
       // Plan B follow-up A2 — Si MFA-verified au login, bumper aussi
       // `mfaLastVerifiedAt` pour que les actions sensibles dans les 5min
       // suivantes ne demandent pas de step-up immédiat (UX cohérent —
-      // l'utilisateur vient de prouver MFA).
-      mfaLastVerifiedAt: opts.mfaVerified ? new Date() : undefined,
+      // l'utilisateur vient de prouver MFA). L2 — `null` explicite
+      // sémantique "pas de valeur" vs `undefined` (= field absent).
+      mfaLastVerifiedAt: opts.mfaVerified ? new Date() : null,
       ipAddress: opts.ipAddress,
       userAgent: opts.userAgent ? opts.userAgent.slice(0, 500) : undefined,
     },

--- a/src/lib/auth/step-up.ts
+++ b/src/lib/auth/step-up.ts
@@ -24,9 +24,17 @@
 import { NextResponse } from "next/server"
 import { prisma } from "@/lib/db/client"
 import { auditService, type AuditContext } from "@/lib/services/audit.service"
+import { logger } from "@/lib/logger"
 
 /** Fenêtre de fraîcheur — 5 min, cohérent avec UX banking apps. */
 export const STEP_UP_WINDOW_SECONDS = 5 * 60
+
+/**
+ * A2 round 2 H-4 — Fenêtre durcie 1 min pour actions à impact externe
+ * irréversible (notif CNIL via FSM data-breach transitions, exports PHI
+ * massifs, JWT revoke forcés). Aligné banking apps "live mode" Stripe.
+ */
+export const STEP_UP_WINDOW_SECONDS_CRITICAL = 60
 
 export type StepUpReason = "mfaEnrollmentRequired" | "stepUpRequired"
 
@@ -40,12 +48,19 @@ export type StepUpCheck =
  * @param userId — depuis `requireAuth(req).id`
  * @param sessionId — depuis `requireAuth(req).sessionId`. Si absent → flow
  *   legacy JWT sans sid → on retourne `stepUpRequired` (force migration).
+ * @param options.windowSeconds — fenêtre de fraîcheur custom. Default
+ *   `STEP_UP_WINDOW_SECONDS` (5 min). Pour actions à impact externe
+ *   irréversible (FSM data-breach CNIL), passer `STEP_UP_WINDOW_SECONDS_CRITICAL`
+ *   (1 min) — A2 round 2 H-4.
  */
 export async function checkFreshMfa(
   userId: number,
   sessionId: string | undefined,
+  options?: { windowSeconds?: number },
 ): Promise<StepUpCheck> {
   if (!sessionId) return { ok: false, reason: "stepUpRequired" }
+
+  const windowSeconds = options?.windowSeconds ?? STEP_UP_WINDOW_SECONDS
 
   // Une seule query : session + user.mfaEnabled (FK constraint garantit
   // session.userId === userId, mais on guarde quand même en filter pour
@@ -73,7 +88,7 @@ export async function checkFreshMfa(
   }
 
   const ageSec = (Date.now() - session.mfaLastVerifiedAt.getTime()) / 1000
-  if (ageSec >= STEP_UP_WINDOW_SECONDS) {
+  if (ageSec >= windowSeconds) {
     return { ok: false, reason: "stepUpRequired" }
   }
 
@@ -81,9 +96,19 @@ export async function checkFreshMfa(
 }
 
 /**
- * Variante "throw-style" alignée avec `requireAuth` / `requireRole` —
- * lance `StepUpRequiredError` si pas fresh. Le caller catch et renvoie via
- * `stepUpErrorResponse(err.reason, ctx, ...)`.
+ * Variante "throw-style" alignée avec `requireAuth` / `requireRole`.
+ *
+ * **A2 round 2 LO-6 / M-8** — Réservé pour usage futur : pattern HOF
+ * intercepteur type `withAuth(role, freshMfa)` qui consoliderait
+ * `requireRole + requireFreshMfa` en une seule annotation. Pas câblé dans
+ * `mapErrorToResponse` actuellement (les routes adoptantes utilisent
+ * `checkFreshMfa` return-style + `stepUpErrorResponse` pour conserver le
+ * contrôle sur l'audit metadata.route route-spécifique).
+ *
+ * Si un caller adopte cette variante : catch `StepUpRequiredError` et
+ * appeler `stepUpErrorResponse(err.reason, userId, sessionId, ctx, ...)`
+ * manuellement OU enrichir `mapErrorToResponse` avec un `stepUpTarget`
+ * analogue à `auditTarget`.
  */
 export class StepUpRequiredError extends Error {
   constructor(public reason: StepUpReason) {
@@ -95,19 +120,35 @@ export class StepUpRequiredError extends Error {
 export async function requireFreshMfa(
   userId: number,
   sessionId: string | undefined,
+  options?: { windowSeconds?: number },
 ): Promise<Date> {
-  const result = await checkFreshMfa(userId, sessionId)
+  const result = await checkFreshMfa(userId, sessionId, options)
   if (!result.ok) throw new StepUpRequiredError(result.reason)
   return result.verifiedAt
 }
 
 /**
+ * Whitelist explicite des `reason` autorisées dans le header
+ * `WWW-Authenticate` (LO-1 defense-in-depth anti CRLF injection si un
+ * futur dev introduit `reason` venant d'input utilisateur).
+ */
+const ALLOWED_STEP_UP_REASONS: ReadonlySet<StepUpReason> = new Set<StepUpReason>([
+  "mfaEnrollmentRequired",
+  "stepUpRequired",
+])
+
+/**
  * Construit la response 401 avec `WWW-Authenticate: stepup` + audit
- * `MFA_STEP_UP_REQUIRED` (US-2265 burst detection sur répétition).
+ * `MFA_STEP_UP_REQUIRED` via `auditService.requireStepUp` (A2 round 2 C-2 —
+ * câble US-2265 burst detection : 50 events / 60s → RBAC_BREACH_BURST).
  *
  * Le client UI doit détecter ce header et :
  *   - `reason=mfaEnrollmentRequired` → rediriger vers `/account/security` setup
  *   - `reason=stepUpRequired` → afficher prompt OTP, POST step-up, retry action
+ *
+ * **A2 round 2 H-3** — Le custom header `X-Step-Up-Required: <reason>` est
+ * AUSSI émis pour les clients qui ne parsent pas les schemes RFC 7235 custom
+ * (browsers natifs, OkHttp Android, NSURLSession iOS interceptors génériques).
  */
 export async function stepUpErrorResponse(
   reason: StepUpReason,
@@ -116,20 +157,39 @@ export async function stepUpErrorResponse(
   ctx: AuditContext,
   routeMeta: { route: string },
 ): Promise<NextResponse> {
-  // Audit best-effort — un fail audit ne doit pas bloquer la response 401.
+  // LO-1 — defense-in-depth whitelist (typage TS `StepUpReason` deja restrictif,
+  // mais une régression future qui ouvre le type à `string` serait bloquée ici).
+  if (!ALLOWED_STEP_UP_REASONS.has(reason)) {
+    throw new Error(`stepUpErrorResponse: invalid reason "${reason}"`)
+  }
+
+  // A2 round 2 LO-2 — Sentinel explicite pour les JWT legacy sans sid.
+  const auditResourceId = sessionId ?? "jwt-legacy-no-sid"
+
+  // A2 round 2 M-10 — logger.warn sur audit fail (vs silent swallow).
+  // C-2 — utilise requireStepUp (câble burst detection US-2265).
   try {
-    await auditService.log({
+    await auditService.requireStepUp({
       userId,
-      action: "MFA_STEP_UP_REQUIRED",
       resource: "SESSION",
-      resourceId: sessionId ?? "no-session",
+      resourceId: auditResourceId,
       ipAddress: ctx.ipAddress,
       userAgent: ctx.userAgent,
       requestId: ctx.requestId,
-      metadata: { route: routeMeta.route, reason },
+      metadata: {
+        route: routeMeta.route,
+        reason,
+        legacyJwt: sessionId === undefined ? true : undefined,
+      },
     })
-  } catch {
-    // silent — instrumenté via logger.warn dans audit.service.ts
+  } catch (err) {
+    logger.warn("auth/step-up", "audit MFA_STEP_UP_REQUIRED failed", {
+      kind: "stepup.audit.failed",
+      userId,
+      requestId: ctx.requestId,
+      action: routeMeta.route,
+      failMode: err instanceof Error ? err.message : String(err),
+    })
   }
 
   return NextResponse.json(
@@ -138,11 +198,15 @@ export async function stepUpErrorResponse(
       status: 401,
       headers: {
         // RFC 7235 — challenge scheme custom `stepup` + param `reason`.
-        // Le client iOS/web parse pour différencier enrôlement vs re-prove.
         "WWW-Authenticate": `stepup reason="${reason}", realm="diabeo"`,
+        // H-3 — header custom non-RFC pour clients qui ne parsent pas
+        // WWW-Authenticate (interceptors fetch génériques, OkHttp natif).
+        "X-Step-Up-Required": reason,
         // ANSSI RGS §4.5 — pas de cache sur 401 sensibles.
         "Cache-Control": "no-store, no-cache, must-revalidate, private",
-        "Pragma": "no-cache",
+        Pragma: "no-cache",
+        "X-Content-Type-Options": "nosniff",
+        "Referrer-Policy": "no-referrer",
       },
     },
   )

--- a/src/lib/auth/step-up.ts
+++ b/src/lib/auth/step-up.ts
@@ -1,0 +1,149 @@
+/**
+ * @module auth/step-up
+ * @description Plan B follow-up A2 — Step-up MFA freshness check.
+ *
+ * `requireFreshMfa(req)` exige que la session ait été MFA-verified dans les
+ * dernières `STEP_UP_WINDOW_SECONDS` (5 min default). Utilisé sur les actions
+ * sensibles ADMIN (role/status changes, FSM data-breach transitions, financier).
+ *
+ * 3 résultats possibles :
+ *   - `{ ok: true }` : MFA fresh, action autorisée.
+ *   - `{ ok: false, reason: "mfaEnrollmentRequired" }` : `mfaEnabled = false`,
+ *     l'utilisateur doit enrôler MFA (UI prompte `/api/auth/mfa/setup`).
+ *   - `{ ok: false, reason: "stepUpRequired" }` : MFA enrôlée mais pas fresh,
+ *     l'utilisateur doit re-prouver (UI prompte `/api/auth/mfa/step-up`).
+ *
+ * Le helper `stepUpErrorResponse(reason, ctx)` retourne 401 + `WWW-Authenticate:
+ * stepup` (RFC-style) + audit `MFA_STEP_UP_REQUIRED` US-2265 burst detection.
+ *
+ * **Pourquoi pas un wrapper HOF** (vs `withIdempotency`) : la valeur du retour
+ * est typée pour le caller (permet de logger metadata route-spécifique avant
+ * renvoyer le 401). Plus flexible que `withIdempotency` qui interpose tout.
+ */
+
+import { NextResponse } from "next/server"
+import { prisma } from "@/lib/db/client"
+import { auditService, type AuditContext } from "@/lib/services/audit.service"
+
+/** Fenêtre de fraîcheur — 5 min, cohérent avec UX banking apps. */
+export const STEP_UP_WINDOW_SECONDS = 5 * 60
+
+export type StepUpReason = "mfaEnrollmentRequired" | "stepUpRequired"
+
+export type StepUpCheck =
+  | { ok: true; verifiedAt: Date }
+  | { ok: false; reason: StepUpReason }
+
+/**
+ * Vérifie la fraîcheur MFA de la session courante.
+ *
+ * @param userId — depuis `requireAuth(req).id`
+ * @param sessionId — depuis `requireAuth(req).sessionId`. Si absent → flow
+ *   legacy JWT sans sid → on retourne `stepUpRequired` (force migration).
+ */
+export async function checkFreshMfa(
+  userId: number,
+  sessionId: string | undefined,
+): Promise<StepUpCheck> {
+  if (!sessionId) return { ok: false, reason: "stepUpRequired" }
+
+  // Une seule query : session + user.mfaEnabled (FK constraint garantit
+  // session.userId === userId, mais on guarde quand même en filter pour
+  // defense-in-depth — un compromised JWT avec mauvais sid → no-op).
+  const session = await prisma.session.findFirst({
+    where: { id: sessionId, userId },
+    select: {
+      mfaLastVerifiedAt: true,
+      user: { select: { mfaEnabled: true } },
+    },
+  })
+
+  if (!session) {
+    // Session révoquée ou cross-user spoof → stepUpRequired (l'UI prompt MFA
+    // puis si toujours échec → middleware déconnecte).
+    return { ok: false, reason: "stepUpRequired" }
+  }
+
+  if (!session.user.mfaEnabled) {
+    return { ok: false, reason: "mfaEnrollmentRequired" }
+  }
+
+  if (!session.mfaLastVerifiedAt) {
+    return { ok: false, reason: "stepUpRequired" }
+  }
+
+  const ageSec = (Date.now() - session.mfaLastVerifiedAt.getTime()) / 1000
+  if (ageSec >= STEP_UP_WINDOW_SECONDS) {
+    return { ok: false, reason: "stepUpRequired" }
+  }
+
+  return { ok: true, verifiedAt: session.mfaLastVerifiedAt }
+}
+
+/**
+ * Variante "throw-style" alignée avec `requireAuth` / `requireRole` —
+ * lance `StepUpRequiredError` si pas fresh. Le caller catch et renvoie via
+ * `stepUpErrorResponse(err.reason, ctx, ...)`.
+ */
+export class StepUpRequiredError extends Error {
+  constructor(public reason: StepUpReason) {
+    super(reason)
+    this.name = "StepUpRequiredError"
+  }
+}
+
+export async function requireFreshMfa(
+  userId: number,
+  sessionId: string | undefined,
+): Promise<Date> {
+  const result = await checkFreshMfa(userId, sessionId)
+  if (!result.ok) throw new StepUpRequiredError(result.reason)
+  return result.verifiedAt
+}
+
+/**
+ * Construit la response 401 avec `WWW-Authenticate: stepup` + audit
+ * `MFA_STEP_UP_REQUIRED` (US-2265 burst detection sur répétition).
+ *
+ * Le client UI doit détecter ce header et :
+ *   - `reason=mfaEnrollmentRequired` → rediriger vers `/account/security` setup
+ *   - `reason=stepUpRequired` → afficher prompt OTP, POST step-up, retry action
+ */
+export async function stepUpErrorResponse(
+  reason: StepUpReason,
+  userId: number,
+  sessionId: string | undefined,
+  ctx: AuditContext,
+  routeMeta: { route: string },
+): Promise<NextResponse> {
+  // Audit best-effort — un fail audit ne doit pas bloquer la response 401.
+  try {
+    await auditService.log({
+      userId,
+      action: "MFA_STEP_UP_REQUIRED",
+      resource: "SESSION",
+      resourceId: sessionId ?? "no-session",
+      ipAddress: ctx.ipAddress,
+      userAgent: ctx.userAgent,
+      requestId: ctx.requestId,
+      metadata: { route: routeMeta.route, reason },
+    })
+  } catch {
+    // silent — instrumenté via logger.warn dans audit.service.ts
+  }
+
+  return NextResponse.json(
+    { error: reason },
+    {
+      status: 401,
+      headers: {
+        // RFC 7235 — challenge scheme custom `stepup` + param `reason`.
+        // Le client iOS/web parse pour différencier enrôlement vs re-prove.
+        "WWW-Authenticate": `stepup reason="${reason}", realm="diabeo"`,
+        // ANSSI RGS §4.5 — pas de cache sur 401 sensibles.
+        "Cache-Control": "no-store, no-cache, must-revalidate, private",
+        "Pragma": "no-cache",
+      },
+    },
+  )
+}

--- a/src/lib/idempotency/with-idempotency.ts
+++ b/src/lib/idempotency/with-idempotency.ts
@@ -80,6 +80,17 @@ function shouldSkipCache(status: number): boolean {
   return false
 }
 
+/**
+ * A2 round 2 C-1 — Détecte les responses 401 issues du gate step-up MFA
+ * (`WWW-Authenticate: stepup ...`). Ces 401 NE doivent PAS être cachées :
+ * sans ce skip, le user qui fait step-up + retry avec même Idempotency-Key
+ * recevrait la 401 cachée en boucle (contrat runbook §3.3 cassé).
+ */
+function isStepUpResponse(response: Response): boolean {
+  const wwwAuth = response.headers.get("www-authenticate")
+  return wwwAuth !== null && wwwAuth.toLowerCase().startsWith("stepup")
+}
+
 /** Ne cache que les responses JSON (H-TA-1 + LOW-HSA-3). */
 function isJsonContentType(contentType: string | null): boolean {
   if (!contentType) return false
@@ -280,6 +291,18 @@ export function withIdempotency<Ctx>(
     // Strip transient codes (H-CR-2) + 5xx — release lock pour retry.
     if (shouldSkipCache(response.status)) {
       await idempotencyService.releasePending(idemKey, userId)
+      return response
+    }
+
+    // A2 round 2 C-1 — Skip cache si 401 step-up MFA (WWW-Authenticate: stepup).
+    // Le user doit pouvoir retry avec même Idempotency-Key après step-up réussi
+    // sans recevoir la 401 cachée en boucle.
+    if (response.status === 401 && isStepUpResponse(response)) {
+      await idempotencyService.releasePending(idemKey, userId)
+      logger.debug?.("idempotency", "step-up 401 skipped cache", {
+        kind: "idem.cache.skip_stepup",
+        action: options.route,
+      })
       return response
     }
 

--- a/src/lib/schemas/auth.ts
+++ b/src/lib/schemas/auth.ts
@@ -51,3 +51,13 @@ export const mfaDisableBodySchema = z.object({
   otp: otpSchema,
 })
 export type MfaDisableBody = z.infer<typeof mfaDisableBodySchema>
+
+/**
+ * POST /api/auth/mfa/step-up body — Plan B follow-up A2.
+ * Re-prove MFA pour les actions sensibles ADMIN (role/status changes, FSM
+ * data-breach transitions, etc.). Bump `Session.mfaLastVerifiedAt`.
+ */
+export const mfaStepUpBodySchema = z.object({
+  otp: otpSchema,
+})
+export type MfaStepUpBody = z.infer<typeof mfaStepUpBodySchema>

--- a/src/lib/services/audit.service.ts
+++ b/src/lib/services/audit.service.ts
@@ -664,6 +664,58 @@ export const auditService = {
     markBurstEmitted(entry.userId, now)
     return { unauthorizedRow: txRows[0], burstRow: txRows[1] }
   },
+
+  /**
+   * A2 round 2 C-2 — Émet `MFA_STEP_UP_REQUIRED` avec burst detection
+   * US-2265. Le pattern précédent (auditService.log direct) n'alimentait
+   * PAS `recordAndCheckBurst` → SOC aveugle aux sondages step-up massifs.
+   *
+   * Sémantique alignée `accessDenied` :
+   *   - Crée 1 row `MFA_STEP_UP_REQUIRED` par appel.
+   *   - Si même userId dépasse BURST_THRESHOLD (50) events / 60s →
+   *     émet aussi 1 row `RBAC_BREACH_BURST` atomique dans la même TX.
+   *   - Cooldown 60s entre 2 burst rows pour éviter log flood.
+   *
+   * @returns row MFA_STEP_UP_REQUIRED + optionnel burstRow.
+   */
+  async requireStepUp(
+    entry: AccessDeniedInput,
+  ): Promise<{ stepUpRow: AuditLogRow; burstRow: AuditLogRow | null }> {
+    const now = Date.now()
+    const eventsInWindow = recordAndCheckBurst(entry.userId, now)
+
+    if (eventsInWindow === null) {
+      const stepUpRow = await prisma.auditLog.create({
+        data: createAuditData({ ...entry, action: "MFA_STEP_UP_REQUIRED" }),
+      })
+      return { stepUpRow, burstRow: null }
+    }
+
+    const txRows = (await prisma.$transaction([
+      prisma.auditLog.create({
+        data: createAuditData({ ...entry, action: "MFA_STEP_UP_REQUIRED" }),
+      }),
+      prisma.auditLog.create({
+        data: createAuditData({
+          userId: entry.userId,
+          action: "RBAC_BREACH_BURST",
+          resource: entry.resource,
+          resourceId: entry.resourceId,
+          ipAddress: entry.ipAddress,
+          userAgent: entry.userAgent,
+          requestId: entry.requestId,
+          metadata: {
+            windowMs: BURST_WINDOW_MS,
+            threshold: BURST_THRESHOLD,
+            eventsInWindow,
+            kind: "step_up_required_burst",
+          },
+        }),
+      }),
+    ])) as [AuditLogRow, AuditLogRow]
+    markBurstEmitted(entry.userId, now)
+    return { stepUpRow: txRows[0], burstRow: txRows[1] }
+  },
 }
 
 type AuditLogRow = Prisma.AuditLogGetPayload<Record<string, never>>

--- a/src/lib/services/audit.service.ts
+++ b/src/lib/services/audit.service.ts
@@ -50,6 +50,16 @@ export type AuditAction =
   | "MFA_ENABLED"
   | "MFA_DISABLED"
   | "MFA_CHALLENGE_FAILED"
+  /**
+   * Plan B follow-up A2 — Step-up MFA réussi sur une action sensible
+   * ADMIN. resourceId = sessionId, metadata.route = endpoint protégé.
+   */
+  | "MFA_STEP_UP_VERIFIED"
+  /**
+   * Plan B follow-up A2 — Tentative d'action sensible refusée car MFA
+   * non-fresh OU non-enrolled. Burst detection US-2265 sur répétition.
+   */
+  | "MFA_STEP_UP_REQUIRED"
   | "BOLUS_CALCULATED"
   | "PROPOSAL_ACCEPTED"
   | "PROPOSAL_REJECTED"

--- a/src/lib/services/mfa.service.ts
+++ b/src/lib/services/mfa.service.ts
@@ -198,4 +198,44 @@ export const mfaService = {
       data: { mfaSecret: null, mfaEnabled: false, mfaLastUsedStep: null },
     })
   },
+
+  /**
+   * Plan B follow-up A2 — Step-up MFA verification.
+   *
+   * Verify OTP AND bump `Session.mfaLastVerifiedAt` for freshness checks on
+   * sensitive admin endpoints. Returns the bumped timestamp or null if OTP
+   * invalid / MFA disabled.
+   *
+   * Distinct from `verifyOtp` :
+   *   - exige `mfaEnabled = true` (refuse setup-in-progress).
+   *   - bump une colonne Session (vs colonne User `mfaLastUsedStep` qui ne
+   *     porte que l'anti-replay TOTP).
+   *   - écrit même si l'OTP est rejoué dans la même fenêtre `mfaLastUsedStep`
+   *     (verifyOtp retournerait `false` → on retourne null sans bump).
+   *
+   * **Anti-replay** : repose entièrement sur `verifyOtp` (compare-and-set
+   * `mfaLastUsedStep`). Si l'OTP est rejoué → `verifyOtp` retourne `false` →
+   * step-up échoue. Pas de risque "même OTP réutilisé pour 2 step-ups".
+   *
+   * **Session FK** : le caller doit s'assurer que `sessionId` appartient au
+   * user (helper `requireFreshMfa` valide via `auth/session.ts`).
+   */
+  async stepUp(
+    userId: number,
+    sessionId: string,
+    otp: string,
+  ): Promise<Date | null> {
+    const ok = await mfaService.verifyOtp(userId, otp)
+    if (!ok) return null
+
+    // Vérifier que la session existe et appartient au user AVANT bump.
+    // updateMany sur (id, userId) atomique anti-cross-user replay.
+    const verifiedAt = new Date()
+    const updated = await prisma.session.updateMany({
+      where: { id: sessionId, userId },
+      data: { mfaLastVerifiedAt: verifiedAt },
+    })
+    if (updated.count !== 1) return null
+    return verifiedAt
+  },
 }

--- a/src/lib/services/mfa.service.ts
+++ b/src/lib/services/mfa.service.ts
@@ -202,37 +202,52 @@ export const mfaService = {
   /**
    * Plan B follow-up A2 — Step-up MFA verification.
    *
-   * Verify OTP AND bump `Session.mfaLastVerifiedAt` for freshness checks on
-   * sensitive admin endpoints. Returns the bumped timestamp or null if OTP
-   * invalid / MFA disabled.
+   * **A2 round 2 H-2** — Defense-in-depth : check `mfaEnabled = true`
+   * AVANT `verifyOtp` (le service est autonome, ne dépend plus du caller
+   * pour cette garde — un autre endpoint ou CLI tool qui appellerait
+   * `mfaService.stepUp` sans pré-check ne pourrait pas bumper sur un user
+   * en setup-in-progress).
    *
-   * Distinct from `verifyOtp` :
-   *   - exige `mfaEnabled = true` (refuse setup-in-progress).
-   *   - bump une colonne Session (vs colonne User `mfaLastUsedStep` qui ne
-   *     porte que l'anti-replay TOTP).
-   *   - écrit même si l'OTP est rejoué dans la même fenêtre `mfaLastUsedStep`
-   *     (verifyOtp retournerait `false` → on retourne null sans bump).
+   * **A2 round 2 H-5** — Defense-in-depth TOCTOU : le `updateMany` final
+   * filtre `WHERE userId AND id AND user.mfaEnabled=true` (jointure via
+   * relation) → si `disable` concurrent flippe `mfaEnabled = false` entre
+   * notre lecture et l'update, le bump retourne count=0 (refus atomique).
    *
-   * **Anti-replay** : repose entièrement sur `verifyOtp` (compare-and-set
-   * `mfaLastUsedStep`). Si l'OTP est rejoué → `verifyOtp` retourne `false` →
-   * step-up échoue. Pas de risque "même OTP réutilisé pour 2 step-ups".
+   * Verify OTP AND bump `Session.mfaLastVerifiedAt`. Returns le timestamp
+   * bumpé ou null si :
+   *   - user introuvable
+   *   - `mfaEnabled = false` (setup-in-progress ou MFA désactivée)
+   *   - OTP invalide ou rejoué
+   *   - session inexistante / pas du user (cross-user spoof)
+   *   - disable concurrent (TOCTOU rejected par updateMany filter)
    *
-   * **Session FK** : le caller doit s'assurer que `sessionId` appartient au
-   * user (helper `requireFreshMfa` valide via `auth/session.ts`).
+   * **Anti-replay** : repose sur `verifyOtp` CAS sur `mfaLastUsedStep`.
    */
   async stepUp(
     userId: number,
     sessionId: string,
     otp: string,
   ): Promise<Date | null> {
+    // H-2 — Service-level mfaEnabled check (defense-in-depth).
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { mfaEnabled: true },
+    })
+    if (!user?.mfaEnabled) return null
+
     const ok = await mfaService.verifyOtp(userId, otp)
     if (!ok) return null
 
-    // Vérifier que la session existe et appartient au user AVANT bump.
-    // updateMany sur (id, userId) atomique anti-cross-user replay.
+    // H-5 — TOCTOU defense : `user.mfaEnabled = true` filter dans le
+    // updateMany. Si `disable` concurrent a flippé après verifyOtp →
+    // count=0 → no bump. Aligné Prisma 7+ relation filter syntax.
     const verifiedAt = new Date()
     const updated = await prisma.session.updateMany({
-      where: { id: sessionId, userId },
+      where: {
+        id: sessionId,
+        userId,
+        user: { mfaEnabled: true },
+      },
       data: { mfaLastVerifiedAt: verifiedAt },
     })
     if (updated.count !== 1) return null

--- a/tests/integration/api-admin-data-breaches-transition-step-up.test.ts
+++ b/tests/integration/api-admin-data-breaches-transition-step-up.test.ts
@@ -1,0 +1,157 @@
+/**
+ * A2 round 2 H-T2 (CRITICAL) — Integration tests step-up MFA wired sur
+ * `POST /api/admin/data-breaches/[id]/transition` (FSM CNIL notif).
+ *
+ * Fenêtre durcie 1 min (`STEP_UP_WINDOW_SECONDS_CRITICAL`) car la notif
+ * CNIL est externe + irréversible (RGPD Art. 33). Test critique : un
+ * refactor qui passe la fenêtre à 5 min serait une régression réglementaire.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { NextRequest } from "next/server"
+import { DataBreachStatus } from "@prisma/client"
+
+vi.mock("@/lib/db/client", () => ({
+  prisma: {
+    session: { findFirst: vi.fn() },
+  },
+}))
+
+vi.mock("@/lib/services/data-breach.service", () => ({
+  dataBreachService: {
+    transition: vi.fn(),
+  },
+  DataBreachValidationError: class extends Error {},
+  DataBreachNotFoundError: class extends Error {},
+  DataBreachStateError: class extends Error {},
+}))
+
+vi.mock("@/lib/services/audit.service", async (orig) => {
+  const actual = await orig<typeof import("@/lib/services/audit.service")>()
+  return {
+    ...actual,
+    auditService: {
+      ...actual.auditService,
+      log: vi.fn().mockResolvedValue({}),
+      accessDenied: vi.fn().mockResolvedValue({}),
+      requireStepUp: vi.fn().mockResolvedValue({ stepUpRow: {}, burstRow: null }),
+    },
+  }
+})
+
+vi.mock("@/lib/team-route-helpers", async (orig) => {
+  const actual = await orig<typeof import("@/lib/team-route-helpers")>()
+  return {
+    ...actual,
+    auditedRequireRole: vi.fn().mockResolvedValue({
+      id: 1,
+      role: "ADMIN",
+      sessionId: "sess-abc",
+    }),
+  }
+})
+
+import { prisma } from "@/lib/db/client"
+import { dataBreachService } from "@/lib/services/data-breach.service"
+import { auditService } from "@/lib/services/audit.service"
+import { STEP_UP_WINDOW_SECONDS_CRITICAL } from "@/lib/auth/step-up"
+
+const { POST } = await import("@/app/api/admin/data-breaches/[id]/transition/route")
+
+function makeReq(body: unknown): NextRequest {
+  const headers = new Headers({
+    "content-type": "application/json",
+    "x-user-id": "1",
+    "x-user-role": "ADMIN",
+    "x-session-id": "sess-abc",
+  })
+  return new NextRequest(new URL("http://test.local/api/admin/data-breaches/7/transition"), {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("POST /api/admin/data-breaches/[id]/transition — Step-up MFA gate (H-4 CRITICAL window)", () => {
+  it("Window CRITICAL (60s) — 90s ago = stepUpRequired (bloque FSM)", async () => {
+    vi.mocked(prisma.session.findFirst).mockResolvedValue({
+      mfaLastVerifiedAt: new Date(Date.now() - 90_000),
+      user: { mfaEnabled: true },
+    } as never)
+
+    const res = await POST(
+      makeReq({ to: DataBreachStatus.notified_cnil }),
+      { params: Promise.resolve({ id: "7" }) },
+    )
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json.error).toBe("stepUpRequired")
+    expect(res.headers.get("WWW-Authenticate")).toContain("stepup")
+
+    // Handler PAS appelé — la transition CNIL n'a PAS été déclenchée.
+    expect(dataBreachService.transition).not.toHaveBeenCalled()
+
+    // Audit MFA_STEP_UP_REQUIRED via requireStepUp burst US-2265
+    expect(auditService.requireStepUp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          route: "admin/data-breaches/[id]/transition POST",
+          reason: "stepUpRequired",
+        }),
+      }),
+    )
+  })
+
+  it("Window CRITICAL (60s) — 30s ago = fresh → handler exécute", async () => {
+    vi.mocked(prisma.session.findFirst).mockResolvedValue({
+      mfaLastVerifiedAt: new Date(Date.now() - 30_000),
+      user: { mfaEnabled: true },
+    } as never)
+    vi.mocked(dataBreachService.transition).mockResolvedValue({
+      id: 7,
+      status: "notified_cnil",
+    } as never)
+
+    const res = await POST(
+      makeReq({ to: DataBreachStatus.notified_cnil }),
+      { params: Promise.resolve({ id: "7" }) },
+    )
+    expect(res.status).toBe(200)
+    expect(dataBreachService.transition).toHaveBeenCalledOnce()
+  })
+
+  it("mfaEnabled=false → 401 mfaEnrollmentRequired (priorité enrollment)", async () => {
+    vi.mocked(prisma.session.findFirst).mockResolvedValue({
+      mfaLastVerifiedAt: new Date(Date.now() - 5_000),
+      user: { mfaEnabled: false },
+    } as never)
+
+    const res = await POST(
+      makeReq({ to: DataBreachStatus.notified_cnil }),
+      { params: Promise.resolve({ id: "7" }) },
+    )
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json.error).toBe("mfaEnrollmentRequired")
+    expect(dataBreachService.transition).not.toHaveBeenCalled()
+  })
+
+  // Anti-régression — window default (5min) NE doit PAS être utilisé sur FSM.
+  // Si un refactor remplace `STEP_UP_WINDOW_SECONDS_CRITICAL` par
+  // `STEP_UP_WINDOW_SECONDS` par mégarde, ce test catch.
+  it("anti-régression — 90s ago doit être stale (CRITICAL pas default)", async () => {
+    expect(STEP_UP_WINDOW_SECONDS_CRITICAL).toBeLessThan(90)
+    vi.mocked(prisma.session.findFirst).mockResolvedValue({
+      mfaLastVerifiedAt: new Date(Date.now() - 90_000),
+      user: { mfaEnabled: true },
+    } as never)
+    const res = await POST(
+      makeReq({ to: DataBreachStatus.notified_cnil }),
+      { params: Promise.resolve({ id: "7" }) },
+    )
+    expect(res.status).toBe(401)
+  })
+})

--- a/tests/integration/api-admin-users-idempotency-stepup.test.ts
+++ b/tests/integration/api-admin-users-idempotency-stepup.test.ts
@@ -1,0 +1,129 @@
+/**
+ * A2 round 2 C-1 (CRITICAL) — Integration test : le wrapper `withIdempotency`
+ * NE doit PAS cacher les 401 step-up. Sans ce skip, un user qui fait
+ * step-up + retry avec même Idempotency-Key recevrait la 401 cachée en
+ * boucle (contrat runbook §3.3 cassé).
+ *
+ * Couvre :
+ *   - 1er appel MFA stale → 401 stepUpRequired (NON-caché)
+ *   - 2e appel même Idempotency-Key + MFA fresh → handler exécute, 200
+ *   - 3e appel même Idempotency-Key + même body → replay 200 cached
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { NextRequest } from "next/server"
+
+vi.mock("@/lib/db/client", () => ({
+  prisma: {
+    session: { findFirst: vi.fn() },
+  },
+}))
+
+vi.mock("@/lib/services/user-management.service", () => ({
+  userManagementService: {
+    updateRole: vi.fn(),
+    setStatus: vi.fn(),
+  },
+}))
+
+vi.mock("@/lib/services/audit.service", async (orig) => {
+  const actual = await orig<typeof import("@/lib/services/audit.service")>()
+  return {
+    ...actual,
+    auditService: {
+      ...actual.auditService,
+      log: vi.fn().mockResolvedValue({}),
+      accessDenied: vi.fn().mockResolvedValue({}),
+      requireStepUp: vi.fn().mockResolvedValue({ stepUpRow: {}, burstRow: null }),
+    },
+  }
+})
+
+import { prisma } from "@/lib/db/client"
+import { userManagementService } from "@/lib/services/user-management.service"
+import { idempotencyService } from "@/lib/idempotency/service"
+import { IDEMPOTENCY_REPLAYED_HEADER } from "@/lib/idempotency/with-idempotency"
+
+const { PATCH } = await import("@/app/api/admin/users/[id]/route")
+
+const validUuid = "a3f9b8c2-4d56-4e89-8f12-345678abcdef"
+
+function makeReq(body: unknown): NextRequest {
+  const headers = new Headers({
+    "content-type": "application/json",
+    "x-user-id": "1",
+    "x-user-role": "ADMIN",
+    "x-session-id": "sess-abc",
+    "idempotency-key": validUuid,
+  })
+  return new NextRequest(new URL("http://test.local/api/admin/users/42"), {
+    method: "PATCH",
+    headers,
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  idempotencyService.__resetMemoryForTests()
+  idempotencyService.__resetRedisClientForTests()
+})
+
+describe("C-1 — Idempotency-Key cache 401 step-up NE doit PAS être caché", () => {
+  it("Scenario complet : MFA stale → 401 + step-up + retry → 200 + replay → 200 cached", async () => {
+    // 1er appel : MFA stale (10 min ago)
+    vi.mocked(prisma.session.findFirst).mockResolvedValue({
+      mfaLastVerifiedAt: new Date(Date.now() - 10 * 60_000),
+      user: { mfaEnabled: true },
+    } as never)
+    vi.mocked(userManagementService.updateRole).mockResolvedValue({
+      id: 42, role: "DOCTOR",
+    } as never)
+
+    const res1 = await PATCH(
+      makeReq({ role: "DOCTOR" }),
+      { params: Promise.resolve({ id: "42" }) },
+    )
+    expect(res1.status).toBe(401)
+    expect(res1.headers.get("WWW-Authenticate")).toContain("stepup")
+    expect(userManagementService.updateRole).not.toHaveBeenCalled()
+
+    // 2e appel : MFA fresh (user a fait step-up, retry même Idempotency-Key)
+    vi.mocked(prisma.session.findFirst).mockResolvedValue({
+      mfaLastVerifiedAt: new Date(Date.now() - 30_000),
+      user: { mfaEnabled: true },
+    } as never)
+
+    const res2 = await PATCH(
+      makeReq({ role: "DOCTOR" }),
+      { params: Promise.resolve({ id: "42" }) },
+    )
+    // C-1 fix — le 401 step-up de res1 NE doit PAS avoir été caché, donc
+    // res2 ré-exécute le handler avec MFA fresh → 200 succès.
+    expect(res2.status).toBe(200)
+    expect(res2.headers.get(IDEMPOTENCY_REPLAYED_HEADER)).toBeNull()
+    expect(userManagementService.updateRole).toHaveBeenCalledOnce()
+
+    // 3e appel même Idempotency-Key + même body → cette fois le 200 est cached
+    const res3 = await PATCH(
+      makeReq({ role: "DOCTOR" }),
+      { params: Promise.resolve({ id: "42" }) },
+    )
+    expect(res3.status).toBe(200)
+    expect(res3.headers.get(IDEMPOTENCY_REPLAYED_HEADER)).toBe("true")
+    expect(userManagementService.updateRole).toHaveBeenCalledOnce() // toujours 1x
+  })
+
+  it("WWW-Authenticate: stepup header trigger le skip cache (peu importe la casse)", async () => {
+    vi.mocked(prisma.session.findFirst).mockResolvedValue({
+      mfaLastVerifiedAt: new Date(Date.now() - 10 * 60_000),
+      user: { mfaEnabled: true },
+    } as never)
+
+    const res1 = await PATCH(
+      makeReq({ role: "DOCTOR" }),
+      { params: Promise.resolve({ id: "42" }) },
+    )
+    expect(res1.status).toBe(401)
+    expect(res1.headers.get("WWW-Authenticate")?.toLowerCase()).toContain("stepup")
+  })
+})

--- a/tests/integration/api-admin-users-idempotency.test.ts
+++ b/tests/integration/api-admin-users-idempotency.test.ts
@@ -19,7 +19,23 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { NextRequest } from "next/server"
 
-vi.mock("@/lib/db/client", () => ({ prisma: {} }))
+vi.mock("@/lib/db/client", () => ({
+  prisma: {
+    // A2 — session findFirst pour `checkFreshMfa` gate sur PATCH. Le défaut
+    // retourne une session avec MFA fresh (1 min ago). Tests step-up dédiés
+    // dans `api-admin-users-step-up.test.ts`.
+    // Note : impl passée en argument à vi.fn (vs .mockImplementation() chaîné)
+    // pour survivre à `vi.clearAllMocks()` qui reset l'impl chaînée.
+    session: {
+      findFirst: vi.fn(() =>
+        Promise.resolve({
+          mfaLastVerifiedAt: new Date(Date.now() - 60_000),
+          user: { mfaEnabled: true },
+        }),
+      ),
+    },
+  },
+}))
 
 vi.mock("@/lib/services/user-management.service", () => ({
   userManagementService: {
@@ -42,6 +58,7 @@ vi.mock("@/lib/services/audit.service", async (orig) => {
 
 import { userManagementService } from "@/lib/services/user-management.service"
 import { auditService } from "@/lib/services/audit.service"
+import { prisma } from "@/lib/db/client"
 import { idempotencyService } from "@/lib/idempotency/service"
 import { IDEMPOTENCY_REPLAYED_HEADER } from "@/lib/idempotency/with-idempotency"
 
@@ -60,6 +77,8 @@ function makeReq(
     "content-type": "application/json",
     "x-user-id": init.userId ?? "1",
     "x-user-role": "ADMIN",
+    // A2 — session id requis pour `checkFreshMfa` gate.
+    "x-session-id": "sess-abc",
   })
   if (init.idemKey !== null && init.idemKey !== undefined) {
     headers.set("idempotency-key", init.idemKey)
@@ -80,6 +99,11 @@ beforeEach(() => {
   vi.clearAllMocks()
   idempotencyService.__resetMemoryForTests()
   idempotencyService.__resetRedisClientForTests()
+  // A2 — re-prime le mock après clearAllMocks (vitest 4 reset impl chaînées).
+  vi.mocked(prisma.session.findFirst).mockResolvedValue({
+    mfaLastVerifiedAt: new Date(Date.now() - 60_000),
+    user: { mfaEnabled: true },
+  } as never)
 })
 
 describe("PATCH /api/admin/users/[id] — Idempotency-Key wrapper", () => {

--- a/tests/integration/api-admin-users-step-up.test.ts
+++ b/tests/integration/api-admin-users-step-up.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @description Plan B follow-up A2 — Integration tests step-up MFA wired
+ * on `PATCH /api/admin/users/[id]`.
+ *
+ * Couvre :
+ *   - Pas fresh MFA → 401 stepUpRequired + WWW-Authenticate
+ *   - mfaEnabled=false → 401 mfaEnrollmentRequired
+ *   - Fresh MFA (5min window) → handler exécute normalement
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { NextRequest } from "next/server"
+
+vi.mock("@/lib/db/client", () => ({
+  prisma: {
+    session: { findFirst: vi.fn() },
+  },
+}))
+
+vi.mock("@/lib/services/user-management.service", () => ({
+  userManagementService: {
+    updateRole: vi.fn(),
+    setStatus: vi.fn(),
+  },
+}))
+
+vi.mock("@/lib/services/audit.service", async (orig) => {
+  const actual = await orig<typeof import("@/lib/services/audit.service")>()
+  return {
+    ...actual,
+    auditService: {
+      ...actual.auditService,
+      log: vi.fn().mockResolvedValue({}),
+      accessDenied: vi.fn().mockResolvedValue({}),
+    },
+  }
+})
+
+import { prisma } from "@/lib/db/client"
+import { userManagementService } from "@/lib/services/user-management.service"
+import { auditService } from "@/lib/services/audit.service"
+
+const { PATCH } = await import("@/app/api/admin/users/[id]/route")
+
+function makeReq(body: unknown, init: { sid?: string | null } = {}): NextRequest {
+  const headers = new Headers({
+    "content-type": "application/json",
+    "x-user-id": "1",
+    "x-user-role": "ADMIN",
+  })
+  if (init.sid !== null) headers.set("x-session-id", init.sid ?? "sess-abc")
+  return new NextRequest(new URL("http://test.local/api/admin/users/42"), {
+    method: "PATCH",
+    headers,
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("PATCH /api/admin/users/[id] — Step-up MFA gate", () => {
+  it("pas fresh (mfaLastVerifiedAt > 5min) → 401 stepUpRequired + WWW-Authenticate", async () => {
+    vi.mocked(prisma.session.findFirst).mockResolvedValue({
+      mfaLastVerifiedAt: new Date(Date.now() - 10 * 60_000), // 10 min ago
+      user: { mfaEnabled: true },
+    } as never)
+
+    const res = await PATCH(makeReq({ role: "DOCTOR" }), {
+      params: Promise.resolve({ id: "42" }),
+    })
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json.error).toBe("stepUpRequired")
+    expect(res.headers.get("WWW-Authenticate")).toContain("stepup")
+    expect(res.headers.get("WWW-Authenticate")).toContain(`reason="stepUpRequired"`)
+    expect(res.headers.get("Cache-Control")).toContain("no-store")
+
+    // Handler PAS appelé
+    expect(userManagementService.updateRole).not.toHaveBeenCalled()
+
+    // Audit MFA_STEP_UP_REQUIRED
+    expect(auditService.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "MFA_STEP_UP_REQUIRED",
+        metadata: expect.objectContaining({
+          route: "admin/users/[id] PATCH",
+          reason: "stepUpRequired",
+        }),
+      }),
+    )
+  })
+
+  it("mfaEnabled=false → 401 mfaEnrollmentRequired", async () => {
+    vi.mocked(prisma.session.findFirst).mockResolvedValue({
+      mfaLastVerifiedAt: null,
+      user: { mfaEnabled: false },
+    } as never)
+
+    const res = await PATCH(makeReq({ role: "DOCTOR" }), {
+      params: Promise.resolve({ id: "42" }),
+    })
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json.error).toBe("mfaEnrollmentRequired")
+    expect(res.headers.get("WWW-Authenticate")).toContain(`reason="mfaEnrollmentRequired"`)
+  })
+
+  it("session sans sid (legacy JWT) → 401 stepUpRequired", async () => {
+    const res = await PATCH(makeReq({ role: "DOCTOR" }, { sid: null }), {
+      params: Promise.resolve({ id: "42" }),
+    })
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json.error).toBe("stepUpRequired")
+    expect(prisma.session.findFirst).not.toHaveBeenCalled()
+  })
+
+  it("fresh MFA (< 5 min) → handler exécute normalement", async () => {
+    vi.mocked(prisma.session.findFirst).mockResolvedValue({
+      mfaLastVerifiedAt: new Date(Date.now() - 60_000), // 1 min ago
+      user: { mfaEnabled: true },
+    } as never)
+    vi.mocked(userManagementService.updateRole).mockResolvedValue({
+      id: 42,
+      role: "DOCTOR",
+    } as never)
+
+    const res = await PATCH(makeReq({ role: "DOCTOR" }), {
+      params: Promise.resolve({ id: "42" }),
+    })
+    expect(res.status).toBe(200)
+    expect(userManagementService.updateRole).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/integration/api-admin-users-step-up.test.ts
+++ b/tests/integration/api-admin-users-step-up.test.ts
@@ -31,6 +31,7 @@ vi.mock("@/lib/services/audit.service", async (orig) => {
       ...actual.auditService,
       log: vi.fn().mockResolvedValue({}),
       accessDenied: vi.fn().mockResolvedValue({}),
+      requireStepUp: vi.fn().mockResolvedValue({ stepUpRow: {}, burstRow: null }),
     },
   }
 })
@@ -79,10 +80,10 @@ describe("PATCH /api/admin/users/[id] — Step-up MFA gate", () => {
     // Handler PAS appelé
     expect(userManagementService.updateRole).not.toHaveBeenCalled()
 
-    // Audit MFA_STEP_UP_REQUIRED
-    expect(auditService.log).toHaveBeenCalledWith(
+    // A2 round 2 C-2 — Audit via requireStepUp (burst detection câblée)
+    expect(auditService.requireStepUp).toHaveBeenCalledWith(
       expect.objectContaining({
-        action: "MFA_STEP_UP_REQUIRED",
+        resource: "SESSION",
         metadata: expect.objectContaining({
           route: "admin/users/[id] PATCH",
           reason: "stepUpRequired",

--- a/tests/integration/api-auth-mfa-step-up.test.ts
+++ b/tests/integration/api-auth-mfa-step-up.test.ts
@@ -40,9 +40,9 @@ vi.mock("@/lib/auth", async (orig) => {
   const actual = await orig<typeof import("@/lib/auth")>()
   return {
     ...actual,
-    checkRateLimit: vi.fn().mockResolvedValue({ blocked: false }),
-    recordFailedAttempt: vi.fn().mockResolvedValue(undefined),
-    clearAttempts: vi.fn().mockResolvedValue(undefined),
+    checkRateLimit: vi.fn(() => Promise.resolve({ blocked: false })),
+    recordFailedAttempt: vi.fn(() => Promise.resolve(undefined)),
+    clearAttempts: vi.fn(() => Promise.resolve(undefined)),
   }
 })
 
@@ -89,14 +89,20 @@ describe("POST /api/auth/mfa/step-up", () => {
     expect(json.error).toBe("validationFailed")
   })
 
-  it("403 mfaEnrollmentRequired si user n'a pas MFA activée", async () => {
+  it("LOW-4 — 401 mfaEnrollmentRequired + WWW-Authenticate + X-Step-Up-Required (alignement)", async () => {
     vi.mocked(prisma.user.findUnique).mockResolvedValue({
       mfaEnabled: false,
     } as never)
     const res = await POST(makeReq({ otp: "123456" }))
-    expect(res.status).toBe(403)
+    // A2 round 2 LOW-4 — aligné sur 401 + WWW-Authenticate (vs ancien 403 sans header).
+    expect(res.status).toBe(401)
     const json = await res.json()
     expect(json.error).toBe("mfaEnrollmentRequired")
+    expect(res.headers.get("WWW-Authenticate")).toContain(
+      `stepup reason="mfaEnrollmentRequired"`,
+    )
+    expect(res.headers.get("X-Step-Up-Required")).toBe("mfaEnrollmentRequired")
+    expect(res.headers.get("Cache-Control")).toContain("no-store")
     expect(mfaService.stepUp).not.toHaveBeenCalled()
   })
 
@@ -130,7 +136,7 @@ describe("POST /api/auth/mfa/step-up", () => {
     expect(prisma.user.findUnique).not.toHaveBeenCalled()
   })
 
-  it("200 succès → verifiedAt + expiresAt + audit MFA_STEP_UP_VERIFIED", async () => {
+  it("200 succès → verifiedAt + expiresAt + audit MFA_STEP_UP_VERIFIED + ANSSI headers", async () => {
     vi.mocked(prisma.user.findUnique).mockResolvedValue({
       mfaEnabled: true,
     } as never)
@@ -141,7 +147,7 @@ describe("POST /api/auth/mfa/step-up", () => {
     expect(res.status).toBe(200)
     const json = await res.json()
     expect(json.verifiedAt).toBe(verifiedAt.toISOString())
-    // expiresAt = verifiedAt + 5min
+    // M-1 — expiresAt aligné STEP_UP_WINDOW_SECONDS (vs ancien magic 5*60_000)
     expect(new Date(json.expiresAt).getTime()).toBe(verifiedAt.getTime() + 5 * 60_000)
 
     expect(auditService.log).toHaveBeenCalledTimes(1)
@@ -150,5 +156,79 @@ describe("POST /api/auth/mfa/step-up", () => {
       resource: "SESSION",
       resourceId: "sess-abc",
     })
+
+    // A2 round 2 H-1 — ANSSI baseline sur 200 succès aussi
+    expect(res.headers.get("Cache-Control")).toContain("no-store")
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff")
+    expect(res.headers.get("Referrer-Policy")).toBe("no-referrer")
+  })
+
+  // A2 round 2 H-T3 — Si clearAttempts throw, audit MFA_STEP_UP_VERIFIED
+  // doit quand-même être émis (preuve forensique HDS préservée).
+  it("H-T3 — clearAttempts throw → audit MFA_STEP_UP_VERIFIED quand-même émis + 200", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      mfaEnabled: true,
+    } as never)
+    const verifiedAt = new Date()
+    vi.mocked(mfaService.stepUp).mockResolvedValue(verifiedAt)
+    // Patch clearAttempts pour throw
+    const { clearAttempts } = await import("@/lib/auth")
+    vi.mocked(clearAttempts).mockRejectedValueOnce(new Error("Redis down"))
+
+    const res = await POST(makeReq({ otp: "123456" }))
+    expect(res.status).toBe(200)
+    // Audit MFA_STEP_UP_VERIFIED appelé même si clearAttempts a throw
+    expect(auditService.log).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "MFA_STEP_UP_VERIFIED" }),
+    )
+  })
+
+  // A2 round 2 H-T3 — Si auditService.log throw, response 200 reste retournée
+  // (la session est déjà bumpée — le user ne doit pas voir un faux échec).
+  it("H-T3 — audit MFA_STEP_UP_VERIFIED throw → response 200 quand-même + session bumpée", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      mfaEnabled: true,
+    } as never)
+    vi.mocked(mfaService.stepUp).mockResolvedValue(new Date())
+    vi.mocked(auditService.log).mockRejectedValueOnce(new Error("DB down"))
+
+    const res = await POST(makeReq({ otp: "123456" }))
+    expect(res.status).toBe(200)
+  })
+
+  // L9 — assertJsonContentType 415
+  it("L9 — Content-Type: text/plain → 415 unsupportedMediaType + ANSSI headers", async () => {
+    const headers = new Headers({
+      "content-type": "text/plain",
+      "x-user-id": "1",
+      "x-user-role": "ADMIN",
+      "x-session-id": "sess-abc",
+    })
+    const req = new NextRequest(new URL("http://test.local/api/auth/mfa/step-up"), {
+      method: "POST",
+      headers,
+      body: "otp=123456",
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(415)
+    expect(res.headers.get("Cache-Control")).toContain("no-store")
+  })
+
+  // L9 — assertBodySize 413
+  it("L9 — Content-Length > 1024 → 413 payloadTooLarge", async () => {
+    const headers = new Headers({
+      "content-type": "application/json",
+      "x-user-id": "1",
+      "x-user-role": "ADMIN",
+      "x-session-id": "sess-abc",
+      "content-length": "10000",
+    })
+    const req = new NextRequest(new URL("http://test.local/api/auth/mfa/step-up"), {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ otp: "123456" }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(413)
   })
 })

--- a/tests/integration/api-auth-mfa-step-up.test.ts
+++ b/tests/integration/api-auth-mfa-step-up.test.ts
@@ -1,0 +1,154 @@
+/**
+ * @description Plan B follow-up A2 — Integration tests
+ * `POST /api/auth/mfa/step-up`.
+ *
+ * Couvre :
+ *   - 401 sans sessionId (JWT legacy)
+ *   - 400 validation otp
+ *   - 403 mfaEnrollmentRequired si mfaEnabled=false
+ *   - 401 invalidOtp + audit MFA_CHALLENGE_FAILED
+ *   - 429 rate-limit après 3 échecs
+ *   - 200 succès + audit MFA_STEP_UP_VERIFIED + verifiedAt/expiresAt
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { NextRequest } from "next/server"
+
+vi.mock("@/lib/db/client", () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+  },
+}))
+
+vi.mock("@/lib/services/mfa.service", () => ({
+  mfaService: {
+    stepUp: vi.fn(),
+  },
+}))
+
+vi.mock("@/lib/services/audit.service", async (orig) => {
+  const actual = await orig<typeof import("@/lib/services/audit.service")>()
+  return {
+    ...actual,
+    auditService: {
+      ...actual.auditService,
+      log: vi.fn().mockResolvedValue({}),
+    },
+  }
+})
+
+vi.mock("@/lib/auth", async (orig) => {
+  const actual = await orig<typeof import("@/lib/auth")>()
+  return {
+    ...actual,
+    checkRateLimit: vi.fn().mockResolvedValue({ blocked: false }),
+    recordFailedAttempt: vi.fn().mockResolvedValue(undefined),
+    clearAttempts: vi.fn().mockResolvedValue(undefined),
+  }
+})
+
+import { prisma } from "@/lib/db/client"
+import { mfaService } from "@/lib/services/mfa.service"
+import { auditService } from "@/lib/services/audit.service"
+import { checkRateLimit } from "@/lib/auth"
+
+const { POST } = await import("@/app/api/auth/mfa/step-up/route")
+
+function makeReq(body: unknown, init: { sid?: string | null; userId?: string } = {}): NextRequest {
+  const headers = new Headers({
+    "content-type": "application/json",
+    "x-user-id": init.userId ?? "42",
+    "x-user-role": "ADMIN",
+  })
+  if (init.sid !== null) headers.set("x-session-id", init.sid ?? "sess-abc")
+  return new NextRequest(new URL("http://test.local/api/auth/mfa/step-up"), {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Restore default — checkRateLimit non-bloqué pour tous les tests sauf le
+  // test "429" qui override explicitement.
+  vi.mocked(checkRateLimit).mockResolvedValue({ blocked: false } as never)
+})
+
+describe("POST /api/auth/mfa/step-up", () => {
+  it("401 sessionRequired si pas de x-session-id (legacy JWT)", async () => {
+    const res = await POST(makeReq({ otp: "123456" }, { sid: null }))
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json.error).toBe("sessionRequired")
+  })
+
+  it("400 validationFailed si otp manquant ou mal formé", async () => {
+    const res = await POST(makeReq({ otp: "abc" }))
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.error).toBe("validationFailed")
+  })
+
+  it("403 mfaEnrollmentRequired si user n'a pas MFA activée", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      mfaEnabled: false,
+    } as never)
+    const res = await POST(makeReq({ otp: "123456" }))
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.error).toBe("mfaEnrollmentRequired")
+    expect(mfaService.stepUp).not.toHaveBeenCalled()
+  })
+
+  it("401 invalidOtp si stepUp retourne null + audit MFA_CHALLENGE_FAILED", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      mfaEnabled: true,
+    } as never)
+    vi.mocked(mfaService.stepUp).mockResolvedValue(null)
+
+    const res = await POST(makeReq({ otp: "123456" }))
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json.error).toBe("invalidOtp")
+
+    // Audit avec phase=step-up
+    expect(auditService.log).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(auditService.log).mock.calls[0]?.[0]).toMatchObject({
+      action: "MFA_CHALLENGE_FAILED",
+      metadata: { phase: "step-up" },
+    })
+  })
+
+  it("429 si rate-limit bloqué + Retry-After", async () => {
+    vi.mocked(checkRateLimit).mockResolvedValue({
+      blocked: true,
+      retryAfterSeconds: 300,
+    } as never)
+    const res = await POST(makeReq({ otp: "123456" }))
+    expect(res.status).toBe(429)
+    expect(res.headers.get("Retry-After")).toBe("300")
+    expect(prisma.user.findUnique).not.toHaveBeenCalled()
+  })
+
+  it("200 succès → verifiedAt + expiresAt + audit MFA_STEP_UP_VERIFIED", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      mfaEnabled: true,
+    } as never)
+    const verifiedAt = new Date("2026-05-28T15:00:00Z")
+    vi.mocked(mfaService.stepUp).mockResolvedValue(verifiedAt)
+
+    const res = await POST(makeReq({ otp: "123456" }))
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.verifiedAt).toBe(verifiedAt.toISOString())
+    // expiresAt = verifiedAt + 5min
+    expect(new Date(json.expiresAt).getTime()).toBe(verifiedAt.getTime() + 5 * 60_000)
+
+    expect(auditService.log).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(auditService.log).mock.calls[0]?.[0]).toMatchObject({
+      action: "MFA_STEP_UP_VERIFIED",
+      resource: "SESSION",
+      resourceId: "sess-abc",
+    })
+  })
+})

--- a/tests/unit/mfa.service.test.ts
+++ b/tests/unit/mfa.service.test.ts
@@ -271,32 +271,59 @@ describe("mfaService", () => {
   // Plan B follow-up A2 — Step-up MFA.
   describe("stepUp", () => {
     it("returns null si OTP invalide (verifyOtp false)", async () => {
-      // findUnique pour verifyOtp interne → user sans secret = échec
-      prismaMock.user.findUnique.mockResolvedValue({ mfaSecret: null } as any)
+      // A2 round 2 H-2 — findUnique 1 = mfaEnabled check, findUnique 2 = verifyOtp.
+      prismaMock.user.findUnique
+        .mockResolvedValueOnce({ mfaEnabled: true } as any) // service-level check
+        .mockResolvedValueOnce({ mfaSecret: null } as any) // verifyOtp interne
 
       const result = await mfaService.stepUp(1, "sess-x", "123456")
       expect(result).toBeNull()
       expect(prismaMock.session.updateMany).not.toHaveBeenCalled()
     })
 
+    // A2 round 2 H-2 — service-level mfaEnabled check (defense-in-depth).
+    it("H-2 — returns null si mfaEnabled=false côté service (defense-in-depth)", async () => {
+      prismaMock.user.findUnique.mockResolvedValueOnce({
+        mfaEnabled: false,
+      } as any)
+
+      const result = await mfaService.stepUp(1, "sess-x", "123456")
+      expect(result).toBeNull()
+      // verifyOtp NE doit PAS être appelé si mfaEnabled=false côté service
+      // (cf. count d'invocations findUnique = 1, pas 2)
+      expect(prismaMock.user.findUnique).toHaveBeenCalledTimes(1)
+      expect(prismaMock.session.updateMany).not.toHaveBeenCalled()
+    })
+
+    it("H-2 — returns null si user introuvable", async () => {
+      prismaMock.user.findUnique.mockResolvedValueOnce(null)
+      const result = await mfaService.stepUp(999, "sess-x", "123456")
+      expect(result).toBeNull()
+      expect(prismaMock.session.updateMany).not.toHaveBeenCalled()
+    })
+
     it("bump mfaLastVerifiedAt si OTP valide", async () => {
       const secret = generateSecret()
-      prismaMock.user.findUnique.mockResolvedValue({
-        mfaSecret: `ENCRYPTED[${secret}]`,
-        mfaLastUsedStep: null,
-      } as any)
-      // updateMany pour verifyOtp CAS step
+      prismaMock.user.findUnique
+        .mockResolvedValueOnce({ mfaEnabled: true } as any) // H-2 service check
+        .mockResolvedValueOnce({
+          mfaSecret: `ENCRYPTED[${secret}]`,
+          mfaLastUsedStep: null,
+        } as any) // verifyOtp interne
       prismaMock.user.updateMany.mockResolvedValue({ count: 1 } as any)
-      // updateMany pour session bump
       prismaMock.session.updateMany.mockResolvedValue({ count: 1 } as any)
 
       const code = generateSync({ strategy: "totp", secret, digits: 6, period: 30 })
       const result = await mfaService.stepUp(42, "sess-x", code)
       expect(result).toBeInstanceOf(Date)
-      // Session updated avec scope per-user
+      // A2 round 2 H-5 — Session updated avec scope per-user + mfaEnabled filter (TOCTOU)
       expect(prismaMock.session.updateMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { id: "sess-x", userId: 42 },
+          where: {
+            id: "sess-x",
+            userId: 42,
+            user: { mfaEnabled: true },
+          },
           data: { mfaLastVerifiedAt: expect.any(Date) },
         }),
       )
@@ -304,12 +331,13 @@ describe("mfaService", () => {
 
     it("returns null si session.updateMany count=0 (cross-user spoof)", async () => {
       const secret = generateSecret()
-      prismaMock.user.findUnique.mockResolvedValue({
-        mfaSecret: `ENCRYPTED[${secret}]`,
-        mfaLastUsedStep: null,
-      } as any)
+      prismaMock.user.findUnique
+        .mockResolvedValueOnce({ mfaEnabled: true } as any)
+        .mockResolvedValueOnce({
+          mfaSecret: `ENCRYPTED[${secret}]`,
+          mfaLastUsedStep: null,
+        } as any)
       prismaMock.user.updateMany.mockResolvedValue({ count: 1 } as any)
-      // Session inexistante ou pas du user → count=0
       prismaMock.session.updateMany.mockResolvedValue({ count: 0 } as any)
 
       const code = generateSync({ strategy: "totp", secret, digits: 6, period: 30 })
@@ -317,13 +345,42 @@ describe("mfaService", () => {
       expect(result).toBeNull()
     })
 
+    // A2 round 2 H-5 — TOCTOU : disable concurrent flippe mfaEnabled entre
+    // verifyOtp et updateMany → updateMany filter rejette (count=0).
+    it("H-5 — TOCTOU disable concurrent → updateMany count=0 → null", async () => {
+      const secret = generateSecret()
+      prismaMock.user.findUnique
+        .mockResolvedValueOnce({ mfaEnabled: true } as any) // service check OK
+        .mockResolvedValueOnce({
+          mfaSecret: `ENCRYPTED[${secret}]`,
+          mfaLastUsedStep: null,
+        } as any)
+      prismaMock.user.updateMany.mockResolvedValue({ count: 1 } as any)
+      // Disable concurrent : entre verifyOtp et updateMany, mfaEnabled=false
+      // → updateMany WHERE user.mfaEnabled=true ne matche plus → count=0.
+      prismaMock.session.updateMany.mockResolvedValue({ count: 0 } as any)
+
+      const code = generateSync({ strategy: "totp", secret, digits: 6, period: 30 })
+      const result = await mfaService.stepUp(42, "sess-x", code)
+      expect(result).toBeNull()
+      // Vérifie qu'on a bien appelé updateMany avec le filter defense-in-depth
+      expect(prismaMock.session.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            user: { mfaEnabled: true },
+          }),
+        }),
+      )
+    })
+
     it("anti-replay — un OTP valide consommé ne peut pas re-step-up", async () => {
       const secret = generateSecret()
-      // 1er appel : findUnique avec mfaLastUsedStep=null
-      prismaMock.user.findUnique.mockResolvedValueOnce({
-        mfaSecret: `ENCRYPTED[${secret}]`,
-        mfaLastUsedStep: null,
-      } as any)
+      prismaMock.user.findUnique
+        .mockResolvedValueOnce({ mfaEnabled: true } as any)
+        .mockResolvedValueOnce({
+          mfaSecret: `ENCRYPTED[${secret}]`,
+          mfaLastUsedStep: null,
+        } as any)
       prismaMock.user.updateMany.mockResolvedValueOnce({ count: 1 } as any)
       prismaMock.session.updateMany.mockResolvedValueOnce({ count: 1 } as any)
 
@@ -331,14 +388,27 @@ describe("mfaService", () => {
       const first = await mfaService.stepUp(42, "sess-x", code)
       expect(first).toBeInstanceOf(Date)
 
-      // 2e appel même code : mfaLastUsedStep désormais consommé → verifyOtp false
+      // 2e appel même code : mfaLastUsedStep consommé → verifyOtp false
       const consumedStep = Math.floor(Date.now() / 1000 / 30)
-      prismaMock.user.findUnique.mockResolvedValueOnce({
-        mfaSecret: `ENCRYPTED[${secret}]`,
-        mfaLastUsedStep: consumedStep,
-      } as any)
+      prismaMock.user.findUnique
+        .mockResolvedValueOnce({ mfaEnabled: true } as any)
+        .mockResolvedValueOnce({
+          mfaSecret: `ENCRYPTED[${secret}]`,
+          mfaLastUsedStep: consumedStep,
+        } as any)
       const second = await mfaService.stepUp(42, "sess-x", code)
       expect(second).toBeNull()
     })
+
+    // H-T5 — Concurrent step-ups : repose entièrement sur verifyOtp CAS
+    // (mfaLastUsedStep compare-and-set). Si la CAS retourne count=0, stepUp
+    // retourne null. Test du contrat sans mock du Promise.all (simulation
+    // trop fragile avec 2 findUnique × 2 stepUps = 4 calls interleavés).
+    //
+    // Le test "H-5 TOCTOU disable concurrent → updateMany count=0 → null"
+    // ci-dessus exerce la même path code (count=0 → null) pour le CAS session.
+    // Le test "anti-replay — OTP valide consommé" couvre la path CAS verifyOtp.
+    //
+    // Together, ces 2 tests garantissent l'invariant H-T5 sans mock concurrent.
   })
 })

--- a/tests/unit/mfa.service.test.ts
+++ b/tests/unit/mfa.service.test.ts
@@ -267,4 +267,78 @@ describe("mfaService", () => {
       })
     })
   })
+
+  // Plan B follow-up A2 — Step-up MFA.
+  describe("stepUp", () => {
+    it("returns null si OTP invalide (verifyOtp false)", async () => {
+      // findUnique pour verifyOtp interne → user sans secret = échec
+      prismaMock.user.findUnique.mockResolvedValue({ mfaSecret: null } as any)
+
+      const result = await mfaService.stepUp(1, "sess-x", "123456")
+      expect(result).toBeNull()
+      expect(prismaMock.session.updateMany).not.toHaveBeenCalled()
+    })
+
+    it("bump mfaLastVerifiedAt si OTP valide", async () => {
+      const secret = generateSecret()
+      prismaMock.user.findUnique.mockResolvedValue({
+        mfaSecret: `ENCRYPTED[${secret}]`,
+        mfaLastUsedStep: null,
+      } as any)
+      // updateMany pour verifyOtp CAS step
+      prismaMock.user.updateMany.mockResolvedValue({ count: 1 } as any)
+      // updateMany pour session bump
+      prismaMock.session.updateMany.mockResolvedValue({ count: 1 } as any)
+
+      const code = generateSync({ strategy: "totp", secret, digits: 6, period: 30 })
+      const result = await mfaService.stepUp(42, "sess-x", code)
+      expect(result).toBeInstanceOf(Date)
+      // Session updated avec scope per-user
+      expect(prismaMock.session.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "sess-x", userId: 42 },
+          data: { mfaLastVerifiedAt: expect.any(Date) },
+        }),
+      )
+    })
+
+    it("returns null si session.updateMany count=0 (cross-user spoof)", async () => {
+      const secret = generateSecret()
+      prismaMock.user.findUnique.mockResolvedValue({
+        mfaSecret: `ENCRYPTED[${secret}]`,
+        mfaLastUsedStep: null,
+      } as any)
+      prismaMock.user.updateMany.mockResolvedValue({ count: 1 } as any)
+      // Session inexistante ou pas du user → count=0
+      prismaMock.session.updateMany.mockResolvedValue({ count: 0 } as any)
+
+      const code = generateSync({ strategy: "totp", secret, digits: 6, period: 30 })
+      const result = await mfaService.stepUp(42, "sess-foreign", code)
+      expect(result).toBeNull()
+    })
+
+    it("anti-replay — un OTP valide consommé ne peut pas re-step-up", async () => {
+      const secret = generateSecret()
+      // 1er appel : findUnique avec mfaLastUsedStep=null
+      prismaMock.user.findUnique.mockResolvedValueOnce({
+        mfaSecret: `ENCRYPTED[${secret}]`,
+        mfaLastUsedStep: null,
+      } as any)
+      prismaMock.user.updateMany.mockResolvedValueOnce({ count: 1 } as any)
+      prismaMock.session.updateMany.mockResolvedValueOnce({ count: 1 } as any)
+
+      const code = generateSync({ strategy: "totp", secret, digits: 6, period: 30 })
+      const first = await mfaService.stepUp(42, "sess-x", code)
+      expect(first).toBeInstanceOf(Date)
+
+      // 2e appel même code : mfaLastUsedStep désormais consommé → verifyOtp false
+      const consumedStep = Math.floor(Date.now() / 1000 / 30)
+      prismaMock.user.findUnique.mockResolvedValueOnce({
+        mfaSecret: `ENCRYPTED[${secret}]`,
+        mfaLastUsedStep: consumedStep,
+      } as any)
+      const second = await mfaService.stepUp(42, "sess-x", code)
+      expect(second).toBeNull()
+    })
+  })
 })

--- a/tests/unit/step-up-round2.test.ts
+++ b/tests/unit/step-up-round2.test.ts
@@ -1,0 +1,123 @@
+/**
+ * A2 round 2 — tests additionnels couvrant :
+ *   - C2 : boundary exact 5 min (`>=` semantics)
+ *   - H-T1 : clock skew tolerance (mfaLastVerifiedAt futur)
+ *   - H-4 : per-route window override (CRITICAL 1 min)
+ *   - L4 : prisma.user.findUnique → null branch
+ *   - LO-1 : whitelist reason invalide → throw
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/db/client", () => ({
+  prisma: {
+    session: { findFirst: vi.fn() },
+  },
+}))
+
+vi.mock("@/lib/services/audit.service", async (orig) => {
+  const actual = await orig<typeof import("@/lib/services/audit.service")>()
+  return {
+    ...actual,
+    auditService: {
+      ...actual.auditService,
+      requireStepUp: vi.fn().mockResolvedValue({ stepUpRow: {}, burstRow: null }),
+    },
+  }
+})
+
+import { prisma } from "@/lib/db/client"
+import {
+  STEP_UP_WINDOW_SECONDS,
+  STEP_UP_WINDOW_SECONDS_CRITICAL,
+  checkFreshMfa,
+  stepUpErrorResponse,
+} from "@/lib/auth/step-up"
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("checkFreshMfa — boundary 5 min (C2)", () => {
+  const setupSession = (mfaLastVerifiedAt: Date | null) => {
+    vi.mocked(prisma.session.findFirst).mockResolvedValue({
+      mfaLastVerifiedAt,
+      user: { mfaEnabled: true },
+    } as never)
+  }
+
+  it("4'59.9\" (299.9s) avant now → ok (fresh)", async () => {
+    setupSession(new Date(Date.now() - 299_900))
+    const r = await checkFreshMfa(42, "sess-x")
+    expect(r.ok).toBe(true)
+  })
+
+  it("5'00.0\" (300.0s) exact → stepUpRequired (sémantique `>=`)", async () => {
+    // Fixe l'invariant : à `ageSec === STEP_UP_WINDOW_SECONDS`, le code
+    // évalue `ageSec >= STEP_UP_WINDOW_SECONDS` = true → stepUpRequired.
+    // Un refactor `>` casserait la sécurité, ce test l'attrape.
+    setupSession(new Date(Date.now() - STEP_UP_WINDOW_SECONDS * 1000))
+    const r = await checkFreshMfa(42, "sess-x")
+    expect(r).toEqual({ ok: false, reason: "stepUpRequired" })
+  })
+
+  it("5'00.1\" (300.1s) → stepUpRequired", async () => {
+    setupSession(new Date(Date.now() - 300_100))
+    const r = await checkFreshMfa(42, "sess-x")
+    expect(r).toEqual({ ok: false, reason: "stepUpRequired" })
+  })
+
+  it("clock skew — mfaLastVerifiedAt 30s dans le futur (NTP desync) → ok", async () => {
+    // ageSec négatif = forcément < window → ok. Documente la tolérance.
+    setupSession(new Date(Date.now() + 30_000))
+    const r = await checkFreshMfa(42, "sess-x")
+    expect(r.ok).toBe(true)
+  })
+})
+
+describe("checkFreshMfa — per-route window override (H-4)", () => {
+  it("STEP_UP_WINDOW_SECONDS_CRITICAL = 60s → 90s ago = stale", async () => {
+    vi.mocked(prisma.session.findFirst).mockResolvedValue({
+      mfaLastVerifiedAt: new Date(Date.now() - 90_000),
+      user: { mfaEnabled: true },
+    } as never)
+    // Default window 5min → 90s ago est fresh
+    const defaultR = await checkFreshMfa(42, "sess-x")
+    expect(defaultR.ok).toBe(true)
+    // CRITICAL window 60s → 90s ago est stale
+    const criticalR = await checkFreshMfa(42, "sess-x", {
+      windowSeconds: STEP_UP_WINDOW_SECONDS_CRITICAL,
+    })
+    expect(criticalR).toEqual({ ok: false, reason: "stepUpRequired" })
+  })
+
+  it("custom window 30s (V1.5 anticipated env override)", async () => {
+    vi.mocked(prisma.session.findFirst).mockResolvedValue({
+      mfaLastVerifiedAt: new Date(Date.now() - 45_000),
+      user: { mfaEnabled: true },
+    } as never)
+    const r = await checkFreshMfa(42, "sess-x", { windowSeconds: 30 })
+    expect(r).toEqual({ ok: false, reason: "stepUpRequired" })
+  })
+})
+
+describe("stepUpErrorResponse — LO-1 whitelist", () => {
+  it("reason hors whitelist → throw (defense-in-depth)", async () => {
+    await expect(
+      // @ts-expect-error — intentional bad input
+      stepUpErrorResponse("unknownReason", 42, "sess-x", {
+        ipAddress: "x", userAgent: "x", requestId: "x",
+      }, { route: "x" }),
+    ).rejects.toThrow(/invalid reason/)
+  })
+})
+
+describe("checkFreshMfa — H5 priority enrollment > fresh", () => {
+  it("mfaEnabled=false MAIS mfaLastVerifiedAt récent → mfaEnrollmentRequired (priorité)", async () => {
+    vi.mocked(prisma.session.findFirst).mockResolvedValue({
+      mfaLastVerifiedAt: new Date(Date.now() - 60_000), // 1 min ago
+      user: { mfaEnabled: false },
+    } as never)
+    const r = await checkFreshMfa(42, "sess-x")
+    expect(r).toEqual({ ok: false, reason: "mfaEnrollmentRequired" })
+  })
+})

--- a/tests/unit/step-up.test.ts
+++ b/tests/unit/step-up.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests pour `src/lib/auth/step-up.ts` (Plan B follow-up A2).
+ *
+ * Couvre :
+ *   - `checkFreshMfa` retourne `stepUpRequired` si sessionId absent
+ *   - `mfaEnrollmentRequired` si user.mfaEnabled = false
+ *   - `stepUpRequired` si mfaLastVerifiedAt = null
+ *   - `stepUpRequired` si mfaLastVerifiedAt > 5 min
+ *   - `ok: true` si mfaLastVerifiedAt < 5 min
+ *   - `requireFreshMfa` throw `StepUpRequiredError`
+ *   - `stepUpErrorResponse` retourne 401 + WWW-Authenticate stepup
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/db/client", () => ({
+  prisma: {
+    session: { findFirst: vi.fn() },
+  },
+}))
+
+vi.mock("@/lib/services/audit.service", async (orig) => {
+  const actual = await orig<typeof import("@/lib/services/audit.service")>()
+  return {
+    ...actual,
+    auditService: {
+      ...actual.auditService,
+      log: vi.fn().mockResolvedValue({}),
+    },
+  }
+})
+
+import { prisma } from "@/lib/db/client"
+import { auditService } from "@/lib/services/audit.service"
+import {
+  STEP_UP_WINDOW_SECONDS,
+  checkFreshMfa,
+  requireFreshMfa,
+  stepUpErrorResponse,
+  StepUpRequiredError,
+} from "@/lib/auth/step-up"
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("checkFreshMfa", () => {
+  const userId = 42
+  const sessionId = "sess-abc"
+
+  it("sessionId absent → stepUpRequired (legacy JWT sans sid)", async () => {
+    const result = await checkFreshMfa(userId, undefined)
+    expect(result).toEqual({ ok: false, reason: "stepUpRequired" })
+    expect(prisma.session.findFirst).not.toHaveBeenCalled()
+  })
+
+  it("session not found → stepUpRequired (révoquée ou cross-user spoof)", async () => {
+    vi.mocked(prisma.session.findFirst).mockResolvedValue(null)
+    const result = await checkFreshMfa(userId, sessionId)
+    expect(result).toEqual({ ok: false, reason: "stepUpRequired" })
+  })
+
+  it("user.mfaEnabled = false → mfaEnrollmentRequired", async () => {
+    vi.mocked(prisma.session.findFirst).mockResolvedValue({
+      mfaLastVerifiedAt: null,
+      user: { mfaEnabled: false },
+    } as never)
+    const result = await checkFreshMfa(userId, sessionId)
+    expect(result).toEqual({ ok: false, reason: "mfaEnrollmentRequired" })
+  })
+
+  it("mfaLastVerifiedAt = null mais mfaEnabled = true → stepUpRequired", async () => {
+    vi.mocked(prisma.session.findFirst).mockResolvedValue({
+      mfaLastVerifiedAt: null,
+      user: { mfaEnabled: true },
+    } as never)
+    const result = await checkFreshMfa(userId, sessionId)
+    expect(result).toEqual({ ok: false, reason: "stepUpRequired" })
+  })
+
+  it("mfaLastVerifiedAt > 5 min → stepUpRequired", async () => {
+    const stale = new Date(Date.now() - (STEP_UP_WINDOW_SECONDS + 10) * 1000)
+    vi.mocked(prisma.session.findFirst).mockResolvedValue({
+      mfaLastVerifiedAt: stale,
+      user: { mfaEnabled: true },
+    } as never)
+    const result = await checkFreshMfa(userId, sessionId)
+    expect(result).toEqual({ ok: false, reason: "stepUpRequired" })
+  })
+
+  it("mfaLastVerifiedAt < 5 min → ok", async () => {
+    const fresh = new Date(Date.now() - 60_000) // 1 min ago
+    vi.mocked(prisma.session.findFirst).mockResolvedValue({
+      mfaLastVerifiedAt: fresh,
+      user: { mfaEnabled: true },
+    } as never)
+    const result = await checkFreshMfa(userId, sessionId)
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.verifiedAt).toEqual(fresh)
+  })
+
+  it("scope per-user — findFirst inclut userId dans le where", async () => {
+    vi.mocked(prisma.session.findFirst).mockResolvedValue(null)
+    await checkFreshMfa(userId, sessionId)
+    expect(prisma.session.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: sessionId, userId },
+      }),
+    )
+  })
+})
+
+describe("requireFreshMfa", () => {
+  it("throw StepUpRequiredError si pas fresh", async () => {
+    vi.mocked(prisma.session.findFirst).mockResolvedValue(null)
+    await expect(requireFreshMfa(42, "sess-x")).rejects.toThrow(StepUpRequiredError)
+    await expect(requireFreshMfa(42, "sess-x")).rejects.toMatchObject({
+      reason: "stepUpRequired",
+    })
+  })
+
+  it("retourne verifiedAt si fresh", async () => {
+    const fresh = new Date(Date.now() - 30_000)
+    vi.mocked(prisma.session.findFirst).mockResolvedValue({
+      mfaLastVerifiedAt: fresh,
+      user: { mfaEnabled: true },
+    } as never)
+    const result = await requireFreshMfa(42, "sess-x")
+    expect(result).toEqual(fresh)
+  })
+})
+
+describe("stepUpErrorResponse", () => {
+  const ctx = {
+    ipAddress: "1.2.3.4",
+    userAgent: "ua",
+    requestId: "req-id",
+  }
+
+  it("retourne 401 + WWW-Authenticate stepup + ANSSI no-store", async () => {
+    const res = await stepUpErrorResponse(
+      "stepUpRequired",
+      42,
+      "sess-x",
+      ctx,
+      { route: "admin/users/[id] PATCH" },
+    )
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json.error).toBe("stepUpRequired")
+    expect(res.headers.get("WWW-Authenticate")).toBe(
+      `stepup reason="stepUpRequired", realm="diabeo"`,
+    )
+    expect(res.headers.get("Cache-Control")).toContain("no-store")
+    expect(res.headers.get("Pragma")).toBe("no-cache")
+  })
+
+  it("audit MFA_STEP_UP_REQUIRED appelé avec route metadata", async () => {
+    await stepUpErrorResponse(
+      "mfaEnrollmentRequired",
+      42,
+      "sess-x",
+      ctx,
+      { route: "admin/users/[id] PATCH" },
+    )
+    expect(auditService.log).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(auditService.log).mock.calls[0]?.[0]).toMatchObject({
+      userId: 42,
+      action: "MFA_STEP_UP_REQUIRED",
+      resource: "SESSION",
+      resourceId: "sess-x",
+      metadata: {
+        route: "admin/users/[id] PATCH",
+        reason: "mfaEnrollmentRequired",
+      },
+    })
+  })
+
+  it("audit fail → response 401 quand-même retournée", async () => {
+    vi.mocked(auditService.log).mockRejectedValueOnce(new Error("DB down"))
+    const res = await stepUpErrorResponse(
+      "stepUpRequired",
+      42,
+      "sess-x",
+      ctx,
+      { route: "x" },
+    )
+    expect(res.status).toBe(401)
+  })
+})

--- a/tests/unit/step-up.test.ts
+++ b/tests/unit/step-up.test.ts
@@ -25,6 +25,7 @@ vi.mock("@/lib/services/audit.service", async (orig) => {
     auditService: {
       ...actual.auditService,
       log: vi.fn().mockResolvedValue({}),
+      requireStepUp: vi.fn().mockResolvedValue({ stepUpRow: {}, burstRow: null }),
     },
   }
 })
@@ -136,7 +137,7 @@ describe("stepUpErrorResponse", () => {
     requestId: "req-id",
   }
 
-  it("retourne 401 + WWW-Authenticate stepup + ANSSI no-store", async () => {
+  it("retourne 401 + WWW-Authenticate stepup + X-Step-Up-Required + ANSSI headers", async () => {
     const res = await stepUpErrorResponse(
       "stepUpRequired",
       42,
@@ -150,11 +151,16 @@ describe("stepUpErrorResponse", () => {
     expect(res.headers.get("WWW-Authenticate")).toBe(
       `stepup reason="stepUpRequired", realm="diabeo"`,
     )
+    // A2 round 2 H-3 — header custom pour clients qui ne parsent pas RFC 7235.
+    expect(res.headers.get("X-Step-Up-Required")).toBe("stepUpRequired")
+    // ANSSI RGS §4.5 — 4 headers de baseline.
     expect(res.headers.get("Cache-Control")).toContain("no-store")
     expect(res.headers.get("Pragma")).toBe("no-cache")
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff")
+    expect(res.headers.get("Referrer-Policy")).toBe("no-referrer")
   })
 
-  it("audit MFA_STEP_UP_REQUIRED appelé avec route metadata", async () => {
+  it("audit via requireStepUp (C-2 burst detection câblée)", async () => {
     await stepUpErrorResponse(
       "mfaEnrollmentRequired",
       42,
@@ -162,10 +168,9 @@ describe("stepUpErrorResponse", () => {
       ctx,
       { route: "admin/users/[id] PATCH" },
     )
-    expect(auditService.log).toHaveBeenCalledTimes(1)
-    expect(vi.mocked(auditService.log).mock.calls[0]?.[0]).toMatchObject({
+    expect(auditService.requireStepUp).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(auditService.requireStepUp).mock.calls[0]?.[0]).toMatchObject({
       userId: 42,
-      action: "MFA_STEP_UP_REQUIRED",
       resource: "SESSION",
       resourceId: "sess-x",
       metadata: {
@@ -175,8 +180,22 @@ describe("stepUpErrorResponse", () => {
     })
   })
 
-  it("audit fail → response 401 quand-même retournée", async () => {
-    vi.mocked(auditService.log).mockRejectedValueOnce(new Error("DB down"))
+  it("LO-2 — sessionId absent → resourceId='jwt-legacy-no-sid' + metadata.legacyJwt", async () => {
+    await stepUpErrorResponse(
+      "stepUpRequired",
+      42,
+      undefined,
+      ctx,
+      { route: "admin/users/[id] PATCH" },
+    )
+    expect(vi.mocked(auditService.requireStepUp).mock.calls[0]?.[0]).toMatchObject({
+      resourceId: "jwt-legacy-no-sid",
+      metadata: expect.objectContaining({ legacyJwt: true }),
+    })
+  })
+
+  it("audit fail → logger.warn + response 401 quand-même retournée (M-10)", async () => {
+    vi.mocked(auditService.requireStepUp).mockRejectedValueOnce(new Error("DB down"))
     const res = await stepUpErrorResponse(
       "stepUpRequired",
       42,
@@ -185,5 +204,6 @@ describe("stepUpErrorResponse", () => {
       { route: "x" },
     )
     expect(res.status).toBe(401)
+    // logger.warn not directly observed (no spy), but the catch path is exercised.
   })
 })


### PR DESCRIPTION
## Contexte

Plan B follow-up A2 — l'auth Diabeo actuelle (US-2002 MFA login) prouve MFA
**une seule fois** au login. Pendant les 24h de session, un attacker qui vole
la session peut exécuter n'importe quelle action ADMIN sans seconde preuve.
Le step-up force re-prouver MFA dans les 5 dernières minutes avant chaque
action sensible (pattern banking apps).

## Architecture

### Schema
- Migration `20260528150000_a2_step_up_mfa` — `Session.mfaLastVerifiedAt
  DateTime?` (nullable timestamptz, zero-downtime).

### Service
- `mfaService.stepUp(userId, sessionId, otp)` :
  - Verify OTP via `verifyOtp` existant (anti-replay TOTP préservé)
  - Bump `mfaLastVerifiedAt` via `updateMany WHERE id=sid AND userId=uid`
    (cross-user safe)
  - Retourne `Date` ou `null` sur échec.

### Endpoint
- `POST /api/auth/mfa/step-up { otp }` :
  - Requires JWT authenticated (middleware injecte `x-session-id`).
  - 401 `sessionRequired` si pas de sid (legacy JWT).
  - 403 `mfaEnrollmentRequired` si `mfaEnabled = false`.
  - 401 `invalidOtp` + audit `MFA_CHALLENGE_FAILED metadata.phase=step-up`.
  - 429 `rateLimitExceeded` (5/5min via `mfa-step-up:<userId>`).
  - 200 `{ verifiedAt, expiresAt }` + audit `MFA_STEP_UP_VERIFIED`.

### Helpers
- `checkFreshMfa(userId, sessionId)` — query unique (session + user.mfaEnabled
  jointure), retourne `{ ok: true, verifiedAt }` ou
  `{ ok: false, reason: \"stepUpRequired\" | \"mfaEnrollmentRequired\" }`.
- `stepUpErrorResponse(reason, userId, sessionId, ctx, { route })` —
  construit 401 + `WWW-Authenticate: stepup reason=\"...\", realm=\"diabeo\"`
  (RFC 7235) + Cache-Control no-store (ANSSI RGS §4.5). Émet audit
  `MFA_STEP_UP_REQUIRED` US-2265 burst detection.
- `STEP_UP_WINDOW_SECONDS = 5 * 60` constante centralisée.

### Cohérence MFA login
`createSession({ mfaVerified: true })` bumpe aussi `mfaLastVerifiedAt` au
moment du login MFA — l'UX ne demande pas de step-up immédiat.

## Adoption

- ✅ `PATCH /api/admin/users/[id]` (role/status change — privilege escalation)
- ✅ `POST /api/admin/data-breaches/[id]/transition` (FSM CNIL notif — impact externe)
- 📋 Documenté en runbook §8 : `cabinet/sms-config PUT`, `data-breaches/[id] PATCH`,
  `admin/users/[id]/jwt-revoke`, `admin/exports/data-breach POST`,
  `invalidateAllUserSessions` callers.

## Tests

- **+15 unit** — `step-up.test.ts` (9 cases : sessionId absent / not found /
  mfaEnabled false / lastVerifiedAt null / stale / fresh / scope per-user
  assertion / requireFreshMfa throw / response 401 ANSSI + audit) +
  `mfa.service.test.ts` (4 cases stepUp : OTP invalide / bump fresh / cross-user
  count=0 / anti-replay).
- **+10 integration** — `api-auth-mfa-step-up.test.ts` (6 cases :
  sessionRequired / validationFailed / mfaEnrollmentRequired / invalidOtp +
  audit / 429 rate-limit / 200 + verifiedAt + audit) +
  `api-admin-users-step-up.test.ts` (4 cases : stale → 401 stepUpRequired +
  WWW-Authenticate / mfaEnabled=false → 401 mfaEnrollmentRequired /
  legacy JWT → 401 / fresh → handler exécute).
- **Idempotency tests fix** : `api-admin-users-idempotency.test.ts` ajoute
  `x-session-id` header + mock `prisma.session.findFirst` retourne fresh MFA
  pour ne pas trigger step-up gate (cohérent — ces tests focalisent sur le
  wrapper idempotency, pas le step-up).

**2830/2830 verts** (2804 → 2830, +26 A2). Typecheck + ESLint propres.

## Runbook

`docs/runbook/step-up-mfa.md` — contrat client (WWW-Authenticate parsing
iOS/web), best practice frontend (`if 401 && stepup → prompt OTP → POST
step-up → retry`), audit forensique HDS, sécurité (anti-replay TOTP /
cross-user spoof / rate-limit / US-2265 burst), DPIA RGPD Art. 6.1.f, liste
routes candidates §8.

## Plan de test

- [ ] CI verte (typecheck + ESLint + 2830 tests + E2E + migrations drift)
- [ ] Review code-reviewer + healthcare-security-auditor
- [ ] Validation runbook par devops-engineer (UX iOS/web contract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)