### PR TITLE
fix(seed): encrypt seed PII so patient names decrypt (#474 §11)

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -164,19 +164,29 @@ async function main() {
     seedPassword("DEV-ONLY-Patient123!"),
   ])
 
+  // #474 §11 — Seed PII chiffrées exactement comme en production
+  // (AES-256-GCM base64). Sans ça, `patientService.safeDecrypt` (qui attend du
+  // base64 chiffré) échoue silencieusement sur du texte clair → renvoie `null`
+  // → les noms patients s'affichent "(?)" partout (liste, combobox, détail).
+  // `emailHmac` reste dérivé de l'email EN CLAIR → lookup login inchangé.
+  const encUserPII = (email: string, firstname: string, lastname: string) => ({
+    email: encryptField(email),
+    emailHmac: hmacEmail(email),
+    firstname: encryptField(firstname),
+    lastname: encryptField(lastname),
+  })
+
   const admin = await prisma.user.upsert({
     where: { emailHmac: hmacEmail("admin@diabeo.test") },
     // M4 — `update: {}` évite de re-hash bcrypt(12) à chaque seed run
     // (5×250ms gaspillés). Si tu veux resync les passwords après une
     // rotation, drop la DB (`docker compose down -v`) et reseed.
-    update: {},
+    // update re-chiffre les PII → répare les rows seedées en clair avant #474.
+    update: encUserPII("admin@diabeo.test", "Admin", "Test"),
     create: {
-      email: "admin@diabeo.test",
-      emailHmac: hmacEmail("admin@diabeo.test"),
+      ...encUserPII("admin@diabeo.test", "Admin", "Test"),
       passwordHash: adminPasswordHash,
       title: "M.",
-      firstname: "Admin",
-      lastname: "Test",
       role: Role.ADMIN,
       language: Language.fr,
       hasSignedTerms: true,
@@ -186,14 +196,11 @@ async function main() {
 
   const doctor = await prisma.user.upsert({
     where: { emailHmac: hmacEmail("docteur@diabeo.test") },
-    update: {},
+    update: encUserPII("docteur@diabeo.test", "Sophie", "Martin"),
     create: {
-      email: "docteur@diabeo.test",
-      emailHmac: hmacEmail("docteur@diabeo.test"),
+      ...encUserPII("docteur@diabeo.test", "Sophie", "Martin"),
       passwordHash: doctorPasswordHash,
       title: "Dr",
-      firstname: "Sophie",
-      lastname: "Martin",
       role: Role.DOCTOR,
       language: Language.fr,
       hasSignedTerms: true,
@@ -203,14 +210,11 @@ async function main() {
 
   const nurse = await prisma.user.upsert({
     where: { emailHmac: hmacEmail("infirmiere@diabeo.test") },
-    update: {},
+    update: encUserPII("infirmiere@diabeo.test", "Marie", "Dupont"),
     create: {
-      email: "infirmiere@diabeo.test",
-      emailHmac: hmacEmail("infirmiere@diabeo.test"),
+      ...encUserPII("infirmiere@diabeo.test", "Marie", "Dupont"),
       passwordHash: nursePasswordHash,
       title: "Mme",
-      firstname: "Marie",
-      lastname: "Dupont",
       role: Role.NURSE,
       language: Language.fr,
       hasSignedTerms: true,
@@ -220,13 +224,10 @@ async function main() {
 
   const patientUserDT1 = await prisma.user.upsert({
     where: { emailHmac: hmacEmail("patient.dt1@diabeo.test") },
-    update: {},
+    update: encUserPII("patient.dt1@diabeo.test", "Jean", "Durand"),
     create: {
-      email: "patient.dt1@diabeo.test",
-      emailHmac: hmacEmail("patient.dt1@diabeo.test"),
+      ...encUserPII("patient.dt1@diabeo.test", "Jean", "Durand"),
       passwordHash: patient1PasswordHash,
-      firstname: "Jean",
-      lastname: "Durand",
       sex: Sex.M,
       birthday: new Date("1990-03-15"),
       timezone: "Europe/Paris",
@@ -239,13 +240,10 @@ async function main() {
 
   const patientUserDT2 = await prisma.user.upsert({
     where: { emailHmac: hmacEmail("patient.dt2@diabeo.test") },
-    update: {},
+    update: encUserPII("patient.dt2@diabeo.test", "Claire", "Bernard"),
     create: {
-      email: "patient.dt2@diabeo.test",
-      emailHmac: hmacEmail("patient.dt2@diabeo.test"),
+      ...encUserPII("patient.dt2@diabeo.test", "Claire", "Bernard"),
       passwordHash: patient2PasswordHash,
-      firstname: "Claire",
-      lastname: "Bernard",
       sex: Sex.F,
       birthday: new Date("1975-08-22"),
       timezone: "Europe/Paris",
@@ -271,13 +269,10 @@ async function main() {
 
   const patientUserDT1Extra = await prisma.user.upsert({
     where: { emailHmac: hmacEmail("patient.dt1bis@diabeo.test") },
-    update: {},
+    update: encUserPII("patient.dt1bis@diabeo.test", "Lucas", "Petit"),
     create: {
-      email: "patient.dt1bis@diabeo.test",
-      emailHmac: hmacEmail("patient.dt1bis@diabeo.test"),
+      ...encUserPII("patient.dt1bis@diabeo.test", "Lucas", "Petit"),
       passwordHash: extraPatientsPasswordHash,
-      firstname: "Lucas",
-      lastname: "Petit",
       sex: Sex.M,
       birthday: new Date("1998-11-04"),
       timezone: "Europe/Paris",
@@ -290,13 +285,10 @@ async function main() {
 
   const patientUserDT2Extra = await prisma.user.upsert({
     where: { emailHmac: hmacEmail("patient.dt2bis@diabeo.test") },
-    update: {},
+    update: encUserPII("patient.dt2bis@diabeo.test", "Hélène", "Moreau"),
     create: {
-      email: "patient.dt2bis@diabeo.test",
-      emailHmac: hmacEmail("patient.dt2bis@diabeo.test"),
+      ...encUserPII("patient.dt2bis@diabeo.test", "Hélène", "Moreau"),
       passwordHash: extraPatientsPasswordHash,
-      firstname: "Hélène",
-      lastname: "Moreau",
       sex: Sex.F,
       birthday: new Date("1958-04-12"),
       timezone: "Europe/Paris",
@@ -309,13 +301,10 @@ async function main() {
 
   const patientUserGD = await prisma.user.upsert({
     where: { emailHmac: hmacEmail("patient.gd@diabeo.test") },
-    update: {},
+    update: encUserPII("patient.gd@diabeo.test", "Amélie", "Rousseau"),
     create: {
-      email: "patient.gd@diabeo.test",
-      emailHmac: hmacEmail("patient.gd@diabeo.test"),
+      ...encUserPII("patient.gd@diabeo.test", "Amélie", "Rousseau"),
       passwordHash: extraPatientsPasswordHash,
-      firstname: "Amélie",
-      lastname: "Rousseau",
       sex: Sex.F,
       birthday: new Date("1993-07-19"),
       timezone: "Europe/Paris",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -12,7 +12,7 @@ import {
 import { PrismaPg } from "@prisma/adapter-pg"
 import { hash as bcryptHash } from "bcryptjs"
 import { assertSeedEnv } from "../src/lib/env"
-import { hmacEmail } from "../src/lib/crypto/hmac"
+import { hmacEmail, hmacField } from "../src/lib/crypto/hmac"
 import { encryptField } from "../src/lib/crypto/fields"
 // Fix M3 round 1 review PR #453 (Issue #448) — static imports pour le bloc
 // 9.bis Messages messagerie (vs dynamic `await import(...)` qui n'apporte
@@ -143,8 +143,8 @@ async function main() {
   console.log(`  ✓ ${insulinCatalog.length} insulins seeded`)
 
   // ─── 1. Users (5) ─────────────────────────────────────────
-  // NOTE: In production, firstname/lastname/email must be encrypted.
-  // Seeds use plaintext for readability — this is dev-only data.
+  // PII (email/firstname/lastname) chiffrées AES-256-GCM comme en production
+  // via `encUserPII` (#474) — voir ci-dessous.
 
   // Parallélise les bcrypt(12) (~250ms chacun) — 5×250ms séquentiel devient
   // ~250ms total. Acceptable même si le seed est run rare.
@@ -168,12 +168,25 @@ async function main() {
   // (AES-256-GCM base64). Sans ça, `patientService.safeDecrypt` (qui attend du
   // base64 chiffré) échoue silencieusement sur du texte clair → renvoie `null`
   // → les noms patients s'affichent "(?)" partout (liste, combobox, détail).
-  // `emailHmac` reste dérivé de l'email EN CLAIR → lookup login inchangé.
+  //
+  // R1 (review) — `firstnameHmac`/`lastnameHmac` peuplés (via `hmacField`) :
+  // `patientService.search` + admin users cherchent EXCLUSIVEMENT par ces HMAC,
+  // sinon la recherche par nom ne retourne aucun user seedé.
+  // `emailHmac` n'est PAS dans ce helper (R2) : il est dérivé du clair et figure
+  // déjà dans le `where` de l'upsert + le `create` ci-dessous — l'inclure dans
+  // `update` produirait un `SET email_hmac` redondant sur une colonne @unique.
+  //
+  // R3 (review) — utilisé en `update` pour AUTO-RÉPARER les rows seedées en clair
+  // (avant #474) sans wipe DB. Effet de bord assumé : AES-GCM ré-encrypte avec un
+  // IV aléatoire à chaque `db seed`, donc le ciphertext de ces colonnes n'est PAS
+  // byte-stable entre runs (le plaintext déchiffré, lui, l'est ; aucun snapshot
+  // ne compare ces colonnes).
   const encUserPII = (email: string, firstname: string, lastname: string) => ({
     email: encryptField(email),
-    emailHmac: hmacEmail(email),
     firstname: encryptField(firstname),
+    firstnameHmac: hmacField(firstname),
     lastname: encryptField(lastname),
+    lastnameHmac: hmacField(lastname),
   })
 
   const admin = await prisma.user.upsert({
@@ -185,6 +198,7 @@ async function main() {
     update: encUserPII("admin@diabeo.test", "Admin", "Test"),
     create: {
       ...encUserPII("admin@diabeo.test", "Admin", "Test"),
+      emailHmac: hmacEmail("admin@diabeo.test"),
       passwordHash: adminPasswordHash,
       title: "M.",
       role: Role.ADMIN,
@@ -199,6 +213,7 @@ async function main() {
     update: encUserPII("docteur@diabeo.test", "Sophie", "Martin"),
     create: {
       ...encUserPII("docteur@diabeo.test", "Sophie", "Martin"),
+      emailHmac: hmacEmail("docteur@diabeo.test"),
       passwordHash: doctorPasswordHash,
       title: "Dr",
       role: Role.DOCTOR,
@@ -213,6 +228,7 @@ async function main() {
     update: encUserPII("infirmiere@diabeo.test", "Marie", "Dupont"),
     create: {
       ...encUserPII("infirmiere@diabeo.test", "Marie", "Dupont"),
+      emailHmac: hmacEmail("infirmiere@diabeo.test"),
       passwordHash: nursePasswordHash,
       title: "Mme",
       role: Role.NURSE,
@@ -227,6 +243,7 @@ async function main() {
     update: encUserPII("patient.dt1@diabeo.test", "Jean", "Durand"),
     create: {
       ...encUserPII("patient.dt1@diabeo.test", "Jean", "Durand"),
+      emailHmac: hmacEmail("patient.dt1@diabeo.test"),
       passwordHash: patient1PasswordHash,
       sex: Sex.M,
       birthday: new Date("1990-03-15"),
@@ -243,6 +260,7 @@ async function main() {
     update: encUserPII("patient.dt2@diabeo.test", "Claire", "Bernard"),
     create: {
       ...encUserPII("patient.dt2@diabeo.test", "Claire", "Bernard"),
+      emailHmac: hmacEmail("patient.dt2@diabeo.test"),
       passwordHash: patient2PasswordHash,
       sex: Sex.F,
       birthday: new Date("1975-08-22"),
@@ -272,6 +290,7 @@ async function main() {
     update: encUserPII("patient.dt1bis@diabeo.test", "Lucas", "Petit"),
     create: {
       ...encUserPII("patient.dt1bis@diabeo.test", "Lucas", "Petit"),
+      emailHmac: hmacEmail("patient.dt1bis@diabeo.test"),
       passwordHash: extraPatientsPasswordHash,
       sex: Sex.M,
       birthday: new Date("1998-11-04"),
@@ -288,6 +307,7 @@ async function main() {
     update: encUserPII("patient.dt2bis@diabeo.test", "Hélène", "Moreau"),
     create: {
       ...encUserPII("patient.dt2bis@diabeo.test", "Hélène", "Moreau"),
+      emailHmac: hmacEmail("patient.dt2bis@diabeo.test"),
       passwordHash: extraPatientsPasswordHash,
       sex: Sex.F,
       birthday: new Date("1958-04-12"),
@@ -304,6 +324,7 @@ async function main() {
     update: encUserPII("patient.gd@diabeo.test", "Amélie", "Rousseau"),
     create: {
       ...encUserPII("patient.gd@diabeo.test", "Amélie", "Rousseau"),
+      emailHmac: hmacEmail("patient.gd@diabeo.test"),
       passwordHash: extraPatientsPasswordHash,
       sex: Sex.F,
       birthday: new Date("1993-07-19"),

--- a/src/lib/services/patient.service.ts
+++ b/src/lib/services/patient.service.ts
@@ -124,16 +124,37 @@ function localDecryptField(value: string): string {
 }
 
 /**
- * #474 R4 — Throttle process-local du warn de `safeDecrypt`. `safeDecrypt` est
- * appelé ~16× par enregistrement sur les chemins de liste ; sans throttle, une
- * mauvaise clé / un dump restauré émettrait des centaines de warns par requête
- * (flooding Loki/OVH + corrélation volumétrique = fuite indirecte de la taille
- * de cohorte). On émet au plus 1 warn / fenêtre / process, avec le compteur
- * cumulé des occurrences supprimées (pattern aligné sur messaging.service).
+ * #474 R4 — Throttle du warn de `safeDecrypt`. `safeDecrypt` est appelé ~16× par
+ * enregistrement sur les chemins de liste ; sans throttle, une mauvaise clé / un
+ * dump restauré émettrait des centaines de warns par requête (flooding Loki/OVH
+ * + corrélation volumétrique = fuite indirecte de la taille de cohorte). On émet
+ * au plus 1 warn / fenêtre / process, en reportant le nombre d'occurrences
+ * supprimées depuis le dernier warn (`suppressedSinceLastLog`).
+ *
+ * RR1 (review round 2) — Le throttle est volontairement **process-global** (un
+ * seul compteur), PAS per-user comme `messaging.service`. Raison : `safeDecrypt`
+ * reçoit un `value` opaque sans `userId`/`patientId` en contexte → une clé
+ * per-entity est impossible sans changer la signature, et un échec isolé (1/min)
+ * émet quand même son warn (non masqué). Seul le scénario de masse est throttlé.
+ *
+ * RR2 (review round 2) — `suppressedSinceLastLog` est remis à 0 à chaque fenêtre
+ * (≠ cumul process-life) + cappé pour éviter tout overflow théorique et borner
+ * l'oracle volumétrique du log SOC.
  */
 const DECRYPT_WARN_WINDOW_MS = 60_000
+const DECRYPT_SUPPRESSED_CAP = 10_000_000
 let lastDecryptWarnAt = 0
 let suppressedDecryptWarns = 0
+
+/**
+ * Test-only — réinitialise l'état du throttle de `safeDecrypt` (RR4) pour que
+ * les specs partent d'un état déterministe (état module partagé entre tests).
+ * @internal
+ */
+export function __resetDecryptWarnThrottleForTests(): void {
+  lastDecryptWarnAt = 0
+  suppressedDecryptWarns = 0
+}
 
 /**
  * Safe decryption — returns null on error instead of throwing.
@@ -159,12 +180,12 @@ function safeDecrypt(value: string | null): string | null {
         "safeDecrypt failed — returning null (plaintext seed or corrupted ciphertext?)",
         {
           kind: "phi.decrypt.fail",
-          ...(suppressedDecryptWarns > 0 ? { cumulativeSuppressed: suppressedDecryptWarns } : {}),
+          ...(suppressedDecryptWarns > 0 ? { suppressedSinceLastLog: suppressedDecryptWarns } : {}),
         },
       )
       lastDecryptWarnAt = now
       suppressedDecryptWarns = 0
-    } else {
+    } else if (suppressedDecryptWarns < DECRYPT_SUPPRESSED_CAP) {
       suppressedDecryptWarns++
     }
     return null

--- a/src/lib/services/patient.service.ts
+++ b/src/lib/services/patient.service.ts
@@ -124,6 +124,18 @@ function localDecryptField(value: string): string {
 }
 
 /**
+ * #474 R4 — Throttle process-local du warn de `safeDecrypt`. `safeDecrypt` est
+ * appelé ~16× par enregistrement sur les chemins de liste ; sans throttle, une
+ * mauvaise clé / un dump restauré émettrait des centaines de warns par requête
+ * (flooding Loki/OVH + corrélation volumétrique = fuite indirecte de la taille
+ * de cohorte). On émet au plus 1 warn / fenêtre / process, avec le compteur
+ * cumulé des occurrences supprimées (pattern aligné sur messaging.service).
+ */
+const DECRYPT_WARN_WINDOW_MS = 60_000
+let lastDecryptWarnAt = 0
+let suppressedDecryptWarns = 0
+
+/**
  * Safe decryption — returns null on error instead of throwing.
  * Used in read operations to handle corrupted or missing data gracefully.
  * @private
@@ -135,11 +147,26 @@ function safeDecrypt(value: string | null): string | null {
   try {
     return localDecryptField(value)
   } catch {
-    // #474 §11 — Surfacer le swallow silencieux : un échec de déchiffrement
-    // signale soit des données seedées en clair (dev — corrigé par le seed
-    // chiffré), soit un PHI réellement corrompu (prod — incident à investiguer).
-    // Aucune valeur loggée (PHI/ciphertext potentiel).
-    logger.warn("patient.service", "safeDecrypt failed — returning null (plaintext seed or corrupted ciphertext?)")
+    // #474 §11 — Surfacer le swallow silencieux : un échec signale soit des
+    // données seedées en clair (dev — corrigé par le seed chiffré), soit un PHI
+    // réellement corrompu / mauvaise clé (prod — incident à investiguer).
+    // Aucune valeur loggée (PHI/ciphertext potentiel) ; throttlé (R4) ; `kind`
+    // pour le filtrage SOC (R7).
+    const now = Date.now()
+    if (now - lastDecryptWarnAt >= DECRYPT_WARN_WINDOW_MS) {
+      logger.warn(
+        "patient.service",
+        "safeDecrypt failed — returning null (plaintext seed or corrupted ciphertext?)",
+        {
+          kind: "phi.decrypt.fail",
+          ...(suppressedDecryptWarns > 0 ? { cumulativeSuppressed: suppressedDecryptWarns } : {}),
+        },
+      )
+      lastDecryptWarnAt = now
+      suppressedDecryptWarns = 0
+    } else {
+      suppressedDecryptWarns++
+    }
     return null
   }
 }

--- a/src/lib/services/patient.service.ts
+++ b/src/lib/services/patient.service.ts
@@ -16,6 +16,7 @@ import { encrypt, decrypt } from "@/lib/crypto/health-data"
 import { encryptField } from "@/lib/crypto/fields"
 import { hmacField, hmacEmail } from "@/lib/crypto/hmac"
 import { auditService, extractRequestContext } from "./audit.service"
+import { logger } from "@/lib/logger"
 import { Prisma } from "@prisma/client"
 import type { Pathology, Sex, PatientMedicalData } from "@prisma/client"
 
@@ -134,6 +135,11 @@ function safeDecrypt(value: string | null): string | null {
   try {
     return localDecryptField(value)
   } catch {
+    // #474 §11 — Surfacer le swallow silencieux : un échec de déchiffrement
+    // signale soit des données seedées en clair (dev — corrigé par le seed
+    // chiffré), soit un PHI réellement corrompu (prod — incident à investiguer).
+    // Aucune valeur loggée (PHI/ciphertext potentiel).
+    logger.warn("patient.service", "safeDecrypt failed — returning null (plaintext seed or corrupted ciphertext?)")
     return null
   }
 }

--- a/tests/manual/appointments-create.spec.ts
+++ b/tests/manual/appointments-create.spec.ts
@@ -131,9 +131,11 @@ test.describe("/appointments — création nouveau RDV", () => {
     // Le hook polling 60s ou le revalidate post-create rappelle GET
     // /api/appointments. On vérifie que le nouvel id est dans la liste.
     const created = postResponses[0].body as { id?: number } | null
+    // `toBeTypeOf` est un matcher Vitest, absent de l'`expect` Playwright
+    // (cassait `tsc -p tsconfig.json` car ce spec est typecheck par le projet).
     expect(
-      created?.id,
+      typeof created?.id,
       `réponse 201 sans id : ${JSON.stringify(created)}`,
-    ).toBeTypeOf("number")
+    ).toBe("number")
   })
 })

--- a/tests/unit/patient-safedecrypt-throttle.test.ts
+++ b/tests/unit/patient-safedecrypt-throttle.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Test suite: safeDecrypt warn throttle (#474 R4/RR4)
+ *
+ * Behavior tested:
+ * - `safeDecrypt` (exercised via `patientService.getById` on a record whose PII
+ *   columns are NOT valid ciphertext) emits at most ONE `logger.warn` per
+ *   throttle window (60s) per process, regardless of how many fields/records
+ *   fail to decrypt — preventing log flooding + volumetric correlation.
+ * - The throttled warn carries `kind: "phi.decrypt.fail"` (SOC filtering, R7)
+ *   and reports `suppressedSinceLastLog` on the next window's emission (RR2).
+ * - No PHI/PII/ciphertext value is ever passed to the logger.
+ *
+ * Risk mitigated:
+ * - A mis-rotated key or a restored dump would otherwise emit hundreds of warns
+ *   per list request and let a log observer infer cohort size.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { prismaMock } from "../helpers/prisma-mock"
+import { logger } from "@/lib/logger"
+import {
+  patientService,
+  __resetDecryptWarnThrottleForTests,
+} from "@/lib/services/patient.service"
+
+/** Patient row whose PII columns are plaintext (invalid ciphertext → decrypt fails). */
+function mockPlaintextPatient() {
+  prismaMock.patient.findFirst.mockResolvedValue({
+    id: 1,
+    userId: 10,
+    pathology: "DT1",
+    deletedAt: null,
+    user: {
+      id: 10,
+      firstname: "PlainTextName",
+      lastname: "PlainTextLast",
+      email: "plain@test.com",
+      sex: "M",
+      birthday: null,
+    },
+    medicalData: null,
+    cgmObjectives: null,
+    annexObjectives: null,
+  } as never)
+  prismaMock.auditLog.create.mockResolvedValue({} as never)
+}
+
+describe("safeDecrypt warn throttle (#474 R4)", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    __resetDecryptWarnThrottleForTests()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-06-04T10:00:00Z"))
+    warnSpy = vi.spyOn(logger, "warn")
+    mockPlaintextPatient()
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    vi.useRealTimers()
+  })
+
+  it("emits a single warn for multiple decrypt failures within one window", async () => {
+    // getById decrypts firstname + lastname + email → 3 safeDecrypt failures.
+    await patientService.getById(1, 1)
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const [scope, , ctx] = warnSpy.mock.calls[0]
+    expect(scope).toBe("patient.service")
+    expect(ctx).toMatchObject({ kind: "phi.decrypt.fail" })
+    // First emission of the window → nothing suppressed yet.
+    expect(ctx).not.toHaveProperty("suppressedSinceLastLog")
+  })
+
+  it("never passes a decrypted value or ciphertext to the logger", async () => {
+    await patientService.getById(1, 1)
+    const serialized = JSON.stringify(warnSpy.mock.calls)
+    expect(serialized).not.toContain("PlainTextName")
+    expect(serialized).not.toContain("PlainTextLast")
+    expect(serialized).not.toContain("plain@test.com")
+  })
+
+  it("reports suppressedSinceLastLog on the next window's emission", async () => {
+    // Window 1: warn #1 emitted, the 2 further failures of the same getById are suppressed.
+    await patientService.getById(1, 1)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+
+    // Advance past the throttle window.
+    vi.setSystemTime(new Date("2026-06-04T10:01:01Z"))
+
+    // Window 2: first failure emits again, now carrying the suppressed count.
+    await patientService.getById(1, 1)
+    expect(warnSpy).toHaveBeenCalledTimes(2)
+    const ctx2 = warnSpy.mock.calls[1][2]
+    expect(ctx2).toMatchObject({ kind: "phi.decrypt.fail", suppressedSinceLastLog: 2 })
+  })
+})

--- a/tests/unit/seed-runtime-hmac-consistency.test.ts
+++ b/tests/unit/seed-runtime-hmac-consistency.test.ts
@@ -45,3 +45,33 @@ describe("seed.ts uses the runtime hmacEmail (no local replica)", () => {
     expect(source).not.toMatch(/dev-seed-hmac-key-not-for-production/)
   })
 })
+
+/**
+ * RR3 (review round 2 PR #479) — Depuis #474, le seed dépend aussi de
+ * `hmacField` (firstnameHmac/lastnameHmac → recherche patient) et de
+ * `encryptField` (chiffrement PII). Ces deux helpers ont la même criticité que
+ * `hmacEmail` : une réplique locale accidentelle produirait un seed fonctionnel
+ * mais incohérent avec le runtime (recherche cassée / champs indéchiffrables).
+ */
+describe("seed.ts uses the runtime hmacField + encryptField (no local replica)", () => {
+  const source = fs.readFileSync(SEED_FILE, "utf8")
+
+  it("imports hmacField from src/lib/crypto/hmac", () => {
+    expect(source).toMatch(
+      /import\s*\{[^}]*\bhmacField\b[^}]*\}\s*from\s*["'](?:\.\.\/)+src\/lib\/crypto\/hmac["']/,
+    )
+  })
+
+  it("imports encryptField from src/lib/crypto/fields", () => {
+    expect(source).toMatch(
+      /import\s*\{[^}]*\bencryptField\b[^}]*\}\s*from\s*["'](?:\.\.\/)+src\/lib\/crypto\/fields["']/,
+    )
+  })
+
+  it("does NOT define a local hmacField / encryptField (would diverge from runtime)", () => {
+    expect(source).not.toMatch(/function\s+hmacField\s*\(/)
+    expect(source).not.toMatch(/(?:const|let|var)\s+hmacField\s*=/)
+    expect(source).not.toMatch(/function\s+encryptField\s*\(/)
+    expect(source).not.toMatch(/(?:const|let|var)\s+encryptField\s*=/)
+  })
+})


### PR DESCRIPTION
Closes #474.

## Bug (§11)

`/api/patients/search`, `/patients`, `/patients/[id]` et le `PatientCombobox` du modal « + Nouveau RDV » affichaient `firstname/lastname/email = null` → libellés "(?)" et "Aucun patient ne correspond".

**Cause** : `prisma/seed.ts` écrivait les PII en **clair** alors que `patientService.safeDecrypt` attend du base64 AES-256-GCM → le déchiffrement throw → `catch` silencieux → `null`.

## Fix

- **`prisma/seed.ts`** : helper `encUserPII(email, firstname, lastname)` chiffre les 3 champs via `encryptField`. `emailHmac` reste dérivé de l'email **en clair** → lookup login inchangé. Appliqué aux **8 users** seedés, dans `create` ET `update` (→ `pnpm prisma db seed` répare en place les rows déjà écrites en clair, pas besoin de wipe DB).
- **`patient.service.ts` `safeDecrypt`** : `logger.warn` dans le `catch` (aucune valeur loggée) — surface le swallow silencieux (seed clair en dev / PHI corrompu en prod).

## Bonus — CI

⚠️ `origin/main` était **rouge au `tsc`** depuis le merge des tests manuels : `tests/manual/appointments-create.spec.ts` utilisait `.toBeTypeOf` (matcher Vitest, absent de l'`expect` Playwright) et ce fichier est typecheck par le tsconfig projet (`**/*.ts`). Corrigé en `expect(typeof id).toBe("number")`. Sans ça, la CI Lint&TypeCheck échoue sur toutes les branches.

## Validation
- ✅ `tsc --noEmit` 0 erreur (corrige aussi le rouge pré-existant de main)
- ✅ `eslint` 0 · patient.service unit tests 28/28
- ℹ️ Vérif fonctionnelle complète : `pnpm prisma db seed` puis ouvrir `/patients` (noms réels attendus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)