### PR TITLE
test(bdd): lot Clinique (11) — contrat API + bornes cliniques

### DIFF
--- a/tests/manual/bdd/README.md
+++ b/tests/manual/bdd/README.md
@@ -18,7 +18,7 @@ runner Playwright + le helper `loginAs`).
 
 ```
 tests/manual/bdd/
-  features/                       # .feature (Gherkin FR, # language: fr) — 72 scénarios
+  features/                       # .feature (Gherkin FR, # language: fr) — 75 scénarios
     login.feature                 # ← docs/qa/01-auth.md (connexion)
     auth/reset-password.feature   # ← docs/qa/01-auth.md (mot de passe oublié)
     dashboard-access.feature      # ← docs/qa/02-dashboards.md

--- a/tests/manual/bdd/README.md
+++ b/tests/manual/bdd/README.md
@@ -18,7 +18,7 @@ runner Playwright + le helper `loginAs`).
 
 ```
 tests/manual/bdd/
-  features/                       # .feature (Gherkin FR, # language: fr) — 65 scénarios
+  features/                       # .feature (Gherkin FR, # language: fr) — 72 scénarios
     login.feature                 # ← docs/qa/01-auth.md (connexion)
     auth/reset-password.feature   # ← docs/qa/01-auth.md (mot de passe oublié)
     dashboard-access.feature      # ← docs/qa/02-dashboards.md
@@ -30,6 +30,7 @@ tests/manual/bdd/
     analytics/{dashboards,glycemia}.feature     # ← docs/qa/07-dashboards-analytics.md (contrat API + RBAC)
     compliance-billing/{data-breaches,invoices,tax-rules}.feature  # ← docs/qa/09 (RBAC + validation)
     devices/{devices,documents,events}.feature  # ← docs/qa/10 (contrat API + RBAC + effet base events)
+    clinical/{insulin-therapy,adjustment-proposals,medications}.feature  # ← docs/qa/11 (bornes cliniques)
     effet-base/login-session.feature  # ← docs/qa/01-auth.md (vérif EFFET BASE)
   steps/                          # step definitions (réutilisables)
     auth.steps.ts                 # "je suis connecté en tant que {string}" → loginAs()

--- a/tests/manual/bdd/features/clinical/adjustment-proposals.feature
+++ b/tests/manual/bdd/features/clinical/adjustment-proposals.feature
@@ -1,0 +1,13 @@
+# language: fr
+# Source : docs/qa/11-clinical.md — propositions d'ajustement (contrat API)
+Fonctionnalité: Propositions d'ajustement
+
+  Scénario: un DOCTOR liste les propositions d'un patient
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/adjustment-proposals?patientId=1"
+    Alors le statut de la réponse est 200
+
+  Scénario: patientId manquant
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/adjustment-proposals"
+    Alors le statut de la réponse est 404

--- a/tests/manual/bdd/features/clinical/insulin-therapy.feature
+++ b/tests/manual/bdd/features/clinical/insulin-therapy.feature
@@ -1,5 +1,7 @@
 # language: fr
 # Source : docs/qa/11-clinical.md — insulinothérapie (contrat API + bornes cliniques)
+# Précondition seed : patient 1 accessible au DOCTOR/NURSE seed ; patient 1 SANS
+# insulin_therapy_settings → un ISF valide passe la validation puis 404 settingsNotFound.
 Fonctionnalité: Configuration insulinothérapie
 
   Scénario: un DOCTOR lit la configuration d'un patient
