### PR TITLE
test(bdd): lot Dashboards & Analytics (02/07) — contrat API + RBAC

### DIFF
--- a/tests/manual/bdd/README.md
+++ b/tests/manual/bdd/README.md
@@ -27,6 +27,7 @@ tests/manual/bdd/
     patients/{list,detail,create}.feature      # ← docs/qa/03-patients.md (contrat API + effet base)
     appointments/{list,create,cancel}.feature  # ← docs/qa/04-appointments.md (contrat API + effet base)
     admin/{users,cabinets,audit}.feature        # ← docs/qa/06-admin.md + 08 (RBAC ADMIN, contrat API)
+    analytics/{dashboards,glycemia}.feature     # ← docs/qa/07-dashboards-analytics.md (contrat API + RBAC)
     effet-base/login-session.feature  # ← docs/qa/01-auth.md (vérif EFFET BASE)
   steps/                          # step definitions (réutilisables)
     auth.steps.ts                 # "je suis connecté en tant que {string}" → loginAs()

--- a/tests/manual/bdd/README.md
+++ b/tests/manual/bdd/README.md
@@ -18,7 +18,7 @@ runner Playwright + le helper `loginAs`).
 
 ```
 tests/manual/bdd/
-  features/                       # .feature (Gherkin FR, # language: fr) — 41 scénarios
+  features/                       # .feature (Gherkin FR, # language: fr) — 50 scénarios
     login.feature                 # ← docs/qa/01-auth.md (connexion)
     auth/reset-password.feature   # ← docs/qa/01-auth.md (mot de passe oublié)
     dashboard-access.feature      # ← docs/qa/02-dashboards.md

--- a/tests/manual/bdd/features/analytics/dashboards.feature
+++ b/tests/manual/bdd/features/analytics/dashboards.feature
@@ -1,0 +1,28 @@
+# language: fr
+# Source : docs/qa/02-dashboards.md + 07-dashboards-analytics.md (contrat API + RBAC)
+Fonctionnalité: Tableaux de bord par rôle
+
+  Scénario: un DOCTOR accède à ses KPI médecin
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/dashboard/medecin/kpi"
+    Alors le statut de la réponse est 200
+
+  Scénario: un DOCTOR accède au bloc urgences
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/dashboard/medecin/urgencies"
+    Alors le statut de la réponse est 200
+
+  Scénario: un VIEWER ne voit pas le dashboard médecin
+    Étant donné que je suis connecté en tant que "VIEWER"
+    Quand j'appelle GET "/api/dashboard/medecin/kpi"
+    Alors le statut de la réponse est 403
+
+  Scénario: un ADMIN accède aux KPI admin
+    Étant donné que je suis connecté en tant que "ADMIN"
+    Quand j'appelle GET "/api/dashboard/admin/kpi"
+    Alors le statut de la réponse est 200
+
+  Scénario: un DOCTOR ne voit pas les KPI admin
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/dashboard/admin/kpi"
+    Alors le statut de la réponse est 403

--- a/tests/manual/bdd/features/analytics/glycemia.feature
+++ b/tests/manual/bdd/features/analytics/glycemia.feature
@@ -1,0 +1,23 @@
+# language: fr
+# Source : docs/qa/07-dashboards-analytics.md — analytics glycémiques (contrat API)
+Fonctionnalité: Analytics glycémiques
+
+  Scénario: un DOCTOR consulte le profil glycémique d'un patient
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/analytics/glycemic-profile?period=7d&patientId=1"
+    Alors le statut de la réponse est 200
+
+  Scénario: un DOCTOR consulte le temps dans la cible
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/analytics/time-in-range?period=7d&patientId=1"
+    Alors le statut de la réponse est 200
+
+  Scénario: période hors bornes (> 90 jours)
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/analytics/glycemic-profile?period=999d&patientId=1"
+    Alors le statut de la réponse est 400
+
+  Scénario: patient non résolu (patientId manquant pour un PS)
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/analytics/glycemic-profile?period=7d"
+    Alors le statut de la réponse est 404

--- a/tests/manual/bdd/features/analytics/glycemia.feature
+++ b/tests/manual/bdd/features/analytics/glycemia.feature
@@ -1,5 +1,7 @@
 # language: fr
 # Source : docs/qa/07-dashboards-analytics.md — analytics glycémiques (contrat API)
+# Précondition seed : le DOCTOR appelant a un consentement RGPD (requireGdprConsent
+# porte sur l'appelant) ET le patient 1 lui est accessible (canAccessPatient).
 Fonctionnalité: Analytics glycémiques
 
   Scénario: un DOCTOR consulte le profil glycémique d'un patient


### PR DESCRIPTION
4e **lot par domaine**. Dashboards & Analytics (`docs/qa/02` + `07`) : **9 scénarios** lecture seule.

| Feature | Scénarios |
|---|---|
| `analytics/dashboards` | DOCTOR KPI médecin (200) · urgences (200) · VIEWER refusé (403) · ADMIN KPI admin (200) · DOCTOR refusé (403) |
| `analytics/glycemia` | DOCTOR profil glycémique patient 1 (200) · TIR (200) · période > 90j → **400** · patientId manquant → **404** |

Aucun nouveau step (infra `api.steps`). Statuts **sondés sur le serveur réel**. Branche stackée. Harness hors-CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)