### PR TITLE
docs(qa): plan de tests QA par écran — lot 2 (reste de l'application, 25 écrans)

### DIFF
--- a/docs/qa/07-dashboards-analytics.md
+++ b/docs/qa/07-dashboards-analytics.md
@@ -1,0 +1,166 @@
+# QA — Dashboards transverses & Analytics
+
+Écrans : `/` (racine dashboard), `/dashboard`, `/analytics`, `/analytics/radar`, `/weekly`.
+Voir [conventions](README.md#3-conventions--légende).
+
+> Écrans **majoritairement en lecture seule** (audit READ, aucune écriture
+> patient). Consentement RGPD requis pour les données glycémiques.
+
+---
+
+## Écran : Redirection racine (`/`) 🟢
+
+**Rôle / RBAC** : redirige selon `x-user-role` — DOCTOR→`/medecin`, NURSE→`/infirmier`,
+ADMIN→`/admin`, VIEWER→`/patient/dashboard`, sinon `/login`.
+**Statut impl.** : 🟢 Réel (redirection serveur, aucun rendu).
+
+```gherkin
+Feature: Redirection de la racine selon le rôle
+
+  Scénario: chaque rôle atterrit sur son dashboard
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand je vais sur "/"
+    Alors je suis redirigé vers "/medecin"
+```
+
+**Cas limites** : JWT expiré / `x-user-role` absent / session révoquée → `/login`.
+
+---
+
+## Écran : Dashboard glycémie (`/dashboard`) 🟢
+
+**Rôle / RBAC** : utilisateurs authentifiés (protégé par le layout). **Consentement RGPD requis.**
+**Statut impl.** : 🟢 Réel. ⚠️ Bouton « Nouvel évènement » câblé mais dialog non livré (US-WEB-202).
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Titre « Glycémie » + sélecteur période (1W/2W/1M/3M) + Refresh | visible |
+| Grille 6 métriques | Glycémie moyenne, HbA1c, TIR %, CV, Écart-type, Hypos |
+| Graphique CGM (timeline) | visible |
+| États | loading (skeleton), erreur + « Réessayer », vide (« noData »), succès |
+| Auto-refresh | silencieux toutes les 5 min (annonce ARIA) |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Changer période / Refresh | `GET /api/analytics/{glycemic-profile,time-in-range,hypoglycemia}` + `/api/cgm` (parallèle) | rechargement, skeleton | **lecture seule** · audit READ (ANALYTICS / CGM_ENTRY) |
+
+```gherkin
+Feature: Dashboard glycémie
+
+  Scénario: affichage des métriques pour un DOCTOR
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand je vais sur "/dashboard"
+    Alors je vois la métrique "TIR"
+    Et je vois le graphique CGM
+    # Effet base: lecture seule, GET analytics + /api/cgm = 200
+
+  Scénario: consentement RGPD manquant
+    Étant donné un patient sans consentement RGPD
+    Quand la page charge les données
+    Alors la réponse analytics est 403 "gdprConsentRequired"
+```
+
+**Cas limites** : 403 `gdprConsentRequired`, 429 rate-limit analytics (`Retry-After`), période > 90 j rejetée (Zod), fenêtre CGM > 30 j → erreur serveur.
+
+---
+
+## Écran : Analytics / Profil glycémique (`/analytics`) 🟢
+
+**Rôle / RBAC** : authentifiés. Consentement RGPD requis.
+**Statut impl.** : 🟢 Réel.
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Titre « Profil glycémique » + plage de dates FR | visible |
+| Sélecteur période (défaut 2W) | visible |
+| Grille 6 métriques + badge capture rate | vert ≥70 %, ambre ≥50 %, rouge <50 % |
+| Graphique AGP (5 percentiles p10/p25/médiane/p75/p90) + références 70/180/54/250 | visible |
+| Pie TIR + barres + histogramme hypos | visible |
+| Alerte « Données insuffisantes » | si capture < 50 % ET pas d'AGP |
+| États | loading / erreur + retry / insufficientData / succès |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Changer période | `GET /api/analytics/{glycemic-profile,time-in-range,agp,hypoglycemia}` | recharge | **lecture seule** · audit READ (ANALYTICS) |
+
+```gherkin
+Feature: Profil glycémique (AGP)
+
+  Scénario: badge capture rate en alerte sous 50%
+    Étant donné un patient avec un capture rate < 50% et aucune donnée AGP
+    Quand j'ouvre "/analytics"
+    Alors je vois l'alerte "Données insuffisantes"
+```
+
+**Cas limites** : capture < 70 % → badge ambre ; toutes API en échec → erreur + retry.
+
+---
+
+## Écran : Graphique radar (`/analytics/radar`) 🟡
+
+**Rôle / RBAC** : authentifiés.
+**Statut impl.** : 🟡 Partiel — le radar SVG est implémenté, mais la répartition
+`weeklyRadar` par jour côté service n'est pas garantie (réponse possiblement vide).
+À tester comme « affichage » + « contrat API » séparément.
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Titre « Graphique radar » + sélecteur période + sélecteur métrique (TIR / Glycémie moyenne / CV) | visible |
+| Radar SVG 7 axes (Lun–Dim) + légende + tableau compagnon (Jour / Valeur / Vs moyenne) | visible si données |
+| États | loading (skeleton), vide (insufficientData), erreur (AlertBanner), succès |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Changer période / métrique | `GET /api/analytics/glycemic-profile?period=…&metric=tir\|averageGlucose\|cv` | radar redessiné | **lecture seule** · audit READ |
+
+**Cas limites** : tous points = 0 → état vide ; réponse 404/204 → aucun graphique ; metric invalide → 400 serveur.
+
+---
+
+## Écran : Vue hebdomadaire (`/weekly`) 🟡
+
+**Rôle / RBAC** : authentifiés.
+**Statut impl.** : 🟢 onglet « Semainier » réel · 🟡 onglets « Historique » et « Tableau » = « Bientôt disponible » (ComingSoon). ⚠️ Insuline hebdo = « — » (TODO `totalInsulin=null`).
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Titre « Vue hebdomadaire » + 3 onglets (Historique / Tableau / Semainier) | seul Semainier actif |
+| Navigation semaine (◄ / plage / ►) + badge « Semaine en cours » | ► désactivé sur la semaine courante |
+| 4 cartes stats hebdo (Glycémie moy., TIR %, Lectures, Insuline U) | « Insuline » = « — » |
+| Grille 7 jours (mini-graphique par jour) | visible |
+| États | loading / erreur + « Réessayer » / vide / succès |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Naviguer semaine | `GET /api/cgm?from&to` (lun 00:00 → dim 23:59) | recharge 7 jours | **lecture seule** · audit READ (CGM_ENTRY) |
+| Onglet Historique / Tableau | — | « Bientôt disponible » | aucun |
+
+```gherkin
+Feature: Vue hebdomadaire
+
+  Scénario: le bouton "semaine suivante" est désactivé sur la semaine courante
+    Étant donné que je suis sur "/weekly" sur la semaine en cours
+    Alors le bouton de navigation vers la semaine suivante est désactivé
+
+  Scénario: onglet Historique non encore livré
+    Quand je clique l'onglet "Historique"
+    Alors je vois "Bientôt disponible"
+```
+
+**Cas limites** : jour sans lectures → TIR/moyenne « — » ; plage CGM > 30 j → erreur serveur.

--- a/docs/qa/08-admin-ops.md
+++ b/docs/qa/08-admin-ops.md
@@ -1,0 +1,169 @@
+# QA — Administration & Opérations
+
+Écrans : `/audit`, `/admin` (hub), `/admin/backups`, `/admin/system-health`.
+Voir [conventions](README.md#3-conventions--légende).
+
+> Tous **ADMIN only** (`redirect("/")` sinon). Le backend audit est opérationnel
+> même quand l'UI de consultation ne l'est pas encore.
+
+---
+
+## Écran : Consultation audit (`/audit`) 🟡
+
+**Statut impl.** : 🟡 **Stub UI** — la page affiche « Bientôt disponible ». Le
+backend `GET /api/admin/audit-logs` est **pleinement opérationnel** (filtres
+userId / resource / action / from / to / pagination). À tester au niveau
+**contrat API**.
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Titre « Consultation audit » + description | visible |
+| Badge « Bientôt disponible » | visible |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| (API) consulter l'audit | `GET /api/admin/audit-logs?userId&resource&action&from&to&page&limit` | JSON paginé | **lecture seule** · la consultation est **elle-même auditée** (READ / SESSION, `resourceId:"audit-logs"`) |
+
+```gherkin
+Feature: Consultation de l'audit (contrat API)
+
+  Scénario: un ADMIN filtre l'audit
+    Étant donné que je suis connecté en tant que "ADMIN"
+    Quand j'appelle GET "/api/admin/audit-logs?resource=PATIENT&action=READ"
+    Alors la réponse est 200 paginée
+    # Effet base: audit_logs(action=READ, resource=SESSION, resourceId="audit-logs", metadata.filters)
+
+  Scénario: paramètres invalides
+    Quand j'appelle GET "/api/admin/audit-logs?limit=9999"
+    Alors la réponse est 400 "validationFailed"
+```
+
+**Cas limites** : `limit` borné 1–200 (défaut 50) ; non-ADMIN → redirection / 401-403.
+
+---
+
+## Écran : Hub administrateur (`/admin`) 🟢
+
+**Statut impl.** : 🟢 Réel (3 cartes en polling, lecture seule).
+
+### Affichage attendu
+
+| Carte | Contenu | Polling |
+|---|---|---|
+| **KPI** | Cabinets, Membres équipe, Patients actifs 14 j, Événements audit 7 j | 5 min |
+| **Facturation** | Éligibles, Non facturés (rouge), Facturés 30 j, Montant non facturé € | 10 min |
+| **Conformité HDS** | Dernier backup (Europe/Paris), Audit 24 h, Backups en échec 30 j · badges « Stale (>2 j) » / « Alerte » | 5 min |
+| États | loading / erreur par carte / bannière « Données obsolètes » | — |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Polling | `GET /api/dashboard/admin/{kpi,billing,compliance}` | cartes mises à jour | **lecture seule** |
+
+```gherkin
+Feature: Hub administrateur
+
+  Scénario: un ADMIN voit les 3 cartes
+    Étant donné que je suis connecté en tant que "ADMIN"
+    Quand je vais sur "/admin"
+    Alors je vois la carte "KPI"
+    Et je vois la carte "Conformité HDS"
+
+  Scénario: un non-ADMIN est redirigé
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand je vais sur "/admin"
+    Alors je suis redirigé vers "/"
+```
+
+**Cas limites** : API en échec → chaque carte affiche son erreur indépendamment ; bannière « obsolète » au-delà de 2× l'intervalle de polling.
+
+---
+
+## Écran : Backups PostgreSQL (`/admin/backups`) 🟢
+
+**Statut impl.** : 🟢 Réel.
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Titre + filtre statut (Tous / En attente / En cours / Terminé / Échoué) + Actualiser + « Déclencher backup » | visible |
+| Ligne backup | badge statut, réf. tronquée (tooltip complet), « Démarré … », durée, taille (Intl), « Par User #ID », erreur dépliable |
+| États | chargement / erreur + Réessayer / vide « Aucun backup » / liste |
+| Après trigger | succès « Backup déclenché (status: pending) » ou erreur mappée (in progress / worker indispo / disque plein) |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Lister / filtrer | `GET /api/admin/backups?status&limit&cursor&from&to` | liste paginée | **lecture seule** · audit READ (BACKUP) · pas de location S3 exposée (`hasLocation:bool`) |
+| Déclencher (dialog confirm) | `POST /api/admin/backups` (CSRF `X-Requested-With`) | « Backup déclenché » · **202** | INSERT `backup_log` (status=pending, triggeredBy) · audit CREATE · **rate-limit 3/h user + 6/h IP** · **concurrency guard** (1 seul pending/running) |
+
+```gherkin
+Feature: Backups PostgreSQL
+
+  Scénario: déclencher un backup manuel
+    Étant donné que je suis connecté en tant que "ADMIN"
+    Et je suis sur "/admin/backups"
+    Quand je clique "Déclencher backup" et je confirme
+    Alors je vois "Backup déclenché"
+    # Effet base: INSERT backup_log(status=pending, triggeredBy) + audit(CREATE/BACKUP) ; HTTP 202
+
+  Scénario: un backup est déjà en cours (concurrency guard)
+    Étant donné qu'un backup est déjà "running"
+    Quand je déclenche un backup
+    Alors je vois "Un backup est déjà en cours"
+    # Effet base: AUCUNE insertion (409 backup_already_in_progress)
+
+  Scénario: rate-limit dépassé
+    Étant donné que j'ai déjà déclenché 3 backups dans l'heure
+    Quand je déclenche un 4e backup
+    Alors la réponse est 429 avec en-tête "Retry-After"
+```
+
+**Cas limites** : 429 (3/h user, 6/h IP, fail-closed) ; 409 concurrency ; `errorMessage` assaini (PHI strippé) ; `sizeBytes` BigInt → number ou string (>TB).
+
+---
+
+## Écran : Santé système (`/admin/system-health`) 🟢
+
+**Statut impl.** : 🟢 Réel (auto-refresh 60 s, pausable).
+
+### Affichage attendu
+
+| Section | Contenu |
+|---|---|
+| Statut global | badge « Opérationnel / Dégradé / Hors service » + « Dernière vérification il y a … » + Pause/Reprendre + Actualiser |
+| Composants (4) | Base de données, Redis, Ingestion CGM, Backups → badge Ok/Dégradé/HS/Inconnu |
+| Métriques (4) | Sessions actives, Tentatives non-autorisées 24 h (highlight >100), CGM lag (highlight >30 min), Dernier backup (highlight >36 h) |
+| États | chargement / erreur + Réessayer / succès |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Charger / Actualiser | `GET /api/admin/system-health` | snapshot | **lecture seule** · audit READ (SYSTEM_HEALTH) · 6 checks timeout 2 s |
+| Pause / Reprendre auto-refresh | — (client) | bascule polling | aucun |
+
+```gherkin
+Feature: Santé système
+
+  Scénario: snapshot santé pour un ADMIN
+    Étant donné que je suis connecté en tant que "ADMIN"
+    Quand je vais sur "/admin/system-health"
+    Alors je vois le statut global
+    Et je vois les 4 composants (Base de données, Redis, Ingestion CGM, Backups)
+    # Effet base: lecture seule + audit_logs(READ/SYSTEM_HEALTH)
+
+  Scénario: alerte sur tentatives non-autorisées élevées
+    Étant donné plus de 100 tentatives non-autorisées sur 24h
+    Quand j'ouvre le snapshot
+    Alors la métrique correspondante est mise en évidence avec un texte d'alerte
+```
+
+**Cas limites** : check > 2 s → fallback `down`/`unknown` ; Redis non configuré → `unknown` (dégradé accepté) ; highlights = couleur **+ texte** (WCAG).

--- a/docs/qa/09-admin-compliance-billing.md
+++ b/docs/qa/09-admin-compliance-billing.md
@@ -1,0 +1,195 @@
+# QA — Conformité & Facturation (Admin)
+
+Écrans : `/admin/data-breaches` (+`[id]`), `/admin/invoices` (+`[id]`), `/admin/tax-rules`.
+Voir [conventions](README.md#3-conventions--légende).
+
+> Tous **ADMIN only** côté UI (`redirect("/")`). Les transitions de violation
+> RGPD exigent un **step-up MFA** + sont **idempotentes**.
+
+---
+
+## Écran : Violations de données — RGPD Art. 33 (`/admin/data-breaches`) 🟢
+
+**Statut impl.** : 🟢 Réel.
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Titre « Violations de données (RGPD Art. 33) » | visible |
+| Filtres statut (draft / under_assessment / notified_cnil / notified_users / closed) + sévérité (low/medium/high/critical) | visible |
+| Bouton « Déclarer une violation » | visible |
+| Ligne violation | titre, badge sévérité, badge statut, date détection, **délai CNIL en rouge si dépassé / orange si < 12 h** |
+| États | vide « Aucune violation enregistrée », erreur réseau |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Filtrer | `GET /api/admin/data-breaches?status&severity` | liste | **lecture** · audit (DATA_BREACH list) |
+| Déclarer (dialog) | `POST /api/admin/data-breaches` | dialog ferme, liste rafraîchie | INSERT `data_breach` (status=draft, **description chiffrée AES-256-GCM**, declaredBy) · audit CREATE |
+
+> Zod déclaration : `severity` enum, `title` 1–200, `description` ≤ 5000.
+> ⚠️ Le formulaire avertit « NE PAS inclure de PHI/PII dans le titre » (titre non chiffré).
+
+```gherkin
+Feature: Registre des violations de données (RGPD Art. 33)
+
+  Scénario: déclarer une violation
+    Étant donné que je suis connecté en tant que "ADMIN"
+    Et je suis sur "/admin/data-breaches"
+    Quand je clique "Déclarer une violation"
+    Et je choisis la sévérité "high" et un titre sans PHI
+    Et je confirme
+    Alors la violation apparaît dans la liste au statut "draft"
+    # Effet base: INSERT data_breach(status=draft, description chiffrée) + audit(CREATE/DATA_BREACH)
+```
+
+**Cas limites** : délai CNIL 72 h (flag dépassé) ; sévérité low/medium → pas d'alerte CNIL ; confirmation si on ferme un formulaire « sale ».
+
+---
+
+## Écran : Détail violation + transitions FSM (`/admin/data-breaches/[id]`) 🟢
+
+**Statut impl.** : 🟢 Réel. **FSM** : draft→{under_assessment, closed} ; under_assessment→{notified_cnil, closed} ; notified_cnil→{notified_users, closed} ; notified_users→{closed} ; closed = terminal.
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| En-tête (titre + badges sévérité/statut) + **alerte CNIL** (dépassé rouge / < 12 h orange) | visible |
+| Section « Détails » (detectedAt, declaredBy, cnilNotifiedAt, usersNotifiedAt, closedAt) | visible |
+| Champs chiffrés (description, remediation, cnilCaseNumber) + bouton « Modifier » (désactivé si closed) | visible |
+| Section « Workflow FSM » | boutons des transitions autorisées ; saisie « Nombre d'utilisateurs notifiés » si transition `notified_users` |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Charger | `GET /api/admin/data-breaches/[id]` | détail (champs déchiffrés) | lecture · audit READ |
+| Éditer champs | `PATCH /api/admin/data-breaches/[id]` | refresh | UPDATE (description/remediation/cnilCaseNumber chiffrés) · audit UPDATE |
+| **Transition FSM** | `POST /api/admin/data-breaches/[id]/transition` | dialog → refresh | UPDATE status + timestamp (cnil/users/closed) · audit (kind notify.cnil/notify.users/close) · **step-up MFA** + `Idempotency-Key` |
+
+```gherkin
+Feature: Transitions d'une violation (FSM)
+
+  Scénario: notifier la CNIL (avec MFA fraîche)
+    Étant donné une violation au statut "under_assessment" et une MFA fraîche
+    Quand je transitionne vers "notified_cnil"
+    Alors le statut passe à "notified_cnil"
+    # Effet base: UPDATE data_breach(status, cnil_notified_at=now) + audit(kind=notify.cnil)
+
+  Scénario: transition interdite par la FSM
+    Étant donné une violation au statut "draft"
+    Quand je tente la transition vers "notified_users"
+    Alors la réponse est 409 "invalidTransition"
+    # Effet base: AUCUNE modif
+
+  Scénario: transition sans MFA récente
+    Étant donné une MFA non récente (> fenêtre critique)
+    Quand je tente une transition
+    Alors la réponse est 401 (step-up requis)
+```
+
+**Cas limites** : transition interdite → 409 ; MFA absente/expirée → 401 ; édition bloquée si `closed` ; rétention 10 ans (CGI) — purge hors-scope UI.
+
+---
+
+## Écran : Liste factures (`/admin/invoices`) 🟢
+
+**Statut impl.** : 🟢 Réel (pagination cursor, V1.5).
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Titre « Factures » + filtre statut (draft/issued/paid/cancelled/refunded) + Actualiser | visible |
+| Ligne facture | numéro (ou « Brouillon #id »), badge statut, montant TTC, date émise, patient#/cabinet# |
+| États | vide « Aucune facture », erreur, **alerte « > 100 factures, affiner le filtre »** si pagination |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Filtrer / actualiser | `GET /api/billing/invoices?status&limit&cursor` | liste paginée | **lecture** · audit (INVOICE) |
+| Clic facture | — | `/admin/invoices/{id}` | aucun |
+
+---
+
+## Écran : Détail facture + PDF (`/admin/invoices/[id]`) 🟢
+
+**Statut impl.** : 🟢 Réel (génération PDF + S3, IBAN chiffré).
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Fil d'Ariane + en-tête (numéro, badges statut/pays) | visible |
+| Section PDF | si draft : « PDF dispo seulement pour les factures émises » · sinon : « Régénérer PDF » + « Télécharger PDF » |
+| Détails (cabinet, patient, devise, pays, mode paiement, dates, créateur) | visible |
+| Lignes (Description, Qté, Prix HT, TVA %, Total TTC) + totaux (sous-total/TVA/TTC) | visible |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Charger | `GET /api/billing/invoices/[id]` | détail | lecture · audit READ (contrôle d'accès interne) |
+| Générer/Régénérer PDF | `POST /api/billing/invoices/[id]/pdf` | « PDF généré » | render PDF + upload **S3** + `pdfHash` (idempotent) · audit |
+| Télécharger PDF | `GET /api/billing/invoices/[id]/pdf` | téléchargement `invoice-{id}.pdf` | stream S3 (Content-Disposition RFC 6266, X-Content-SHA256, ANSSI) |
+
+```gherkin
+Feature: Facture PDF
+
+  Scénario: générer puis télécharger le PDF d'une facture émise
+    Étant donné que je suis connecté en tant que "ADMIN"
+    Et une facture au statut "issued"
+    Quand je clique "Régénérer PDF"
+    Alors je vois "PDF généré"
+    # Effet base: render PDF + upload S3 + pdfHash (idempotent) + audit
+    Quand je clique "Télécharger PDF"
+    Alors le navigateur télécharge "invoice-{id}.pdf"
+
+  Scénario: PDF indisponible pour un brouillon
+    Étant donné une facture au statut "draft"
+    Quand j'ouvre son détail
+    Alors je vois "Le PDF n'est disponible que pour les factures émises"
+```
+
+**Cas limites** : IBAN chiffré AES-256 (échec déchiffrement → `renderFailed`) ; race de génération concurrente (`concurrentGenerationRaceLost`) ; rétention 10 ans CGI.
+
+---
+
+## Écran : Règles fiscales / TVA (`/admin/tax-rules`) 🟢
+
+**Statut impl.** : 🟢 Réel en **lecture seule** (création/édition via runbook). Backend lecture = NURSE+.
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Titre « Règles fiscales » + mention « Lecture seule » | visible |
+| Formulaire : Pays (ISO alpha-2, datalist), Type de taxe (VAT / IR / IS / cotisation), Date (défaut aujourd'hui) | visible |
+| Résultat | « Aucun taux actif… » OU grand % + détails (pays, type, taux, statut, effet depuis/jusqu'au, description) |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Rechercher taux actif | `GET /api/config/tax-rules/active?countryCode&taxType&date` | affiche le taux ou 404 | **lecture seule** · audit READ (COUNTRY_TAX_RULE, `found:bool`) |
+
+```gherkin
+Feature: Résolution d'un taux fiscal actif
+
+  Scénario: taux de TVA français à une date donnée
+    Étant donné que je suis connecté en tant que "ADMIN"
+    Quand je recherche le taux "VAT" pour "FR" au "2026-06-05"
+    Alors je vois le taux actif en pourcentage
+    # Effet base: lecture seule + audit(READ/COUNTRY_TAX_RULE, found=true)
+
+  Scénario: aucun taux actif
+    Quand je recherche un pays/type sans règle active
+    Alors je vois "Aucun taux actif"
+    # Effet base: 404 noActiveRule (countryCode/taxType/atDate inclus pour rejeu)
+```
+
+**Cas limites** : code pays libre (validé regex `^[A-Z]{2}$`) ; date locale (pas UTC, évite « demain par défaut »).

--- a/docs/qa/10-devices-documents-events.md
+++ b/docs/qa/10-devices-documents-events.md
@@ -1,0 +1,196 @@
+# QA — Appareils, Documents & Événements
+
+Écrans : `/devices`, `/devices/pair`, `/documents`, `/events/new`.
+Voir [conventions](README.md#3-conventions--légende).
+
+> Écrans d'écriture côté patient/soignant. **Consentement RGPD requis** partout.
+> Documents : antivirus **ClamAV** obligatoire avant stockage S3.
+
+---
+
+## Écran : Supervision appareils (`/devices`) 🟢
+
+**Rôle / RBAC** : patient (ses appareils) + staff (NURSE/ADMIN). Consentement RGPD requis.
+**Statut impl.** : 🟢 Réel. **Max 9 appareils** par patient.
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Titre « Appareils connectés » | visible |
+| Groupes par catégorie (CGM / GLUCOMETER / PUMP / OTHER), cartes 2 colonnes | visible |
+| Par appareil | nom/marque/modèle, icône Cloud si OAuth, tags connexion (bluetooth/usb/api), **indicateur sync** (vert <1 h / orange <24 h / rouge >24 h / gris jamais) |
+| Bannière « hors-ligne » (>24 h) + « Actualiser tout » | si applicable |
+| États | vide « Aucun appareil » + « Ajouter le 1er appareil », loading, erreur + Retry |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Charger | `GET /api/devices` + `GET /api/devices/sync-status` | groupes + indicateurs | lecture · audit READ |
+| Ajouter appareil (dialog) | `POST /api/devices` `{category,brand,model,connectionTypes}` | apparaît dans la liste | INSERT `patient_device` · audit CREATE |
+| OAuth (Dexcom/LibreView) | — (flow externe `window.open`) | onglet OAuth | aucun POST direct |
+| Rafraîchir sync | `GET /api/devices/sync-status` | indicateurs MAJ | lecture |
+
+```gherkin
+Feature: Supervision des appareils
+
+  Scénario: ajouter un appareil non-cloud
+    Étant donné que je suis connecté en tant que "NURSE"
+    Et je suis sur "/devices"
+    Quand j'ajoute un appareil de catégorie "GLUCOMETER" marque "Accu-Chek" modèle "Guide"
+    Alors l'appareil apparaît dans la liste
+    # Effet base: INSERT patient_device + audit(CREATE/DEVICE)
+
+  Scénario: limite de 9 appareils atteinte
+    Étant donné un patient avec 9 appareils
+    Quand je tente d'en ajouter un 10e
+    Alors la réponse est 400 "maxDevicesReached"
+```
+
+**Cas limites** : 9 appareils max ; 403 `gdprConsentRequired` ; 404 patient introuvable.
+
+---
+
+## Écran : Wizard pairing appareil (`/devices/pair?patientId=X`) 🟢
+
+**Rôle / RBAC** : `patientId` requis ; RBAC via `resolvePatientId` (patient = soi, staff = patient autorisé).
+**Statut impl.** : 🟢 Réel (3 étapes + a11y live region).
+
+### Affichage attendu
+
+| Étape | Contenu |
+|---|---|
+| En-tête | « #{patientId} — Étape X/3 » + indicateur d'étapes |
+| 1 — Type/Modèle | Catégorie + Marque* + Modèle* · « Suivant » désactivé si incomplet |
+| 2 — N° série + connexion | SN* + fieldset connexion (bluetooth/usb/api, ≥1 requis) |
+| 3 — Confirmation | récap (catégorie, marque/modèle, SN, connexions) + « Confirmer » |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Suivant / Retour | — | change d'étape | aucun |
+| Confirmer | `POST /api/devices` `{patientId,category,brand,model,sn,connectionTypes}` | redirection `/patients/{id}?tab=devices` | INSERT `patient_device` · audit CREATE |
+
+```gherkin
+Feature: Pairing d'un appareil (wizard 3 étapes)
+
+  Scénario: pairing complet
+    Étant donné que je suis connecté en tant que "NURSE"
+    Et je suis sur "/devices/pair?patientId=1"
+    Quand je remplis le type, la marque et le modèle puis je clique "Suivant"
+    Et je saisis le n° de série et sélectionne "bluetooth" puis je clique "Suivant"
+    Et je clique "Confirmer"
+    Alors je suis redirigé vers "/patients/1?tab=devices"
+    # Effet base: INSERT patient_device + audit(CREATE/DEVICE)
+```
+
+**Cas limites** : `patientId` absent/invalide → carte « Patient requis » ; 403 consentement ; 400 `maxDevicesReached`.
+
+---
+
+## Écran : Documents médicaux (`/documents`) 🟢
+
+**Rôle / RBAC** : lecture filtrée RBAC (VIEWER = `patientShare=true`). **Upload : NURSE+.** Consentement RGPD requis.
+**Statut impl.** : 🟢 Réel (upload XHR avec progression, ClamAV, S3).
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Titre « Documents médicaux » + compteur | visible |
+| Recherche + bouton Upload (accept .pdf/.png/.jpg/.jpeg) | visible |
+| Progression upload (aria-live) / erreur upload | si applicable |
+| Documents groupés par catégorie (general/forDoctor/personal/prescription/labResults/other), dépliables | visible |
+| Par document | icône + titre (cliquable si PDF/image) + date + taille + bouton télécharger |
+| États | loading, erreur, vide, « aucun résultat » de recherche |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Upload | `POST /api/documents` (multipart, `X-Requested-With`) | barre 0→100 % puis apparaît | **ClamAV scan** → upload **S3** → INSERT `medical_document` (fileUrl=clé S3, fileSize BigInt) · audit CREATE |
+| Aperçu | — | PDF nouvel onglet · image dans dialog | aucun |
+| Télécharger | `GET /api/documents/[id]/download?patientId` | téléchargement | stream S3 · audit READ (`operation:download`) |
+| Rechercher | — (client) | filtre la liste | aucun |
+
+> Limites : taille ≤ **50 Mo**, MIME ∈ {pdf, png, jpeg}.
+
+```gherkin
+Feature: Documents médicaux
+
+  Scénario: un NURSE upload une ordonnance PDF
+    Étant donné que je suis connecté en tant que "NURSE"
+    Et je suis sur "/documents"
+    Quand j'upload un fichier PDF valide (< 50 Mo)
+    Alors la barre de progression atteint 100%
+    Et le document apparaît dans sa catégorie
+    # Effet base: ClamAV scan + upload S3 + INSERT medical_document + audit(CREATE)
+
+  Scénario: fichier infecté rejeté par l'antivirus
+    Quand j'upload un fichier détecté comme infecté par ClamAV
+    Alors la réponse est 422 "virusDetected"
+    # Effet base: AUCUN stockage S3, aucune ligne medical_document
+
+  Scénario: type de fichier non autorisé
+    Quand j'upload un fichier .docx
+    Alors l'upload est refusé (type invalide)
+```
+
+**Cas limites** : 422 `virusDetected` ; 413 (>50 Mo) ; 400 MIME invalide ; 403 consentement ; 503 S3 non configuré ; VIEWER ne voit que `patientShare=true`.
+
+---
+
+## Écran : Création d'événement (`/events/new`) 🟢
+
+**Rôle / RBAC** : patient (soi) / staff (via `patientId`). Consentement RGPD requis.
+**Statut impl.** : 🟢 Réel. **Commentaire chiffré AES-256-GCM.**
+
+### Affichage attendu
+
+| Section | Contenu |
+|---|---|
+| Date/Heure | datetime-local requis |
+| Types (multi-select) | glycemia / insulinMeal / physicalActivity / context / occasional |
+| Glycémie (si sélectionné) | valeur 20–600 mg/dL (requis) |
+| Insuline/Repas | glucides 0–500 (requis), bolus 0–25, basal 0–10 |
+| Activité physique | type (requis) + durée 1–1440 min |
+| Contexte | type (requis) |
+| Occasionnel | poids 1–300, HbA1c 4.0–14.0, cétones 0–20, tension sys 50–300 / dia 20–200 |
+| Commentaire | ≤ 1000 caractères |
+| Boutons | « Annuler » / « Enregistrer » (désactivé si aucun type) |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Soumettre | `POST /api/events` | succès → redirection `/dashboard` ; erreur → bannière | INSERT `diabetes_event` (eventTypes[], mesures, **comment chiffré**) · audit CREATE (`metadata.patientId`) |
+
+> Validation serveur (Zod + superRefine) : champs requis conditionnels au type
+> sélectionné, bornes cliniques ci-dessus. Bolus borné 0–25 U (sécurité).
+
+```gherkin
+Feature: Création d'un événement diabète
+
+  Scénario: enregistrer une glycémie + repas
+    Étant donné que je suis connecté en tant que "VIEWER" avec consentement RGPD
+    Et je suis sur "/events/new"
+    Quand je sélectionne les types "glycemia" et "insulinMeal"
+    Et je saisis une glycémie de 145 et 60 g de glucides
+    Et je clique "Enregistrer"
+    Alors je suis redirigé vers "/dashboard"
+    # Effet base: INSERT diabetes_event(eventTypes=[glycemia,insulinMeal], comment chiffré) + audit(CREATE)
+
+  Scénario: glycémie hors bornes refusée
+    Quand je saisis une glycémie de 5 (sous la borne 20)
+    Alors la soumission est bloquée (validation)
+    # Effet base: AUCUNE insertion (400 si atteint le serveur)
+
+  Scénario: protection des modifications non enregistrées
+    Étant donné un formulaire modifié non enregistré
+    Quand je tente de quitter la page
+    Alors le navigateur demande confirmation
+```
+
+**Cas limites** : 403 consentement ; 404 patient ; bornes Zod (glycémie 20–600, bolus ≤25) ; commentaire ≤1000 ; garde `beforeunload` si formulaire « sale ».

--- a/docs/qa/11-clinical.md
+++ b/docs/qa/11-clinical.md
@@ -1,0 +1,208 @@
+# QA — Écrans cliniques
+
+Écrans : `/insulin-therapy`, `/adjustment-proposals`, `/medications`, `/import`.
+Voir [conventions](README.md#3-conventions--légende).
+
+> **Sécurité patient = priorité.** Bornes cliniques réelles
+> (`src/lib/clinical-bounds.ts`) :
+>
+> | Paramètre | Min | Max | Unité |
+> |---|---|---|---|
+> | ISF | 0.10 | 1.00 | g/L/U |
+> | ICR | 3.0 | 30.0 | g/U |
+> | Basal | 0.05 | 5.0 | U/h |
+> | Glucose cible | 60 | 250 | mg/dL |
+> | Durée d'action insuline | 3.5 | 5.0 | **heures** |
+> | Bolus unique max | — | 25.0 | U |
+>
+> ⚠️ **Anomalie doc** : ces bornes **diffèrent du `CLAUDE.md`** (qui indique ISF
+> 0.20–1.00, ICR 5.0–20.0, Basal 0.05–10.0). La **référence faisant foi est le
+> code** (`clinical-bounds.ts`). → mettre à jour `CLAUDE.md`.
+
+---
+
+## Écran : Configuration insulinothérapie (`/insulin-therapy`) 🟢
+
+**Rôle / RBAC** : écriture **NURSE+** (API `requireRole NURSE`) ; VIEWER en lecture.
+DELETE réservé DOCTOR. ⚠️ La page ne masque pas l'UI pour VIEWER (le backend
+renvoie 403 à l'écriture — défense côté API uniquement).
+**Statut impl.** : 🟢 Réel.
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Paramètres de base | marque bolus, marque basal, durée d'action, glucose cible |
+| Timeline 24 h | 24 rectangles colorés (teal=ISF, corail=ICR ; gris=non couvert) |
+| Slots ISF | `HH:00 – HH:00` + sensibilité **g/L/U** + Éditer/Supprimer |
+| Slots ICR | `HH:00 – HH:00` + ratio **g/U** + label repas optionnel + Éditer/Supprimer |
+| Paramètres avancés | toggles « Considérer IOB » + « Bolus étendu » (% 10–90, durée 15–480 min) |
+| Bannières | « changements non enregistrés » + erreur |
+| Boutons | « Réinitialiser aux défauts » (confirmation) + « Enregistrer » (grisé si inchangé) |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Éditer paramètres de base + Enregistrer | `PUT /api/insulin-therapy/settings` | succès, flag dirty reset | UPSERT settings · audit UPDATE |
+| Ajouter/Éditer slot ISF | `POST /api/insulin-therapy/sensitivity-factors` | timeline MAJ | INSERT/UPDATE `insulin_sensitivity_factor` · audit · **borne ISF 0.10–1.00** + détection chevauchement |
+| Ajouter/Éditer slot ICR | `POST /api/insulin-therapy/carb-ratios` | timeline MAJ | INSERT/UPDATE `carb_ratio` · **borne ICR 3.0–30.0** |
+| Supprimer slot | `DELETE …/{id}` (au Save) | retiré (optimiste) | DELETE (best-effort) |
+
+```gherkin
+Feature: Configuration insulinothérapie
+
+  Scénario: ajouter un slot ISF valide
+    Étant donné que je suis connecté en tant que "NURSE"
+    Et je suis sur "/insulin-therapy"
+    Quand j'ajoute un slot ISF 08:00–12:00 avec une sensibilité de 0.50 g/L/U
+    Alors le slot apparaît et la timeline est mise à jour
+    # Effet base: INSERT insulin_sensitivity_factor + audit(UPDATE/CREATE)
+
+  Scénario: sensibilité ISF hors borne refusée
+    Quand j'ajoute un slot ISF avec une sensibilité de 2.00 g/L/U (> 1.00)
+    Alors la valeur est refusée (validation 400)
+    # Effet base: AUCUNE insertion
+
+  Scénario: un VIEWER ne peut pas écrire
+    Étant donné que je suis connecté en tant que "VIEWER"
+    Quand je PUT "/api/insulin-therapy/settings"
+    Alors la réponse est 403
+```
+
+**Cas limites & anomalies** :
+- ⚠️ **Incohérence d'unité (à corriger)** : l'UI saisit la durée d'action en
+  **minutes** (60–480) tandis que l'API `PUT …/settings` valide en **heures**
+  (3.5–5.0). À vérifier : conversion manquante côté client ?
+- Chevauchement de slots : le service lève une erreur — **vérifier** qu'elle
+  remonte en message utilisateur (risque 500 non explicite).
+- Suppression de slot = optimiste, sans rollback visuel si le DELETE échoue.
+
+---
+
+## Écran : Propositions d'ajustement (`/adjustment-proposals`) 🟢
+
+**Rôle / RBAC** : accept/reject **DOCTOR uniquement** (`requireRole DOCTOR` + `canAccessPatient`). Liste = authentifiés (filtrage backend).
+**Statut impl.** : 🟢 Réel. Suggestion **jamais auto-appliquée** sans validation.
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Liste des propositions « pending » (cartes) | une par proposition |
+| Badge paramètre | « Facteur de sensibilité (FSI) » / « Ratio I/G (RIG) » / « Débit basal » |
+| Badge horodatage relatif + « Patient #N — Raison : … » | visible |
+| Comparaison valeur | `ancienne → nouvelle` (2 décimales, isolation RTL) |
+| Boutons « Rejeter » / « Accepter » | grisés pendant l'action |
+| Annonce SR + erreur scopée à la ligne | visible |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Accepter | `PATCH /api/adjustment-proposals/[id]/accept` `{applyImmediately}` | ligne retirée | UPDATE `adjustment_proposal` (status=accepted, reviewedBy/At) · si `applyImmediately` : UPDATE params insuline · audit PROPOSAL_ACCEPTED · **FCM patient** · **bornes cliniques revalidées** |
+| Rejeter | `PATCH /api/adjustment-proposals/[id]/reject` | ligne retirée | UPDATE status=rejected · audit PROPOSAL_REJECTED · FCM patient |
+
+```gherkin
+Feature: Propositions d'ajustement (validation médecin)
+
+  Scénario: un DOCTOR accepte une proposition
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Et une proposition "pending" pour un de mes patients
+    Quand je clique "Accepter"
+    Alors la proposition disparaît de la liste
+    # Effet base: UPDATE adjustment_proposal(status=accepted, reviewedBy) + audit + FCM patient
+
+  Scénario: proposition pour un patient hors portefeuille
+    Étant donné une proposition d'un patient d'un autre médecin
+    Quand je tente de l'accepter
+    Alors la réponse est 403 "forbidden" (erreur affichée sur la ligne)
+
+  Scénario: valeur proposée hors bornes cliniques
+    Quand j'accepte une proposition dont la valeur dépasse les bornes
+    Alors l'application est rejetée
+    # ⚠️ Anomalie: actuellement 500 "serverError" (devrait être 400/422) — à corriger
+```
+
+**Cas limites & anomalies** :
+- ⚠️ **Bornes dépassées → 500** (au lieu de 400/422), erreur non scopée à la
+  ligne — UX faible, à corriger.
+- Race statut (pending→accepted entre fetch et action) → 404 `proposalNotFound`.
+- Double-clic protégé (`actionPending`).
+
+---
+
+## Écran : Médications / BDPM (`/medications`) 🟡
+
+**Rôle / RBAC** : authentifiés (recherche publique BDPM, **aucune** donnée patient).
+**Statut impl.** : 🟡 Dépend de l'import BDPM (ANSM). Vide si l'import cron n'a pas tourné.
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Barre de recherche (nom / DCI / CIP, min 2 car., debounce 300 ms) | visible |
+| Mention source « BDPM — ANSM (Licence Ouverte 2.0) » + date d'import | visible |
+| Carte médicament | nom, DCI/substances, forme, titulaire, présentations (CIP13, remboursement, prix), badge AMM, code ATC |
+| États | initial « Recherchez… (min 2 car.) », aucun résultat |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Rechercher | `GET /api/medications/search?q&atc&limit` | liste de cartes | **lecture seule** (référentiel public, pas d'audit patient) |
+
+```gherkin
+Feature: Recherche de médicaments (BDPM)
+
+  Scénario: rechercher par DCI
+    Étant donné que je suis connecté
+    Et je suis sur "/medications"
+    Quand je saisis "paracetamol"
+    Alors je vois une liste de médicaments correspondants
+    # Effet base: lecture seule du référentiel BDPM
+```
+
+**Cas limites** : base vide → « Aucun résultat » ; ATC invalide → 400 (échec silencieux UI).
+
+---
+
+## Écran : Import MyDiabby (`/import`) 🟡
+
+**Rôle / RBAC** : **DOCTOR uniquement**. Consentement RGPD requis.
+**Statut impl.** : 🟡 **Staging-only** (403 `stagingOnly` en production). Intégration MyDiabby partiellement mockée.
+
+### Affichage attendu
+
+| État | Contenu |
+|---|---|
+| Bandeau | « Fonctionnalité en test sur staging » |
+| STAGING_ONLY (prod) | « Non disponible » |
+| NO_ACCOUNTS | formulaire de connexion MyDiabby (email + mot de passe + « Connecter ») |
+| HAS_ACCOUNTS | carte par compte (email masqué, badge « Connecté », dernière sync) + « Synchroniser » / « Déconnecter » |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Connecter | `POST /api/import/mydiabby/connect` | compte ajouté | INSERT credential MyDiabby (chiffré) · (staging) |
+| Synchroniser | `POST /api/import/mydiabby/sync` `{credentialId}` | « N données importées » | INSERT/UPDATE données patient (CGM…) · audit |
+| Déconnecter | `DELETE /api/import/mydiabby/disconnect` | carte retirée | DELETE credential · audit |
+
+```gherkin
+Feature: Import MyDiabby (staging)
+
+  Scénario: import indisponible en production
+    Étant donné un environnement de production
+    Quand un DOCTOR ouvre "/import"
+    Alors la réponse des endpoints est 403 "stagingOnly"
+    Et l'écran affiche "Non disponible"
+
+  Scénario: connecter un compte MyDiabby en staging
+    Étant donné un environnement staging et un DOCTOR avec consentement RGPD
+    Quand je connecte un compte MyDiabby valide
+    Alors le compte apparaît comme "Connecté"
+    # Effet base: INSERT credential MyDiabby (chiffré)
+```
+
+**Cas limites** : production → 403 `stagingOnly` ; consentement → 403 `gdprConsentRequired` ; email masqué ; import manuel uniquement (pas de job de fond).

--- a/docs/qa/12-communication.md
+++ b/docs/qa/12-communication.md
@@ -1,0 +1,153 @@
+# QA — Communication & écran legacy
+
+Écrans : `/messages`, `/patient/appointments`, `/users` (legacy).
+Voir [conventions](README.md#3-conventions--légende).
+
+---
+
+## Écran : Messagerie sécurisée (`/messages`) 🟢
+
+**Rôle / RBAC** : NURSE+ (VIEWER redirigé `/login` + audit `accessDenied`).
+Canaux : patient↔PS (si le PS encadre le patient via `PatientReferent`/`PatientService`),
+staff↔staff (même cabinet), ADMIN. `self↔self` et `patient↔patient` interdits.
+**Consentement RGPD bilatéral** (émetteur ET destinataire). **Corps chiffré AES-256-GCM.**
+**Statut impl.** : 🟢 Réel (US-2076 scope A : REST + polling 60 s + FCM).
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| En-tête (titre/sous-titre) | visible |
+| Sidebar threads (320 px desktop) | recherche, filtre « Tous » / « Non lus », badge non-lus, « Patient #N » |
+| Threads triés `lastMessage DESC` | visible |
+| Viewer central + composer | si thread sélectionné |
+| Badge non-lus (polling 60 s) | `GET /api/messages/unread-count` |
+| États | loading, erreur, vide « Aucune conversation » |
+| A11y | skip-link, `role=list`, `aria-current`, live region « X conversations / Y non lues », cibles ≥ 44 px |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Lister threads | `GET /api/messages?limit=100` | sidebar | lecture · `Cache-Control: no-store` · audit |
+| Ouvrir thread | `GET /api/messages/thread/[conversationKey]` | messages affichés | lecture (participant requis sinon 404) · audit READ |
+| Envoyer | `POST /api/messages` `{toUserId, body}` | message ajouté | INSERT `messages` (**bodyEnc chiffré**, `conversationKey`=HMAC) · **FCM data-only** · audit CREATE (`metadata.patientId`) |
+| Marquer lu | `PUT /api/messages/[id]/read` | badge MAJ | UPDATE `read_at` (idempotent) · audit UPDATE |
+
+> Validation envoi : `toUserId` entier positif, `body` 1–8164 **octets UTF-8**.
+> Rate-limit 100 msg/min/user. Consentement requis aux 4 routes.
+
+```gherkin
+Feature: Messagerie sécurisée
+
+  Scénario: un NURSE envoie un message à un patient qu'il encadre
+    Étant donné que je suis connecté en tant que "NURSE"
+    Et un patient que j'encadre avec consentement RGPD
+    Quand j'envoie le message "Pensez à votre contrôle"
+    Alors le message apparaît dans le fil
+    # Effet base: INSERT messages(bodyEnc chiffré, conversationKey HMAC) + FCM + audit(CREATE/MESSAGE, metadata.patientId)
+
+  Scénario: corps de message trop long
+    Quand j'envoie un message de plus de 8164 octets
+    Alors la réponse est 422
+    # Effet base: AUCUNE insertion
+
+  Scénario: destinataire ayant retiré son consentement (anti-énumération)
+    Étant donné un destinataire ayant révoqué son consentement
+    Quand je tente d'envoyer un message
+    Alors la réponse est 403 "forbidden" (raison réelle masquée)
+    # Effet base: audit serveur(accessDenied, kind=message.send.recipientConsentRevoked)
+
+  Scénario: marquer un message comme lu est idempotent
+    Quand je marque un message déjà lu
+    Alors la réponse indique "alreadyRead"
+    # Effet base: pas de double écriture
+```
+
+**Cas limites** : consentement bilatéral ; 429 rate-limit (`Retry-After`) ; non-participant → 404 (anti-énumération) ; `conversationKey` peppered (dump DB inexploitable seul) ; purge RGPD Art. 17 → thread sélectionné réinitialisé.
+
+---
+
+## Écran : Mes RDV (patient) (`/patient/appointments`) 🟢
+
+**Rôle / RBAC** : **VIEWER strict** (layout patient + audit `accessDenied` si autre rôle).
+Lecture seule : le patient voit ses RDV ; peut **accepter une alternative**.
+**Consentement RGPD requis** (sinon redirection `/account/privacy`).
+**Statut impl.** : 🟢 Réel (US-2500-UI).
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Deux sections : « Prochains RDV » (ASC) et « Passés » (DESC) | landmarks `<section>` |
+| Par carte | date (longue, fr), heure HH:MM, type + durée + lieu, **badge statut** (couleurs Sérénité, `pending_validation` ambre WCAG AA) |
+| « Alternative proposée : [date] » + bouton « Accepter alternative » | si `status=cancelled` + alternative proposée |
+| États | loading, erreur « Impossible de charger » + dernière sync, vide |
+| Toast action (succès/erreur) 4 s | aria-live |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Charger mes RDV | `GET /api/appointments?from&to&patientId` | 2 sections | lecture · `canAccessPatient` (sinon `accessDenied`) · `Cache-Control: no-store` |
+| Accepter alternative | `POST /api/appointments/[id]/accept-alternative` | RDV repasse « confirmé » | UPDATE `status=confirmed`, alternative effacée, `acceptedAt` · audit UPDATE |
+
+```gherkin
+Feature: RDV côté patient
+
+  Scénario: le patient voit ses prochains RDV
+    Étant donné que je suis connecté en tant que "VIEWER" avec consentement RGPD
+    Quand je vais sur "/patient/appointments"
+    Alors je vois la section "Prochains RDV"
+    # Effet base: lecture seule (canAccessPatient) ; aucune écriture
+
+  Scénario: accepter une alternative proposée
+    Étant donné un de mes RDV annulé avec une alternative proposée
+    Quand je clique "Accepter alternative"
+    Alors le RDV repasse au statut "confirmé"
+    # Effet base: UPDATE appointment(status=confirmed, acceptedAt, alternative effacée) + audit
+
+  Scénario: alternative expirée
+    Étant donné une alternative dont le délai est dépassé
+    Quand je clique "Accepter alternative"
+    Alors je vois "Délai dépassé"
+    # Effet base: 423 alternativeExpired, aucune modif
+```
+
+**Cas limites** : VIEWER orphelin (`patientId=null`) → message unifié (anti-énumération) ; consentement absent → redirection ; 409 conflit de créneau ; 423 délai dépassé ; double-submit protégé par carte ; dates en UTC (contrat).
+
+---
+
+## Écran : Utilisateurs — legacy (`/users`) ⚠️🟡
+
+**Statut impl.** : 🟡 **Stub legacy** affichant « Bientôt disponible » (ADMIN only,
+sinon redirection vers le home du rôle). **L'UI réelle de gestion des utilisateurs
+est `/admin/users`** (voir [`06-admin.md`](06-admin.md)).
+
+> ⚠️ **Anomalie / doublon** : `/users` et `/admin/users` coexistent. `/users` est
+> un stub obsolète, sans données ni audit. → **Recommandation : supprimer `/users`
+> ou le rediriger vers `/admin/users`** (lever l'ambiguïté UX).
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Titre « Gestion des utilisateurs » + mention API opérationnelle | visible |
+| Badge « Bientôt disponible » | visible |
+
+```gherkin
+Feature: Écran utilisateurs legacy
+
+  Scénario: la page /users est un stub
+    Étant donné que je suis connecté en tant que "ADMIN"
+    Quand je vais sur "/users"
+    Alors je vois "Bientôt disponible"
+    # ⚠️ La gestion réelle est sur "/admin/users"
+
+  Scénario: un non-ADMIN est redirigé
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand je vais sur "/users"
+    Alors je suis redirigé vers le home de mon rôle
+```
+
+**Cas limites** : aucune action ; pas d'audit (TODO V1.5) ; à dédoublonner avec `/admin/users`.

--- a/docs/qa/README.md
+++ b/docs/qa/README.md
@@ -1,8 +1,7 @@
 # Plan de tests QA — Diabeo Backoffice
 
-> **Lot 1 (cœur MVP)** — 13 écrans. Lot 2 (audit, analytics, documents, messages,
-> devices, insulin-therapy, import, propositions d'ajustement, médications,
-> backups, data-breaches, factures, tax-rules, system-health) à suivre.
+> **Lot 1 (cœur MVP)** — 13 écrans · **Lot 2** — 25 écrans. **Couverture
+> complète des ~38 écrans de l'application.**
 >
 > Source des faits : lecture du code réel (composants + routes API + services)
 > au 2026-06-05. Chaque « effet base » est tracé jusqu'au fichier qui le produit.
@@ -26,6 +25,8 @@ Les tests sont joués **soit par un humain** (le tableau + les `Then` suffisent)
 
 ## 2. Découpage des fichiers
 
+**Lot 1 — cœur MVP**
+
 | Fichier | Écrans |
 |---|---|
 | [`01-auth.md`](01-auth.md) | `/login`, `/reset-password` |
@@ -34,6 +35,29 @@ Les tests sont joués **soit par un humain** (le tableau + les `Then` suffisent)
 | [`04-appointments.md`](04-appointments.md) | `/appointments` |
 | [`05-settings.md`](05-settings.md) | `/settings` |
 | [`06-admin.md`](06-admin.md) | `/admin/users`, `/admin/users/[id]`, `/admin/cabinets` (+ `[id]`) |
+
+**Lot 2 — reste de l'application**
+
+| Fichier | Écrans |
+|---|---|
+| [`07-dashboards-analytics.md`](07-dashboards-analytics.md) | `/`, `/dashboard`, `/analytics`, `/analytics/radar`, `/weekly` |
+| [`08-admin-ops.md`](08-admin-ops.md) | `/audit`, `/admin`, `/admin/backups`, `/admin/system-health` |
+| [`09-admin-compliance-billing.md`](09-admin-compliance-billing.md) | `/admin/data-breaches` (+`[id]`), `/admin/invoices` (+`[id]`), `/admin/tax-rules` |
+| [`10-devices-documents-events.md`](10-devices-documents-events.md) | `/devices`, `/devices/pair`, `/documents`, `/events/new` |
+| [`11-clinical.md`](11-clinical.md) | `/insulin-therapy`, `/adjustment-proposals`, `/medications`, `/import` |
+| [`12-communication.md`](12-communication.md) | `/messages`, `/patient/appointments`, `/users` (legacy) |
+
+## 2bis. Anomalies relevées (à trier par l'équipe)
+
+Détectées pendant l'extraction des faits — à confirmer puis corriger hors de ce plan QA :
+
+| # | Écran | Anomalie |
+|---|---|---|
+| A1 | `/login` | Lien « Créer un compte » → `/register`, **page inexistante** (404). |
+| A2 | `/insulin-therapy` | **Unité durée d'action** : UI en minutes (60–480), API en heures (3.5–5.0) → conversion manquante probable. |
+| A3 | (transverse) | **Bornes cliniques `CLAUDE.md` périmées** vs `clinical-bounds.ts` (ISF/ICR/Basal). Le code fait foi. |
+| A4 | `/adjustment-proposals` | Valeur hors bornes à l'acceptation → **500** au lieu de 400/422. |
+| A5 | `/users` | **Doublon legacy** de `/admin/users` (stub « Bientôt disponible ») → supprimer/rediriger. |
 
 ## 3. Conventions & légende
 


### PR DESCRIPTION
## Objet

Complète le plan de tests QA (PR #489 = lot 1) : avec ce lot 2, **les ~38 écrans de l'application sont couverts**. Même format hybride : *affichage attendu* (tableau), *actions + endpoint + effet visuel + effet base*, *scénarios Gherkin* (`# Effet base:`), *cas limites*. Faits **sourcés depuis le code réel** (6 explorations parallèles du dépôt).

## Fichiers ajoutés

| Fichier | Écrans |
|---|---|
| `07-dashboards-analytics.md` | `/`, `/dashboard`, `/analytics`, `/analytics/radar`, `/weekly` |
| `08-admin-ops.md` | `/audit`, `/admin`, `/admin/backups`, `/admin/system-health` |
| `09-admin-compliance-billing.md` | `/admin/data-breaches` (+`[id]`), `/admin/invoices` (+`[id]`), `/admin/tax-rules` |
| `10-devices-documents-events.md` | `/devices`, `/devices/pair`, `/documents`, `/events/new` |
| `11-clinical.md` | `/insulin-therapy`, `/adjustment-proposals`, `/medications`, `/import` |
| `12-communication.md` | `/messages`, `/patient/appointments`, `/users` (legacy) |

## Statuts honnêtes

Écrans non-pleinement-réels signalés (🟡) : `/audit` (stub UI, backend OK), `/weekly` (onglets Historique/Tableau « Bientôt disponible »), `/analytics/radar` (partiel), `/medications` (dépend import BDPM), `/import` (staging-only), `/users` (stub legacy).

## Anomalies relevées (README §2bis — à trier hors de ce plan QA)

| # | Écran | Anomalie |
|---|---|---|
| A1 | `/login` | Lien « Créer un compte » → `/register`, page inexistante (404). |
| A2 | `/insulin-therapy` | Durée d'action : UI en **minutes** (60–480) vs API en **heures** (3.5–5.0) → conversion manquante probable. |
| A3 | transverse | Bornes cliniques **`CLAUDE.md` périmées** vs `clinical-bounds.ts` (ISF 0.10–1.00, ICR 3–30, Basal 0.05–5). Le code fait foi. |
| A4 | `/adjustment-proposals` | Valeur hors bornes à l'acceptation → **500** au lieu de 400/422. |
| A5 | `/users` | Doublon legacy de `/admin/users` → supprimer/rediriger. |

> Changement **docs-only**. Les bornes cliniques citées (A3) ont été **vérifiées directement dans `clinical-bounds.ts`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)