### PR TITLE
fix(appointments): migrate Schedule-X calendar to v4 Temporal API

### DIFF
--- a/docs/UserStory/pro-user-stories/23-rdv/US-2500-UI-calendrier-rdv-pro.md
+++ b/docs/UserStory/pro-user-stories/23-rdv/US-2500-UI-calendrier-rdv-pro.md
@@ -190,6 +190,19 @@ Le backend RDV est livré et déployé en prod depuis **PR #392** (Groupe 8 RDV 
 - **Optimistic UI** : drag & drop applique localement avant PUT API, rollback si fail
 - **Tests** : 25-40 tests unit (composants calendrier, drag handler, modal) + 8-12 E2E Playwright (création/annulation/alternative workflow)
 
+### ⚠️ Contrainte Schedule-X v4 — Temporal (PR #466, session dev 2026-06-03)
+
+La stack retenue est `@schedule-x/*` v4. Contrairement à la v3, l'API v4 **n'accepte plus de strings ISO** :
+
+- `selectedDate` exige un `Temporal.PlainDate` (TC39 Temporal proposal).
+- `event.start` / `event.end` exigent un `Temporal.ZonedDateTime` (timed) ou `Temporal.PlainDate` (all-day).
+
+Conséquences pour le code (`adapter.ts` + `AppointmentCalendar.tsx`) :
+
+1. **Dépendance directe** : `temporal-polyfill` doit être déclaré dans `package.json` (pas seulement en peer transitive de `@schedule-x/calendar`) — sinon `pnpm install` le **prune silencieusement** → crash au mount du calendrier.
+2. **Side-effect import** : `import "temporal-polyfill/global"` est requis EN PLUS de l'import nommé `{ Temporal }`. Le bundle Schedule-X référence `Temporal` en **global** (`instanceof Temporal.PlainDate` dans `validateConfig`/`validateEvents`) ; sans le patch `globalThis`, les `instanceof` échouent (classes distinctes).
+3. **Wall-clock contract** : l'adapter construit les `ZonedDateTime` sur `Temporal.Now.timeZoneId()` (TZ navigateur), sans conversion — l'heure cabinet "09:30" stockée reste "09:30" affichée. V1.5 : `HealthcareService.timezone` (cf. en-tête `adapter.ts`).
+
 ---
 
 ## 🚫 Hors scope (reporté V2 ou autre US)

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "shadcn": "^4.1.1",
     "sharp": "^0.34.5",
     "tailwind-merge": "^3.5.0",
+    "temporal-polyfill": "0.3.0",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.3.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      temporal-polyfill:
+        specifier: 0.3.0
+        version: 0.3.0
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0

