### PR TITLE
test(bdd): étendre les features QA exécutables + vérification « effet base »

### DIFF
--- a/tests/manual/bdd/README.md
+++ b/tests/manual/bdd/README.md
@@ -18,15 +18,26 @@ runner Playwright + le helper `loginAs`).
 
 ```
 tests/manual/bdd/
-  features/                       # .feature (Gherkin FR, # language: fr)
-    login.feature                 # ← docs/qa/01-auth.md
+  features/                       # .feature (Gherkin FR, # language: fr) — 15 scénarios
+    login.feature                 # ← docs/qa/01-auth.md (connexion)
+    auth/reset-password.feature   # ← docs/qa/01-auth.md (mot de passe oublié)
     dashboard-access.feature      # ← docs/qa/02-dashboards.md
+    rbac/redirects.feature        # ← 02-dashboards / 06-admin / 12-communication (RBAC + A5)
+    settings/rbac.feature         # ← docs/qa/05-settings.md (PS vs patient)
+    effet-base/login-session.feature  # ← docs/qa/01-auth.md (vérif EFFET BASE)
   steps/                          # step definitions (réutilisables)
     auth.steps.ts                 # "je suis connecté en tant que {string}" → loginAs()
     login.steps.ts                # steps de l'écran connexion (data-testid)
-    navigation.steps.ts           # "je vais sur {string}", "je suis redirigé vers {string}", "je vois le titre {string}"
+    navigation.steps.ts           # "je vais sur / je suis redirigé vers / je reste sur / je vois (pas) le titre"
+    page.steps.ts                 # "je vois l'élément / je remplis le champ / je clique / je vois le texte"
+    db.steps.ts                   # "une session active existe en base pour {string}" — VÉRIF EFFET BASE (pg)
 playwright.bdd.config.ts          # config (racine du repo) — pas de webServer
 ```
+
+> **Vérification « effet base »** (`db.steps.ts`) : ce step interroge directement
+> PostgreSQL (driver `pg`, `.env` chargé via `dotenv`) pour valider la ligne
+> `# Effet base:` d'un scénario (ici : la connexion a bien créé une ligne
+> `sessions`). C'est ce qui distingue ces tests d'un simple test d'UI.
 
 Le dossier `.features-gen/` (specs générées depuis les `.feature`) est
 **gitignoré** : il est régénéré par `bddgen`.
@@ -62,6 +73,13 @@ pnpm bdd:gen
 pnpm exec playwright test --config playwright.bdd.config.ts \
   .features-gen/tests/manual/bdd/features/login.feature.spec.js
 ```
+
+> **État frais entre rejeux** : le scénario « identifiants invalides » incrémente
+> le rate-limit de connexion (in-memory dans le dev server sans Redis configuré).
+> Après plusieurs rejeux complets, un lockout IP peut faire échouer le `loginAs`
+> de scénarios suivants. → relancer `pnpm dev` (purge le compteur in-memory) ou
+> attendre la fin de la fenêtre (≈ 1 min) avant un nouveau run complet. En CI
+> (un seul run sur base/serveur frais) le souci ne se pose pas.
 
 ## Étendre
 

--- a/tests/manual/bdd/README.md
+++ b/tests/manual/bdd/README.md
@@ -91,11 +91,11 @@ pnpm exec playwright test --config playwright.bdd.config.ts \
 
 ### Prochaines étapes recommandées (hors POC)
 
-- **Vérification « effet base »** : ajouter `steps/db.steps.ts` qui interroge
-  PostgreSQL (client Prisma en lecture) pour valider les lignes
-  `# Effet base:` des scénarios (ex. `appointments.status='cancelled'`,
-  présence d'une ligne `audit_logs`). C'est ce qui distingue ce harness d'un
-  simple test d'UI.
+- ✅ **Vérification « effet base »** : `steps/db.steps.ts` livré (interroge
+  PostgreSQL via `pg`). À étendre à d'autres effets (ex. `appointments.status`,
+  présence d'une ligne `audit_logs`) au fil des features d'écriture.
 - **Reset déterministe** entre features d'écriture (transaction rollback ou
   `prisma migrate reset`) pour l'idempotence.
-- **`data-testid`** systématiques sur les écrans à automatiser.
+- **`data-testid`** systématiques sur les écrans à automatiser : les features
+  assertent aujourd'hui des **libellés FR** (le dev server tourne en locale FR
+  par défaut) ; des `data-testid` les rendraient indépendantes de l'i18n.

