### PR TITLE
test(bdd): lot Patients (03) — contrat API + vérification effet base

### DIFF
--- a/tests/manual/bdd/README.md
+++ b/tests/manual/bdd/README.md
@@ -92,9 +92,12 @@ pnpm exec playwright test --config playwright.bdd.config.ts \
 > frais) le souci ne se pose pas.
 >
 > Note : le scénario de **création patient** insère une vraie ligne en base à
-> chaque exécution (email unique horodaté) — données de test, à purger
-> éventuellement (`DELETE FROM users WHERE email_hmac IN (...)` via les emails
-> `qa.bdd.*@diabeo.test`).
+> chaque exécution (email unique horodaté `qa.bdd.*@diabeo.test`) — données de
+> test synthétiques. ⚠️ Un simple `DELETE FROM users WHERE …` **échoue** (FK
+> `audit_logs.user_id` + trigger d'**immutabilité** sur `audit_logs`). Pour
+> repartir propre : `pnpm prisma migrate reset --force && pnpm prisma db seed`.
+> Une **garde anti-prod** (`steps/hooks.steps.ts`) refuse toute `DATABASE_URL`
+> non-locale pour éviter de créer de faux patients en staging/prod.
 
 ## Étendre
 

--- a/tests/manual/bdd/README.md
+++ b/tests/manual/bdd/README.md
@@ -18,26 +18,35 @@ runner Playwright + le helper `loginAs`).
 
 ```
 tests/manual/bdd/
-  features/                       # .feature (Gherkin FR, # language: fr) — 15 scénarios
+  features/                       # .feature (Gherkin FR, # language: fr) — 25 scénarios
     login.feature                 # ← docs/qa/01-auth.md (connexion)
     auth/reset-password.feature   # ← docs/qa/01-auth.md (mot de passe oublié)
     dashboard-access.feature      # ← docs/qa/02-dashboards.md
     rbac/redirects.feature        # ← 02-dashboards / 06-admin / 12-communication (RBAC + A5)
     settings/rbac.feature         # ← docs/qa/05-settings.md (PS vs patient)
+    patients/{list,detail,create}.feature  # ← docs/qa/03-patients.md (contrat API + effet base)
     effet-base/login-session.feature  # ← docs/qa/01-auth.md (vérif EFFET BASE)
   steps/                          # step definitions (réutilisables)
     auth.steps.ts                 # "je suis connecté en tant que {string}" → loginAs()
     login.steps.ts                # steps de l'écran connexion (data-testid)
     navigation.steps.ts           # "je vais sur / je suis redirigé vers / je reste sur / je vois (pas) le titre"
     page.steps.ts                 # "je vois l'élément / je remplis le champ / je clique / je vois le texte"
-    db.steps.ts                   # "une session active existe en base pour {string}" — VÉRIF EFFET BASE (pg)
+    api.steps.ts                  # "j'appelle GET / je POST … avec le JSON" → page.request (cookie auth)
+    db.steps.ts                   # vérif EFFET BASE (pg) : session active, compte patient créé…
+    world.ts                      # état partagé entre steps (réponse API, email créé) — exécution série
 playwright.bdd.config.ts          # config (racine du repo) — pas de webServer
 ```
 
-> **Vérification « effet base »** (`db.steps.ts`) : ce step interroge directement
-> PostgreSQL (driver `pg`, `.env` chargé via `dotenv`) pour valider la ligne
-> `# Effet base:` d'un scénario (ici : la connexion a bien créé une ligne
-> `sessions`). C'est ce qui distingue ces tests d'un simple test d'UI.
+> **Vérification « effet base »** (`db.steps.ts`) : ces steps interrogent
+> directement PostgreSQL (driver `pg`, `.env` chargé via `dotenv`) pour valider la
+> ligne `# Effet base:` d'un scénario (ex. la connexion a créé une ligne
+> `sessions` ; la création patient a inséré `users`+`patients`). C'est ce qui
+> distingue ces tests d'un simple test d'UI.
+>
+> **Contrat API** (`api.steps.ts`) : nombre de scénarios QA sont au niveau API
+> (`Quand j'appelle GET "/api/…"` / `Alors le statut … est 200`) — exécutés via
+> `page.request` qui hérite du cookie d'auth injecté par `loginAs`. Robuste (pas
+> de sélecteur UI fragile).
 
 Le dossier `.features-gen/` (specs générées depuis les `.feature`) est
 **gitignoré** : il est régénéré par `bddgen`.
