### PR TITLE
test(bdd): lot Appointments (04) — contrat API + effet base RDV

### DIFF
--- a/tests/manual/bdd/README.md
+++ b/tests/manual/bdd/README.md
@@ -98,9 +98,10 @@ pnpm exec playwright test --config playwright.bdd.config.ts \
 > in-memory) avant un nouveau run complet. **En CI** (un seul run sur base/serveur
 > frais) le souci ne se pose pas.
 >
-> Note : le scénario de **création patient** insère une vraie ligne en base à
-> chaque exécution (email unique horodaté `qa.bdd.*@diabeo.test`) — données de
-> test synthétiques. ⚠️ Un simple `DELETE FROM users WHERE …` **échoue** (FK
+> Note : les scénarios d'**écriture** insèrent de vraies lignes à chaque run —
+> **création patient** (`users`+`patients`, email horodaté `qa.bdd.*@diabeo.test`)
+> et **création/annulation RDV** (`appointments`, créneau futur unique) — données
+> de test synthétiques. ⚠️ Un simple `DELETE FROM users WHERE …` **échoue** (FK
 > `audit_logs.user_id` + trigger d'**immutabilité** sur `audit_logs`). Pour
 > repartir propre : `pnpm prisma migrate reset --force && pnpm prisma db seed`.
 > Une **garde anti-prod** (`steps/hooks.steps.ts`) refuse toute `DATABASE_URL`

--- a/tests/manual/bdd/README.md
+++ b/tests/manual/bdd/README.md
@@ -18,13 +18,14 @@ runner Playwright + le helper `loginAs`).
 
 ```
 tests/manual/bdd/
-  features/                       # .feature (Gherkin FR, # language: fr) — 25 scénarios
+  features/                       # .feature (Gherkin FR, # language: fr) — 32 scénarios
     login.feature                 # ← docs/qa/01-auth.md (connexion)
     auth/reset-password.feature   # ← docs/qa/01-auth.md (mot de passe oublié)
     dashboard-access.feature      # ← docs/qa/02-dashboards.md
     rbac/redirects.feature        # ← 02-dashboards / 06-admin / 12-communication (RBAC + A5)
     settings/rbac.feature         # ← docs/qa/05-settings.md (PS vs patient)
-    patients/{list,detail,create}.feature  # ← docs/qa/03-patients.md (contrat API + effet base)
+    patients/{list,detail,create}.feature      # ← docs/qa/03-patients.md (contrat API + effet base)
+    appointments/{list,create,cancel}.feature  # ← docs/qa/04-appointments.md (contrat API + effet base)
     effet-base/login-session.feature  # ← docs/qa/01-auth.md (vérif EFFET BASE)
   steps/                          # step definitions (réutilisables)
     auth.steps.ts                 # "je suis connecté en tant que {string}" → loginAs()
@@ -32,10 +33,16 @@ tests/manual/bdd/
     navigation.steps.ts           # "je vais sur / je suis redirigé vers / je reste sur / je vois (pas) le titre"
     page.steps.ts                 # "je vois l'élément / je remplis le champ / je clique / je vois le texte"
     api.steps.ts                  # "j'appelle GET / je POST … avec le JSON" → page.request (cookie auth)
-    db.steps.ts                   # vérif EFFET BASE (pg) : session active, compte patient créé…
-    world.ts                      # état partagé entre steps (réponse API, email créé) — exécution série
+    appointments.steps.ts         # "je crée un RDV pour le patient {int} et le membre {int}" / "j'annule…"
+    db.steps.ts                   # vérif EFFET BASE (pg) : session active, compte patient créé, statut RDV…
+    hooks.steps.ts                # Before : reset `world` + garde anti-prod (DATABASE_URL local uniquement)
+    world.ts                      # état partagé entre steps (réponse API, email/RDV créé) — exécution série
 playwright.bdd.config.ts          # config (racine du repo) — pas de webServer
 ```
+
+> ⚠️ **Cucumber-expressions** : ne PAS mettre de parenthèses contenant un
+> paramètre dans le texte d'un step (`… (membre {int})` casse tout le registre :
+> « optional may not contain a parameter »). Utiliser `… et le membre {int}`.
 
 > **Vérification « effet base »** (`db.steps.ts`) : ces steps interrogent
 > directement PostgreSQL (driver `pg`, `.env` chargé via `dotenv`) pour valider la

--- a/tests/manual/bdd/features/appointments/cancel.feature
+++ b/tests/manual/bdd/features/appointments/cancel.feature
@@ -1,0 +1,12 @@
+# language: fr
+# Source : docs/qa/04-appointments.md — annulation RDV (effet base UPDATE)
+Fonctionnalité: Annulation d'un rendez-vous
+
+  Scénario: un DOCTOR annule un RDV qu'il a créé
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand je crée un RDV pour le patient 1 et le membre 1
+    Alors le statut de la réponse est 201
+    Quand j'annule le RDV créé en tant que "doctor"
+    Alors le statut de la réponse est 200
+    Et le RDV créé a le statut "cancelled" en base
+    # Effet base: UPDATE appointments(status=cancelled, cancelledBy, cancelReasonEncrypted) + audit

