### PR TITLE
fix(insulin): A2 — durée d'action insuline en heures (UI alignée sur l'API)

### DIFF
--- a/docs/qa/11-clinical.md
+++ b/docs/qa/11-clinical.md
@@ -75,15 +75,28 @@ Feature: Configuration insulinothérapie
   240, bornes 60–480) alors que l'API `PUT …/settings` valide en **heures**
   (3.5–5.0) → toute sauvegarde échouait (400). L'input est désormais en **heures**
   (défaut 4, bornes 3.5–5.0, pas 0.5).
-- ⚠️ **A2b (suivi dédié, NON corrigé ici)** : `upsertSettings`
-  (`insulin-therapy.service.ts`) écrit `bolusInsulinBrand` / `basalInsulinBrand` /
-  `insulinActionDuration` dans la table `insulin_therapy_settings`, **qui ne
-  possède aucune de ces colonnes** (seulement `bolus_insulin_id`,
-  `basal_insulin_id`, `delivery_method`). En base réelle → erreur Prisma (champs
-  inconnus) → **500**. Masqué en CI car les tests **mockent Prisma**. Correction =
-  décision data-model (brand → FK `PatientInsulin` ; durée → `PatientInsulin.
-  action_duration_hours`) + test d'intégration sur **vraie** base. Requiert
-  `prisma-specialist` + `medical-domain-validator`.
+- ⚠️ **A2b — Persistance des paramètres cassée (suivi dédié, NON corrigé ici).**
+  A2 corrige l'unité, mais la **sauvegarde reste KO end-to-end** pour deux raisons
+  indépendantes, à traiter dans un seul chantier « persistance insulinothérapie » :
+  1. **400 `deliveryMethod` manquant** : le body `PUT` (`page.tsx handleSave`)
+     n'envoie pas `deliveryMethod`, requis non-optionnel par le schéma Zod
+     (`route.ts`) → `validationFailed` systématique.
+  2. **500 colonnes inexistantes** : `upsertSettings` (`insulin-therapy.service.ts`)
+     écrit `bolusInsulinBrand` / `basalInsulinBrand` / `insulinActionDuration` dans
+     `insulin_therapy_settings`, **qui ne possède aucune de ces colonnes** (seulement
+     `bolus_insulin_id`, `basal_insulin_id`, `delivery_method`) → erreur Prisma.
+     Masqué en CI car les tests **mockent Prisma**.
+  3. **Câblage DIA→IOB manquant** (sécurité) : même réparé, la durée saisie ne
+     piloterait pas l'IOB — le moteur de bolus lit `IobSettings.actionDurationHours`
+     (table distincte, défaut 4 h), jamais le champ de cet écran. Un médecin réglant
+     5 h croirait modifier l'IOB sans effet.
+  Correction = décision data-model (brand → FK `PatientInsulin` ; durée →
+  `IobSettings.actionDurationHours` + round-trip GET) + `deliveryMethod` dans le
+  body + **test d'intégration sur vraie base**. Requiert `prisma-specialist` +
+  `medical-domain-validator`.
+- ℹ️ **Bornes 3.5–5.0 h** (clinical-bounds, hors périmètre A2) : couvrent les
+  analogues rapides adultes, mais excluent des réglages 2–3 h (pédiatrie / Fiasp /
+  pompes 2–8 h). À arbitrer côté `clinical-bounds.ts` si le périmètre s'élargit.
 - Chevauchement de slots : le service lève une erreur — **vérifier** qu'elle
   remonte en message utilisateur (risque 500 non explicite).
 - Suppression de slot = optimiste, sans rollback visuel si le DELETE échoue.

