### PR TITLE
fix(auth): A1 — retirer le lien mort « Créer un compte » → /register (404)

### DIFF
--- a/docs/qa/01-auth.md
+++ b/docs/qa/01-auth.md
@@ -19,7 +19,6 @@ DOCTOR → `/medecin`, NURSE → `/infirmier`, ADMIN → `/admin`, VIEWER → `/
 | Champ mot de passe | vide, type `password` + bouton bascule visibilité |
 | Bouton « Connexion » | **désactivé** si email ou mot de passe vide |
 | Lien « Mot de passe oublié ? » | → `/reset-password` |
-| Lien « Créer un compte » | → `/register` ⚠️ (voir cas limites — page inexistante) |
 | Mention « Hébergement HDS » | visible en pied |
 | État chargement | bouton « Connexion en cours… », champs désactivés |
 | État rate-limit | bannière rouge « Compte verrouillé. Réessayez dans X » + compte à rebours, champs/bouton désactivés |
@@ -94,9 +93,9 @@ Feature: Connexion au backoffice
   rate-limit (anti-DoS : un attaquant ne peut pas re-verrouiller un compte déjà
   suspendu).
 - **Token MFA pending expiré** (> ~5 min) : OTP rejeté (401), recommencer le login.
-- ⚠️ **Lien « Créer un compte » → `/register`** : la page `(auth)/register`
-  **n'existe pas** (`src/app/(auth)/login/page.tsx:224`). Cliquer mène à un 404.
-  → **À corriger** : retirer le lien ou créer la page (selon le scope produit).
+- ✅ **Lien « Créer un compte » retiré** (anomalie A1, corrigée) : il pointait
+  vers `/register` (page inexistante → 404). L'inscription patient se fait par le
+  personnel via `/patients/new` ; il n'y a pas d'auto-inscription publique.
 
 ---
 

--- a/docs/qa/README.md
+++ b/docs/qa/README.md
@@ -53,7 +53,7 @@ Détectées pendant l'extraction des faits — à confirmer puis corriger hors d
 
 | # | Écran | Anomalie |
 |---|---|---|
-| A1 | `/login` | Lien « Créer un compte » → `/register`, **page inexistante** (404). |
+| A1 | `/login` | ✅ **Corrigé** — lien mort « Créer un compte » → `/register` (404) retiré. |
 | A2 | `/insulin-therapy` | **Unité durée d'action** : UI en minutes (60–480), API en heures (3.5–5.0) → conversion manquante probable. |
 | A3 | (transverse) | **Bornes cliniques `CLAUDE.md` périmées** vs `clinical-bounds.ts` (ISF/ICR/Basal). Le code fait foi. |
 | A4 | `/adjustment-proposals` | Valeur hors bornes à l'acceptation → **500** au lieu de 400/422. |

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -136,8 +136,6 @@
     "forgotPassword": "نسيت كلمة المرور؟",
     "loginButton": "دخول",
     "loggingIn": "جاري تسجيل الدخول...",
-    "createAccount": "إنشاء حساب",
-    "noAccount": "ليس لديك حساب؟",
     "loginError": "بيانات غير صحيحة",
     "invalidEmail": "عنوان بريد إلكتروني غير صالح",
     "accountLocked": "الحساب مقفل مؤقتاً. أعد المحاولة خلال {time}.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -136,8 +136,6 @@
     "forgotPassword": "Forgot password?",
     "loginButton": "Sign in",
     "loggingIn": "Signing in...",
-    "createAccount": "Create account",
-    "noAccount": "Don't have an account?",
     "loginError": "Invalid credentials",
     "invalidEmail": "Invalid email address",
     "accountLocked": "Account temporarily locked. Try again in {time}.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -136,8 +136,6 @@
     "forgotPassword": "Mot de passe oublie ?",
     "loginButton": "Se connecter",
     "loggingIn": "Connexion en cours...",
-    "createAccount": "Creer un compte",
-    "noAccount": "Pas encore de compte ?",
     "loginError": "Identifiants incorrects",
     "invalidEmail": "Adresse e-mail invalide",
     "accountLocked": "Compte temporairement bloque. Reessayez dans {time}.",

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -216,18 +216,6 @@ export default function LoginPage() {
         </CardContent>
       </Card>
 
-      {/* Footer — Create account */}
-      <div className="mt-6 flex flex-col items-center gap-2">
-        <p className="text-sm text-muted-foreground">{t("noAccount")}</p>
-        <Link
-          data-testid="create-account-button"
-          href="/register"
-          className="text-sm font-medium text-teal-600 hover:text-teal-700 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-600 rounded-sm"
-        >
-          {t("createAccount")}
-        </Link>
-      </div>
-
       {/* HDS footer */}
       <p className="mt-4 text-center text-xs text-muted-foreground">
         {t("welcome")} &mdash; {t("hostedHds")}

--- a/tests/components/phase11/phase11-auth.test.tsx
+++ b/tests/components/phase11/phase11-auth.test.tsx
@@ -98,9 +98,16 @@ describe("LoginPage", () => {
     expect(link.getAttribute("href")).toBe("/reset-password")
   })
 
-  it("renders create account button with data-testid='create-account-button'", () => {
+  // A1 — le lien « Créer un compte » pointait vers /register, page inexistante
+  // (404). L'inscription patient se fait par le personnel via /patients/new ;
+  // il n'y a pas d'auto-inscription publique. Le lien mort a été retiré.
+  it("does NOT render a dead create-account link to /register", () => {
     render(<LoginPage />)
-    expect(screen.getByTestId("create-account-button")).toBeTruthy()
+    expect(screen.queryByTestId("create-account-button")).toBeNull()
+    const registerLinks = screen
+      .queryAllByRole("link")
+      .filter((el) => el.getAttribute("href") === "/register")
+    expect(registerLinks).toHaveLength(0)
   })
 
   it("login button is disabled when fields are empty", () => {
@@ -137,17 +144,6 @@ describe("LoginPage", () => {
     render(<LoginPage />)
     const link = screen.getByTestId("forgot-password-button")
     expect(link.textContent).toBe("auth.forgotPassword")
-  })
-
-  it("shows i18n text for create account button", () => {
-    render(<LoginPage />)
-    const button = screen.getByTestId("create-account-button")
-    expect(button.textContent).toBe("auth.createAccount")
-  })
-
-  it("shows i18n text for no account prompt", () => {
-    render(<LoginPage />)
-    expect(screen.getByText("auth.noAccount")).toBeTruthy()
   })
 
   it("calls login on form submission with email and password", async () => {

--- a/tests/e2e/login-flow.spec.ts
+++ b/tests/e2e/login-flow.spec.ts
@@ -95,8 +95,11 @@ test.describe("Login page", () => {
     await expect(page.getByTestId("forgot-password-button")).toBeVisible()
   })
 
-  test("create account link exists", async ({ page }) => {
+  // A1 — le lien « Créer un compte » pointait vers /register (page inexistante,
+  // 404). L'inscription patient se fait par le personnel via /patients/new ;
+  // pas d'auto-inscription publique. Le lien mort a été retiré.
+  test("create account link is removed (A1)", async ({ page }) => {
     await page.goto("/login")
-    await expect(page.getByTestId("create-account-button")).toBeVisible()
+    await expect(page.getByTestId("create-account-button")).toHaveCount(0)
   })
 })


### PR DESCRIPTION
## Anomalie A1 (audit QA)

La page `/login` affichait un lien « Créer un compte » → `/register`, **mais aucune page `(auth)/register` n'existe** → 404. Dans ce backoffice, l'inscription patient est faite par le personnel via `/patients/new` ; il n'y a pas d'auto-inscription publique. **Le lien mort est retiré.**

## Changements

- `src/app/(auth)/login/page.tsx` : suppression du bloc footer « Créer un compte ».
- `tests/components/phase11/phase11-auth.test.tsx` : assertions **inversées** — le testid `create-account-button` et tout `href="/register"` doivent être **absents**.
- `messages/{fr,en,ar}.json` : retrait des clés i18n orphelines `auth.createAccount` / `auth.noAccount` (review M1).
- `docs/qa/01-auth.md` + `docs/qa/README.md` : anomalie A1 marquée corrigée.

## Vérifs

- Test composant login : **34/34 verts**. `tsc` + `eslint` OK. JSON locales valides.
- Review `code-reviewer` : 0 Critical/High ; 1 Medium (clés i18n orphelines) **corrigé** ; Low (layout/a11y) vérifiés sans régression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)