--- a/tests/manual/bdd/features/appointments/create.feature
+++ b/tests/manual/bdd/features/appointments/create.feature
@@ -1,0 +1,26 @@
+# language: fr
+# Source : docs/qa/04-appointments.md — création RDV (POST /api/appointments)
+Fonctionnalité: Création d'un rendez-vous
+
+  Scénario: un DOCTOR crée un RDV — vérification effet base
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand je crée un RDV pour le patient 1 et le membre 1
+    Alors le statut de la réponse est 201
+    Et le RDV créé a le statut "scheduled" en base
+    # Effet base: INSERT appointments(status=scheduled, motifEncrypted) + audit CREATE
+
+  Scénario: en-tête CSRF manquant
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand je POST "/api/appointments" sans en-tête CSRF avec le JSON:
+      """
+      {"patientId":1,"memberId":1,"date":"2026-09-01","hour":"10:00","durationMinutes":30,"location":"in_person","type":"diabeto"}
+      """
+    Alors le statut de la réponse est 403
+
+  Scénario: un VIEWER ne peut pas créer de RDV
+    Étant donné que je suis connecté en tant que "VIEWER"
+    Quand je POST "/api/appointments" avec le JSON:
+      """
+      {"patientId":1,"memberId":1,"date":"2026-09-01","hour":"10:00","durationMinutes":30,"location":"in_person","type":"diabeto"}
+      """
+    Alors le statut de la réponse est 403

--- a/tests/manual/bdd/features/appointments/list.feature
+++ b/tests/manual/bdd/features/appointments/list.feature
@@ -1,5 +1,7 @@
 # language: fr
 # Source : docs/qa/04-appointments.md — liste RDV (contrat API)
+# Pré-requis seed : le DOCTOR gère le service du membre 1
+# (assertMemberServiceAccess s'exécute avant la plage → sinon 403, pas 200/422).
 Fonctionnalité: Liste des rendez-vous
 
   Scénario: un DOCTOR liste les RDV de son cabinet

--- a/tests/manual/bdd/features/appointments/list.feature
+++ b/tests/manual/bdd/features/appointments/list.feature
@@ -1,0 +1,19 @@
+# language: fr
+# Source : docs/qa/04-appointments.md — liste RDV (contrat API)
+Fonctionnalité: Liste des rendez-vous
+
+  Scénario: un DOCTOR liste les RDV de son cabinet
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/appointments?from=2026-06-01&to=2026-07-31&memberId=1"
+    Alors le statut de la réponse est 200
+
+  Scénario: plage de dates trop large refusée
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/appointments?from=2026-05-01&to=2026-08-01&memberId=1"
+    Alors le statut de la réponse est 422
+    Et le corps contient "rangeTooLarge"
+
+  Scénario: paramètres de plage manquants
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/appointments"
+    Alors le statut de la réponse est 400