@@ -20,6 +22,30 @@ Fonctionnalité: Configuration insulinothérapie
     Quand je POST "/api/insulin-therapy/sensitivity-factors?patientId=1" avec le JSON:
       """
       {"startHour":8,"endHour":12,"sensitivityFactorGl":0.05}
+      """
+    Alors le statut de la réponse est 400
+
+  Scénario: ISF à la borne min exacte (0.10) accepté par la validation
+    Étant donné que je suis connecté en tant que "NURSE"
+    Quand je POST "/api/insulin-therapy/sensitivity-factors?patientId=1" avec le JSON:
+      """
+      {"startHour":8,"endHour":12,"sensitivityFactorGl":0.10}
+      """
+    Alors le statut de la réponse est 404
+
+  Scénario: ISF à la borne max exacte (1.00) accepté par la validation
+    Étant donné que je suis connecté en tant que "NURSE"
+    Quand je POST "/api/insulin-therapy/sensitivity-factors?patientId=1" avec le JSON:
+      """
+      {"startHour":8,"endHour":12,"sensitivityFactorGl":1.00}
+      """
+    Alors le statut de la réponse est 404
+
+  Scénario: ISF juste au-dessus de la borne max (1.01) refusé
+    Étant donné que je suis connecté en tant que "NURSE"
+    Quand je POST "/api/insulin-therapy/sensitivity-factors?patientId=1" avec le JSON:
+      """
+      {"startHour":8,"endHour":12,"sensitivityFactorGl":1.01}
       """
     Alors le statut de la réponse est 400
 

--- a/tests/manual/bdd/features/clinical/insulin-therapy.feature
+++ b/tests/manual/bdd/features/clinical/insulin-therapy.feature
@@ -1,0 +1,32 @@
+# language: fr
+# Source : docs/qa/11-clinical.md — insulinothérapie (contrat API + bornes cliniques)
+Fonctionnalité: Configuration insulinothérapie
+
+  Scénario: un DOCTOR lit la configuration d'un patient
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/insulin-therapy/settings?patientId=1"
+    Alors le statut de la réponse est 200
+
+  Scénario: ISF au-dessus de la borne max (1.00 g/L/U) refusé
+    Étant donné que je suis connecté en tant que "NURSE"
+    Quand je POST "/api/insulin-therapy/sensitivity-factors?patientId=1" avec le JSON:
+      """
+      {"startHour":8,"endHour":12,"sensitivityFactorGl":5.0}
+      """
+    Alors le statut de la réponse est 400
+
+  Scénario: ISF sous la borne min (0.10 g/L/U) refusé
+    Étant donné que je suis connecté en tant que "NURSE"
+    Quand je POST "/api/insulin-therapy/sensitivity-factors?patientId=1" avec le JSON:
+      """
+      {"startHour":8,"endHour":12,"sensitivityFactorGl":0.05}
+      """
+    Alors le statut de la réponse est 400
+
+  Scénario: un VIEWER ne peut pas écrire la configuration
+    Étant donné que je suis connecté en tant que "VIEWER"
+    Quand je POST "/api/insulin-therapy/sensitivity-factors?patientId=1" avec le JSON:
+      """
+      {"startHour":8,"endHour":12,"sensitivityFactorGl":0.50}
+      """
+    Alors le statut de la réponse est 403

--- a/tests/manual/bdd/features/clinical/medications.feature
+++ b/tests/manual/bdd/features/clinical/medications.feature
@@ -1,0 +1,10 @@
+# language: fr
+# Source : docs/qa/11-clinical.md — recherche médicaments BDPM (contrat API)
+Fonctionnalité: Recherche de médicaments
+# Note : référentiel BDPM possiblement vide (import cron) → liste vide mais 200.
+
+  Scénario: recherche par nom renvoie une réponse BDPM
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/medications/search?q=paracetamol"
+    Alors le statut de la réponse est 200
+    Et le corps contient "BDPM"


### PR DESCRIPTION
7e **lot par domaine**. Clinique (`docs/qa/11`) : **7 scénarios**.

| Feature | Scénarios |
|---|---|
| `insulin-therapy` | DOCTOR lit la config (200) · **ISF > 1.00 → 400** · **ISF < 0.10 → 400** (valide les bornes corrigées en A3) · VIEWER écriture refusée (**403**) |
| `adjustment-proposals` | DOCTOR liste pour patient (200) · patientId manquant → **404** |
| `medications` | recherche BDPM (200, corps contient "BDPM") |

Aucun nouveau step. Statuts **sondés sur le serveur réel** (Zod bornes ISF avant le check `settingsNotFound`). Branche stackée. Harness hors-CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)