--- a/src/components/diabeo/appointments/AppointmentCalendar.tsx
+++ b/src/components/diabeo/appointments/AppointmentCalendar.tsx
@@ -43,6 +43,15 @@ import {
 import { createEventsServicePlugin } from "@schedule-x/events-service"
 import { createDragAndDropPlugin } from "@schedule-x/drag-and-drop"
 import "@schedule-x/theme-default/dist/index.css"
+// Schedule-X v4 — `selectedDate` et `event.start/.end` exigent des objets
+// `Temporal` (TC39). Le bundle Schedule-X référence `Temporal` en GLOBAL (sans
+// import) : il faut donc le side-effect `temporal-polyfill/global` pour patcher
+// `globalThis.Temporal`, sinon les `instanceof Temporal.PlainDate` de
+// `validateConfig` échouent (classes distinctes). L'import nommé sert à
+// construire les objets côté React. Les deux pointent vers la même classe
+// (chunks/classApi) → `instanceof` true. Cf. doc session dev 2026-06-03 §4.
+import "temporal-polyfill/global"
+import { Temporal } from "temporal-polyfill"
 import { useAppointments } from "./useAppointments"
 import {
   appointmentToScheduleXEvent,
@@ -319,7 +328,10 @@ export function AppointmentCalendar({
   const calendar = useNextCalendarApp({
     views: [createViewMonthGrid(), createViewWeek(), createViewDay()],
     events,
-    selectedDate: selectedDate.toISOString().split("T")[0],
+    // Schedule-X v4 — `selectedDate` n'accepte plus un string ISO `yyyy-mm-dd`
+    // (v3) mais un `Temporal.PlainDate`. On extrait la composante date du
+    // `Date` JS pour préserver le comportement (jour courant sélectionné).
+    selectedDate: Temporal.PlainDate.from(selectedDate.toISOString().split("T")[0]),
     locale: sxLocale,
     calendars: APPOINTMENT_CALENDARS,
     plugins: [eventsService, dragAndDropPlugin],

--- a/src/components/diabeo/appointments/adapter.ts
+++ b/src/components/diabeo/appointments/adapter.ts
@@ -20,10 +20,12 @@
  * et reminders RDV).
  *
  * Backend stocke `date` (yyyy-mm-dd) + `hour` (hh:mm:ss) séparément
- * (`@db.Date` + `@db.Time()` timezone-less). On combine en string locale
- * `"yyyy-mm-dd hh:mm"` attendue par Schedule-X (cf. docs sx events format).
+ * (`@db.Date` + `@db.Time()` timezone-less). On combine en
+ * `Temporal.ZonedDateTime` (Schedule-X v4 — l'ancien string
+ * `"yyyy-mm-dd hh:mm"` v3 est rejeté par `validateEvents`).
  *
- * `end` calculé via `durationMinutes` (defaults 30 min si null = legacy).
+ * `end` calculé via `durationMinutes` (defaults 30 min si null = legacy),
+ * additionné nativement par `ZonedDateTime.add` (rollover géré).
  *
  * Couleurs par statut (palette Sérénité Active + glycemia clinical) :
  *   - scheduled         → teal-600 (default cabinet)
@@ -37,13 +39,22 @@
  * avec defaults backend US-2505 (cf. `rdv.service` defaults).
  */
 
+import { Temporal } from "temporal-polyfill"
 import type { AppointmentListItem } from "./useAppointments"
 
 export interface ScheduleXEvent {
   id: string
   title: string
-  start: string // "yyyy-mm-dd hh:mm"
-  end: string // "yyyy-mm-dd hh:mm"
+  /**
+   * Schedule-X v4 — `start`/`end` doivent être des `Temporal.ZonedDateTime`
+   * (events "timed") ou `Temporal.PlainDate` (all-day). On utilise toujours
+   * `ZonedDateTime` ici (les RDV ont une heure ou un fallback 09:00).
+   *
+   * v3 utilisait un string `"yyyy-mm-dd hh:mm"` — `validateEvents`
+   * (`core.js`) le rejette désormais. Cf. doc session dev 2026-06-03 §5.
+   */
+  start: Temporal.ZonedDateTime
+  end: Temporal.ZonedDateTime
   calendarId?: string // Schedule-X calendars (color groups)
   /**
    * Fix US-2500-UI iter 7 — Schedule-X event options pour gater drag&drop +
@@ -90,41 +101,32 @@ const KNOWN_APPOINTMENT_TYPES = new Set(["ide", "diabeto", "hdj"])
 const UNSCHEDULED_CALENDAR_ID = "unscheduled"
 
 /**
- * Combine `date` (yyyy-mm-dd) + `hour` (hh:mm:ss) en `"yyyy-mm-dd hh:mm"`.
- * Renvoie null si `hour` est null (RDV sans heure = legacy, on les place
- * arbitrairement à 09:00 pour qu'ils apparaissent au début de la journée).
+ * Combine `date` (yyyy-mm-dd) + `hour` (hh:mm:ss) en un
+ * `Temporal.ZonedDateTime` (Schedule-X v4).
+ *
+ * RDV sans heure (`hour=null`, legacy) → fallback 09:00 pour qu'ils
+ * apparaissent en début de journée (signalés visuellement via
+ * `calendarId="unscheduled"`, cf. `UNSCHEDULED_CALENDAR_ID`).
+ *
+ * **Timezone wall-clock contract (cf. en-tête de fichier H-5)** : on
+ * construit le `ZonedDateTime` sur la timezone du navigateur
+ * (`Temporal.Now.timeZoneId()`) en y plaquant l'heure stockée telle quelle
+ * ("09:30" stocké → "09:30" affiché). Aucune conversion. V1.5 :
+ * `HealthcareService.timezone` quand le schema l'introduira.
  */
-function combineDateTime(date: string, hour: string | null): string {
+function combineDateTime(date: string, hour: string | null): Temporal.ZonedDateTime {
   // `date` est "yyyy-mm-dd" (ou ISO complet selon serializer JSON). Normaliser.
   const datePart = date.includes("T") ? date.split("T")[0] : date
-  if (!hour) return `${datePart} 09:00`
-  // `hour` est "hh:mm:ss" → garde "hh:mm"
-  const timePart = hour.includes("T") ? hour.split("T")[1].slice(0, 5) : hour.slice(0, 5)
-  return `${datePart} ${timePart}`
-}
-
-/**
- * Fix CR-3 round 2 review PR #431 — `Date.setMinutes` natif gère le
- * rollover minuit correctement. L'ancien `% 24` perdait les RDV soirée
- * (22:00 + 180min retournait `01:00` même jour au lieu de J+1 01:00),
- * ce qui produisait `end < start` côté Schedule-X (events corrompus).
- *
- * Use `Date(Date.UTC(...))` pour éviter de dépendre de la TZ locale du
- * navigateur ; on garde le wall-clock `yyyy-mm-dd hh:mm` (cohérent avec
- * `combineDateTime` qui ne convertit pas non plus).
- */
-function addMinutes(dateTime: string, minutes: number): string {
-  const [datePart, timePart] = dateTime.split(" ")
-  const [y, mo, d] = datePart.split("-").map(Number)
-  const [h, m] = timePart.split(":").map(Number)
-  const base = new Date(Date.UTC(y, mo - 1, d, h, m, 0))
-  base.setUTCMinutes(base.getUTCMinutes() + minutes)
-  const yy = base.getUTCFullYear()
-  const mm = String(base.getUTCMonth() + 1).padStart(2, "0")
-  const dd = String(base.getUTCDate()).padStart(2, "0")
-  const hh = String(base.getUTCHours()).padStart(2, "0")
-  const mi = String(base.getUTCMinutes()).padStart(2, "0")
-  return `${yy}-${mm}-${dd} ${hh}:${mi}`
+  // `hour` est "hh:mm:ss" (ou ISO complet) → garde "hh:mm". Fallback 09:00.
+  const timePart = !hour
+    ? "09:00"
+    : hour.includes("T")
+      ? hour.split("T")[1].slice(0, 5)
+      : hour.slice(0, 5)
+  // `PlainDateTime.from` exige un séparateur "T" ISO strict (pas l'espace v3).
+  return Temporal.PlainDateTime.from(`${datePart}T${timePart}`).toZonedDateTime(
+    Temporal.Now.timeZoneId(),
+  )
 }
 
 /**
@@ -137,7 +139,10 @@ function addMinutes(dateTime: string, minutes: number): string {
 export function appointmentToScheduleXEvent(appt: AppointmentListItem): ScheduleXEvent {
   const start = combineDateTime(appt.date, appt.hour)
   const durationMin = appt.durationMinutes ?? 30
-  const end = addMinutes(start, durationMin)
+  // `ZonedDateTime.add` gère nativement le rollover minuit/mois/année
+  // (ex: 22:00 + 180min → J+1 01:00) — plus de calcul manuel `% 24`
+  // (ancien fix CR-3 round 2 PR #431 désormais couvert par Temporal).
+  const end = start.add({ minutes: durationMin })
 
   // Fix L-3 — whitelist types : si type inconnu (ou PHI accidentelle),
   // afficher "OTHER" plutôt que `appt.type.toUpperCase()` raw.

--- a/tests/unit/AppointmentDetailModal.test.tsx
+++ b/tests/unit/AppointmentDetailModal.test.tsx
@@ -374,8 +374,14 @@ describe("<AppointmentDetailModal>", () => {
       expect(dateInput.value).toBe("2026-05-25")
       expect(timeInput.value).toBe("09:30")
 
-      // Change date+time
-      fireEvent.change(dateInput, { target: { value: "2026-06-01" } })
+      // Change date+time. The propose-alternative date input has `min={today}`
+      // and jsdom enforces rangeUnderflow on submit — so a hardcoded date in the
+      // past (relative to the wall clock) would block the submit and the POST
+      // would never fire. Compute a date safely in the future so the test is
+      // not a time-bomb (was hardcoded "2026-06-01", which broke once the clock
+      // passed that day).
+      const futureDate = new Date(Date.now() + 14 * 86_400_000).toISOString().split("T")[0]
+      fireEvent.change(dateInput, { target: { value: futureDate } })
       fireEvent.change(timeInput, { target: { value: "14:00" } })
       fireEvent.click(screen.getByText("actionConfirmPropose"))
 
@@ -386,7 +392,7 @@ describe("<AppointmentDetailModal>", () => {
             method: "POST",
             // Fix HSA-2-3 round 2 — suffix `Z` explicite pour forcer
             // l'interprétation UTC déterministe côté backend `z.coerce.date()`.
-            body: JSON.stringify({ alternativeAt: "2026-06-01T14:00:00Z" }),
+            body: JSON.stringify({ alternativeAt: `${futureDate}T14:00:00Z` }),
           }),
         )
       })

--- a/tests/unit/appointment-adapter.test.ts
+++ b/tests/unit/appointment-adapter.test.ts
@@ -38,61 +38,68 @@ function makeAppt(overrides: Partial<AppointmentListItem> = {}): AppointmentList
 }
 
 describe("appointmentToScheduleXEvent", () => {
+  // Schedule-X v4 — `start`/`end` sont des `Temporal.ZonedDateTime`. On
+  // assert sur `.toPlainDateTime().toString()` ("yyyy-mm-ddThh:mm:ss") pour
+  // une comparaison wall-clock indépendante de la timezone du runner CI
+  // (l'offset/zone de `.toString()` varie selon `Temporal.Now.timeZoneId()`).
+  const wall = (zdt: { toPlainDateTime(): { toString(): string } }) =>
+    zdt.toPlainDateTime().toString()
+
   describe("date/time combine", () => {
-    it("combine date yyyy-mm-dd + hour hh:mm:ss → 'yyyy-mm-dd hh:mm'", () => {
+    it("combine date yyyy-mm-dd + hour hh:mm:ss → ZonedDateTime wall-clock", () => {
       const evt = appointmentToScheduleXEvent(makeAppt())
-      expect(evt.start).toBe("2026-05-15 09:30")
+      expect(wall(evt.start)).toBe("2026-05-15T09:30:00")
     })
 
     it("supporte hour au format ISO complet (post-JSON serialization)", () => {
       const evt = appointmentToScheduleXEvent(
         makeAppt({ hour: "1970-01-01T09:30:00.000Z" }),
       )
-      expect(evt.start).toBe("2026-05-15 09:30")
+      expect(wall(evt.start)).toBe("2026-05-15T09:30:00")
     })
 
     it("hour=null fallback à 09:00 (V1 — TODO M-3 badge UI à venir)", () => {
       const evt = appointmentToScheduleXEvent(makeAppt({ hour: null }))
-      expect(evt.start).toBe("2026-05-15 09:00")
+      expect(wall(evt.start)).toBe("2026-05-15T09:00:00")
     })
   })
 
-  describe("addMinutes rollover (fix CR-3)", () => {
+  describe("end = start.add({ minutes }) rollover (fix CR-3 via Temporal)", () => {
     it("rollover minuit J → J+1 (22:00 + 180min → J+1 01:00)", () => {
       const evt = appointmentToScheduleXEvent(
         makeAppt({ hour: "22:00:00", durationMinutes: 180 }),
       )
-      expect(evt.start).toBe("2026-05-15 22:00")
-      expect(evt.end).toBe("2026-05-16 01:00")
+      expect(wall(evt.start)).toBe("2026-05-15T22:00:00")
+      expect(wall(evt.end)).toBe("2026-05-16T01:00:00")
     })
 
     it("rollover fin de mois (31 → 01 du mois suivant)", () => {
       const evt = appointmentToScheduleXEvent(
         makeAppt({ date: "2026-05-31", hour: "23:45:00", durationMinutes: 30 }),
       )
-      expect(evt.start).toBe("2026-05-31 23:45")
-      expect(evt.end).toBe("2026-06-01 00:15")
+      expect(wall(evt.start)).toBe("2026-05-31T23:45:00")
+      expect(wall(evt.end)).toBe("2026-06-01T00:15:00")
     })
 
     it("durée standard 30 min sans rollover", () => {
       const evt = appointmentToScheduleXEvent(
         makeAppt({ hour: "09:30:00", durationMinutes: 30 }),
       )
-      expect(evt.end).toBe("2026-05-15 10:00")
+      expect(wall(evt.end)).toBe("2026-05-15T10:00:00")
     })
 
     it("durée max 240 min ne corrompt pas si pas de rollover", () => {
       const evt = appointmentToScheduleXEvent(
         makeAppt({ hour: "08:00:00", durationMinutes: 240 }),
       )
-      expect(evt.end).toBe("2026-05-15 12:00")
+      expect(wall(evt.end)).toBe("2026-05-15T12:00:00")
     })
 
     it("fallback durationMinutes=null → 30 min", () => {
       const evt = appointmentToScheduleXEvent(
         makeAppt({ hour: "09:30:00", durationMinutes: null }),
       )
-      expect(evt.end).toBe("2026-05-15 10:00")
+      expect(wall(evt.end)).toBe("2026-05-15T10:00:00")
     })
   })
 

--- a/tests/unit/appointment-adapter.test.ts
+++ b/tests/unit/appointment-adapter.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { describe, it, expect } from "vitest"
+import { Temporal } from "temporal-polyfill"
 import {
   appointmentToScheduleXEvent,
   APPOINTMENT_CALENDARS,
@@ -380,5 +381,38 @@ describe("appointmentToScheduleXEvent", () => {
     it("comparaison idempotente : '09:00' === normalize('09:00:00')", () => {
       expect("09:00" === normalizeHourForCompare("09:00:00")).toBe(true)
     })
+  })
+})
+
+/**
+ * Fix F13 (review multi-agents PR #466) — preuve d'indépendance fuseau avec de
+ * VRAIS objets `Temporal` (et non un faux `{ toString }`). L'extracteur doit
+ * lire les composantes WALL-CLOCK locales quel que soit l'offset/la zone, et
+ * indépendamment du `TZ` du runner CI. Couvre aussi le gap "fake toString" :
+ * `extractDateHourFromScheduleXStart` consomme l'output réel de
+ * `Temporal.ZonedDateTime.toString()` / `Temporal.PlainDate.toString()`.
+ */
+describe("extractDateHourFromScheduleXStart — real Temporal objects (F13)", () => {
+  it("ZonedDateTime Europe/Paris (+02:00) → wall-clock local 14:30", () => {
+    const zdt = Temporal.ZonedDateTime.from("2026-05-26T14:30:00+02:00[Europe/Paris]")
+    expect(extractDateHourFromScheduleXStart(zdt)).toEqual({ date: "2026-05-26", hour: "14:30" })
+  })
+
+  it("ZonedDateTime America/New_York (-05:00) → wall-clock local 09:05 (offset-indépendant)", () => {
+    const zdt = Temporal.ZonedDateTime.from("2026-12-15T09:05:00-05:00[America/New_York]")
+    expect(extractDateHourFromScheduleXStart(zdt)).toEqual({ date: "2026-12-15", hour: "09:05" })
+  })
+
+  it("même wall-clock, zones différentes → même date/hour extraits", () => {
+    const paris = Temporal.ZonedDateTime.from("2026-05-26T14:30:00+02:00[Europe/Paris]")
+    const ny = Temporal.ZonedDateTime.from("2026-05-26T14:30:00-04:00[America/New_York]")
+    expect(extractDateHourFromScheduleXStart(paris)).toEqual(
+      extractDateHourFromScheduleXStart(ny),
+    )
+  })
+
+  it("PlainDate réel (all-day) → fallback hour 00:00", () => {
+    const pd = Temporal.PlainDate.from("2026-05-26")
+    expect(extractDateHourFromScheduleXStart(pd)).toEqual({ date: "2026-05-26", hour: "00:00" })
   })
 })


### PR DESCRIPTION
## Contexte

Session de tests `pnpm dev` du 2026-06-03 — la page `/appointments` crashait au mount du calendrier après l'upgrade `@schedule-x/*` v3 → v4.

## Problèmes corrigés (§4 + §5 doc session dev)

1. **`selectedDate must be a temporal plain date`** — v4 exige un `Temporal.PlainDate` (plus un string ISO `yyyy-mm-dd`).
2. **`Event start time needs to be a Temporal.ZonedDateTime or Temporal.PlainDate`** — v4 exige des objets Temporal pour `event.start/.end`.
3. **Root cause `temporal-polyfill` pruné** — peer dep transitive de `@schedule-x/calendar`, supprimée silencieusement par `pnpm install`.

## Changements

- **`package.json`** : `temporal-polyfill@0.3.0` déclaré en dep directe (anti-prune).
- **`AppointmentCalendar.tsx`** : side-effect import `temporal-polyfill/global` (Schedule-X référence `Temporal` en global → `instanceof` doit matcher la même classe) + `selectedDate` → `Temporal.PlainDate.from(...)`.
- **`adapter.ts`** : `ScheduleXEvent.start/.end` → `Temporal.ZonedDateTime` ; `combineDateTime` construit un `ZonedDateTime` (contrat wall-clock cabinet préservé, aucune conversion TZ) ; `end = start.add({ minutes })` remplace `addMinutes` (rollover minuit/mois/année natif Temporal — couvre l'ancien fix CR-3).
- **Tests adapter** : assertions sur `.toPlainDateTime().toString()` (wall-clock indépendant de la TZ du runner CI).

## Validation

- ✅ `vitest run tests/unit/appointment-adapter.test.ts` → 51/51 green
- ✅ `tsc --noEmit` → 0 erreur

## Notes / follow-ups hors scope

- `HealthcareService.timezone` (V1.5) : l'adapter utilise `Temporal.Now.timeZoneId()` (TZ navigateur) — un DOCTOR voyageant hors EU verrait un décalage. Documenté en tête de `adapter.ts`.
- Cohérence majors `@schedule-x/*` : `drag-and-drop` pinné v3.7.3 (pas de v4 publiée), reste en `^4.x` ailleurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)