--- a/docs/qa/11-clinical.md
+++ b/docs/qa/11-clinical.md
@@ -71,9 +71,19 @@ Feature: Configuration insulinothérapie
 ```
 
 **Cas limites & anomalies** :
-- ⚠️ **Incohérence d'unité (à corriger)** : l'UI saisit la durée d'action en
-  **minutes** (60–480) tandis que l'API `PUT …/settings` valide en **heures**
-  (3.5–5.0). À vérifier : conversion manquante côté client ?
+- ✅ **A2 corrigé** : l'UI saisissait la durée d'action en **minutes** (défaut
+  240, bornes 60–480) alors que l'API `PUT …/settings` valide en **heures**
+  (3.5–5.0) → toute sauvegarde échouait (400). L'input est désormais en **heures**
+  (défaut 4, bornes 3.5–5.0, pas 0.5).
+- ⚠️ **A2b (suivi dédié, NON corrigé ici)** : `upsertSettings`
+  (`insulin-therapy.service.ts`) écrit `bolusInsulinBrand` / `basalInsulinBrand` /
+  `insulinActionDuration` dans la table `insulin_therapy_settings`, **qui ne
+  possède aucune de ces colonnes** (seulement `bolus_insulin_id`,
+  `basal_insulin_id`, `delivery_method`). En base réelle → erreur Prisma (champs
+  inconnus) → **500**. Masqué en CI car les tests **mockent Prisma**. Correction =
+  décision data-model (brand → FK `PatientInsulin` ; durée → `PatientInsulin.
+  action_duration_hours`) + test d'intégration sur **vraie** base. Requiert
+  `prisma-specialist` + `medical-domain-validator`.
 - Chevauchement de slots : le service lève une erreur — **vérifier** qu'elle
   remonte en message utilisateur (risque 500 non explicite).
 - Suppression de slot = optimiste, sans rollback visuel si le DELETE échoue.

--- a/docs/qa/README.md
+++ b/docs/qa/README.md
@@ -55,7 +55,7 @@ Détectées pendant l'extraction des faits — à confirmer puis corriger hors d
 |---|---|---|
 | A1 | `/login` | Lien « Créer un compte » → `/register`, **page inexistante** (404). |
 | A2 | `/insulin-therapy` | ✅ **Corrigé** — durée d'action alignée en **heures** (UI envoyait des minutes à une API en heures → 400). |
-| A2b | `/insulin-therapy` | ⚠️ **Découvert pendant A2** — `upsertSettings` écrit des colonnes inexistantes (`insulinActionDuration`/`bolusInsulinBrand`) dans `insulin_therapy_settings` → **500** en base réelle (masqué par les mocks). Suivi data-model dédié. |
+| A2b | `/insulin-therapy` | ⚠️ **Découvert pendant A2** — sauvegarde des paramètres cassée end-to-end : (1) `deliveryMethod` manquant dans le body → **400** ; (2) `upsertSettings` écrit des colonnes inexistantes → **500** (masqué par les mocks) ; (3) la durée saisie n'alimente pas l'IOB (`IobSettings.actionDurationHours` séparé). Suivi data-model dédié (`prisma-specialist` + `medical-domain-validator`). |
 | A3 | (transverse) | **Bornes cliniques `CLAUDE.md` périmées** vs `clinical-bounds.ts` (ISF/ICR/Basal). Le code fait foi. |
 | A4 | `/adjustment-proposals` | Valeur hors bornes à l'acceptation → **500** au lieu de 400/422. |
 | A5 | `/users` | **Doublon legacy** de `/admin/users` (stub « Bientôt disponible ») → supprimer/rediriger. |

--- a/docs/qa/README.md
+++ b/docs/qa/README.md
@@ -54,7 +54,8 @@ Détectées pendant l'extraction des faits — à confirmer puis corriger hors d
 | # | Écran | Anomalie |
 |---|---|---|
 | A1 | `/login` | Lien « Créer un compte » → `/register`, **page inexistante** (404). |
-| A2 | `/insulin-therapy` | **Unité durée d'action** : UI en minutes (60–480), API en heures (3.5–5.0) → conversion manquante probable. |
+| A2 | `/insulin-therapy` | ✅ **Corrigé** — durée d'action alignée en **heures** (UI envoyait des minutes à une API en heures → 400). |
+| A2b | `/insulin-therapy` | ⚠️ **Découvert pendant A2** — `upsertSettings` écrit des colonnes inexistantes (`insulinActionDuration`/`bolusInsulinBrand`) dans `insulin_therapy_settings` → **500** en base réelle (masqué par les mocks). Suivi data-model dédié. |
 | A3 | (transverse) | **Bornes cliniques `CLAUDE.md` périmées** vs `clinical-bounds.ts` (ISF/ICR/Basal). Le code fait foi. |
 | A4 | `/adjustment-proposals` | Valeur hors bornes à l'acceptation → **500** au lieu de 400/422. |
 | A5 | `/users` | **Doublon legacy** de `/admin/users` (stub « Bientôt disponible ») → supprimer/rediriger. |

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -670,8 +670,8 @@
     "basalInsulinBrand": "الأنسولين بطيء المفعول (قاعدي)",
     "targetGlucose": "هدف الجلوكوز (mg/dL)",
     "targetGlucoseHint": "القيمة المستهدفة لحساب التصحيح — بين 60 و 250 mg/dL",
-    "insulinActionDuration": "مدة التأثير (دقائق)",
-    "insulinActionDurationHint": "المدة الإجمالية لتأثير الأنسولين — بين 60 و 480 دقيقة",
+    "insulinActionDuration": "مدة التأثير (ساعات)",
+    "insulinActionDurationHint": "المدة الإجمالية لتأثير الأنسولين — بين 3.5 و 5 ساعات",
     "timeline24h": "الفترات الزمنية المغطاة (24 ساعة)",
     "brand": {
       "humalog": "Humalog (ليسبرو)",

--- a/messages/en.json
+++ b/messages/en.json
@@ -670,8 +670,8 @@
     "basalInsulinBrand": "Long-acting insulin (basal)",
     "targetGlucose": "Target glucose (mg/dL)",
     "targetGlucoseHint": "Target value for correction calculation — between 60 and 250 mg/dL",
-    "insulinActionDuration": "Action duration (minutes)",
-    "insulinActionDurationHint": "Total insulin action duration — between 60 and 480 min",
+    "insulinActionDuration": "Action duration (hours)",
+    "insulinActionDurationHint": "Total insulin action duration — between 3.5 and 5 h",
     "timeline24h": "Covered time slots (24h)",
     "brand": {
       "humalog": "Humalog (lispro)",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -670,8 +670,8 @@
     "basalInsulinBrand": "Insuline lente (basale)",
     "targetGlucose": "Glycemie cible (mg/dL)",
     "targetGlucoseHint": "Valeur cible pour le calcul de correction — entre 60 et 250 mg/dL",
-    "insulinActionDuration": "Duree d'action (minutes)",
-    "insulinActionDurationHint": "Duree totale d'action de l'insuline — entre 60 et 480 min",
+    "insulinActionDuration": "Duree d'action (heures)",
+    "insulinActionDurationHint": "Duree totale d'action de l'insuline — entre 3,5 et 5 h",
     "timeline24h": "Plages horaires couvertes (24h)",
     "brand": {
       "humalog": "Humalog (lispro)",

--- a/src/app/(dashboard)/insulin-therapy/page.tsx
+++ b/src/app/(dashboard)/insulin-therapy/page.tsx
@@ -199,7 +199,7 @@ export default function InsulinTherapyPage() {
   const [settings, setSettings] = useState<InsulinSettings>({
     bolusInsulinBrand: "novorapid",
     basalInsulinBrand: "lantus",
-    insulinActionDuration: 240,
+    insulinActionDuration: 4,
     targetGlucoseMgdl: 100,
     considerIob: true,
     extendedBolusEnabled: false,
@@ -266,7 +266,7 @@ export default function InsulinTherapyPage() {
         let fetchedSettings: InsulinSettings = {
           bolusInsulinBrand: "novorapid",
           basalInsulinBrand: "lantus",
-          insulinActionDuration: 240,
+          insulinActionDuration: 4,
           targetGlucoseMgdl: 100,
           considerIob: true,
           extendedBolusEnabled: false,
@@ -385,7 +385,7 @@ export default function InsulinTherapyPage() {
     setSettings({
       bolusInsulinBrand: "novorapid",
       basalInsulinBrand: "lantus",
-      insulinActionDuration: 240,
+      insulinActionDuration: 4,
       targetGlucoseMgdl: 100,
       considerIob: true,
       extendedBolusEnabled: false,
@@ -619,18 +619,21 @@ export default function InsulinTherapyPage() {
               hint={t("targetGlucoseHint")}
             />
 
-            {/* Insulin action duration */}
+            {/* Insulin action duration — en HEURES (contrat API + clinical-bounds
+                INSULIN_ACTION_MIN/MAX = 3.5–5.0 h). A2 : l'UI envoyait des minutes
+                à une API attendant des heures → toute sauvegarde échouait (400). */}
             <DiabeoTextField
               label={t("insulinActionDuration")}
               type="number"
-              min={60}
-              max={480}
+              min={3.5}
+              max={5}
+              step={0.5}
               value={settings.insulinActionDuration}
               onChange={(e) => {
-                // C2: guard against NaN and enforce bounds [60, 480] minutes (1–8 hours)
-                const val = e.target.value === "" ? 0 : parseInt(e.target.value, 10)
+                // C2: guard against NaN and enforce bounds [3.5, 5.0] hours.
+                const val = e.target.value === "" ? 0 : parseFloat(e.target.value)
                 if (Number.isNaN(val)) return
-                const clamped = Math.min(480, Math.max(60, val))
+                const clamped = Math.min(5, Math.max(3.5, val))
                 updateSettings("insulinActionDuration", clamped)
               }}
               hint={t("insulinActionDurationHint")}

--- a/tests/pages/insulin-therapy.test.tsx
+++ b/tests/pages/insulin-therapy.test.tsx
@@ -108,7 +108,7 @@ function setupFetchMocks(overrides?: {
         json: async () => overrides?.settings ?? {
           bolusInsulinBrand: "novorapid",
           basalInsulinBrand: "lantus",
-          insulinActionDuration: 240,
+          insulinActionDuration: 4,
           targetGlucoseMgdl: 100,
           considerIob: true,
           extendedBolusEnabled: false,
@@ -211,6 +211,46 @@ describe("InsulinTherapyPage", () => {
     await waitFor(() => {
       const val = parseInt((targetInput as HTMLInputElement).value, 10)
       expect(val).toBeLessThanOrEqual(250)
+    })
+  })
+
+  // ── A2 : durée d'action en HEURES (pas minutes) ─────────────────────────
+  // L'UI envoyait des minutes (défaut 240, bornes 60–480) à une API qui valide
+  // 3.5–5.0 heures → toute sauvegarde échouait (400). Bornes alignées en heures.
+  it("insulin action duration is in hours (3.5–5.0), default 4", async () => {
+    await renderAndWaitForLoad()
+
+    const input = screen.getByLabelText(
+      "insulinTherapy.insulinActionDuration",
+    ) as HTMLInputElement
+    expect(input.value).toBe("4")
+    expect(input.getAttribute("min")).toBe("3.5")
+    expect(input.getAttribute("max")).toBe("5")
+  })
+
+  it("insulin action duration clamps to 3.5–5.0 hours and keeps half-hours", async () => {
+    await renderAndWaitForLoad()
+
+    const input = screen.getByLabelText(
+      "insulinTherapy.insulinActionDuration",
+    ) as HTMLInputElement
+
+    // Sous la borne basse → ramené à 3.5
+    fireEvent.change(input, { target: { value: "1" } })
+    await waitFor(() => {
+      expect(parseFloat(input.value)).toBeGreaterThanOrEqual(3.5)
+    })
+
+    // Au-dessus de la borne haute → ramené à 5
+    fireEvent.change(input, { target: { value: "9" } })
+    await waitFor(() => {
+      expect(parseFloat(input.value)).toBeLessThanOrEqual(5)
+    })
+
+    // Demi-heure conservée (parseFloat, pas parseInt)
+    fireEvent.change(input, { target: { value: "4.5" } })
+    await waitFor(() => {
+      expect(input.value).toBe("4.5")
     })
   })
 


### PR DESCRIPTION
## Anomalie A2 (audit QA)

L'écran `/insulin-therapy` saisissait la **durée d'action insuline en minutes** (défaut 240, bornes 60–480) et envoyait cette valeur à `PUT /api/insulin-therapy/settings`, qui la valide en **heures** (`clinical-bounds.ts` `INSULIN_ACTION_MIN/MAX = 3.5–5.0`). → toute sauvegarde échouait en **400** (240 > 5).

## Correction (UI alignée sur les heures)

- `src/app/(dashboard)/insulin-therapy/page.tsx` : defaults 240 → **4** (état initial, mapping GET, reset) ; input `min 60→3.5`, `max 480→5`, `step 0.5`, `parseInt→parseFloat`, clamp `[3.5,5]`.
- `messages/{fr,en,ar}.json` : libellé « (minutes) » → « (heures) », hint « 60–480 min » → « 3,5–5 h ».
- `tests/pages/insulin-therapy.test.tsx` : mock GET 240→4 + **2 tests** (bornes heures, demi-heures préservées).

## Vérifs

- Tests : **13/13** (page) + **28/28** (service + RBAC) verts. `tsc` + `eslint` OK. JSON locales valides.
- **Review clinique (`medical-domain-validator`)** : verdict **SÛR** — le moteur bolus/IOB lit `IobSettings.actionDurationHours` (table distincte, déjà en heures) → **aucun risque de dosage** ; défaut 4 h cohérent avec `@default(4.0)` DB.
- **Review `code-reviewer`** : conversion cohérente partout, i18n OK.

## ⚠️ Bloqueurs résiduels (documentés, suivi dédié A2b — PAS dans cette PR)

La review a confirmé que la **sauvegarde reste KO end-to-end** pour des raisons indépendantes de l'unité :
1. `deliveryMethod` manquant dans le body PUT → 400 ;
2. `upsertSettings` écrit des colonnes inexistantes dans `insulin_therapy_settings` → 500 (masqué par les mocks Prisma) ;
3. la durée saisie n'alimente pas l'IOB (`IobSettings.actionDurationHours` séparé).

→ Chantier « persistance insulinothérapie » dédié (`prisma-specialist` + `medical-domain-validator`), tracé dans `docs/qa/11-clinical.md` + README §2bis. **Cette PR corrige uniquement l'unité (le 400 d'unité), pas le câblage data-model.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)