### PR TITLE
docs(qa): plan de tests QA par écran — lot 1 (cœur MVP, 13 écrans)

### DIFF
--- a/docs/qa/01-auth.md
+++ b/docs/qa/01-auth.md
@@ -1,0 +1,152 @@
+# QA — Authentification
+
+Écrans : `/login`, `/reset-password`. Voir [conventions](README.md#3-conventions--légende).
+
+---
+
+## Écran : Connexion (`/login`) 🟢
+
+**Rôle / RBAC** : public (non authentifié). Après succès, redirection selon rôle :
+DOCTOR → `/medecin`, NURSE → `/infirmier`, ADMIN → `/admin`, VIEWER → `/patient/dashboard`.
+**Statut impl.** : 🟢 Réel (`POST /api/auth/login` + `sessions` + JWT cookie).
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Logo Diabeo + titre « Bienvenue » | visible |
+| Champ email | vide, type `email`, requis |
+| Champ mot de passe | vide, type `password` + bouton bascule visibilité |
+| Bouton « Connexion » | **désactivé** si email ou mot de passe vide |
+| Lien « Mot de passe oublié ? » | → `/reset-password` |
+| Lien « Créer un compte » | → `/register` ⚠️ (voir cas limites — page inexistante) |
+| Mention « Hébergement HDS » | visible en pied |
+| État chargement | bouton « Connexion en cours… », champs désactivés |
+| État rate-limit | bannière rouge « Compte verrouillé. Réessayez dans X » + compte à rebours, champs/bouton désactivés |
+| État erreur | bannière jaune « Identifiants invalides » + bouton fermer |
+| Champ MFA (conditionnel) | apparaît si `mfaRequired:true` — input numérique 6 chiffres, auto-focus |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Soumettre identifiants valides (sans MFA) | `POST /api/auth/login` | redirection vers home du rôle | INSERT `sessions` (token, expires +24 h, ip, ua) · INSERT `audit_logs` (`LOGIN`/`SESSION`) · cookie httpOnly `diabeo_token` |
+| Soumettre identifiants valides (MFA activée) | `POST /api/auth/login` puis `POST /api/auth/mfa/challenge` | affichage champ OTP, puis redirection | login renvoie `{mfaRequired,mfaToken}` (TTL court) ; session complète créée après OTP valide |
+| Soumettre identifiants invalides | `POST /api/auth/login` → 401 | bannière « Identifiants invalides » + focus email | INSERT `audit_logs` (`UNAUTHORIZED`) · incrément compteur rate-limit (Redis) |
+| 3+ échecs | `POST /api/auth/login` → 429 | bannière verrouillage + countdown | lockout progressif 5 / 15 / 60 min |
+| Clic « Mot de passe oublié ? » | — | navigation `/reset-password` | aucun |
+
+### Scénarios (Gherkin)
+
+```gherkin
+Feature: Connexion au backoffice
+
+  Scenario: DOCTOR se connecte avec des identifiants valides
+    Given je suis sur "/login"
+    When je remplis "email" avec "docteur@diabeo.test"
+    And je remplis "mot de passe" avec "DEV-ONLY-Doctor123!"
+    And je clique "Connexion"
+    Then je suis redirigé vers "/medecin"
+    And un cookie httpOnly "diabeo_token" est présent
+    # Effet base: INSERT sessions (userId=docteur, expires≈now+24h) + audit_logs(action=LOGIN, resource=SESSION)
+
+  Scenario: bouton désactivé tant que le formulaire est incomplet
+    Given je suis sur "/login"
+    Then le bouton "Connexion" est désactivé
+    When je remplis "email" avec "docteur@diabeo.test"
+    Then le bouton "Connexion" est désactivé
+    When je remplis "mot de passe" avec "DEV-ONLY-Doctor123!"
+    Then le bouton "Connexion" est activé
+
+  Scenario: identifiants invalides — message générique anti-énumération
+    Given je suis sur "/login"
+    When je remplis "email" avec "inconnu@diabeo.test"
+    And je remplis "mot de passe" avec "mauvais"
+    And je clique "Connexion"
+    Then je vois "Identifiants invalides"
+    And je reste sur "/login"
+    # Effet base: audit_logs(action=UNAUTHORIZED, resource=SESSION, userId=null) + incrément rate-limit Redis
+    # Note: message IDENTIQUE pour email inexistant / mot de passe faux / compte suspendu
+
+  Scenario: verrouillage après 3 échecs
+    Given je suis sur "/login"
+    When j'échoue la connexion 3 fois avec "docteur@diabeo.test"
+    Then je vois un message de verrouillage avec un compte à rebours
+    And le bouton "Connexion" est désactivé
+    # Effet base: lockout Redis (5 min au 3e échec, 15 au 4e, 60 au 5e+)
+
+  Scenario: connexion avec MFA activée
+    Given un utilisateur avec MFA activée
+    And je suis sur "/login"
+    When je soumets des identifiants valides
+    Then le champ code MFA apparaît
+    When je saisis un code TOTP valide à 6 chiffres
+    Then je suis redirigé vers le home de mon rôle
+    # Effet base: session créée seulement APRÈS validation OTP (mfaVerified=true)
+```
+
+### Cas limites
+
+- **Anti-énumération** : même message « Identifiants invalides » pour email
+  inexistant / mot de passe faux / compte suspendu. `bcrypt.compare` exécuté
+  même si l'utilisateur n'existe pas (dummy hash) → pas de timing oracle.
+- **Compte suspendu** (`status≠active`) : 401 générique, **sans** incrément
+  rate-limit (anti-DoS : un attaquant ne peut pas re-verrouiller un compte déjà
+  suspendu).
+- **Token MFA pending expiré** (> ~5 min) : OTP rejeté (401), recommencer le login.
+- ⚠️ **Lien « Créer un compte » → `/register`** : la page `(auth)/register`
+  **n'existe pas** (`src/app/(auth)/login/page.tsx:224`). Cliquer mène à un 404.
+  → **À corriger** : retirer le lien ou créer la page (selon le scope produit).
+
+---
+
+## Écran : Mot de passe oublié (`/reset-password`) 🟢
+
+**Rôle / RBAC** : public.
+**Statut impl.** : 🟢 Réel (`POST /api/auth/reset-password`, anti-énumération + anti-timing).
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Titre « Réinitialiser le mot de passe » | visible |
+| Champ email | vide, requis |
+| Bouton « Réinitialiser » | désactivé si email vide ; « Envoi… » en cours |
+| Lien « Retour à la connexion » | → `/login` |
+| État succès (après envoi) | check vert + « Si un compte existe avec cet email, un lien de réinitialisation a été envoyé. » |
+| État erreur réseau | « Vérifiez votre connexion réseau. » |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Soumettre un email **existant** | `POST /api/auth/reset-password` → 200 | écran succès générique | DELETE puis INSERT `verification_token` (TTL 1 h) · email envoyé (best-effort) · INSERT `audit_logs` (`UPDATE`/`USER`, `password_reset_requested`) |
+| Soumettre un email **inexistant** | `POST /api/auth/reset-password` → 200 | **même** écran succès | aucune écriture (silencieux) |
+
+### Scénarios (Gherkin)
+
+```gherkin
+Feature: Réinitialisation du mot de passe
+
+  Scenario: demande pour un email existant
+    Given je suis sur "/reset-password"
+    When je remplis "email" avec "docteur@diabeo.test"
+    And je clique "Réinitialiser"
+    Then je vois "un lien de réinitialisation a été envoyé"
+    # Effet base: verification_token (identifier=emailHmac, expires≈now+1h) + audit_logs(UPDATE/USER)
+
+  Scenario: demande pour un email inexistant — réponse identique (anti-énumération)
+    Given je suis sur "/reset-password"
+    When je remplis "email" avec "personne@diabeo.test"
+    And je clique "Réinitialiser"
+    Then je vois "un lien de réinitialisation a été envoyé"
+    # Effet base: AUCUNE (pas de token, pas d'email, pas d'audit)
+```
+
+### Cas limites
+
+- **Réponse 200 identique** quel que soit l'email (existant ou non) +
+  délai aléatoire 500–800 ms côté serveur (anti-timing).
+- **Rate-limit** : clé Redis `reset:{emailHash}`, même progression que le login.
+- **Échec déchiffrement email** : le token est créé mais l'email ne part pas
+  (loggé en erreur) → l'utilisateur ne reçoit rien (cas de données corrompues).

--- a/docs/qa/02-dashboards.md
+++ b/docs/qa/02-dashboards.md
@@ -1,0 +1,184 @@
+# QA — Tableaux de bord par rôle
+
+Écrans : `/medecin` (DOCTOR), `/infirmier` (NURSE), `/patient/dashboard` (VIEWER).
+Voir [conventions](README.md#3-conventions--légende).
+
+> Les 3 dashboards sont **en lecture seule** : aucune action n'écrit en base.
+> Les écritures viennent des écrans cibles (patient, RDV…). Les cartes
+> rafraîchissent par **polling** ; un indicateur « données obsolètes » apparaît
+> si la dernière donnée dépasse le seuil de fraîcheur.
+
+---
+
+## Écran : Dashboard Médecin (`/medecin`) 🟢
+
+**Rôle / RBAC** : DOCTOR, NURSE, ADMIN. Sinon → `/login` (VIEWER → `/patient/dashboard`).
+**Statut impl.** : 🟢 Réel (4 endpoints `GET /api/dashboard/medecin/*`, lecture seule).
+
+### Affichage attendu
+
+| Bloc | État attendu |
+|---|---|
+| Titre « Tableau de bord médecin » | visible |
+| **Urgences en cours** | liste ≤ 5 triée par criticité (badge sévérité + patient + valeur) · vide : « Aucune urgence » · polling 30 s · bannière « obsolète » si > 60 s |
+| **RDV du jour** | liste ≤ 3 (badge heure, `imminent` si < 30 min, patient, Visio/Présence) · vide : « Aucun RDV » · polling 5 min |
+| **Patients à suivre** | liste ≤ 3 (avatar, lien `/patients/{id}`, badge raison, métrique) · polling 5 min |
+| **KPI cabinet 14 j** | 4 cartes (Patients actifs, TIR moyen %, Urgences 7 j, Propositions en attente) · loading = « — » + skeleton |
+| États communs | loading (spinner), erreur (« Impossible de charger… ») |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Clic sur un patient (urgence / à suivre / RDV) | — (navigation) | va sur `/patients/{id}` | aucun |
+| Polling automatique | `GET /api/dashboard/medecin/{urgencies,appointments,patients-at-risk,kpi}` | cartes mises à jour | **lecture seule** (scope portefeuille) ; `patients-at-risk` requiert DOCTOR |
+
+### Scénarios (Gherkin)
+
+```gherkin
+Feature: Dashboard médecin
+
+  Scenario: affichage des 4 blocs pour un DOCTOR
+    Given je suis connecté en tant que "DOCTOR"
+    When je vais sur "/medecin"
+    Then je vois le bloc "Urgences en cours"
+    And je vois le bloc "RDV du jour"
+    And je vois le bloc "Patients à suivre"
+    And je vois le bloc "KPI cabinet — 14 derniers jours"
+    # Effet base: AUCUN (lecture seule) ; 4 GET /api/dashboard/medecin/* renvoient 200
+
+  Scenario: clic sur un patient à risque ouvre sa fiche
+    Given je suis connecté en tant que "DOCTOR"
+    And je suis sur "/medecin"
+    When je clique sur un patient du bloc "Patients à suivre"
+    Then je suis redirigé vers une URL "/patients/{id}"
+
+  Scenario: un VIEWER ne peut pas accéder au dashboard médecin
+    Given je suis connecté en tant que "VIEWER"
+    When je vais sur "/medecin"
+    Then je suis redirigé vers "/patient/dashboard"
+```
+
+### Cas limites
+
+- **VIEWER** sur `/medecin` → redirigé vers `/patient/dashboard` (layout).
+- **Session expirée** → les `GET` renvoient 401 → cartes affichent « Impossible
+  de charger… ».
+- **Bloc « Patients à suivre »** requiert le rôle DOCTOR (403 pour NURSE).
+
+---
+
+## Écran : Dashboard Infirmier (`/infirmier`) 🟢
+
+**Rôle / RBAC** : NURSE, DOCTOR, ADMIN. Sinon redirection.
+**Statut impl.** : 🟢 Réel (4 endpoints `GET /api/dashboard/infirmier/*`, lecture seule).
+
+### Affichage attendu
+
+| Bloc | État attendu |
+|---|---|
+| Titre « Tableau de bord infirmier » | visible |
+| **Ma journée (KPI)** | 4 cartes (RDV à préparer, Événements à valider, Urgences observées, Propositions à connaître) · polling 60 s |
+| **To-do du jour** | liste ≤ 20 triée par score (badge type, lien patient, action, deadline) · vide : « Aucune tâche » · polling 60 s · **lecture seule (pas de checkbox V1)** |
+| **Coordination équipe** | liste DelegationRequest (badge statut, direction ⇩/⇧, action, date) · polling 60 s · **lecture seule (chat V2)** |
+| **Relances en attente** | liste patients (avatar, badge raison, métrique, boutons « Appeler » `tel:` / « SMS » `sms:`) · polling 120 s |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Clic patient (to-do / relance) | — | `/patients/{id}` | aucun |
+| Clic « Appeler » / « SMS » | — (`tel:` / `sms:` natif) | ouvre le client natif | aucun |
+| Polling | `GET /api/dashboard/infirmier/{kpi,todo,team-inbox,recall-list}` | cartes mises à jour | **lecture seule** |
+
+### Scénarios (Gherkin)
+
+```gherkin
+Feature: Dashboard infirmier
+
+  Scenario: affichage des blocs pour un NURSE
+    Given je suis connecté en tant que "NURSE"
+    When je vais sur "/infirmier"
+    Then je vois le bloc "Ma journée"
+    And je vois le bloc "To-do du jour"
+    And je vois le bloc "Coordination équipe"
+    And je vois le bloc "Relances en attente"
+    # Effet base: AUCUN (lecture seule)
+
+  Scenario: bouton Appeler masqué si le téléphone patient est absent/invalide
+    Given je suis connecté en tant que "NURSE"
+    And je suis sur "/infirmier"
+    When un patient de la liste "Relances" n'a pas de téléphone valide
+    Then le bouton "Appeler" n'est pas affiché pour ce patient
+```
+
+### Cas limites
+
+- Numéro de téléphone validé par regex avant d'exposer `tel:`/`sms:`.
+- « Aucune tâche » est un message explicite (pas une absence silencieuse).
+
+---
+
+## Écran : Dashboard Patient (`/patient/dashboard`) 🟢
+
+**Rôle / RBAC** : VIEWER uniquement. Autres rôles → home de leur rôle.
+**Statut impl.** : 🟢 Réel. **Consentement RGPD requis** : chaque `GET` renvoie
+403 `gdprConsentRequired` si le consentement n'est pas donné.
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Titre « Mon tableau de bord » + sous-titre « Aperçu des N derniers jours » | N selon sélecteur |
+| **Sélecteur période** | 1W / 2W / 1M / 3M (défaut 1W) |
+| **4 cartes KPI** | Temps dans la cible (TIR %), Glycémie moyenne (mg/dL), Variabilité (CV %), HbA1c estimée (GMI %) — « — » si absent |
+| **Graphique CGM 24 h** | courbe + zone cible 70–180, hauteur ~320 px (fenêtre 24 h fixe, indépendante du sélecteur) |
+| **AGP (profil ambulatoire)** | graphique percentiles selon période |
+| **Actions rapides** | boutons → toast « Bientôt disponible » (V2) |
+| États erreur | bannière `role="alert"` par section (indépendantes) |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Changer la période | `GET /api/analytics/glycemic-profile?period=…` + `…/agp?period=…` | KPI + AGP rechargés ; CGM 24 h inchangé | **lecture seule** (audit READ) |
+| Chargement initial | 3 `GET` parallèles : `/api/cgm`, `/api/analytics/glycemic-profile`, `/api/analytics/agp` | sections remplies | **lecture seule** |
+| Clic action rapide | — | toast « Bientôt disponible » 2,5 s | aucun |
+
+### Scénarios (Gherkin)
+
+```gherkin
+Feature: Dashboard patient
+
+  Scenario: le patient voit ses indicateurs glycémiques
+    Given je suis connecté en tant que "VIEWER" avec consentement RGPD donné
+    When je vais sur "/patient/dashboard"
+    Then je vois la carte "Temps dans la cible"
+    And je vois le graphique CGM sur 24 h
+    # Effet base: AUCUN (lecture seule) ; GET /api/cgm + /api/analytics/* renvoient 200
+
+  Scenario: changement de période recharge KPI et AGP mais pas le CGM 24h
+    Given je suis sur "/patient/dashboard"
+    When je sélectionne la période "1M"
+    Then le sous-titre indique "30 derniers jours"
+    And les cartes KPI sont rechargées
+    And le graphique CGM affiche toujours les dernières 24 h
+
+  Scenario: consentement RGPD manquant bloque l'affichage des données
+    Given je suis connecté en tant que "VIEWER" sans consentement RGPD
+    When je vais sur "/patient/dashboard"
+    Then je vois "Acceptez la politique de confidentialité"
+    # Effet base: GET /api/cgm renvoie 403 gdprConsentRequired
+```
+
+### Cas limites
+
+- **Consentement absent** → 403 `gdprConsentRequired` → message « Acceptez la
+  politique de confidentialité dans vos préférences ».
+- **Session expirée** → 401 → « Session expirée. Reconnectez-vous. »
+- **Rate-limit analytics** → 429 + `Retry-After` → « Service temporairement
+  indisponible ».
+- **Sections indépendantes** : si CGM OK mais métriques KO, seule la section
+  métriques affiche l'erreur.
+- Pas d'indicateur « obsolète » ici (fetch one-shot au montage, contrairement
+  aux dashboards pro).

--- a/docs/qa/03-patients.md
+++ b/docs/qa/03-patients.md
@@ -1,0 +1,227 @@
+# QA — Patients
+
+Écrans : `/patients`, `/patients/[id]`, `/patients/new`.
+Voir [conventions](README.md#3-conventions--légende).
+
+> ⚠️ **Important QA** : les écrans **liste** et **détail** affichent actuellement
+> des **DEMO_DATA** synthétiques (`src/app/(dashboard)/patients/page.tsx`,
+> `.../[id]/page.tsx`). Les routes API réelles existent et sont testables au
+> niveau **contrat** (auth, RBAC, chiffrement, audit), mais l'UI ne les consomme
+> pas encore. → Tester en 2 volets : *affichage (demo)* et *contrat API (réel)*.
+> Le **wizard de création** (`/patients/new`), lui, appelle la **vraie** API.
+
+---
+
+## Écran : Liste patients (`/patients`) 🟡
+
+**Rôle / RBAC** : NURSE+ (NURSE, DOCTOR, ADMIN). ADMIN voit tout ; DOCTOR/NURSE
+via `PatientService → HealthcareService`. Patients soft-deleted exclus.
+**Statut impl.** : 🟡 DEMO_DATA pour l'affichage · 🟢 `GET /api/patients/search` réel.
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Titre « Patients » | visible |
+| Barre de recherche | placeholder « Rechercher un patient… » |
+| Filtres pathologie | boutons [Tous] [DT1] [DT2] [GD] · sélectionné en teal |
+| Bouton « + Ajouter patient » | → `/patients/new` |
+| Colonnes table | Patient (+ badge « Inactif »), Pathologie (badge couleur), Âge, Dernière glycémie (mg/dL ou « — »), TIR (% + badge qualité), Dernière sync, chevron |
+| Compteur | « N patient(s) » |
+| État vide | « Aucun patient trouvé » / « Aucun patient trouvé pour « X » » |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Recherche par nom | (demo : filtre client) · réel : `GET /api/patients/search?search=…` | liste filtrée | **lecture** · audit READ (`resourceId:"search"`) · `Cache-Control: no-store` · match **HMAC exact** sur `firstnameHmac`/`lastnameHmac` |
+| Filtre pathologie | (demo : filtre client) | bouton actif + liste filtrée | aucun |
+| Clic ligne | — | `/patients/{id}` | (déclenche le détail) |
+| Clic « Ajouter patient » | — | `/patients/new` | aucun |
+
+### Scénarios (Gherkin)
+
+```gherkin
+Feature: Liste des patients
+
+  Scenario: un NURSE accède à la liste
+    Given je suis connecté en tant que "NURSE"
+    When je vais sur "/patients"
+    Then je vois la barre de recherche "Rechercher un patient"
+    And je vois les filtres "DT1", "DT2", "GD"
+
+  Scenario: filtrer par pathologie DT1
+    Given je suis sur "/patients"
+    When je clique le filtre "DT1"
+    Then seules les lignes de pathologie "DT1" sont affichées
+    And le filtre "DT1" est visuellement actif
+
+  Scenario: la recherche réelle utilise un match HMAC exact (contrat API)
+    Given je suis connecté en tant que "NURSE"
+    When j'appelle GET "/api/patients/search?search=Durand"
+    Then la réponse est 200 avec en-tête "Cache-Control: no-store"
+    # Effet base: audit_logs(action=READ, resource=PATIENT, resourceId="search")
+    # Note: recherche par nom EXACT (HMAC), pas de recherche partielle (protection PHI)
+
+  Scenario: un VIEWER ne peut pas lister les patients
+    Given je suis connecté en tant que "VIEWER"
+    When j'appelle GET "/api/patients"
+    Then la réponse est 401 ou 403
+```
+
+### Cas limites
+
+- **Recherche = match exact** (HMAC), pas de recherche partielle/trigramme
+  (protection PHI). Taper un nom partiel ne renvoie rien côté API réelle.
+- **Soft-delete** : patients `deletedAt != null` jamais listés.
+- **Consentement** : la liste réelle filtre `shareWithProviders=true`.
+
+---
+
+## Écran : Détail patient (`/patients/[id]`) 🟡
+
+**Rôle / RBAC** : NURSE+ avec `canAccessPatient(user, role, patientId)`. 403
+`forbidden` si pas d'accès, 404 `patientNotFound` si soft-deleted, 400
+`invalidPatientId` si non numérique.
+**Statut impl.** : 🟡 DEMO_DATA pour l'affichage · 🟢 `GET /api/patients/[id]`,
+`PUT/PATCH /api/patient/objectives` réels.
+
+### Affichage attendu
+
+| Onglet | Contenu attendu |
+|---|---|
+| En-tête | « {nom} \| {pathologie} — {âge} ans — Suivi par {référent} » |
+| **Vue d'ensemble** | 4 KPI (Glycémie actuelle, TIR 7 j + badge, GMI, CV + badge) · carte profil (pathologie, diagnostic, sexe, âge, référent, glycémie moyenne 14 j, objectifs) · donut TIR 7 j |
+| **Glycémie** | « Profil glycémique (24 h) » + CgmChart 288 points + zones cibles |
+| **Traitements** | carte insulinothérapie (méthode, pompe, insuline bolus, basal moyen, ICR, ISF) · « Aucun traitement complémentaire enregistré » |
+| **Documents** | « Aucun document enregistré » |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Chargement page (réel) | `GET /api/patients/{id}` | onglets remplis (PII déchiffrée) | **lecture** · audit READ (`resource:PATIENT`, `metadata.patientId`) |
+| Changer d'onglet | — | onglet affiché | aucun |
+| Éditer objectifs CGM (DOCTOR) | `PUT /api/patient/objectives` | toast « Objectifs mis à jour » | UPSERT `cgm_objective` · audit UPDATE (`resource:OBJECTIVE`, `metadata.kind:"cgm"`) |
+| Éditer objectifs annexes (DOCTOR) | `PATCH /api/patient/objectives` | toast | UPSERT `annex_objective` · audit UPDATE (`metadata.kind:"annex"`) |
+
+> Bornes Zod objectifs CGM (g/L) : `veryLow ∈ [0.30,1.00]`, `low ∈ [0.40,1.50]`,
+> `ok ∈ [1.00,3.00]`, `high ∈ [1.50,5.00]`, ordre strict `veryLow<low<ok<high`,
+> `titrLow<titrHigh`. Annexes : `hba1c ∈ [4.0,14.0]`, `poids ∈ [20,300]` kg,
+> `minWeight ≤ maxWeight`, `walk ∈ [0,600]` min/j.
+
+### Scénarios (Gherkin)
+
+```gherkin
+Feature: Détail patient
+
+  Scenario: un DOCTOR ouvre la fiche d'un patient de son portefeuille
+    Given je suis connecté en tant que "DOCTOR"
+    When j'appelle GET "/api/patients/1"
+    Then la réponse est 200 avec les PII déchiffrées
+    # Effet base: audit_logs(action=READ, resource=PATIENT, resourceId="1", metadata.patientId=1)
+
+  Scenario: accès refusé à un patient hors portefeuille (anti-énumération)
+    Given je suis connecté en tant que "DOCTOR"
+    When j'appelle GET "/api/patients/9999" pour un patient hors de mon cabinet
+    Then la réponse est 403 "forbidden"
+
+  Scenario: patient soft-deleted renvoie 404
+    Given un patient avec deletedAt non nul
+    When j'appelle GET "/api/patients/{id}"
+    Then la réponse est 404 "patientNotFound"
+
+  Scenario: un DOCTOR met à jour les objectifs glycémiques
+    Given je suis connecté en tant que "DOCTOR"
+    When je PUT "/api/patient/objectives" avec veryLow=0.54 low=0.70 ok=1.80 high=2.50
+    Then la réponse est 200
+    And je vois "Objectifs mis à jour"
+    # Effet base: UPSERT cgm_objective + audit_logs(UPDATE/OBJECTIVE, metadata.kind="cgm")
+
+  Scenario: objectifs hors bornes cliniques rejetés
+    Given je suis connecté en tant que "DOCTOR"
+    When je PUT "/api/patient/objectives" avec ok=0.50 (sous la borne)
+    Then la réponse est 400 "validationFailed"
+    # Effet base: AUCUNE écriture
+```
+
+### Cas limites
+
+- 400 `invalidPatientId` (id non numérique), 403 `forbidden`, 404
+  `patientNotFound`, 403 `gdprConsentRequired`.
+- Édition objectifs réservée **DOCTOR** (NURSE en lecture).
+
+---
+
+## Écran : Création patient — wizard (`/patients/new`) 🟢
+
+**Rôle / RBAC** : NURSE+. `POST /api/patients`.
+**Statut impl.** : 🟢 Réel (couvert par le test manuel `tests/manual/patients-new.spec.ts`).
+
+### Affichage attendu
+
+| Étape | Contenu attendu |
+|---|---|
+| Barre progression | 2 barres (étape active en teal) |
+| **Étape 1 — Identité** | « Ces données seront chiffrées » · Email* · Prénom* · Nom* · Sexe (Homme/Femme/Autre) · Date de naissance (optionnelle) · [Annuler] [Suivant] |
+| **Étape 2 — Pathologie** | radios DT1 / DT2 / GD (sélection en teal) · Année du diagnostic (1900–année courante, optionnelle) · [Retour] [Créer patient] |
+| Bouton « Suivant » | désactivé si email invalide OU prénom/nom vides |
+| Bouton « Créer patient » | « Création en cours… » pendant l'envoi · désactivé si année invalide |
+| Erreur | bannière critique en haut |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Étape 1 → 2 / Retour | — (local) | change d'étape | aucun |
+| Annuler | — | `/patients` | aucun |
+| Soumettre | `POST /api/patients` (header `X-Requested-With` requis) | succès → redirection `/patients/{id}` · erreur → bannière | **transaction Prisma** : INSERT `users` (PII chiffrées + HMAC, role VIEWER, `needPasswordUpdate`), INSERT `patients` (pathology), INSERT `patient_medical_data` (yearDiag), INSERT `verification_token` (invitation 1 h) · 2× `audit_logs` (CREATE USER + CREATE PATIENT) · email invitation best-effort |
+
+> Validation Zod : email RFC max 254 (trim+lowercase), prénom/nom 1–100, sexe
+> ∈ {M,F,X}, birthday ∈ [1900, today], pathology ∈ {DT1,DT2,GD} requis,
+> yearDiag ∈ [1900, année courante]. Body ≤ 16 KB.
+
+### Scénarios (Gherkin)
+
+```gherkin
+Feature: Création d'un patient (wizard 2 étapes)
+
+  Scenario: création réussie par un DOCTOR
+    Given je suis connecté en tant que "DOCTOR"
+    And je suis sur "/patients/new"
+    When je remplis "email" avec un email unique
+    And je remplis "prénom" avec "Test" et "nom" avec "QA"
+    And je clique "Suivant"
+    And je sélectionne la pathologie "DT1"
+    And je clique "Créer patient"
+    Then la réponse de POST "/api/patients" est 201
+    And je suis redirigé vers "/patients/{id}"
+    # Effet base: INSERT users(role=VIEWER, PII chiffrées AES-256-GCM, emailHmac)
+    #             + INSERT patients(pathology=DT1) + INSERT patient_medical_data
+    #             + INSERT verification_token(TTL 1h)
+    #             + audit_logs ×2 (CREATE/USER via patient_creation, CREATE/PATIENT)
+
+  Scenario: bouton Suivant désactivé tant que l'identité est incomplète
+    Given je suis sur "/patients/new"
+    Then le bouton "Suivant" est désactivé
+    When je remplis un email valide, un prénom et un nom
+    Then le bouton "Suivant" est activé
+
+  Scenario: email déjà utilisé
+    Given un patient existe déjà avec "patient.dt1@diabeo.test"
+    When je soumets le wizard avec ce même email
+    Then la réponse est 409 "emailExists"
+    And je vois le message d'erreur correspondant
+    # Effet base: AUCUNE création + audit anti-énumération
+
+  Scenario: requête sans en-tête CSRF rejetée
+    When je POST "/api/patients" sans en-tête "X-Requested-With"
+    Then la réponse est 403 "csrfMissing"
+```
+
+### Cas limites
+
+- 409 `emailExists` (+ rate-limit anti-énumération), 403 `csrfMissing`, 413 si
+  body > 16 KB, 429 `tooManyAttempts`.
+- L'échec d'envoi de l'email d'invitation **ne rollback pas** la création.
+- Le patient est créé en rôle **VIEWER** avec `needPasswordUpdate=true`.

--- a/docs/qa/04-appointments.md
+++ b/docs/qa/04-appointments.md
@@ -1,0 +1,133 @@
+# QA — Rendez-vous (calendrier)
+
+Écran : `/appointments` (Schedule-X v4). Voir [conventions](README.md#3-conventions--légende).
+
+> Écran déjà partiellement couvert par les tests manuels :
+> `tests/manual/appointments-{create,detail-modal,view-switch,time-axis}.spec.ts`.
+> Cycle de vie d'un RDV : `scheduled` / `pending_validation` → `confirmed` →
+> `completed` ; ou `cancelled` (→ `proposed alternative` → `scheduled`) ; ou `no_show`.
+
+---
+
+## Écran : Calendrier RDV (`/appointments`) 🟢
+
+**Rôle / RBAC** : NURSE+. VIEWER redirigé vers son home. **« Proposer
+alternative » visible DOCTOR+ uniquement** (caché pour NURSE).
+**Statut impl.** : 🟢 Réel (`/api/appointments` + actions `[id]/{confirm,cancel,propose-alternative,accept-alternative}` + `PUT /api/appointments/[id]`).
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Vue calendrier | Semaine / Mois / Jour via sélecteur Schedule-X |
+| Axe horaire (vue Semaine) | 24 libellés `00 h` → `23 h`, ordonnés (locale fr-FR) |
+| Couleur des événements | par statut (scheduled = vert, pending_validation = gris, confirmed = teal, cancelled/no_show = rouge, completed = gris) |
+| Bouton « + Nouveau RDV » | visible NURSE+ |
+| Filtres | Membre cabinet (auto-résolu si 1 seul), Patient (optionnel), Statut (multi-select client, défaut scheduled/pending_validation/confirmed) |
+| Compteur | « N RDV » |
+| États | chargement (spinner), erreur « Erreur lors du chargement du calendrier », plage vide |
+| A11y | skip-link vers le calendrier |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Changer de vue (Semaine/Mois/Jour) | — (client) | re-layout | aucun |
+| Filtrer (membre / patient / statut) | re-`GET /api/appointments?from&to&memberId&patientId` | calendrier re-fetch | aucun (filtre de requête) |
+| **Créer un RDV** | `POST /api/appointments` | modal se ferme, toast **« ✓ Rendez-vous créé avec succès »**, événement vert apparaît | INSERT `appointments` (`motifEncrypted` AES-256-GCM, `status` selon `bookingMode`) · audit CREATE/APPOINTMENT |
+| Ouvrir le détail (clic événement) | `GET /api/appointments/[id]` | modal détail (motif/note déchiffrés) | lecture |
+| **Confirmer** (pending_validation) | `POST /api/appointments/[id]/confirm` | badge passe en teal | UPDATE `status='confirmed'`, `proposedAlternativeAt=NULL` · audit |
+| **Annuler** | `POST /api/appointments/[id]/cancel` | badge rouge, raison enregistrée | UPDATE `status='cancelled'`, `cancelledBy`, `cancelReasonEncrypted`, `cancelledAt`, flag `lateCancel` (<24 h) · audit |
+| **Proposer alternative** (DOCTOR, après annulation médecin) | `POST /api/appointments/[id]/propose-alternative` | bannière « Alternative proposée » (TTL 7 j) | UPDATE `proposedAlternativeAt` · audit |
+| **Accepter alternative** | `POST /api/appointments/[id]/accept-alternative` | RDV repasse vert (scheduled) | UPDATE `status='scheduled'`, nouvelle date/heure, reset champs annulation · audit |
+| **Déplacer (drag & drop)** | `PUT /api/appointments/[id]` | événement saute au nouveau créneau | UPDATE `date/hour/durationMinutes`, `proposedAlternativeAt=NULL` · audit |
+
+> Validation création (Zod) : `patientId>0`, `memberId>0`, `date` `YYYY-MM-DD`,
+> `hour` `HH:MM`, `durationMinutes ∈ [15,240]` (défaut 30), `location ∈
+> {in_person,video,phone}`, `type ≤ 50`, `motif ≤ 200`. **Anti-chevauchement**
+> en transaction **Serializable** (`assertNoOverlap` sur statuts actifs du même
+> `memberId`). Date/heure dans le futur (contrôle client + serveur).
+
+### Scénarios (Gherkin)
+
+```gherkin
+Feature: Gestion des rendez-vous
+
+  Background:
+    Given je suis connecté en tant que "DOCTOR"
+    And je suis sur "/appointments"
+    And le calendrier est monté
+
+  Scenario: changer la vue du calendrier
+    When je change la vue pour "Mois"
+    Then la grille mensuelle est affichée
+    # Effet base: AUCUN (état client)
+
+  Scenario: l'axe horaire de la vue Semaine affiche 24 heures ordonnées
+    When je sélectionne la vue "Semaine"
+    Then l'axe horaire affiche 24 libellés de "00 h" à "23 h" en ordre croissant
+    # (anti-régression réactivité Schedule-X / format locale fr-FR)
+
+  Scenario: créer un nouveau rendez-vous
+    When je clique "+ Nouveau RDV"
+    And je sélectionne le patient "Jean Durand #1"
+    And je choisis une date et une heure futures uniques
+    And je saisis le motif "Contrôle trimestriel"
+    And je clique "Créer le RDV"
+    Then la réponse de POST "/api/appointments" est 201
+    And la modale se ferme
+    And je vois "✓ Rendez-vous créé avec succès"
+    # Effet base: INSERT appointments(motifEncrypted, status=scheduled|pending_validation)
+    #             + audit_logs(action=CREATE, resource=APPOINTMENT, metadata.patientId)
+
+  Scenario: créneau déjà pris (double-booking)
+    When je crée un RDV sur un créneau déjà occupé pour le même membre
+    Then la réponse est 409
+    And je vois un message indiquant que le créneau est occupé
+    # Effet base: AUCUNE insertion (transaction Serializable rejette le chevauchement)
+
+  Scenario: annuler un rendez-vous avec motif
+    Given un RDV "scheduled" existe
+    When j'ouvre son détail et je clique "Annuler"
+    And je choisis l'acteur "doctor" et la raison "Indisponibilité"
+    And je confirme l'annulation
+    Then le badge du RDV passe à "cancelled"
+    # Effet base: UPDATE appointments(status=cancelled, cancelledBy=doctor,
+    #             cancelReasonEncrypted, cancelledAt) + audit_logs(kind=cancel, lateCancel)
+
+  Scenario: proposer puis accepter une alternative
+    Given un RDV annulé par le médecin
+    When je propose une alternative à une date/heure future
+    Then le patient voit "Alternative proposée"
+    # Effet base: UPDATE appointments(proposedAlternativeAt) + audit
+    When le patient accepte l'alternative
+    Then le RDV repasse en "scheduled" à la nouvelle date
+    # Effet base: UPDATE appointments(status=scheduled, date, hour,
+    #             proposedAlternativeAt=NULL, cancelledBy=NULL) + audit(kind=accept-alternative)
+
+  Scenario: le bouton "Proposer alternative" est caché pour un NURSE
+    Given je suis connecté en tant que "NURSE"
+    And j'ouvre le détail d'un RDV annulé par le médecin
+    Then je ne vois pas le bouton "Proposer alternative"
+    # (l'API renverrait 403 — bouton masqué côté UI par défense en profondeur)
+
+  Scenario: création bloquée si le patient a retiré son consentement
+    Given un patient sans consentement de partage
+    When je tente de créer un RDV pour ce patient
+    Then la réponse est 422 "gdprConsentRequired"
+    # Effet base: AUCUNE insertion
+```
+
+### Cas limites
+
+- **Double-booking (409)** : isolation Serializable, 1er commit gagne, message
+  « créneau occupé ».
+- **Accès non autorisé (403)** : RDV d'un patient hors périmètre → audit
+  `accessDenied`.
+- **Consentement RGPD manquant (422)** à la création.
+- **Alternative expirée (422)** : > 7 j (`PROPOSAL_TTL_MS`).
+- **Créneau occupé entre propose et accept (409)** : race tracée en audit.
+- **Mode `validation`** (`member.bookingMode`) : RDV créé en
+  `pending_validation`, n'apparaît au patient qu'après confirmation.
+- **Idempotence des tests d'écriture** : utiliser un créneau futur unique par
+  run (cf. correctif de la spec manuelle `appointments-create`).

--- a/docs/qa/05-settings.md
+++ b/docs/qa/05-settings.md
@@ -1,0 +1,105 @@
+# QA — Paramètres du compte
+
+Écran : `/settings` (Server Component `page.tsx` → `SettingsClient.tsx`).
+Voir [conventions](README.md#3-conventions--légende).
+
+> Les sections affichées dépendent du rôle. `PATIENT_ONLY_SECTIONS` masque pour
+> les professionnels de santé (PS) : Données médicales, Administratif, Moments
+> de la journée, Confidentialité (+ toggles notifications glycémie/insuline).
+> Ces sections **ne sont pas fetchées** pour un PS (défense en profondeur).
+
+---
+
+## Écran : Paramètres (`/settings`) 🟢
+
+**Rôle / RBAC** : tout utilisateur authentifié. VIEWER (patient) = 9 sections ;
+PS = sous-ensemble. Le rôle est lu côté serveur (`x-user-role`) ; fail-closed
+`redirect("/login")` si invalide.
+**Statut impl.** : 🟢 Réel.
+
+### Affichage attendu
+
+| Section | Visibilité | Contenu |
+|---|---|---|
+| **Infos personnelles** | tous | Prénom, Nom, Sexe, Date de naissance · bouton « Enregistrer » + indicateur (spinner → ✓ 3 s) |
+| **Données médicales** | patient | Type diabète, Année diagnostic (1900–now), Taille (50–250 cm) |
+| **Administratif** | patient | NIRPP / INS **masqués** (toggle révéler + event analytics, copiable si révélé), OID (lecture seule) |
+| **Contact** | tous | Téléphone, Adresse, Ville |
+| **Unités** | tous | Glycémie (mg/dL\|mmol/L\|g/L), Poids (kg\|lbs), Taille (cm\|in) |
+| **Moments de la journée** | patient | 4 plages (MORNING/NOON/EVENING/NIGHT), `startTime < endTime` |
+| **Notifications** | tous (toggles glycémie/insuline = patient) | Rappels glycémie/insuline (patient), Rendez-vous (défaut on), Export auto (défaut off) |
+| **Confidentialité** | patient | Partage chercheurs (off), prestataires (on), Analytics (on), Consentement RGPD (off) |
+| **Sessions** | tous | liste sessions actives (device, IP, dernière activité) + « Déconnecter » |
+| Export RGPD | tous | boutons « Exporter PDF » / « Exporter JSON » |
+| Layout | — | desktop 2 panneaux · mobile accordéon |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Modifier infos perso | `PUT /api/account` | toast « ✓ Enregistré » | UPDATE `users` (firstname/lastname chiffrés + HMAC, sex, birthday) · audit UPDATE/USER |
+| Modifier données médicales | `PUT /api/patient` + `PUT /api/patient/medical-data` | toast | UPDATE `patients.pathology` · UPDATE `patient_medical_data` (size, yearDiag) |
+| Révéler NIRPP/INS | — (client) | masque ↔ clair + bouton copier | aucun (event analytics `administrative_field_revealed`) |
+| Modifier contact | `PUT /api/account` | toast | UPDATE `users` (phone/address1/city chiffrés) |
+| Modifier unités | `PUT /api/account/units` | toast | UPSERT `user_unit_preferences` · audit |
+| Modifier moments | `PUT /api/account/day-moments` | toast | UPSERT `user_day_moments` (par type) |
+| Modifier notifications | `PUT /api/account/notifications` | toggles + toast | UPSERT `user_notification_preferences` · audit |
+| Modifier confidentialité | `PUT /api/account/privacy` | toggles + toast | UPSERT `user_privacy_settings` (gdprConsent → `consentDate` auto) · **invalide le cache de consentement** · audit |
+| Gérer sessions | `GET /api/account/sessions` · `DELETE /api/account/sessions/[id]` | session retirée de la liste | DELETE `sessions` (révocation) |
+| Exporter (RGPD Art. 20) | `GET /api/account/export` | spinner → téléchargement | lecture agrégée · audit EXPORT · **rate-limit 3/h/user** |
+
+### Scénarios (Gherkin)
+
+```gherkin
+Feature: Paramètres du compte
+
+  Scenario: un patient met à jour ses infos personnelles
+    Given je suis connecté en tant que "VIEWER"
+    And je suis sur "/settings"
+    When je modifie le prénom en "Camille" et je clique "Enregistrer"
+    Then je vois l'indicateur "✓ Enregistré"
+    # Effet base: UPDATE users(firstname chiffré AES-256-GCM + firstnameHmac) + audit_logs(UPDATE/USER)
+
+  Scenario: un professionnel de santé ne voit pas les sections patient-only
+    Given je suis connecté en tant que "DOCTOR"
+    When je vais sur "/settings"
+    Then je ne vois pas la section "Données médicales"
+    And je ne vois pas la section "Confidentialité"
+    # (sections non rendues ET non fetchées — défense en profondeur)
+
+  Scenario: révéler le NIRPP émet un événement analytics sans appel API
+    Given je suis connecté en tant que "VIEWER"
+    And je suis sur la section "Administratif"
+    When je clique le bouton de révélation du NIRPP
+    Then le NIRPP est affiché en clair
+    # Effet base: AUCUN (event client diabeo_analytics: administrative_field_revealed)
+
+  Scenario: retirer le consentement RGPD invalide immédiatement le cache
+    Given je suis connecté en tant que "VIEWER" avec consentement donné
+    When je désactive "Consentement RGPD" dans Confidentialité
+    Then je vois "✓ Enregistré"
+    # Effet base: UPSERT user_privacy_settings(gdprConsent=false, consentDate=NULL)
+    #             + invalidation cache consentement (TTL 0) → prochains GET data = 403
+
+  Scenario: export RGPD limité à 3 par heure
+    Given je suis connecté en tant que "VIEWER"
+    When je déclenche un 4e export dans l'heure
+    Then la réponse est 429 avec en-tête "Retry-After"
+    # Effet base: audit_logs(action=EXPORT) sur les exports réussis uniquement
+
+  Scenario: déconnecter une session distante
+    Given je suis sur la section "Sessions" avec 2 sessions actives
+    When je clique "Déconnecter" sur l'autre session
+    Then elle disparaît de la liste
+    # Effet base: DELETE sessions WHERE id = {sessionId}
+```
+
+### Cas limites
+
+- **PS** : section patient-only masquée **et** non fetchée (la nav ne l'affiche
+  pas).
+- **Champ chiffré non déchiffrable** → affiché « (non disponible) » (nullable).
+- **Révocation consentement** : cache invalidé immédiatement (TTL 0 vs 5 min) →
+  prochaine création de RDV / accès données = 422/403.
+- **Double-save** : bouton désactivé pendant l'envoi (`loading`).
+- **Non authentifié** → `redirect("/login")`.

--- a/docs/qa/06-admin.md
+++ b/docs/qa/06-admin.md
@@ -1,0 +1,241 @@
+# QA — Administration
+
+Écrans : `/admin/users`, `/admin/users/[id]`, `/admin/cabinets`, `/admin/cabinets/[id]`.
+Voir [conventions](README.md#3-conventions--légende).
+
+> **RBAC** : toutes ces pages sont **strictement ADMIN** (`redirect("/")` sinon,
+> côté serveur). Les actions sensibles (changement de rôle/statut) exigent un
+> **step-up MFA** (fraîcheur < 5 min) et sont **idempotentes**
+> (`Idempotency-Key`). Garde **anti-lockout** : impossible de retirer/suspendre
+> le dernier ADMIN (transaction Serializable).
+
+---
+
+## Écran : Utilisateurs — liste (`/admin/users`) 🟢
+
+**Statut impl.** : 🟢 Réel (`GET /api/admin/users`).
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Titre « Utilisateurs » + description | visible |
+| Recherche | email/nom/prénom (`autocomplete=off`) |
+| Filtres | Rôle (Administrateur/Médecin/Infirmier·ère/Patient) + Statut (Actif/Suspendu/Archivé) |
+| Bouton « Actualiser » | visible |
+| Ligne utilisateur | icône + nom (ou email) · badge rôle (ADMIN rouge, DOCTOR bleu, NURSE gris, VIEWER contour) · badge statut · badge « MFA » si activé · email + date création |
+| Bandeau PHI | rappel usage strictement admin |
+| États | chargement « Chargement… » · erreur « Liste indisponible » + « Réessayer » · vide « Aucun utilisateur » |
+| Pagination | max 100 · alerte si > 100 « Affiner les filtres » |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Charger / filtrer / chercher | `GET /api/admin/users?role&status&search&limit&cursor` | liste | **lecture** · audit READ (`resource:USER`, `resourceId:"admin:users:list"`) |
+| Clic ligne | — | `/admin/users/{id}` | aucun |
+
+### Scénarios (Gherkin)
+
+```gherkin
+Feature: Liste des utilisateurs (admin)
+
+  Scenario: un ADMIN liste les utilisateurs
+    Given je suis connecté en tant que "ADMIN"
+    When je vais sur "/admin/users"
+    Then je vois la liste des utilisateurs avec leurs badges rôle et statut
+    # Effet base: audit_logs(action=READ, resource=USER, resourceId="admin:users:list")
+
+  Scenario: un non-ADMIN est redirigé
+    Given je suis connecté en tant que "DOCTOR"
+    When je vais sur "/admin/users"
+    Then je suis redirigé vers "/"
+
+  Scenario: filtrer par rôle et statut
+    Given je suis sur "/admin/users"
+    When je filtre rôle="Médecin" et statut="Actif"
+    Then seuls les DOCTOR actifs sont affichés
+```
+
+### Cas limites
+
+- Recherche = **match exact HMAC** (pas de recherche partielle, protection PHI).
+- Scope cabinet : un ADMIN de cabinet ne voit que ses utilisateurs.
+
+---
+
+## Écran : Utilisateur — détail / édition (`/admin/users/[id]`) 🟢
+
+**Statut impl.** : 🟢 Réel (`PATCH /api/admin/users/[id]`).
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Breadcrumb « ← Retour à la liste » | visible |
+| En-tête | nom + badge rôle + badge statut + « MFA activé » si activé |
+| Section « Détails » (lecture) | Email, Prénom, Nom, Langue · Créé le / Statut modifié le / Mis à jour le |
+| Section « Changer le rôle » | boutons « Définir le rôle : {actuel} → {cible} » ; **« vers ADMIN » désactivé si MFA non activée** (avertissement jaune) |
+| Section « Changer le statut » | boutons active/suspended/archived (archivé = rouge destructive) + avertissement « l'archivage révoque tous les tokens » |
+| Dialog de confirmation | titre dynamique + avertissement + « Action tracée dans l'audit log immuable » |
+| États action | en cours (disabled+spinner) · succès (bandeau vert 3 s) · erreur (texte rouge) |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Changer le rôle | `PATCH /api/admin/users/[id]` `{role}` | dialog → succès → refetch | UPDATE `users.role` · audit UPDATE (old/new role) · **step-up MFA requis** |
+| Changer le statut | `PATCH /api/admin/users/[id]` `{status}` | dialog → succès | UPDATE `users.status/statusChangedAt/statusChangedBy` · si archive/suspend : **DELETE sessions** + **revoke Redis** (TTL 900 s) · audit (transition, revokedSessionsCount) |
+
+> Body = exactement **un** champ (`role` XOR `status`). Header
+> `Idempotency-Key` (UUID v4) → rejeu = réponse cachée, zéro double audit/revoke.
+
+### Scénarios (Gherkin)
+
+```gherkin
+Feature: Détail et édition d'un utilisateur (admin)
+
+  Scenario: promouvoir un utilisateur en DOCTOR (avec MFA fraîche)
+    Given je suis connecté en tant que "ADMIN" avec MFA fraîche
+    And je suis sur "/admin/users/{id}"
+    When je clique "Définir le rôle : Patient → Médecin"
+    And je confirme
+    Then je vois "Action effectuée."
+    # Effet base: UPDATE users.role=DOCTOR + audit_logs(UPDATE/USER, old={role}, new={role:DOCTOR})
+
+  Scenario: promotion vers ADMIN interdite si la cible n'a pas la MFA
+    Given un utilisateur cible sans MFA activée
+    When j'ouvre son détail
+    Then le bouton "Définir vers ADMIN" est désactivé
+    And je vois l'avertissement "MFA requise pour les comptes à privilèges"
+
+  Scenario: step-up MFA exigé pour toute modification
+    Given je suis connecté en tant que "ADMIN" sans MFA récente (> 5 min)
+    When je PATCH "/api/admin/users/{id}" avec {role: "NURSE"}
+    Then la réponse est 401 avec en-tête "WWW-Authenticate"
+    # Effet base: AUCUNE modif + audit_logs(stepUp.failed)
+
+  Scenario: impossible de rétrograder le dernier ADMIN (anti-lockout)
+    Given il ne reste qu'un seul ADMIN actif
+    When je tente de le rétrograder en DOCTOR
+    Then la réponse est 409 "last_admin_cannot_be_demoted"
+    # Effet base: AUCUNE modif (transaction Serializable)
+
+  Scenario: archiver un utilisateur révoque ses sessions
+    Given je suis connecté en tant que "ADMIN" avec MFA fraîche
+    When je passe le statut d'un utilisateur à "archived"
+    Then je vois "Action effectuée."
+    # Effet base: UPDATE users.status=archived + DELETE sessions(user)
+    #             + revoke Redis(sid, TTL 900s) + audit(transition="active->archived", revokedSessionsCount)
+
+  Scenario: un ADMIN ne peut pas changer son propre statut/rôle
+    Given je suis connecté en tant que "ADMIN"
+    When je tente de modifier mon propre statut
+    Then la réponse est 403 "cannot_change_own_status"
+
+  Scenario: idempotence — double-clic ne double pas l'action
+    Given je modifie un rôle avec un Idempotency-Key donné
+    When la même requête est rejouée avec la même clé
+    Then la réponse est identique avec "X-Idempotency-Replayed: true"
+    # Effet base: AUCUN second UPDATE / audit / revoke
+```
+
+### Cas limites
+
+- **Step-up MFA** (< 5 min) obligatoire ; sinon 401 + `WWW-Authenticate`.
+- **Anti-lockout** dernier ADMIN (409), **anti-self-demote** (403),
+  **anti-self-status** (403).
+- **Révocation JWT atomique** : sessions supprimées en base + révoquées Redis
+  (TTL 900 s ≥ validité access token).
+- **Idempotency** : rejeu de la même clé = pas de double effet.
+
+---
+
+## Écran : Cabinets — liste (`/admin/cabinets`) 🟢
+
+**Statut impl.** : 🟢 Réel (`GET /api/admin/healthcare-services`).
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Titre « Cabinets & structures » + description | visible |
+| Recherche | nom / ville / établissement |
+| Ligne cabinet | icône + nom · badge type (Clinique/Hôpital/Cabinet libéral) · badge bleu « SMS activé (N crédits) » si activé · badge rouge « Pas de manager » si `managerId=null` · établissement · ville |
+| États | chargement · erreur « Liste indisponible » + « Réessayer » · vide « Aucun cabinet enregistré » |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Charger / chercher | `GET /api/admin/healthcare-services?type&search&limit&cursor` | liste | **lecture** · audit READ (`resource:HEALTHCARE_SERVICE`, `resourceId:"admin:healthcare:list"`) |
+| Clic ligne | — | `/admin/cabinets/{id}` | aucun |
+
+---
+
+## Écran : Cabinet — détail / édition (`/admin/cabinets/[id]`) 🟢
+
+**Statut impl.** : 🟢 Réel (`PUT /api/cabinet/[id]/settings`, `PUT /api/cabinet/[id]/sms-config`).
+
+### Affichage attendu
+
+| Section | Contenu attendu |
+|---|---|
+| En-tête | nom + établissement + badges type / SIRET / « Pas de manager » |
+| **Paramètres cabinet** (manager-level) | lecture : téléphone, email, site, capacité, adresses, CP, ville, pays, spécialités, noVideos, noFood + bouton « Modifier » · édition : inputs + « Annuler »/« Enregistrer » + dialog confirmation (N champs modifiés) |
+| **Config SMS** (V1 mock) | « SMS activé » oui/non · « Crédits restants » + « ⚠ Faible » si < 10 · bandeau « V1 mock : aucun SMS réel envoyé » + bouton « Modifier » |
+
+### Actions & effets
+
+| Action | Endpoint | RBAC | Effet visuel | Effet base |
+|---|---|---|---|---|
+| Éditer paramètres cabinet | `PUT /api/cabinet/[id]/settings` | DOCTOR (manager) ou ADMIN | dialog → succès « Paramètres cabinet mis à jour » | UPDATE `healthcare_service` (champs modifiés) · audit UPDATE (`resource:CABINET_SETTINGS`) · `Idempotency-Key` |
+| Modifier config SMS | `PUT /api/cabinet/[id]/sms-config` | **ADMIN only** | dialog → succès « Configuration SMS mise à jour » | UPDATE `healthcare_service` (smsEnabled, smsCreditBalance) · audit (`sms.config.toggled` / `credits_adjusted`) |
+
+> Validation settings (Zod) : phone ≤ 30, email ≤ 255, website url ≤ 500,
+> adresses ≤ 255, CP ≤ 10, ville ≤ 100, spécialités ≤ 20 × ≤ 60 car., capacité
+> ∈ [0,10000]. SMS : `smsCreditBalance ∈ [0, 1 000 000]`. Champs régaliens
+> (SIRET, TVA, type, licence) modifiables uniquement via la route admin
+> `/api/admin/healthcare-services/[id]` (pas la route manager).
+
+### Scénarios (Gherkin)
+
+```gherkin
+Feature: Détail et édition d'un cabinet (admin)
+
+  Scenario: éditer les coordonnées d'un cabinet
+    Given je suis connecté en tant que "ADMIN"
+    And je suis sur "/admin/cabinets/{id}"
+    When je clique "Modifier" sur les paramètres cabinet
+    And je change le téléphone et je clique "Enregistrer"
+    And je confirme
+    Then je vois "Paramètres cabinet mis à jour."
+    # Effet base: UPDATE healthcare_service(phone) + audit_logs(UPDATE/CABINET_SETTINGS)
+
+  Scenario: activer le SMS et créditer (ADMIN only)
+    Given je suis connecté en tant que "ADMIN"
+    And je suis sur "/admin/cabinets/{id}"
+    When j'active "SMS" et je fixe les crédits à 100
+    And je confirme
+    Then je vois "Configuration SMS mise à jour."
+    # Effet base: UPDATE healthcare_service(smsEnabled=true, smsCreditBalance=100)
+    #             + audit_logs(sms.config.toggled / credits_adjusted)
+
+  Scenario: la config SMS est interdite à un non-ADMIN
+    Given je suis connecté en tant que "DOCTOR" manager du cabinet
+    When je PUT "/api/cabinet/{id}/sms-config"
+    Then la réponse est 401 ou 403
+
+  Scenario: alerte crédits SMS faibles
+    Given un cabinet avec SMS activé et un solde de 5 crédits
+    When j'ouvre son détail
+    Then je vois "⚠ Faible" à côté des crédits SMS
+```
+
+### Cas limites
+
+- **SMS V1 = mock** : aucun SMS réel n'est envoyé (`provider="mock"`), mais le
+  crédit décrémente pour simuler le coût (décrément atomique
+  `WHERE smsCreditBalance >= cost`).
+- **Séparation des routes** : paramètres généraux = manager OU admin ;
+  config SMS = **admin only** ; champs régaliens = route admin dédiée.

--- a/docs/qa/README.md
+++ b/docs/qa/README.md
@@ -1,0 +1,179 @@
+# Plan de tests QA — Diabeo Backoffice
+
+> **Lot 1 (cœur MVP)** — 13 écrans. Lot 2 (audit, analytics, documents, messages,
+> devices, insulin-therapy, import, propositions d'ajustement, médications,
+> backups, data-breaches, factures, tax-rules, system-health) à suivre.
+>
+> Source des faits : lecture du code réel (composants + routes API + services)
+> au 2026-06-05. Chaque « effet base » est tracé jusqu'au fichier qui le produit.
+
+## 1. Objet
+
+Ce document décrit, **pour chaque écran** :
+
+1. **Affichage attendu** — ce qui doit être à l'écran (éléments, états vide /
+   chargement / erreur), sous forme de tableau lisible par un testeur humain.
+2. **Actions possibles** — chaque action utilisateur, l'endpoint API appelé,
+   l'**effet visuel** (ce qui change à l'écran) et l'**effet en base** (tables
+   PostgreSQL écrites + événement audit).
+3. **Scénarios Gherkin** — `Given / When / Then` directement exécutables par un
+   bot (voir §5 Stratégie d'automatisation). La ligne `# Effet base:` documente
+   l'attendu côté base pour vérification.
+4. **Cas limites** — erreurs, RBAC, anti-énumération, RGPD.
+
+Les tests sont joués **soit par un humain** (le tableau + les `Then` suffisent),
+**soit par un bot** (les blocs Gherkin sont le contrat d'automatisation).
+
+## 2. Découpage des fichiers
+
+| Fichier | Écrans |
+|---|---|
+| [`01-auth.md`](01-auth.md) | `/login`, `/reset-password` |
+| [`02-dashboards.md`](02-dashboards.md) | `/medecin`, `/infirmier`, `/patient/dashboard` |
+| [`03-patients.md`](03-patients.md) | `/patients`, `/patients/[id]`, `/patients/new` |
+| [`04-appointments.md`](04-appointments.md) | `/appointments` |
+| [`05-settings.md`](05-settings.md) | `/settings` |
+| [`06-admin.md`](06-admin.md) | `/admin/users`, `/admin/users/[id]`, `/admin/cabinets` (+ `[id]`) |
+
+## 3. Conventions & légende
+
+| Symbole | Signification |
+|---|---|
+| 🟢 **Réel** | L'écran lit/écrit les vraies routes API + base. |
+| 🟡 **DEMO_DATA** | L'écran affiche des **données synthétiques** en dur (`DEMO_*`). La route API existe et est testable séparément (au niveau contrat API), mais l'UI ne la consomme pas encore. À tester en 2 volets : *affichage (demo)* vs *contrat API (réel)*. |
+| ⚠️ **Anomalie** | Comportement à corriger, relevé pendant la rédaction. |
+| `# Effet base:` | Ligne de commentaire Gherkin décrivant l'écriture base + audit attendus. |
+
+**Rôles RBAC** : `ADMIN > DOCTOR > NURSE > VIEWER`. Le middleware injecte
+`x-user-id` / `x-user-role` ; chaque route revalide via `requireRole`.
+
+**Effets base transverses** (valables pour quasi toutes les actions d'écriture) :
+
+- Toute donnée de santé / PII est **chiffrée AES-256-GCM** (base64) avant
+  insertion ; jamais en clair en base ni en logs.
+- Toute action sensible écrit une ligne **`audit_logs`** (immuable par trigger)
+  avec `userId, action, resource, resourceId, metadata.patientId?, ipAddress,
+  userAgent`.
+- Les patients sont en **soft-delete** (`deletedAt`) — jamais de DELETE physique.
+
+## 4. Comptes & données de seed (environnement QA)
+
+Seed déterministe (`prisma/seed.ts`, voir `pnpm prisma db seed`) :
+
+| Rôle | Email | Mot de passe |
+|---|---|---|
+| ADMIN | `admin@diabeo.test` | `DEV-ONLY-Admin123!` |
+| DOCTOR | `docteur@diabeo.test` | `DEV-ONLY-Doctor123!` |
+| NURSE | `infirmiere@diabeo.test` | `DEV-ONLY-Nurse123!` |
+| VIEWER (patient DT1) | `patient.dt1@diabeo.test` | `DEV-ONLY-Patient123!` |
+| VIEWER (patient DT2) | `patient.dt2@diabeo.test` | `DEV-ONLY-Patient123!` |
+
+> Helper d'auth automatisé : `tests/e2e/helpers/auth.ts` → `loginAs(context, request, role)`
+> (login API + injection cookie httpOnly `diabeo_token`).
+
+## 5. Stratégie d'automatisation (recommandation : Gherkin + Playwright-BDD)
+
+### 5.1. Choix d'outillage
+
+Décision retenue : **Gherkin exécutable**. Recommandation d'implémentation :
+**[`playwright-bdd`](https://github.com/vitalets/playwright-bdd)** plutôt que
+`cucumber-js` pur, car il :
+
+- réutilise tel quel l'existant : `playwright.manual.config.ts`, le runner
+  Playwright, les traces/screenshots, et surtout le helper `loginAs` ;
+- exécute les `.feature` directement (les blocs Gherkin de ce document
+  deviennent la source de vérité — *doc = test*) ;
+- évite la double config (Cucumber a son propre runner, ses reporters, son
+  glue ; playwright-bdd génère des specs Playwright à partir des `.feature`).
+
+> Alternative `cucumber-js` : viable mais ajoute un runner parallèle à
+> maintenir. À ne retenir que si l'équipe a déjà un existant Cucumber.
+
+### 5.2. Arborescence cible
+
+```
+tests/
+  bdd/
+    features/                 # .feature extraits 1:1 de docs/qa/*.md
+      auth/login.feature
+      patients/create.feature
+      appointments/create.feature
+      ...
+    steps/                    # step definitions réutilisables
+      auth.steps.ts           # Given je suis connecté en tant que "DOCTOR"
+      navigation.steps.ts     # When je vais sur "/appointments"
+      form.steps.ts           # When je remplis "#create-motif" avec "..."
+      assertions.steps.ts     # Then je vois "✓ Rendez-vous créé avec succès"
+      db.steps.ts             # Then la table "appointments" contient ... (effet base)
+    playwright-bdd.config.ts
+```
+
+### 5.3. Conventions à mettre en place (pré-requis automatisation)
+
+1. **`data-testid` stables** sur les éléments clés (boutons d'action, lignes de
+   liste, badges de statut, bannières d'erreur/succès, champs de formulaire).
+   Aujourd'hui les specs manuelles ciblent des classes Schedule-X (`.sx__*`) et
+   des libellés FR — fragile à l'i18n. Ajouter `data-testid` rend les steps
+   indépendants de la langue.
+2. **Seed QA déterministe** (déjà en place) + un **reset base entre features**
+   d'écriture (`prisma migrate reset --force` ou transaction rollback) pour
+   l'idempotence — cf. le bug de double-booking corrigé sur la spec manuelle
+   `appointments-create`.
+3. **Vérification « effet base »** : un step `db.steps.ts` qui interroge
+   PostgreSQL (Prisma client en lecture) pour valider l'`# Effet base:` du
+   scénario (ex. `appointments.status = 'cancelled'`, présence d'une ligne
+   `audit_logs`). C'est ce qui distingue ce plan d'un simple test d'UI.
+
+### 5.4. Où un bot LLM apporte de la valeur
+
+| Tâche | Valeur LLM |
+|---|---|
+| **Génération initiale des step definitions** | Élevée — mapping `.feature` → Playwright. |
+| **Maintenance des sélecteurs** | Moyenne — proposer le `data-testid` quand un libellé change. |
+| **Triage des échecs** | Élevée — lire la trace + le screenshot et classer *bug applicatif* vs *bug de test* (cf. les 2 specs manuelles : format locale + race, qui étaient des bugs de test, pas d'app). |
+| **Exploration d'écran non couvert** | Élevée — proposer de nouveaux scénarios à partir du composant + de la route. |
+
+> ⚠️ Un bot ne décide pas seul d'un *attendu clinique* (bornes glycémiques,
+> sécurité bolus) : ces scénarios sont validés par `medical-domain-validator` /
+> un soignant. Le bot exécute et triage ; l'humain tranche le médical.
+
+### 5.5. Intégration CI
+
+- Les `.feature` d'écriture nécessitent une **base + dev server** → garder
+  hors du job unit (`vitest`), dans un job dédié type
+  `playwright.manual.config.ts` (pas de `webServer`, suppose un stack lancé) ou
+  un job E2E avec `docker compose --profile local up` + seed.
+- **Environnement navigateur** (sandbox sans GUI) : nécessite polices +
+  libs (`cairo`/`pango`) — sinon Chromium SIGTRAP sur les pages lourdes. Voir
+  le runbook interne d'exécution des tests manuels.
+
+## 6. Modèle de cas de test (template par écran)
+
+Chaque écran suit ce gabarit (voir les fichiers de domaine) :
+
+```markdown
+## Écran : <Nom> (`<route>`)   🟢/🟡
+**Rôle / RBAC** : …
+**Statut impl.** : 🟢 Réel | 🟡 DEMO_DATA
+
+### Affichage attendu
+| Élément | État attendu |
+|---|---|
+
+### Actions & effets
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+
+### Scénarios (Gherkin)
+``​`gherkin
+Feature: …
+  Scenario: …
+    Given …
+    When …
+    Then …
+    # Effet base: …
+``​`
+
+### Cas limites
+- …
+```


### PR DESCRIPTION
## Objet

Document QA décrivant **chaque écran** du lot 1 (cœur MVP) :
- **Affichage attendu** (tableau lisible par un testeur humain),
- **Actions possibles** + endpoint API + **effet visuel** + **effet en base** (tables PostgreSQL + audit),
- **Scénarios Gherkin** exécutables (ligne `# Effet base:` par scénario),
- **Cas limites** (RBAC, anti-énumération, RGPD, idempotence).

Conçu pour exécution **humaine** (tableaux + `Then`) **ou bot** (blocs Gherkin = contrat d'automatisation).

## Périmètre (lot 1 — 13 écrans)

| Fichier | Écrans |
|---|---|
| `01-auth.md` | `/login`, `/reset-password` |
| `02-dashboards.md` | `/medecin`, `/infirmier`, `/patient/dashboard` |
| `03-patients.md` | `/patients`, `/patients/[id]`, `/patients/new` |
| `04-appointments.md` | `/appointments` |
| `05-settings.md` | `/settings` |
| `06-admin.md` | `/admin/users`, `/admin/users/[id]`, `/admin/cabinets` (+ `[id]`) |

Lot 2 (audit, analytics, documents, messages, devices, insulin-therapy, import, propositions, médications, backups, data-breaches, factures, tax-rules, system-health) à suivre.

## Méthode

Tous les « effets base » sont **sourcés depuis le code réel** (composants + routes API + services), via 4 explorations ciblées du dépôt. Quelques routes signalées incertaines ont été vérifiées (`confirm/cancel/propose-alternative/accept-alternative`, `auth/mfa/challenge`, `PUT /api/appointments/[id]`, routes admin/cabinet).

## Stratégie d'automatisation

`README.md` §5 détaille la reco : **Gherkin + [playwright-bdd](https://github.com/vitalets/playwright-bdd)** (réutilise le runner Playwright + le helper `loginAs` existants, *doc = test*), l'arborescence cible `tests/bdd/`, les pré-requis (`data-testid` stables, seed QA déterministe, step de vérification « effet base » côté PostgreSQL), la place d'un bot LLM (génération de steps, triage des échecs) et l'intégration CI.

## Anomalies relevées pendant la rédaction

- ⚠️ `/login` : lien « Créer un compte » → `/register`, **mais la page `(auth)/register` n'existe pas** (`src/app/(auth)/login/page.tsx:224`) → 404.
- 🟡 `patients` liste + détail : l'UI affiche des **DEMO_DATA** ; les routes API réelles existent et sont documentées séparément (volet « contrat API »). Le wizard `/patients/new` appelle bien la vraie API.

> Changement **docs-only** (aucun code applicatif modifié).

🤖 Generated with [Claude Code](https://claude.com/claude-code)