### PR TITLE
test(bdd): POC Gherkin exécutable (playwright-bdd) — tests manuels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ __pycache__/
 figma-export-script.js
 2026-*-*.txt
 .claude/scheduled_tasks.lock
+
+# Playwright-BDD generated specs
+.features-gen/

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:setup": "./scripts/test-e2e.sh",
-    "test:all": "vitest run && playwright test"
+    "test:all": "vitest run && playwright test",
+    "bdd:gen": "bddgen --config playwright.bdd.config.ts",
+    "bdd:test": "bddgen --config playwright.bdd.config.ts && playwright test --config playwright.bdd.config.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1041.0",
@@ -80,6 +82,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.2.1",
     "jsdom": "^29.0.1",
+    "playwright-bdd": "^9.0.0",
     "tailwindcss": "^4",
     "tsx": "^4.19.0",
     "typescript": "^5",

--- a/playwright.bdd.config.ts
+++ b/playwright.bdd.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig } from "@playwright/test"
+import { defineBddConfig } from "playwright-bdd"
+
+/**
+ * Config Playwright-BDD — preuve de concept "Gherkin exécutable".
+ *
+ * Rangée avec les tests **MANUELS** (`tests/manual/bdd/`) :
+ *   - PAS de `webServer` : on suppose un `pnpm dev` déjà lancé (comme
+ *     `playwright.manual.config.ts`) ;
+ *   - JAMAIS en CI (nécessite base + dev server + navigateur complet).
+ *
+ * Les `.feature` sont la source de vérité (extraits du plan QA `docs/qa/`).
+ * `bddgen` génère des specs Playwright à partir des `.feature` + des step
+ * definitions, puis `playwright test` les exécute.
+ *
+ * Usage :
+ *   pnpm bdd:gen     # génère les specs (dossier .features-gen, gitignoré)
+ *   pnpm bdd:test    # bddgen + exécution
+ *
+ * Pré-requis navigateur (sandbox sans GUI) : voir tests/manual/bdd/README.md.
+ */
+const testDir = defineBddConfig({
+  features: "tests/manual/bdd/features/**/*.feature",
+  steps: "tests/manual/bdd/steps/**/*.ts",
+})
+
+export default defineConfig({
+  testDir,
+  fullyParallel: false,
+  forbidOnly: false,
+  retries: 0,
+  workers: 1,
+  reporter: "list",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { browserName: "chromium" },
+    },
+  ],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       jsdom:
         specifier: ^29.0.1
         version: 29.0.1(@noble/hashes@2.2.0)
+      playwright-bdd:
+        specifier: ^9.0.0
+        version: 9.0.0(@playwright/test@1.59.0)
       tailwindcss:
         specifier: ^4
         version: 4.2.2
@@ -564,6 +567,10 @@ packages:
   '@clack/prompts@0.11.0':
     resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
 
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
+
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
     engines: {node: '>=20.19.0'}