@@ -74,12 +83,18 @@ pnpm exec playwright test --config playwright.bdd.config.ts \
   .features-gen/tests/manual/bdd/features/login.feature.spec.js
 ```
 
-> **État frais entre rejeux** : le scénario « identifiants invalides » incrémente
-> le rate-limit de connexion (in-memory dans le dev server sans Redis configuré).
-> Après plusieurs rejeux complets, un lockout IP peut faire échouer le `loginAs`
-> de scénarios suivants. → relancer `pnpm dev` (purge le compteur in-memory) ou
-> attendre la fin de la fenêtre (≈ 1 min) avant un nouveau run complet. En CI
-> (un seul run sur base/serveur frais) le souci ne se pose pas.
+> **État frais entre rejeux** : certains endpoints ont un rate-limit **in-memory**
+> (dev server sans Redis configuré) qui s'accumule entre rejeux complets :
+> `POST /api/auth/login` (scénario « identifiants invalides ») et `POST /api/patients`
+> (anti-énumération). Après plusieurs runs, un 429 / lockout IP peut faire échouer
+> le `loginAs` ou la création patient. → relancer `pnpm dev` (purge le compteur
+> in-memory) avant un nouveau run complet. **En CI** (un seul run sur base/serveur
+> frais) le souci ne se pose pas.
+>
+> Note : le scénario de **création patient** insère une vraie ligne en base à
+> chaque exécution (email unique horodaté) — données de test, à purger
+> éventuellement (`DELETE FROM users WHERE email_hmac IN (...)` via les emails
+> `qa.bdd.*@diabeo.test`).
 
 ## Étendre
 

--- a/tests/manual/bdd/features/patients/create.feature
+++ b/tests/manual/bdd/features/patients/create.feature
@@ -1,0 +1,35 @@
+# language: fr
+# Source : docs/qa/03-patients.md — Création patient (POST /api/patients)
+Fonctionnalité: Création d'un patient
+
+  Scénario: création réussie par un DOCTOR — vérification effet base
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand je crée un patient avec un email unique
+    Alors le statut de la réponse est 201
+    Et un compte patient existe en base avec l'email créé
+    # Effet base: INSERT users(role=VIEWER, PII chiffrées) + patients + audit CREATE
+
+  Scénario: email déjà utilisé
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand je POST "/api/patients" avec le JSON:
+      """
+      {"email":"patient.dt1@diabeo.test","firstName":"A","lastName":"B","pathology":"DT1"}
+      """
+    Alors le statut de la réponse est 409
+    Et le corps contient "emailExists"
+
+  Scénario: en-tête CSRF manquant
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand je POST "/api/patients" sans en-tête CSRF avec le JSON:
+      """
+      {"email":"qa.csrf@diabeo.test","firstName":"A","lastName":"B","pathology":"DT1"}
+      """
+    Alors le statut de la réponse est 403
+
+  Scénario: validation échouée (pathologie manquante)
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand je POST "/api/patients" avec le JSON:
+      """
+      {"email":"qa.val@diabeo.test","firstName":"A","lastName":"B"}
+      """
+    Alors le statut de la réponse est 400

--- a/tests/manual/bdd/features/patients/detail.feature
+++ b/tests/manual/bdd/features/patients/detail.feature
@@ -1,0 +1,19 @@
+# language: fr
+# Source : docs/qa/03-patients.md — Détail patient (contrat API + RBAC)
+Fonctionnalité: Détail d'un patient
+
+  Scénario: un DOCTOR accède à un patient de son portefeuille
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/patients/1"
+    Alors le statut de la réponse est 200
+    Et le corps contient "DT1"
+
+  Scénario: accès refusé à un patient hors portefeuille / inexistant
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/patients/99999"
+    Alors le statut de la réponse est 403
+
+  Scénario: identifiant patient invalide
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/patients/abc"
+    Alors le statut de la réponse est 400

--- a/tests/manual/bdd/features/patients/list.feature
+++ b/tests/manual/bdd/features/patients/list.feature
@@ -1,0 +1,19 @@
+# language: fr
+# Source : docs/qa/03-patients.md — Liste patients (contrat API + RBAC)
+Fonctionnalité: Liste des patients
+
+  Scénario: un NURSE peut lister les patients
+    Étant donné que je suis connecté en tant que "NURSE"
+    Quand j'appelle GET "/api/patients"
+    Alors le statut de la réponse est 200
+
+  Scénario: un VIEWER ne peut pas lister les patients
+    Étant donné que je suis connecté en tant que "VIEWER"
+    Quand j'appelle GET "/api/patients"
+    Alors le statut de la réponse est 403
+
+  Scénario: la recherche par nom (match HMAC exact) renvoie le patient
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/patients/search?search=Durand"
+    Alors le statut de la réponse est 200
+    Et le corps contient "Durand"

--- a/tests/manual/bdd/steps/api.steps.ts
+++ b/tests/manual/bdd/steps/api.steps.ts
@@ -1,0 +1,56 @@
+import { expect } from "@playwright/test"
+import { createBdd } from "playwright-bdd"
+import { world } from "./world"
+
+const { When, Then } = createBdd()
+
+const JSON_HEADERS = { "Content-Type": "application/json" }
+const CSRF_HEADERS = { ...JSON_HEADERS, "X-Requested-With": "XMLHttpRequest" }
+
+// `page.request` partage les cookies du BrowserContext (cookie httpOnly
+// `diabeo_token` injecté par loginAs dans le Given « je suis connecté »).
+
+When("j'appelle GET {string}", async ({ page }, url: string) => {
+  const res = await page.request.get(url)
+  world.status = res.status()
+  world.body = await res.json().catch(() => null)
+})
+
+When("je POST {string} avec le JSON:", async ({ page }, url: string, body: string) => {
+  const res = await page.request.post(url, { headers: CSRF_HEADERS, data: JSON.parse(body) })
+  world.status = res.status()
+  world.body = await res.json().catch(() => null)
+})
+
+When(
+  "je POST {string} sans en-tête CSRF avec le JSON:",
+  async ({ page }, url: string, body: string) => {
+    const res = await page.request.post(url, { headers: JSON_HEADERS, data: JSON.parse(body) })
+    world.status = res.status()
+    world.body = await res.json().catch(() => null)
+  },
+)
+
+// Création patient avec email unique (idempotence des rejeux) + lien effet base.
+When("je crée un patient avec un email unique", async ({ page }) => {
+  world.createdEmail = `qa.bdd.${Date.now()}@diabeo.test`
+  const res = await page.request.post("/api/patients", {
+    headers: CSRF_HEADERS,
+    data: {
+      email: world.createdEmail,
+      firstName: "QA",
+      lastName: "BDD",
+      pathology: "DT1",
+    },
+  })
+  world.status = res.status()
+  world.body = await res.json().catch(() => null)
+})
+
+Then("le statut de la réponse est {int}", async ({}, code: number) => {
+  expect(world.status).toBe(code)
+})
+
+Then("le corps contient {string}", async ({}, text: string) => {
+  expect(JSON.stringify(world.body)).toContain(text)
+})

--- a/tests/manual/bdd/steps/db.steps.ts
+++ b/tests/manual/bdd/steps/db.steps.ts
@@ -2,6 +2,7 @@ import "dotenv/config"
 import { Pool } from "pg"
 import { expect } from "@playwright/test"
 import { createBdd } from "playwright-bdd"
+import { world } from "./world"
 // Source de vérité unique du HMAC email (évite toute divergence avec le code).
 // `dotenv/config` ci-dessus charge HMAC_SECRET avant le 1er appel (lecture lazy).
 import { hmacEmail } from "../../../../src/lib/crypto/hmac"
@@ -55,3 +56,15 @@ Then(
     expect(Number(rows[0].n)).toBeGreaterThan(0)
   },
 )
+
+Then("un compte patient existe en base avec l'email créé", async ({}) => {
+  expect(world.createdEmail, "aucun email créé (step de création manquant ?)").not.toBe("")
+  const { rows } = await db().query<{ n: string }>(
+    `SELECT COUNT(*)::int AS n
+       FROM users u
+       JOIN patients p ON p.user_id = u.id
+      WHERE u.email_hmac = $1 AND u.role = 'VIEWER'`,
+    [hmacEmail(world.createdEmail)],
+  )
+  expect(Number(rows[0].n)).toBe(1)
+})

--- a/tests/manual/bdd/steps/hooks.steps.ts
+++ b/tests/manual/bdd/steps/hooks.steps.ts
@@ -1,0 +1,35 @@
+import "dotenv/config"
+import { createBdd } from "playwright-bdd"
+import { world } from "./world"
+
+const { Before } = createBdd()
+
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1", ""])
+
+/**
+ * Hook exécuté avant chaque scénario :
+ *  1. **Garde anti-prod** — ces tests CRÉENT/LISENT des données patient. On refuse
+ *     toute `DATABASE_URL` non-locale → jamais de faux patients créés en
+ *     staging/prod (sécurité, reco healthcare-security-auditor).
+ *  2. **Reset de l'état partagé** (`world`) entre scénarios — évite qu'un scénario
+ *     lise la réponse/email d'un précédent (reco code-reviewer).
+ */
+Before(async () => {
+  const url = process.env.DATABASE_URL ?? ""
+  let host = ""
+  try {
+    host = new URL(url).hostname
+  } catch {
+    host = ""
+  }
+  if (!LOCAL_HOSTS.has(host)) {
+    throw new Error(
+      `BDD refusé : DATABASE_URL non-local (host="${host}"). ` +
+        `Ce harness manuel ne doit tourner que sur une base de dev locale.`,
+    )
+  }
+
+  world.status = 0
+  world.body = null
+  world.createdEmail = ""
+})

--- a/tests/manual/bdd/steps/world.ts
+++ b/tests/manual/bdd/steps/world.ts
@@ -1,0 +1,14 @@
+/**
+ * État partagé entre steps (réponse API courante, email créé…).
+ * L'exécution BDD est sérielle (workers: 1) → un module mutable est sûr et
+ * évite de configurer une fixture « World » playwright-bdd.
+ */
+export const world: {
+  status: number
+  body: unknown
+  createdEmail: string
+} = {
+  status: 0,
+  body: null,
+  createdEmail: "",
+}


### PR DESCRIPTION
## Objet

Premier **lot par domaine** de la conversion du plan QA (`docs/qa/`) en BDD exécutable. Domaine **Patients** (`docs/qa/03-patients.md`) : **10 scénarios**, suite complète **25/25 verts** sur dev server frais + base seedée.

## Infrastructure réutilisable (pour tous les lots suivants)

- **`steps/api.steps.ts`** : `j'appelle GET "/api/…"`, `je POST "/api/…" (sans en-tête CSRF) avec le JSON: """…"""`, assertions `le statut … est {int}` / `le corps contient {string}`. Exécuté via **`page.request`** (hérite du cookie d'auth injecté par `loginAs`) → robuste, pas de sélecteur UI fragile.
- **`steps/db.steps.ts`** : + vérif **effet base** « un compte patient existe en base avec l'email créé » (jointure `users`/`patients` sur `email_hmac`).
- **`steps/world.ts`** : état partagé entre steps (réponse API, email créé) — exécution série (`workers: 1`).

## Features patients

| Feature | Scénarios (ancrés sur les réponses réelles du serveur) |
|---|---|
| `list` | NURSE liste (200), VIEWER refusé (**403**), recherche HMAC « Durand » (200, contient "Durand") |
| `detail` | DOCTOR `/api/patients/1` (200, "DT1"), hors-portefeuille/inexistant (**403**), id invalide (**400**) |
| `create` | création unique → **201 + effet base** (ligne patient vérifiée en base) · email existant (409 `emailExists`) · CSRF manquant (403) · validation (400) |

> Les statuts asserts ont été **sondés sur le serveur réel** avant écriture (ex. `/api/patients/99999` → 403 via `canAccessPatient`, pas 404).

## Vérification

**25/25 verts** (`pnpm bdd:test`) sur dev frais. `tsc` + `eslint` OK.

> Harness **hors-CI** (manuel). Note rate-limit (login + `POST /api/patients`) + purge des données de test patients documentées dans le README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)