--- a/tests/manual/bdd/features/auth/reset-password.feature
+++ b/tests/manual/bdd/features/auth/reset-password.feature
@@ -1,0 +1,21 @@
+# language: fr
+# Source : docs/qa/01-auth.md — Écran Mot de passe oublié (/reset-password)
+Fonctionnalité: Réinitialisation du mot de passe
+
+  Scénario: la page affiche le formulaire de réinitialisation
+    Étant donné que je suis sur "/reset-password"
+    Alors je vois l'élément "reset-password-screen"
+    Et je vois l'élément "reset-email-field"
+
+  Scénario: demande pour un email existant — message générique anti-énumération
+    Étant donné que je suis sur "/reset-password"
+    Quand je remplis le champ "#reset-email" avec "docteur@diabeo.test"
+    Et je clique l'élément "reset-submit-button"
+    Alors je vois le texte "compte existe avec cette adresse"
+    # Effet base attendu : verification_token (TTL 1h) — non assertable ici (anti-énumération volontaire)
+
+  Scénario: demande pour un email inexistant — réponse identique
+    Étant donné que je suis sur "/reset-password"
+    Quand je remplis le champ "#reset-email" avec "personne@diabeo.test"
+    Et je clique l'élément "reset-submit-button"
+    Alors je vois le texte "compte existe avec cette adresse"

--- a/tests/manual/bdd/features/effet-base/login-session.feature
+++ b/tests/manual/bdd/features/effet-base/login-session.feature
@@ -1,0 +1,8 @@
+# language: fr
+# Source : docs/qa/01-auth.md — effet base de la connexion (INSERT sessions)
+Fonctionnalité: Vérification « effet base » — session de connexion
+
+  Scénario: la connexion DOCTOR crée une session active en base
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Alors une session active existe en base pour "DOCTOR"
+    # Effet base: INSERT sessions (cf. docs/qa/01-auth.md)

--- a/tests/manual/bdd/features/rbac/redirects.feature
+++ b/tests/manual/bdd/features/rbac/redirects.feature
@@ -1,0 +1,23 @@
+# language: fr
+# Source : docs/qa/02-dashboards.md, 06-admin.md, 12-communication.md
+Fonctionnalité: Redirections RBAC entre rôles
+
+  Scénario: un VIEWER est redirigé hors des pages pro
+    Étant donné que je suis connecté en tant que "VIEWER"
+    Quand je vais sur "/patients"
+    Alors je suis redirigé vers "/patient/dashboard"
+
+  Scénario: un DOCTOR n'accède pas au hub admin
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand je vais sur "/admin"
+    Alors je ne vois pas le titre "Tableau de bord administrateur"
+
+  Scénario: un ADMIN accède au hub admin
+    Étant donné que je suis connecté en tant que "ADMIN"
+    Quand je vais sur "/admin"
+    Alors je vois le titre "Tableau de bord administrateur"
+
+  Scénario: /users (legacy) redirige vers /admin/users (anomalie A5)
+    Étant donné que je suis connecté en tant que "ADMIN"
+    Quand je vais sur "/users"
+    Alors je suis redirigé vers "/admin/users"

--- a/tests/manual/bdd/features/settings/rbac.feature
+++ b/tests/manual/bdd/features/settings/rbac.feature
@@ -1,0 +1,13 @@
+# language: fr
+# Source : docs/qa/05-settings.md — accès /settings PS vs patient (§7)
+Fonctionnalité: Accès RBAC aux paramètres (/settings)
+
+  Scénario: un professionnel de santé accède à /settings (non redirigé)
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand je vais sur "/settings"
+    Alors je reste sur "/settings"
+
+  Scénario: un patient (VIEWER) est redirigé hors de /settings (layout dashboard)
+    Étant donné que je suis connecté en tant que "VIEWER"
+    Quand je vais sur "/settings"
+    Alors je suis redirigé vers "/patient/dashboard"

