### PR TITLE
test(bdd): lot Devices/Documents/Events (10) — contrat API + effet base events

### DIFF
--- a/tests/manual/bdd/README.md
+++ b/tests/manual/bdd/README.md
@@ -18,7 +18,7 @@ runner Playwright + le helper `loginAs`).
 
 ```
 tests/manual/bdd/
-  features/                       # .feature (Gherkin FR, # language: fr) — 58 scénarios
+  features/                       # .feature (Gherkin FR, # language: fr) — 65 scénarios
     login.feature                 # ← docs/qa/01-auth.md (connexion)
     auth/reset-password.feature   # ← docs/qa/01-auth.md (mot de passe oublié)
     dashboard-access.feature      # ← docs/qa/02-dashboards.md
@@ -29,6 +29,7 @@ tests/manual/bdd/
     admin/{users,cabinets,audit}.feature        # ← docs/qa/06-admin.md + 08 (RBAC ADMIN, contrat API)
     analytics/{dashboards,glycemia}.feature     # ← docs/qa/07-dashboards-analytics.md (contrat API + RBAC)
     compliance-billing/{data-breaches,invoices,tax-rules}.feature  # ← docs/qa/09 (RBAC + validation)
+    devices/{devices,documents,events}.feature  # ← docs/qa/10 (contrat API + RBAC + effet base events)
     effet-base/login-session.feature  # ← docs/qa/01-auth.md (vérif EFFET BASE)
   steps/                          # step definitions (réutilisables)
     auth.steps.ts                 # "je suis connecté en tant que {string}" → loginAs()

--- a/tests/manual/bdd/features/devices/devices.feature
+++ b/tests/manual/bdd/features/devices/devices.feature
@@ -1,0 +1,18 @@
+# language: fr
+# Source : docs/qa/10-devices-documents-events.md — supervision appareils (contrat API + RBAC)
+Fonctionnalité: Appareils
+
+  Scénario: un patient voit ses appareils
+    Étant donné que je suis connecté en tant que "VIEWER"
+    Quand j'appelle GET "/api/devices"
+    Alors le statut de la réponse est 200
+
+  Scénario: un DOCTOR accède au statut de sync de cohorte
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/devices/sync-status/cohort"
+    Alors le statut de la réponse est 200
+
+  Scénario: un patient ne voit pas la cohorte
+    Étant donné que je suis connecté en tant que "VIEWER"
+    Quand j'appelle GET "/api/devices/sync-status/cohort"
+    Alors le statut de la réponse est 403

--- a/tests/manual/bdd/features/devices/documents.feature
+++ b/tests/manual/bdd/features/devices/documents.feature
@@ -1,0 +1,8 @@
+# language: fr
+# Source : docs/qa/10-devices-documents-events.md — documents médicaux (contrat API)
+Fonctionnalité: Documents médicaux
+
+  Scénario: un patient liste ses documents
+    Étant donné que je suis connecté en tant que "VIEWER"
+    Quand j'appelle GET "/api/documents"
+    Alors le statut de la réponse est 200

--- a/tests/manual/bdd/features/devices/events.feature
+++ b/tests/manual/bdd/features/devices/events.feature
@@ -1,0 +1,29 @@
+# language: fr
+# Source : docs/qa/10-devices-documents-events.md — création événement (effet base)
+Fonctionnalité: Création d'un événement diabète
+
+  Scénario: un DOCTOR crée un événement glycémie pour un patient — effet base
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand je POST "/api/events?patientId=1" avec le JSON:
+      """
+      {"eventDate":"2026-06-05T10:00:00.000Z","eventTypes":["glycemia"],"glycemiaValue":145}
+      """
+    Alors le statut de la réponse est 201
+    Et un événement existe en base avec l'id de la réponse
+    # Effet base: INSERT diabetes_events(eventTypes, glycemiaValue, comment chiffré) + audit
+
+  Scénario: glycémie hors bornes cliniques refusée
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand je POST "/api/events?patientId=1" avec le JSON:
+      """
+      {"eventDate":"2026-06-05T10:00:00.000Z","eventTypes":["glycemia"],"glycemiaValue":5}
+      """
+    Alors le statut de la réponse est 400
+
+  Scénario: un patient enregistre son propre événement
+    Étant donné que je suis connecté en tant que "VIEWER"
+    Quand je POST "/api/events" avec le JSON:
+      """
+      {"eventDate":"2026-06-05T10:00:00.000Z","eventTypes":["glycemia"],"glycemiaValue":120}
+      """
+    Alors le statut de la réponse est 201

--- a/tests/manual/bdd/features/devices/events.feature
+++ b/tests/manual/bdd/features/devices/events.feature
@@ -1,5 +1,6 @@
 # language: fr
 # Source : docs/qa/10-devices-documents-events.md — création événement (effet base)
+# Précondition seed : les patients ont gdprConsent=true (sinon 403 gdprConsentRequired).
 Fonctionnalité: Création d'un événement diabète
 
   Scénario: un DOCTOR crée un événement glycémie pour un patient — effet base
@@ -10,7 +11,8 @@ Fonctionnalité: Création d'un événement diabète
       """
     Alors le statut de la réponse est 201
     Et un événement existe en base avec l'id de la réponse
-    # Effet base: INSERT diabetes_events(eventTypes, glycemiaValue, comment chiffré) + audit
+    # Effet base: INSERT diabetes_events(eventTypes, glycemiaValue) + audit
+    # (le chiffrement du `comment` n'est pas exercé ici : aucun comment envoyé)
 
   Scénario: glycémie hors bornes cliniques refusée
     Étant donné que je suis connecté en tant que "DOCTOR"

--- a/tests/manual/bdd/steps/db.steps.ts
+++ b/tests/manual/bdd/steps/db.steps.ts
@@ -66,6 +66,16 @@ Then("le RDV créé a le statut {string} en base", async ({}, expected: string) 
   expect(rows[0]?.s).toBe(expected)
 })
 
+Then("un événement existe en base avec l'id de la réponse", async ({}) => {
+  const id = (world.body as { id?: string } | null)?.id
+  expect(id, "réponse sans id (création échouée ?)").toBeTruthy()
+  const { rows } = await db().query<{ n: string }>(
+    `SELECT COUNT(*)::int AS n FROM diabetes_events WHERE id = $1`,
+    [id],
+  )
+  expect(Number(rows[0].n)).toBe(1)
+})
+
 Then("un compte patient existe en base avec l'email créé", async ({}) => {
   expect(world.createdEmail, "aucun email créé (step de création manquant ?)").not.toBe("")
   const { rows } = await db().query<{ n: string }>(


### PR DESCRIPTION
6e **lot par domaine**. Devices / Documents / Events (`docs/qa/10`) : **7 scénarios**.

| Feature | Scénarios |
|---|---|
| `devices` | VIEWER liste ses appareils (200) · DOCTOR cohorte sync (200) · VIEWER refusé cohorte (**403**) |
| `documents` | VIEWER liste ses documents (200) |
| `events` | DOCTOR crée un événement glycémie patient 1 (**201 + effet base** : ligne `diabetes_events` vérifiée) · glycémie hors bornes → **400** · VIEWER enregistre son propre événement (201) |

Nouveau step DB : `un événement existe en base avec l'id de la réponse`. Statuts **sondés sur le serveur réel**. Le test event insère une vraie ligne (données de test, garde anti-prod active). Branche stackée. Harness hors-CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)