@@ -599,6 +606,40 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@cucumber/cucumber-expressions@19.0.0':
+    resolution: {integrity: sha512-4FKoOQh2Uf6F6/Ln+1OxuK8LkTg6PyAqekhf2Ix8zqV2M54sH+m7XNJNLhOFOAW/t9nxzRbw2CcvXbCLjcvHZg==}
+
+  '@cucumber/gherkin-utils@11.0.0':
+    resolution: {integrity: sha512-LJ+s4+TepHTgdKWDR4zbPyT7rQjmYIcukTwNbwNwgqr6i8Gjcmzf6NmtbYDA19m1ZFg6kWbFsmHnj37ZuX+kZA==}
+    hasBin: true
+
+  '@cucumber/gherkin@38.0.0':
+    resolution: {integrity: sha512-duEXK+KDfQUzu3vsSzXjkxQ2tirF5PRsc1Xrts6THKHJO6mjw4RjM8RV+vliuDasmhhrmdLcOcM7d9nurNTJKw==}
+
+  '@cucumber/gherkin@39.1.0':
+    resolution: {integrity: sha512-pqmSO2bUWxJm3TbNrKXlDaHjL6c77+ez9kWmfCd9oRPeTRPEVH3spZvpAqdXYWOZYSNYwWFCAAeZ4RGpkauNoQ==}
+
+  '@cucumber/html-formatter@23.1.0':
+    resolution: {integrity: sha512-DcCSFoGs6jbwzXPgX1CwgJKEE+ZMcIEzq/0Memg0o24maNn9NJizBFHmoFWG4iv/OxHza+mvc+56cTHetfHndw==}
+    peerDependencies:
+      '@cucumber/messages': '>=18'
+
+  '@cucumber/junit-xml-formatter@0.13.3':
+    resolution: {integrity: sha512-w9ujOxiuKDtU6fLzJz+wp4Sgp5Xu6ba7ls00LHJccVmQU0Ba7zs+AHnv3iIgPjKZAQe1w8x93dr8Gaubh7Vqkg==}
+    peerDependencies:
+      '@cucumber/messages': '*'
+
+  '@cucumber/messages@32.3.1':
+    resolution: {integrity: sha512-yNQq1KoXRYaEKrWMFmpUQX7TdeQuU9jeGgJAZ3dArTsC/T4NpJ6DnqaJIIgwPnz/wtQIQTNX7/h0rOuF5xY4qQ==}
+
+  '@cucumber/query@15.0.1':
+    resolution: {integrity: sha512-FMfT3orJblRsOxvU2doECBvQmauizYlj+5JsM8atAKKPbnQTj7v2/OrnuykvQpfZNBf19DYbRq1e832vllRP/g==}
+    peerDependencies:
+      '@cucumber/messages': '*'
+
+  '@cucumber/tag-expressions@9.1.0':
+    resolution: {integrity: sha512-bvHjcRFZ+J1TqIa9eFNO1wGHqwx4V9ZKV3hYgkuK/VahHx73uiP4rKV3JVrvWSMrwrFvJG6C8aEwnCWSvbyFdQ==}
 
   '@dotenvx/dotenvx@1.59.1':
     resolution: {integrity: sha512-Qg+meC+XFxliuVSDlEPkKnaUjdaJKK6FNx/Wwl2UxhQR8pyPIuLhMavsF7ePdB9qFZUWV1jEK3ckbJir/WmF4w==}
@@ -2157,6 +2198,10 @@ packages:
   '@tailwindcss/postcss@4.2.2':
     resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
 
+  '@teppeis/multimaps@3.0.0':
+    resolution: {integrity: sha512-ID7fosbc50TbT0MK0EG12O+gAP3W3Aa/Pz4DaTtQtEvlc9Odaqi0de+xuZ7Li2GtK4HzEX7IuRWS/JmZLksR3Q==}
+    engines: {node: '>=14'}
+
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -2697,6 +2742,9 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -2769,6 +2817,9 @@ packages:
     resolution: {integrity: sha512-XBOxUiGOcQGuKmCn5qaM5rIK153fGCwsvJMbjVtcnNJ+j/YHrSj2gKNjyP65yr/E8JsKTTDtKYFG++p7Lzigyw==}
     engines: {node: '>=16.0.0'}
 