--- a/tests/manual/bdd/steps/db.steps.ts
+++ b/tests/manual/bdd/steps/db.steps.ts
@@ -1,0 +1,62 @@
+import "dotenv/config"
+import { createHmac } from "node:crypto"
+import { Pool } from "pg"
+import { expect } from "@playwright/test"
+import { createBdd } from "playwright-bdd"
+
+const { Then } = createBdd()
+
+/**
+ * Steps de vérification « effet base » — interrogent directement PostgreSQL.
+ *
+ * C'est ce qui distingue ces tests d'un simple test d'UI : on valide la ligne
+ * `# Effet base:` des scénarios du plan QA (`docs/qa/`) contre la vraie base.
+ *
+ * Pré-requis : `.env` (DATABASE_URL + HMAC_SECRET) + Postgres seedé + dev server.
+ * `dotenv/config` charge le `.env` à l'import du fichier de steps.
+ */
+
+let pool: Pool | null = null
+function db(): Pool {
+  if (!pool) {
+    pool = new Pool({
+      connectionString: process.env.DATABASE_URL,
+      max: 1,
+      idleTimeoutMillis: 1000,
+      allowExitOnIdle: true, // laisse le process Playwright se terminer
+    })
+  }
+  return pool
+}
+
+/** Réplique `hmacEmail` (`src/lib/crypto/hmac.ts`) : HMAC-SHA256 sur l'email normalisé. */
+function emailHmac(email: string): string {
+  const secret = process.env.HMAC_SECRET
+  if (!secret) throw new Error("HMAC_SECRET absent de l'environnement (.env)")
+  return createHmac("sha256", secret).update(email.toLowerCase().trim()).digest("hex")
+}
+
+const SEED_EMAIL: Record<string, string> = {
+  ADMIN: "admin@diabeo.test",
+  DOCTOR: "docteur@diabeo.test",
+  NURSE: "infirmiere@diabeo.test",
+  VIEWER: "patient.dt1@diabeo.test",
+}
+
+Then(
+  "une session active existe en base pour {string}",
+  // 1er param destructuré (même vide) — requis par playwright-bdd pour
+  // inférer les fixtures ; ce step n'utilise aucune fixture Playwright.
+  async ({}, role: string) => {
+    const email = SEED_EMAIL[role]
+    if (!email) throw new Error(`Rôle QA inconnu : "${role}"`)
+    const { rows } = await db().query<{ n: string }>(
+      `SELECT COUNT(*)::int AS n
+         FROM sessions s
+         JOIN users u ON u.id = s.user_id
+        WHERE u.email_hmac = $1 AND s.expires > NOW()`,
+      [emailHmac(email)],
+    )
+    expect(Number(rows[0].n)).toBeGreaterThan(0)
+  },
+)

--- a/tests/manual/bdd/steps/db.steps.ts
+++ b/tests/manual/bdd/steps/db.steps.ts
@@ -1,8 +1,10 @@
 import "dotenv/config"
-import { createHmac } from "node:crypto"
 import { Pool } from "pg"
 import { expect } from "@playwright/test"
 import { createBdd } from "playwright-bdd"
+// Source de vérité unique du HMAC email (évite toute divergence avec le code).
+// `dotenv/config` ci-dessus charge HMAC_SECRET avant le 1er appel (lecture lazy).
+import { hmacEmail } from "../../../../src/lib/crypto/hmac"
 
 const { Then } = createBdd()
 
@@ -29,13 +31,6 @@ function db(): Pool {
   return pool
 }
 
-/** Réplique `hmacEmail` (`src/lib/crypto/hmac.ts`) : HMAC-SHA256 sur l'email normalisé. */
-function emailHmac(email: string): string {
-  const secret = process.env.HMAC_SECRET
-  if (!secret) throw new Error("HMAC_SECRET absent de l'environnement (.env)")
-  return createHmac("sha256", secret).update(email.toLowerCase().trim()).digest("hex")
-}
-
 const SEED_EMAIL: Record<string, string> = {
   ADMIN: "admin@diabeo.test",
   DOCTOR: "docteur@diabeo.test",
@@ -55,7 +50,7 @@ Then(
          FROM sessions s
          JOIN users u ON u.id = s.user_id
         WHERE u.email_hmac = $1 AND s.expires > NOW()`,
-      [emailHmac(email)],
+      [hmacEmail(email)],
     )
     expect(Number(rows[0].n)).toBeGreaterThan(0)
   },

--- a/tests/manual/bdd/steps/login.steps.ts
+++ b/tests/manual/bdd/steps/login.steps.ts
@@ -33,6 +33,8 @@ Then("je reste sur la page de connexion", async ({ page }) => {
 })
 
 Then("je vois une alerte d'erreur", async ({ page }) => {
-  // AlertBanner severity="warning" → role="alert" (cf. AlertBanner.tsx).
-  await expect(page.getByRole("alert")).toBeVisible()
+  // AlertBanner severity="warning"/"critical" → role="alert" (cf. AlertBanner.tsx).
+  // `.first()` : en cas de rate-limit, plusieurs alertes (erreur + lockout)
+  // peuvent coexister — on valide qu'au moins une est visible.
+  await expect(page.getByRole("alert").first()).toBeVisible()
 })

--- a/tests/manual/bdd/steps/navigation.steps.ts
+++ b/tests/manual/bdd/steps/navigation.steps.ts
@@ -1,23 +1,40 @@
 import { expect } from "@playwright/test"
 import { createBdd } from "playwright-bdd"
 
-const { When, Then } = createBdd()
+const { Given, When, Then } = createBdd()
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 }
+
+Given("je suis sur {string}", async ({ page }, path: string) => {
+  await page.goto(path)
+})
 
 When("je vais sur {string}", async ({ page }, path: string) => {
   await page.goto(path)
 })
 
 Then("je suis redirigé vers {string}", async ({ page }, path: string) => {
-  // Tolère un slash final éventuel.
-  await expect(page).toHaveURL(new RegExp(`${escapeRegExp(path)}/?(\\?.*)?$`))
+  // Ancré sur l'origine pour distinguer "/" des sous-chemins ("/admin"…),
+  // tolère un slash final + une query string éventuelle.
+  await expect(page).toHaveURL(
+    new RegExp(`^https?://[^/]+${escapeRegExp(path)}/?(\\?.*)?$`),
+  )
 })
 
 Then("je vois le titre {string}", async ({ page }, title: string) => {
   await expect(
     page.getByRole("heading", { name: title }),
   ).toBeVisible()
+})
+
+Then("je ne vois pas le titre {string}", async ({ page }, title: string) => {
+  await expect(page.getByRole("heading", { name: title })).toHaveCount(0)
+})
+
+Then("je reste sur {string}", async ({ page }, path: string) => {
+  await expect(page).toHaveURL(
+    new RegExp(`^https?://[^/]+${escapeRegExp(path)}/?(\\?.*)?$`),
+  )
 })