--- a/tests/manual/bdd/steps/appointments.steps.ts
+++ b/tests/manual/bdd/steps/appointments.steps.ts
@@ -10,14 +10,20 @@ const CSRF_HEADERS = {
 
 const pad2 = (n: number) => n.toString().padStart(2, "0")
 
-/** Créneau futur quasi-unique (idempotence des rejeux ; évite slotConflict 409). */
+/**
+ * Créneau futur quasi-unique pour rendre les rejeux idempotents (évite un
+ * chevauchement `slotOverlapAppointment` → 422 sur le même membre).
+ * Jour, heure et minute dérivent d'échelles de temps distinctes de `now` pour
+ * être décorrélés (pas le même résidu `% 60`).
+ */
 function uniqueFutureSlot(): { date: string; hour: string } {
   const now = Date.now()
   const d = new Date()
   d.setDate(d.getDate() + 30 + (now % 60)) // J+30..J+89
   const date = `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`
-  const hour = `${pad2(8 + (Math.floor(now / 1000) % 11))}:${pad2(now % 60)}` // 08–18h
-  return { date, hour }
+  const hour = 8 + (Math.floor(now / 3_600_000) % 11) // 08h..18h
+  const minute = Math.floor(now / 1_000) % 60 // 00..59
+  return { date, hour: `${pad2(hour)}:${pad2(minute)}` }
 }
 
 When(

--- a/tests/manual/bdd/steps/appointments.steps.ts
+++ b/tests/manual/bdd/steps/appointments.steps.ts
@@ -1,0 +1,53 @@
+import { createBdd } from "playwright-bdd"
+import { world } from "./world"
+
+const { When } = createBdd()
+
+const CSRF_HEADERS = {
+  "Content-Type": "application/json",
+  "X-Requested-With": "XMLHttpRequest",
+}
+
+const pad2 = (n: number) => n.toString().padStart(2, "0")
+
+/** Créneau futur quasi-unique (idempotence des rejeux ; évite slotConflict 409). */
+function uniqueFutureSlot(): { date: string; hour: string } {
+  const now = Date.now()
+  const d = new Date()
+  d.setDate(d.getDate() + 30 + (now % 60)) // J+30..J+89
+  const date = `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`
+  const hour = `${pad2(8 + (Math.floor(now / 1000) % 11))}:${pad2(now % 60)}` // 08–18h
+  return { date, hour }
+}
+
+When(
+  "je crée un RDV pour le patient {int} et le membre {int}",
+  async ({ page }, patientId: number, memberId: number) => {
+    const { date, hour } = uniqueFutureSlot()
+    const res = await page.request.post("/api/appointments", {
+      headers: CSRF_HEADERS,
+      data: {
+        patientId,
+        memberId,
+        date,
+        hour,
+        durationMinutes: 30,
+        location: "in_person",
+        type: "diabeto",
+        motif: "QA BDD",
+      },
+    })
+    world.status = res.status()
+    world.body = await res.json().catch(() => null)
+    world.createdAppointmentId = (world.body as { id?: number } | null)?.id ?? 0
+  },
+)
+
+When("j'annule le RDV créé en tant que {string}", async ({ page }, actor: string) => {
+  const res = await page.request.post(
+    `/api/appointments/${world.createdAppointmentId}/cancel`,
+    { headers: CSRF_HEADERS, data: { actor, reason: "QA BDD cancel" } },
+  )
+  world.status = res.status()
+  world.body = await res.json().catch(() => null)
+})

--- a/tests/manual/bdd/steps/db.steps.ts
+++ b/tests/manual/bdd/steps/db.steps.ts
@@ -57,6 +57,15 @@ Then(
   },
 )
 
+Then("le RDV créé a le statut {string} en base", async ({}, expected: string) => {
+  expect(world.createdAppointmentId, "aucun RDV créé (step de création manquant ?)").toBeGreaterThan(0)
+  const { rows } = await db().query<{ s: string }>(
+    `SELECT status::text AS s FROM appointments WHERE id = $1`,
+    [world.createdAppointmentId],
+  )
+  expect(rows[0]?.s).toBe(expected)
+})
+
 Then("un compte patient existe en base avec l'email créé", async ({}) => {
   expect(world.createdEmail, "aucun email créé (step de création manquant ?)").not.toBe("")
   const { rows } = await db().query<{ n: string }>(

--- a/tests/manual/bdd/steps/hooks.steps.ts
+++ b/tests/manual/bdd/steps/hooks.steps.ts
@@ -32,4 +32,5 @@ Before(async () => {
   world.status = 0
   world.body = null
   world.createdEmail = ""
+  world.createdAppointmentId = 0
 })

--- a/tests/manual/bdd/steps/world.ts
+++ b/tests/manual/bdd/steps/world.ts
@@ -7,8 +7,10 @@ export const world: {
   status: number
   body: unknown
   createdEmail: string
+  createdAppointmentId: number
 } = {
   status: 0,
   body: null,
   createdEmail: "",
+  createdAppointmentId: 0,
 }


### PR DESCRIPTION
## Objet

2e **lot par domaine** de conversion du plan QA en BDD exécutable. Domaine **Appointments** (`docs/qa/04-appointments.md`) : **7 scénarios**, suite complète **32/32 verte** (dev seedé).

## Contenu

| Feature | Scénarios (ancrés sur les réponses réelles du serveur) |
|---|---|
| `list` | DOCTOR liste (200) · plage > ~90j → **422 `rangeTooLarge`** · params manquants (400) |
| `create` | création → **201 + effet base** (`appointments.status = scheduled` en base) · CSRF manquant (403) · VIEWER refusé (403) |
| `cancel` | création → annulation → **200 + effet base** (`status = cancelled`) |

## Steps ajoutés

- `appointments.steps.ts` : `je crée un RDV pour le patient {int} et le membre {int}` (créneau futur **unique** → idempotence, évite `slotConflict`) + `j'annule le RDV créé en tant que {string}` (stocke l'id créé dans `world`).
- `db.steps.ts` : + `le RDV créé a le statut {string} en base` (lecture `appointments.status`).
- `world.ts` + `hooks.steps.ts` : + `createdAppointmentId` (reset par le `Before`).

## Notes

- Statuts **sondés sur le serveur réel** avant écriture (ex. l'API **accepte une date passée** — validation futur uniquement côté UI ; plage > ~90j → 422).
- README : ajout d'une note **cucumber-expressions** (parenthèses contenant un paramètre interdites — `(membre {int})` casse le registre).
- Harness **hors-CI** (manuel) ; la création RDV insère une vraie ligne (données de test) — garde anti-prod active (`hooks.steps.ts`).

`tsc` + `eslint` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)