+  class-transformer@0.5.1:
+    resolution: {integrity: sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -2779,6 +2830,10 @@ packages:
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
+
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
 
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
@@ -2815,6 +2870,14 @@ packages:
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
+  commander@14.0.2:
+    resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
+    engines: {node: '>=20'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -4195,6 +4258,9 @@ packages:
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
+  lodash.sortby@4.7.0:
+    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
+
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
@@ -4228,6 +4294,10 @@ packages:
     resolution: {integrity: sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -4676,6 +4746,13 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
+  playwright-bdd@9.0.0:
+    resolution: {integrity: sha512-0Mhi/myWUmS+jjK23I4x8x30vpnZy45GHIxuKk2HMKugUnXpZgofjonV3C0OzSA4EBtIxYdmtThxv/aYHfM6ag==}
+    engines: {node: '>=20'}
+    hasBin: true
+    peerDependencies:
+      '@playwright/test': '>=1.44'
+
   playwright-core@1.59.0:
     resolution: {integrity: sha512-PW/X/IoZ6BMUUy8rpwHEZ8Kc0IiLIkgKYGNFaMs5KmQhcfLILNx9yCQD0rnWeWfz1PNeqcFP1BsihQhDOBCwZw==}
     engines: {node: '>=18'}
@@ -4884,9 +4961,19 @@ packages:
   redux@5.0.1:
     resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
+
+  regexp-match-indices@1.0.2:
+    resolution: {integrity: sha512-DwZuAkt8NF5mKwGGER1EGh2PRqyvhRhhLviH+R8y8dIuaQROlUfXjt4s9ZTXstIsSkptf06BSvwcEmmfheJJWQ==}
+
+  regexp-tree@0.1.27:
+    resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
+    hasBin: true
 
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -5086,6 +5173,9 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -5272,6 +5362,10 @@ packages:
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tinyrainbow@3.1.0:
@@ -5648,6 +5742,10 @@ packages:
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
+
+  xmlbuilder@15.1.1:
+    resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
+    engines: {node: '>=8.0'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -6446,6 +6544,9 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
+  '@colors/colors@1.5.0':
+    optional: true
+
   '@csstools/color-helpers@6.0.2': {}
 
   '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
@@ -6469,6 +6570,51 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@cucumber/cucumber-expressions@19.0.0':
+    dependencies:
+      regexp-match-indices: 1.0.2
+
+  '@cucumber/gherkin-utils@11.0.0':
+    dependencies:
+      '@cucumber/gherkin': 38.0.0
+      '@cucumber/messages': 32.3.1
+      '@teppeis/multimaps': 3.0.0
+      commander: 14.0.2
+      source-map-support: 0.5.21
+
+  '@cucumber/gherkin@38.0.0':
+    dependencies:
+      '@cucumber/messages': 32.3.1
+
+  '@cucumber/gherkin@39.1.0':
+    dependencies:
+      '@cucumber/messages': 32.3.1
+
+  '@cucumber/html-formatter@23.1.0(@cucumber/messages@32.3.1)':
+    dependencies:
+      '@cucumber/messages': 32.3.1
+
+  '@cucumber/junit-xml-formatter@0.13.3(@cucumber/messages@32.3.1)':
+    dependencies:
+      '@cucumber/messages': 32.3.1
+      '@cucumber/query': 15.0.1(@cucumber/messages@32.3.1)
+      '@teppeis/multimaps': 3.0.0
+      luxon: 3.7.2
+      xmlbuilder: 15.1.1
+
+  '@cucumber/messages@32.3.1':
+    dependencies:
+      class-transformer: 0.5.1
+      reflect-metadata: 0.2.2
+
+  '@cucumber/query@15.0.1(@cucumber/messages@32.3.1)':
+    dependencies:
+      '@cucumber/messages': 32.3.1
+      '@teppeis/multimaps': 3.0.0
+      lodash.sortby: 4.7.0
+
+  '@cucumber/tag-expressions@9.1.0': {}
 
   '@dotenvx/dotenvx@1.59.1':
     dependencies:
@@ -7935,6 +8081,8 @@ snapshots:
       postcss: 8.5.8
       tailwindcss: 4.2.2
 
+  '@teppeis/multimaps@3.0.0': {}
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -8516,6 +8664,8 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
+  buffer-from@1.1.2: {}
+
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
@@ -8587,6 +8737,8 @@ snapshots:
 
   clamscan@2.4.0: {}
 
+  class-transformer@0.5.1: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -8596,6 +8748,12 @@ snapshots:
       restore-cursor: 5.1.0
 
   cli-spinners@2.9.2: {}
+
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
 
   cli-width@4.1.0: {}
 
@@ -8629,6 +8787,10 @@ snapshots:
     optional: true
 
   commander@11.1.0: {}
+
+  commander@13.1.0: {}
+
+  commander@14.0.2: {}
 
   commander@14.0.3: {}
 
@@ -10200,6 +10362,8 @@ snapshots:
 
   lodash.once@4.1.1: {}
 
+  lodash.sortby@4.7.0: {}
+
   log-symbols@6.0.0:
     dependencies:
       chalk: 5.6.2
@@ -10231,6 +10395,8 @@ snapshots:
   lucide-react@1.7.0(react@19.2.4):
     dependencies:
       react: 19.2.4
+
+  luxon@3.7.2: {}
 
   lz-string@1.5.0: {}
 
@@ -10682,6 +10848,22 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
+  playwright-bdd@9.0.0(@playwright/test@1.59.0):
+    dependencies:
+      '@cucumber/cucumber-expressions': 19.0.0
+      '@cucumber/gherkin': 39.1.0
+      '@cucumber/gherkin-utils': 11.0.0
+      '@cucumber/html-formatter': 23.1.0(@cucumber/messages@32.3.1)
+      '@cucumber/junit-xml-formatter': 0.13.3(@cucumber/messages@32.3.1)
+      '@cucumber/messages': 32.3.1
+      '@cucumber/query': 15.0.1(@cucumber/messages@32.3.1)
+      '@cucumber/tag-expressions': 9.1.0
+      '@playwright/test': 1.59.0
+      cli-table3: 0.6.5
+      commander: 13.1.0
+      mime-types: 3.0.2
+      tinyglobby: 0.2.16
+
   playwright-core@1.59.0: {}
 
   playwright@1.59.0:
@@ -10907,6 +11089,8 @@ snapshots:
 
   redux@5.0.1: {}
 
+  reflect-metadata@0.2.2: {}
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.8
@@ -10917,6 +11101,12 @@ snapshots:
       get-intrinsic: 1.3.0
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
+
+  regexp-match-indices@1.0.2:
+    dependencies:
+      regexp-tree: 0.1.27
+
+  regexp-tree@0.1.27: {}
 
   regexp.prototype.flags@1.5.4:
     dependencies:
@@ -11229,6 +11419,11 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
   source-map@0.6.1: {}
 
   split2@4.2.0: {}
@@ -11420,6 +11615,11 @@ snapshots:
   tinyexec@1.0.4: {}
 
   tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
@@ -11817,6 +12017,8 @@ snapshots:
       powershell-utils: 0.1.0
 
   xml-name-validator@5.0.0: {}
+
+  xmlbuilder@15.1.1: {}
 
   xmlchars@2.2.0: {}
 

--- a/tests/manual/bdd/README.md
+++ b/tests/manual/bdd/README.md
@@ -1,0 +1,83 @@
+# Tests BDD (Gherkin exécutable) — preuve de concept
+
+Harness **[playwright-bdd](https://github.com/vitalets/playwright-bdd)** qui rend
+les scénarios Gherkin du plan QA (`docs/qa/`) **directement exécutables**.
+
+> Rangé avec les tests **manuels** : pas de `webServer`, **jamais en CI**.
+> Suppose un `pnpm dev` lancé + une base seedée. C'est une POC à étendre, pas
+> (encore) une suite de non-régression bloquante.
+
+## Pourquoi
+
+Décision QA : *doc = test*. Les blocs `Given/When/Then` de `docs/qa/*.md` sont
+recopiés en `.feature` ici, et exécutés par Playwright via des **step
+definitions réutilisables** — pas de second runner à maintenir (on réutilise le
+runner Playwright + le helper `loginAs`).
+
+## Arborescence
+
+```
+tests/manual/bdd/
+  features/                       # .feature (Gherkin FR, # language: fr)
+    login.feature                 # ← docs/qa/01-auth.md
+    dashboard-access.feature      # ← docs/qa/02-dashboards.md
+  steps/                          # step definitions (réutilisables)
+    auth.steps.ts                 # "je suis connecté en tant que {string}" → loginAs()
+    login.steps.ts                # steps de l'écran connexion (data-testid)
+    navigation.steps.ts           # "je vais sur {string}", "je suis redirigé vers {string}", "je vois le titre {string}"
+playwright.bdd.config.ts          # config (racine du repo) — pas de webServer
+```
+
+Le dossier `.features-gen/` (specs générées depuis les `.feature`) est
+**gitignoré** : il est régénéré par `bddgen`.
+
+## Pré-requis
+
+1. **Base seedée** (utilisateurs de seed, cf. `docs/qa/README.md` §4) :
+   ```bash
+   docker compose --profile local up -d postgres
+   pnpm prisma migrate deploy && pnpm prisma db seed
+   ```
+2. **Dev server lancé** : `pnpm dev` (http://localhost:3000).
+3. **Navigateur** : un Chromium complet. Sur un poste de dev classique :
+   ```bash
+   pnpm exec playwright install chromium --with-deps
+   ```
+   ⚠️ **Sandbox sans GUI / sans root** : Chromium SIGTRAP sur les pages lourdes
+   s'il manque les polices + libs `cairo`/`pango`. Installer les `.deb` en
+   rootless (`apt-get download` → `dpkg-deb -x`) et exporter `LD_LIBRARY_PATH` +
+   `FONTCONFIG_FILE` avant de lancer (voir la mémoire projet « Manual tests env »).
+
+## Lancer
+
+```bash
+pnpm bdd:gen     # génère les specs depuis les .feature (dossier .features-gen)
+pnpm bdd:test    # bddgen + exécution Playwright
+```
+
+Ciblage d'un seul fichier :
+
+```bash
+pnpm bdd:gen
+pnpm exec playwright test --config playwright.bdd.config.ts \
+  .features-gen/tests/manual/bdd/features/login.feature.spec.js
+```
+
+## Étendre
+
+1. Copier un bloc Gherkin depuis `docs/qa/*.md` dans un nouveau `.feature`.
+2. Réutiliser les steps existants ; pour un nouveau geste, ajouter un step dans
+   `steps/` (préférer un **`data-testid`** à un libellé FR pour être robuste à
+   l'i18n).
+3. `pnpm bdd:test`.
+
+### Prochaines étapes recommandées (hors POC)
+
+- **Vérification « effet base »** : ajouter `steps/db.steps.ts` qui interroge
+  PostgreSQL (client Prisma en lecture) pour valider les lignes
+  `# Effet base:` des scénarios (ex. `appointments.status='cancelled'`,
+  présence d'une ligne `audit_logs`). C'est ce qui distingue ce harness d'un
+  simple test d'UI.
+- **Reset déterministe** entre features d'écriture (transaction rollback ou
+  `prisma migrate reset`) pour l'idempotence.
+- **`data-testid`** systématiques sur les écrans à automatiser.

--- a/tests/manual/bdd/features/dashboard-access.feature
+++ b/tests/manual/bdd/features/dashboard-access.feature
@@ -1,0 +1,14 @@
+# language: fr
+# Source : docs/qa/02-dashboards.md — Dashboard médecin (RBAC)
+Fonctionnalité: Accès au tableau de bord médecin selon le rôle
+
+  Scénario: un DOCTOR accède à son tableau de bord
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand je vais sur "/medecin"
+    Alors je vois le titre "Tableau de bord médecin"
+    # Effet base attendu : AUCUN (écran en lecture seule)
+
+  Scénario: un VIEWER est redirigé hors du tableau de bord médecin
+    Étant donné que je suis connecté en tant que "VIEWER"
+    Quand je vais sur "/medecin"
+    Alors je suis redirigé vers "/patient/dashboard"

--- a/tests/manual/bdd/features/login.feature
+++ b/tests/manual/bdd/features/login.feature
@@ -1,0 +1,27 @@
+# language: fr
+# Source : docs/qa/01-auth.md — Écran Connexion (/login)
+Fonctionnalité: Connexion au backoffice
+
+  Scénario: le bouton reste désactivé tant que le formulaire est incomplet
+    Étant donné que je suis sur la page de connexion
+    Alors le bouton de connexion est désactivé
+    Quand je saisis l'email "docteur@diabeo.test"
+    Et je saisis le mot de passe "DEV-ONLY-Doctor123!"
+    Alors le bouton de connexion est activé
+
+  Scénario: connexion réussie d'un DOCTOR
+    Étant donné que je suis sur la page de connexion
+    Quand je saisis l'email "docteur@diabeo.test"
+    Et je saisis le mot de passe "DEV-ONLY-Doctor123!"
+    Et je clique sur le bouton de connexion
+    Alors je suis redirigé vers "/medecin"
+    # Effet base attendu : INSERT sessions + audit_logs(action=LOGIN, resource=SESSION)
+
+  Scénario: identifiants invalides — message générique anti-énumération
+    Étant donné que je suis sur la page de connexion
+    Quand je saisis l'email "inconnu@diabeo.test"
+    Et je saisis le mot de passe "mauvais-mot-de-passe"
+    Et je clique sur le bouton de connexion
+    Alors je reste sur la page de connexion
+    Et je vois une alerte d'erreur
+    # Effet base attendu : audit_logs(action=UNAUTHORIZED) + incrément rate-limit

--- a/tests/manual/bdd/steps/auth.steps.ts
+++ b/tests/manual/bdd/steps/auth.steps.ts
@@ -1,0 +1,28 @@
+import { createBdd } from "playwright-bdd"
+import { loginAs, type SeedUserRole } from "../../../e2e/helpers/auth"
+
+const { Given } = createBdd()
+
+/**
+ * Mapping rôle QA (libellé Gherkin) → utilisateur de seed.
+ * Voir docs/qa/README.md §4 (comptes de seed) et prisma/seed.ts.
+ */
+const ROLE_MAP: Record<string, SeedUserRole> = {
+  ADMIN: "admin",
+  DOCTOR: "doctor",
+  NURSE: "nurse",
+  VIEWER: "patient_dt1",
+}
+
+Given(
+  "je suis connecté en tant que {string}",
+  async ({ context, request }, role: string) => {
+    const seed = ROLE_MAP[role]
+    if (!seed) {
+      throw new Error(
+        `Rôle QA inconnu : "${role}" (attendu ADMIN | DOCTOR | NURSE | VIEWER)`,
+      )
+    }
+    await loginAs(context, request, seed)
+  },
+)

--- a/tests/manual/bdd/steps/login.steps.ts
+++ b/tests/manual/bdd/steps/login.steps.ts
@@ -1,0 +1,38 @@
+import { expect } from "@playwright/test"
+import { createBdd } from "playwright-bdd"
+
+const { Given, When, Then } = createBdd()
+
+Given("je suis sur la page de connexion", async ({ page }) => {
+  await page.goto("/login")
+  await expect(page.getByTestId("login-screen")).toBeVisible()
+})
+
+When("je saisis l'email {string}", async ({ page }, email: string) => {
+  await page.locator("#login-email").fill(email)
+})
+
+When("je saisis le mot de passe {string}", async ({ page }, password: string) => {
+  await page.locator("#login-password").fill(password)
+})
+
+When("je clique sur le bouton de connexion", async ({ page }) => {
+  await page.getByTestId("login-button").click()
+})
+
+Then("le bouton de connexion est désactivé", async ({ page }) => {
+  await expect(page.getByTestId("login-button")).toBeDisabled()
+})
+
+Then("le bouton de connexion est activé", async ({ page }) => {
+  await expect(page.getByTestId("login-button")).toBeEnabled()
+})
+
+Then("je reste sur la page de connexion", async ({ page }) => {
+  await expect(page).toHaveURL(/\/login\/?(\?.*)?$/)
+})
+
+Then("je vois une alerte d'erreur", async ({ page }) => {
+  // AlertBanner severity="warning" → role="alert" (cf. AlertBanner.tsx).
+  await expect(page.getByRole("alert")).toBeVisible()
+})

--- a/tests/manual/bdd/steps/navigation.steps.ts
+++ b/tests/manual/bdd/steps/navigation.steps.ts
@@ -1,0 +1,23 @@
+import { expect } from "@playwright/test"
+import { createBdd } from "playwright-bdd"
+
+const { When, Then } = createBdd()
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+When("je vais sur {string}", async ({ page }, path: string) => {
+  await page.goto(path)
+})
+
+Then("je suis redirigé vers {string}", async ({ page }, path: string) => {
+  // Tolère un slash final éventuel.
+  await expect(page).toHaveURL(new RegExp(`${escapeRegExp(path)}/?(\\?.*)?$`))
+})
+
+Then("je vois le titre {string}", async ({ page }, title: string) => {
+  await expect(
+    page.getByRole("heading", { name: title }),
+  ).toBeVisible()
+})


### PR DESCRIPTION
## Objet

Preuve de concept demandée : rendre les scénarios Gherkin du plan QA (`docs/qa/`, PR #489) **directement exécutables** via **[playwright-bdd](https://github.com/vitalets/playwright-bdd)** — *doc = test*.

Rangé avec les **tests manuels** (comme demandé) : **pas de `webServer`, hors CI**, suppose un `pnpm dev` lancé + base seedée. Même posture que `playwright.manual.config.ts`.

## Contenu

| Fichier | Rôle |
|---|---|
| `playwright.bdd.config.ts` | config BDD (pas de webServer, hors CI) |
| `tests/manual/bdd/features/login.feature` | ← `docs/qa/01-auth.md` |
| `tests/manual/bdd/features/dashboard-access.feature` | ← `docs/qa/02-dashboards.md` |
| `tests/manual/bdd/steps/auth.steps.ts` | `je suis connecté en tant que {string}` → `loginAs()` |
| `tests/manual/bdd/steps/login.steps.ts` | steps écran connexion (via `data-testid`) |
| `tests/manual/bdd/steps/navigation.steps.ts` | `je vais sur` / `je suis redirigé vers` / `je vois le titre` |
| `tests/manual/bdd/README.md` | prérequis + lancement + extension |
| scripts `bdd:gen` / `bdd:test` | génération + exécution |

`.features-gen/` (specs générées) est gitignoré.

## Résultat (vrai navigateur, stack local seedé)

**5/5 scénarios verts** :
- bouton de connexion désactivé → activé selon le formulaire ;
- connexion DOCTOR réussie (vraie session créée) ;
- identifiants invalides → alerte (anti-énumération) ;
- DOCTOR accède à `/medecin` ; VIEWER redirigé vers `/patient/dashboard`.

`tsc -p tsconfig.json` et `eslint` : OK.

## Prochaines étapes (documentées dans le README, hors POC)

- step `db.steps.ts` de **vérification « effet base »** (lecture PostgreSQL) — ce qui distingue ce harness d'un simple test d'UI ;
- reset déterministe entre features d'écriture ;
- `data-testid` systématiques sur les écrans à automatiser.

> Réutilise `loginAs` (`tests/e2e/helpers/auth.ts`). Aucune route ni code applicatif modifié. La suite BDD n'est **pas** branchée en CI (volontaire — nécessite base + dev server + navigateur complet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)