### PR TITLE
fix(deps): pin preact >=10.25.0 so Schedule-X reactivity works (#477 §8 + #478 §10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,10 @@
     "onlyBuiltDependencies": [
       "@prisma/engines",
       "prisma"
-    ]
+    ],
+    "overrides": {
+      "preact": ">=10.25.0 <11"
+    }
   },
   "devDependencies": {
     "@apidevtools/swagger-parser": "^12.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  preact: '>=10.25.0 <11'
+
 importers:
 
   .:
@@ -22,7 +25,7 @@ importers:
         version: 7.6.0(prisma@7.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
       '@schedule-x/calendar':
         specifier: ^4.6.0
-        version: 4.6.0(@preact/signals@2.9.0(preact@10.24.3))(preact@10.24.3)(temporal-polyfill@0.3.0)
+        version: 4.6.0(@preact/signals@2.9.0(preact@10.29.2))(preact@10.29.2)(temporal-polyfill@0.3.0)
       '@schedule-x/drag-and-drop':
         specifier: 3.7.3
         version: 3.7.3
@@ -31,7 +34,7 @@ importers:
         version: 4.6.0
       '@schedule-x/react':
         specifier: ^4.1.0
-        version: 4.1.0(@schedule-x/calendar@4.6.0(@preact/signals@2.9.0(preact@10.24.3))(preact@10.24.3)(temporal-polyfill@0.3.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.1.0(@schedule-x/calendar@4.6.0(@preact/signals@2.9.0(preact@10.29.2))(preact@10.29.2)(temporal-polyfill@0.3.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@schedule-x/theme-default':
         specifier: ^4.6.0
         version: 4.6.0
@@ -1425,7 +1428,7 @@ packages:
   '@preact/signals@2.9.0':
     resolution: {integrity: sha512-hYrY0KyUqkDgOl1qba/JGn6y81pXnurn21PMaxfcMwdncdZ3M/oVdmpTvEnsGjh48dIwDVc7bjWHqIsngSjYug==}
     peerDependencies:
-      preact: '>= 10.25.0 || >=11.0.0-0'
+      preact: '>=10.25.0 <11'
 
   '@prisma/adapter-pg@7.8.0':
     resolution: {integrity: sha512-ygb3UkerK3v8MDpXVgCISdRNDozpxh6+JVJgiIGbSr5KBgz10LLf5ejUskPGoXlsIjxsOu6nuy1JVQr2EKGSlg==}
@@ -1713,7 +1716,7 @@ packages:
     resolution: {integrity: sha512-8Rf5bUf0DVphJB2BaudtG4IHkw21wgMJiiuk5o+7SIOq6YH4hkVJo+Kk12pWSfp2KTZ9mnnUuLV+szBVhiEPlg==}
     peerDependencies:
       '@preact/signals': ^2.0.2
-      preact: ^10.19.2
+      preact: '>=10.25.0 <11'
       temporal-polyfill: 0.3.0
 
   '@schedule-x/drag-and-drop@3.7.3':
@@ -4740,10 +4743,10 @@ packages:
   preact-render-to-string@6.5.11:
     resolution: {integrity: sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==}
     peerDependencies:
-      preact: '>=10'
+      preact: '>=10.25.0 <11'
 
-  preact@10.24.3:
-    resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
+  preact@10.29.2:
+    resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -5764,8 +5767,8 @@ snapshots:
       '@panva/hkdf': 1.2.1
       jose: 6.2.2
       oauth4webapi: 3.8.5
-      preact: 10.24.3
-      preact-render-to-string: 6.5.11(preact@10.24.3)
+      preact: 10.29.2
+      preact-render-to-string: 6.5.11(preact@10.29.2)
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -7173,10 +7176,10 @@ snapshots:
 
   '@preact/signals-core@1.14.2': {}
 
-  '@preact/signals@2.9.0(preact@10.24.3)':
+  '@preact/signals@2.9.0(preact@10.29.2)':
     dependencies:
       '@preact/signals-core': 1.14.2
-      preact: 10.24.3
+      preact: 10.29.2
 
   '@prisma/adapter-pg@7.8.0':
     dependencies:
@@ -7434,19 +7437,19 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
-  '@schedule-x/calendar@4.6.0(@preact/signals@2.9.0(preact@10.24.3))(preact@10.24.3)(temporal-polyfill@0.3.0)':
+  '@schedule-x/calendar@4.6.0(@preact/signals@2.9.0(preact@10.29.2))(preact@10.29.2)(temporal-polyfill@0.3.0)':
     dependencies:
-      '@preact/signals': 2.9.0(preact@10.24.3)
-      preact: 10.24.3
+      '@preact/signals': 2.9.0(preact@10.29.2)
+      preact: 10.29.2
       temporal-polyfill: 0.3.0
 
   '@schedule-x/drag-and-drop@3.7.3': {}
 
   '@schedule-x/events-service@4.6.0': {}
 
-  '@schedule-x/react@4.1.0(@schedule-x/calendar@4.6.0(@preact/signals@2.9.0(preact@10.24.3))(preact@10.24.3)(temporal-polyfill@0.3.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@schedule-x/react@4.1.0(@schedule-x/calendar@4.6.0(@preact/signals@2.9.0(preact@10.29.2))(preact@10.29.2)(temporal-polyfill@0.3.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@schedule-x/calendar': 4.6.0(@preact/signals@2.9.0(preact@10.24.3))(preact@10.24.3)(temporal-polyfill@0.3.0)
+      '@schedule-x/calendar': 4.6.0(@preact/signals@2.9.0(preact@10.29.2))(preact@10.29.2)(temporal-polyfill@0.3.0)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
@@ -10728,11 +10731,11 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
-  preact-render-to-string@6.5.11(preact@10.24.3):
+  preact-render-to-string@6.5.11(preact@10.29.2):
     dependencies:
-      preact: 10.24.3
+      preact: 10.29.2
 
-  preact@10.24.3: {}
+  preact@10.29.2: {}
 
   prelude-ls@1.2.1: {}
 

--- a/tests/unit/schedule-x-reactivity.test.ts
+++ b/tests/unit/schedule-x-reactivity.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+/**
+ * Régression #477 (§8) + #478 (§10) — réactivité Schedule-X (preact-signals).
+ *
+ * Root cause : `@preact/signals@2.x` exige `preact >= 10.25.0` ; une résolution
+ * basse (10.24.3) cassait silencieusement la réactivité signals → les mises à
+ * jour pilotées par signal de Schedule-X ne se propageaient plus :
+ *   - le sélecteur de vue ne s'ouvrait pas (classe `is-open` jamais ajoutée) — §8
+ *   - l'axe horaire de la vue Semaine restait vide (aucun `hour-text`) — §10
+ *
+ * Garde-fou : si un futur `pnpm install` ré-abaisse preact < 10.25.0 (override
+ * retiré dans package.json), ce test échoue. Il rend la vue Schedule-X v4 dans
+ * jsdom (avec stubs ResizeObserver/getBoundingClientRect que le navigateur
+ * fournit nativement) et vérifie que les deux comportements signal fonctionnent.
+ */
+import { describe, it, expect, beforeAll } from "vitest"
+import "temporal-polyfill/global"
+
+describe("Schedule-X v4 reactivity (preact-signals) — #477/#478 regression", () => {
+  beforeAll(() => {
+    // Le navigateur fournit ces APIs ; jsdom non. Schedule-X mesure le conteneur
+    // (ResizeObserver + getBoundingClientRect) pour calculer la grille horaire.
+    ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+      private cb: (entries: unknown[], obs: unknown) => void
+      constructor(cb: (entries: unknown[], obs: unknown) => void) { this.cb = cb }
+      observe(target: Element) {
+        this.cb([{ target, contentRect: { width: 900, height: 640, top: 0, left: 0, right: 900, bottom: 640 } }], this)
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+    if (!window.matchMedia) {
+      ;(window as unknown as { matchMedia: unknown }).matchMedia = () => ({
+        matches: false, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {},
+      })
+    }
+    Element.prototype.getBoundingClientRect = function () {
+      return { width: 900, height: 640, top: 0, left: 0, right: 900, bottom: 640, x: 0, y: 0, toJSON() {} } as DOMRect
+    }
+  })
+
+  it("week view time-axis renders hour labels and the view selector opens on click", async () => {
+    const { createCalendar, createViewWeek, createViewDay, createViewMonthGrid } =
+      (await import("@schedule-x/calendar")) as unknown as {
+        createCalendar: (cfg: unknown) => { render: (el: Element) => void }
+        createViewWeek: () => { name: string }
+        createViewDay: () => unknown
+        createViewMonthGrid: () => unknown
+      }
+
+    const el = document.createElement("div")
+    document.body.appendChild(el)
+    const week = createViewWeek()
+    createCalendar({
+      views: [createViewMonthGrid(), week, createViewDay()],
+      defaultView: week.name,
+      events: [],
+    }).render(el)
+    await new Promise((r) => setTimeout(r, 120))
+
+    // §10 — l'axe horaire est peuplé (24 heures par défaut).
+    const hourTexts = el.querySelectorAll(".sx__week-grid__hour-text")
+    expect(hourTexts.length).toBeGreaterThan(0)
+
+    // §8 — cliquer le bouton de sélection de vue ajoute `is-open` (signal réactif).
+    const selBtn = el.querySelector(".sx__view-selection-selected-item") as HTMLElement
+    expect(selBtn).toBeTruthy()
+    selBtn.click()
+    await new Promise((r) => setTimeout(r, 40))
+    expect(el.querySelector(".sx__view-selection")?.className).toContain("is-open")
+    expect(el.querySelectorAll(".sx__view-selection-item").length).toBeGreaterThan(0)
+  })
+})

--- a/tests/unit/schedule-x-reactivity.test.ts
+++ b/tests/unit/schedule-x-reactivity.test.ts
@@ -8,66 +8,127 @@
  *   - le sélecteur de vue ne s'ouvrait pas (classe `is-open` jamais ajoutée) — §8
  *   - l'axe horaire de la vue Semaine restait vide (aucun `hour-text`) — §10
  *
- * Garde-fou : si un futur `pnpm install` ré-abaisse preact < 10.25.0 (override
- * retiré dans package.json), ce test échoue. Il rend la vue Schedule-X v4 dans
- * jsdom (avec stubs ResizeObserver/getBoundingClientRect que le navigateur
- * fournit nativement) et vérifie que les deux comportements signal fonctionnent.
+ * Fix : `pnpm.overrides.preact: ">=10.25.0 <11"` (package.json) → preact@10.29.2.
+ * NB : l'override est une range (laisse les patchs de sécu) bornée `<11` car
+ * Schedule-X / @preact/signals ne sont pas testés contre preact 11 — à relever
+ * lors d'une future migration. L'override touche aussi la dep preact bundlée de
+ * `@auth/core` (SSR next-auth), mais c'est inerte ici (next-auth = types only,
+ * ADR #16).
+ *
+ * Deux garde-fous :
+ *   1. assertion déterministe sur `preact.version` — échoue immédiatement si
+ *      l'override est retiré (le vrai filet anti-régression de package.json) ;
+ *   2. rendu fonctionnel de Schedule-X v4 en jsdom (stubs ResizeObserver /
+ *      getBoundingClientRect / matchMedia que le navigateur fournit nativement),
+ *      vérifiant axe horaire peuplé + sélecteur de vue qui s'ouvre.
  */
-import { describe, it, expect, beforeAll } from "vitest"
+import { describe, it, expect, beforeAll, afterAll } from "vitest"
+import { waitFor } from "@testing-library/react"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
 import "temporal-polyfill/global"
 
+// preact n'est pas une dep directe (override only) → on lit la version RÉSOLUE
+// depuis le lockfile (source de vérité de la CI `--frozen-lockfile`).
+// Vitest exécute depuis la racine du repo (process.cwd()).
+const LOCKFILE = readFileSync(join(process.cwd(), "pnpm-lock.yaml"), "utf8")
+
+interface CalendarApp {
+  render: (el: Element) => void
+}
+interface ScheduleXModule {
+  createCalendar: (cfg: unknown) => CalendarApp
+  createViewWeek: () => { name: string }
+  createViewDay: () => unknown
+  createViewMonthGrid: () => unknown
+}
+
+const FAKE_RECT: DOMRect = {
+  width: 900, height: 640, top: 0, left: 0, right: 900, bottom: 640, x: 0, y: 0,
+  toJSON() { return {} },
+}
+
 describe("Schedule-X v4 reactivity (preact-signals) — #477/#478 regression", () => {
-  beforeAll(() => {
-    // Le navigateur fournit ces APIs ; jsdom non. Schedule-X mesure le conteneur
-    // (ResizeObserver + getBoundingClientRect) pour calculer la grille horaire.
-    ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
-      private cb: (entries: unknown[], obs: unknown) => void
-      constructor(cb: (entries: unknown[], obs: unknown) => void) { this.cb = cb }
-      observe(target: Element) {
-        this.cb([{ target, contentRect: { width: 900, height: 640, top: 0, left: 0, right: 900, bottom: 640 } }], this)
-      }
-      unobserve() {}
-      disconnect() {}
-    }
-    if (!window.matchMedia) {
-      ;(window as unknown as { matchMedia: unknown }).matchMedia = () => ({
-        matches: false, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {},
-      })
-    }
-    Element.prototype.getBoundingClientRect = function () {
-      return { width: 900, height: 640, top: 0, left: 0, right: 900, bottom: 640, x: 0, y: 0, toJSON() {} } as DOMRect
+  // Garde-fou direct (F4) : si l'override package.json est retiré, le lockfile
+  // re-résout preact < 10.25.0 et CETTE assertion échoue de façon déterministe
+  // (avant même le rendu jsdom ci-dessous).
+  it("every resolved preact in the lockfile satisfies @preact/signals (>= 10.25.0)", () => {
+    const versions = [...LOCKFILE.matchAll(/preact@(10\.\d+\.\d+)/g)].map((m) => m[1])
+    expect(versions.length).toBeGreaterThan(0)
+    for (const v of versions) {
+      const minor = Number(v.split(".")[1])
+      expect(
+        minor,
+        `preact ${v} < 10.25.0 → réactivité @preact/signals cassée (#477/#478) — override retiré ?`,
+      ).toBeGreaterThanOrEqual(25)
     }
   })
 
-  it("week view time-axis renders hour labels and the view selector opens on click", async () => {
-    const { createCalendar, createViewWeek, createViewDay, createViewMonthGrid } =
-      (await import("@schedule-x/calendar")) as unknown as {
-        createCalendar: (cfg: unknown) => { render: (el: Element) => void }
-        createViewWeek: () => { name: string }
-        createViewDay: () => unknown
-        createViewMonthGrid: () => unknown
+  describe("functional render in jsdom", () => {
+    let originalGBCR: typeof Element.prototype.getBoundingClientRect
+    let originalRO: typeof globalThis.ResizeObserver | undefined
+    let originalMatchMedia: typeof window.matchMedia | undefined
+
+    beforeAll(() => {
+      // jsdom ne fournit pas ces APIs. On sauvegarde puis restaure (anti-pollution
+      // des autres tests jsdom — F1).
+      originalGBCR = Element.prototype.getBoundingClientRect
+      originalRO = globalThis.ResizeObserver
+      originalMatchMedia = window.matchMedia
+
+      class StubResizeObserver implements ResizeObserver {
+        private cb: ResizeObserverCallback
+        constructor(cb: ResizeObserverCallback) { this.cb = cb }
+        observe(target: Element) {
+          this.cb([{ target, contentRect: FAKE_RECT } as ResizeObserverEntry], this)
+        }
+        unobserve() {}
+        disconnect() {}
       }
+      globalThis.ResizeObserver = StubResizeObserver
+      Element.prototype.getBoundingClientRect = () => FAKE_RECT
+      if (!window.matchMedia) {
+        window.matchMedia = ((): MediaQueryList => ({
+          matches: false, media: "", onchange: null,
+          addEventListener() {}, removeEventListener() {},
+          addListener() {}, removeListener() {}, dispatchEvent() { return false },
+        })) as typeof window.matchMedia
+      }
+    })
 
-    const el = document.createElement("div")
-    document.body.appendChild(el)
-    const week = createViewWeek()
-    createCalendar({
-      views: [createViewMonthGrid(), week, createViewDay()],
-      defaultView: week.name,
-      events: [],
-    }).render(el)
-    await new Promise((r) => setTimeout(r, 120))
+    afterAll(() => {
+      Element.prototype.getBoundingClientRect = originalGBCR
+      if (originalRO) globalThis.ResizeObserver = originalRO
+      else delete (globalThis as { ResizeObserver?: unknown }).ResizeObserver
+      if (originalMatchMedia) window.matchMedia = originalMatchMedia
+    })
 
-    // §10 — l'axe horaire est peuplé (24 heures par défaut).
-    const hourTexts = el.querySelectorAll(".sx__week-grid__hour-text")
-    expect(hourTexts.length).toBeGreaterThan(0)
+    it("week view time-axis renders hour labels and the view selector opens on click", async () => {
+      const { createCalendar, createViewWeek, createViewDay, createViewMonthGrid } =
+        (await import("@schedule-x/calendar")) as unknown as ScheduleXModule
 
-    // §8 — cliquer le bouton de sélection de vue ajoute `is-open` (signal réactif).
-    const selBtn = el.querySelector(".sx__view-selection-selected-item") as HTMLElement
-    expect(selBtn).toBeTruthy()
-    selBtn.click()
-    await new Promise((r) => setTimeout(r, 40))
-    expect(el.querySelector(".sx__view-selection")?.className).toContain("is-open")
-    expect(el.querySelectorAll(".sx__view-selection-item").length).toBeGreaterThan(0)
+      const el = document.createElement("div")
+      document.body.appendChild(el)
+      const week = createViewWeek()
+      createCalendar({
+        views: [createViewMonthGrid(), week, createViewDay()],
+        defaultView: week.name,
+        events: [],
+      }).render(el)
+
+      // §10 — axe horaire peuplé (24h par défaut). Polling (F2) vs setTimeout fixe.
+      await waitFor(() => {
+        expect(el.querySelectorAll(".sx__week-grid__hour-text").length).toBeGreaterThan(0)
+      })
+
+      // §8 — cliquer le sélecteur de vue ajoute `is-open` (signal réactif).
+      const selBtn = el.querySelector<HTMLButtonElement>(".sx__view-selection-selected-item")
+      expect(selBtn).toBeTruthy()
+      selBtn!.click()
+      await waitFor(() => {
+        expect(el.querySelector(".sx__view-selection")?.className).toContain("is-open")
+        expect(el.querySelectorAll(".sx__view-selection-item").length).toBeGreaterThan(0)
+      })
+    })
   })
 })


### PR DESCRIPTION
Closes #477 (§8 sélecteur de vue), closes #478 (§10 axe horaire).

## Root cause (les 2 bugs, 1 fix)

`@schedule-x/calendar@4.6.0` utilise `@preact/signals@2.9.0` pour sa réactivité, qui **exige `preact >= 10.25.0`**. pnpm avait résolu **`preact@10.24.3`** (via le peer plus large `^10.19.2` de Schedule-X), **en-dessous** du minimum de signals v2 → les re-renders pilotés par signal cassaient silencieusement :

- **§8 (#477)** : le sélecteur de vue ne s'ouvrait jamais (le clic n'ajoutait pas `is-open` — l'update du signal `isOpen` n'était pas reflété).
- **§10 (#478)** : l'axe horaire de la vue Semaine restait vide (le signal `gridSteps` qui peuple `.sx__week-grid__hour-text` ne se propageait pas).

## Fix

`pnpm.overrides.preact: ">=10.25.0 <11"` → résout **preact@10.29.2** (satisfait `@preact/signals@2.9.0`). preact n'est utilisé que par les internals de Schedule-X (l'app tourne en React 19) → bump isolé, sans impact applicatif.

## Vérification (sans navigateur)

Sonde jsdom **avant** : `hourTexts=0`, clic → pas de `is-open`. **Après** bump : `hourTexts=24`, clic → `is-open` + 3 items de vue. Capturé en **test de non-régression** `tests/unit/schedule-x-reactivity.test.ts` (rend Schedule-X v4 vue Semaine dans jsdom avec stubs ResizeObserver/getBoundingClientRect, et vérifie axe horaire peuplé + sélecteur de vue qui s'ouvre).

- ✅ `tsc` 0 · `eslint` 0 · tests RDV 95/95
- ℹ️ Les specs Playwright manuelles (`tests/manual/appointments-view-switch` / `-time-axis`) devraient maintenant passer en navigateur headed (hors CI) — à confirmer côté toi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)