### PR TITLE
test(bdd): lot Admin (06/08) — contrat API + RBAC ADMIN

### DIFF
--- a/tests/manual/bdd/README.md
+++ b/tests/manual/bdd/README.md
@@ -18,7 +18,7 @@ runner Playwright + le helper `loginAs`).
 
 ```
 tests/manual/bdd/
-  features/                       # .feature (Gherkin FR, # language: fr) — 32 scénarios
+  features/                       # .feature (Gherkin FR, # language: fr) — 41 scénarios
     login.feature                 # ← docs/qa/01-auth.md (connexion)
     auth/reset-password.feature   # ← docs/qa/01-auth.md (mot de passe oublié)
     dashboard-access.feature      # ← docs/qa/02-dashboards.md
@@ -26,6 +26,7 @@ tests/manual/bdd/
     settings/rbac.feature         # ← docs/qa/05-settings.md (PS vs patient)
     patients/{list,detail,create}.feature      # ← docs/qa/03-patients.md (contrat API + effet base)
     appointments/{list,create,cancel}.feature  # ← docs/qa/04-appointments.md (contrat API + effet base)
+    admin/{users,cabinets,audit}.feature        # ← docs/qa/06-admin.md + 08 (RBAC ADMIN, contrat API)
     effet-base/login-session.feature  # ← docs/qa/01-auth.md (vérif EFFET BASE)
   steps/                          # step definitions (réutilisables)
     auth.steps.ts                 # "je suis connecté en tant que {string}" → loginAs()

--- a/tests/manual/bdd/features/admin/audit.feature
+++ b/tests/manual/bdd/features/admin/audit.feature
@@ -1,0 +1,18 @@
+# language: fr
+# Source : docs/qa/08-admin-ops.md — consultation audit (contrat API + RBAC ADMIN)
+Fonctionnalité: Consultation de l'audit
+
+  Scénario: un ADMIN consulte l'audit
+    Étant donné que je suis connecté en tant que "ADMIN"
+    Quand j'appelle GET "/api/admin/audit-logs?limit=5"
+    Alors le statut de la réponse est 200
+
+  Scénario: un DOCTOR ne peut pas consulter l'audit
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/admin/audit-logs?limit=5"
+    Alors le statut de la réponse est 403
+
+  Scénario: limite de pagination invalide
+    Étant donné que je suis connecté en tant que "ADMIN"
+    Quand j'appelle GET "/api/admin/audit-logs?limit=9999"
+    Alors le statut de la réponse est 400

--- a/tests/manual/bdd/features/admin/cabinets.feature
+++ b/tests/manual/bdd/features/admin/cabinets.feature
@@ -1,0 +1,13 @@
+# language: fr
+# Source : docs/qa/06-admin.md — cabinets / structures (contrat API + RBAC ADMIN)
+Fonctionnalité: Administration des cabinets
+
+  Scénario: un ADMIN liste les cabinets
+    Étant donné que je suis connecté en tant que "ADMIN"
+    Quand j'appelle GET "/api/admin/healthcare-services"
+    Alors le statut de la réponse est 200
+
+  Scénario: un DOCTOR ne peut pas administrer les cabinets
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/admin/healthcare-services"
+    Alors le statut de la réponse est 403

--- a/tests/manual/bdd/features/admin/cabinets.feature
+++ b/tests/manual/bdd/features/admin/cabinets.feature
@@ -6,6 +6,7 @@ Fonctionnalité: Administration des cabinets
     Étant donné que je suis connecté en tant que "ADMIN"
     Quand j'appelle GET "/api/admin/healthcare-services"
     Alors le statut de la réponse est 200
+    Et le corps contient "items"
 
   Scénario: un DOCTOR ne peut pas administrer les cabinets
     Étant donné que je suis connecté en tant que "DOCTOR"

--- a/tests/manual/bdd/features/admin/users.feature
+++ b/tests/manual/bdd/features/admin/users.feature
@@ -6,11 +6,13 @@ Fonctionnalité: Administration des utilisateurs
     Étant donné que je suis connecté en tant que "ADMIN"
     Quand j'appelle GET "/api/admin/users"
     Alors le statut de la réponse est 200
+    Et le corps contient "items"
 
   Scénario: filtrer par rôle DOCTOR
     Étant donné que je suis connecté en tant que "ADMIN"
     Quand j'appelle GET "/api/admin/users?role=DOCTOR"
     Alors le statut de la réponse est 200
+    Et le corps contient "items"
 
   Scénario: un DOCTOR ne peut pas administrer les utilisateurs
     Étant donné que je suis connecté en tant que "DOCTOR"

--- a/tests/manual/bdd/features/admin/users.feature
+++ b/tests/manual/bdd/features/admin/users.feature
@@ -1,0 +1,23 @@
+# language: fr
+# Source : docs/qa/06-admin.md — gestion utilisateurs (contrat API + RBAC ADMIN)
+Fonctionnalité: Administration des utilisateurs
+
+  Scénario: un ADMIN liste les utilisateurs
+    Étant donné que je suis connecté en tant que "ADMIN"
+    Quand j'appelle GET "/api/admin/users"
+    Alors le statut de la réponse est 200
+
+  Scénario: filtrer par rôle DOCTOR
+    Étant donné que je suis connecté en tant que "ADMIN"
+    Quand j'appelle GET "/api/admin/users?role=DOCTOR"
+    Alors le statut de la réponse est 200
+
+  Scénario: un DOCTOR ne peut pas administrer les utilisateurs
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/admin/users"
+    Alors le statut de la réponse est 403
+
+  Scénario: un NURSE ne peut pas administrer les utilisateurs
+    Étant donné que je suis connecté en tant que "NURSE"
+    Quand j'appelle GET "/api/admin/users"
+    Alors le statut de la réponse est 403


### PR DESCRIPTION
## Objet

3e **lot par domaine**. **Admin** (`docs/qa/06-admin.md` + `08-admin-ops.md`) : **9 scénarios** contrat-API **lecture seule** (pas de pollution, ré-exécutables). Suite globale verte.

| Feature | Scénarios |
|---|---|
| `admin/users` | ADMIN liste (200) · filtre `role=DOCTOR` (200) · DOCTOR refusé (**403**) · NURSE refusé (**403**) |
| `admin/cabinets` | ADMIN liste `healthcare-services` (200) · DOCTOR refusé (**403**) |
| `admin/audit` | ADMIN `audit-logs` (200) · DOCTOR refusé (**403**) · limite > 200 → **400** |

Aucun nouveau step (l'infra `api.steps` suffit). Statuts **sondés sur le serveur réel** (non-ADMIN avec session fraîche → 403 ; le 401 observé initialement venait d'un cookie périmé). `tsc` OK.

> Branche stackée sur appointments (#502). Harness hors-CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)