--- a/tests/manual/bdd/steps/page.steps.ts
+++ b/tests/manual/bdd/steps/page.steps.ts
@@ -1,0 +1,33 @@
+import { expect } from "@playwright/test"
+import { createBdd } from "playwright-bdd"
+
+const { When, Then } = createBdd()
+
+// --- Présence / absence par data-testid ---
+
+Then("je vois l'élément {string}", async ({ page }, testId: string) => {
+  await expect(page.getByTestId(testId)).toBeVisible()
+})
+
+Then("l'élément {string} est absent", async ({ page }, testId: string) => {
+  await expect(page.getByTestId(testId)).toHaveCount(0)
+})
+
+// --- Interactions ---
+
+When(
+  "je remplis le champ {string} avec {string}",
+  async ({ page }, selector: string, value: string) => {
+    await page.locator(selector).fill(value)
+  },
+)
+
+When("je clique l'élément {string}", async ({ page }, testId: string) => {
+  await page.getByTestId(testId).click()
+})
+
+// --- Texte ---
+
+Then("je vois le texte {string}", async ({ page }, text: string) => {
+  await expect(page.getByText(text, { exact: false }).first()).toBeVisible()
+})


### PR DESCRIPTION
## Objet

Étend le harness **playwright-bdd** (POC #490) avec des features dérivées du **plan QA** (`docs/qa/`) — passant de **5 à 15 scénarios** exécutables, **tous verts** en vrai navigateur contre le stack local seedé.

## Ajouts

| Feature | Source QA | Scénarios |
|---|---|---|
| `auth/reset-password.feature` | `01-auth.md` | formulaire + anti-énumération (×3) |
| `rbac/redirects.feature` | `02`/`06`/`12` | VIEWER→`/patient/dashboard`, DOCTOR↛`/admin`, ADMIN→hub, **A5** `/users`→`/admin/users` |
| `settings/rbac.feature` | `05-settings.md` | PS accède `/settings`, VIEWER redirigé |
| `effet-base/login-session.feature` | `01-auth.md` | **vérif effet base** : la connexion crée une ligne `sessions` |

### Step « effet base » (le différenciateur)

`steps/db.steps.ts` interroge **directement PostgreSQL** (`pg` + `dotenv`) pour valider la ligne `# Effet base:` d'un scénario — ici, que la connexion a bien inséré une `sessions` active pour l'utilisateur (jointure `email_hmac`). C'est ce que le README QA recommandait pour distinguer ces tests d'un simple test d'UI.

### Steps réutilisables ajoutés/améliorés

- `page.steps.ts` : voir l'élément / remplir le champ / cliquer / voir le texte.
- `navigation.steps.ts` : `je reste sur`, `je ne vois pas le titre`, redirect **ancré sur l'origine** (distingue `/` des sous-chemins).
- `login.steps.ts` : alerte d'erreur en `.first()` (robuste au multi-alertes du rate-limit).

## Vérification

**15/15 verts** (`pnpm bdd:test`) sur un dev server frais + base seedée. `tsc` + `eslint` OK.

> Harness **hors-CI** (manuel) : nécessite dev server + base seedée + Chromium complet (cf. `tests/manual/bdd/README.md`). Note rate-limit documentée pour les rejeux complets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)