### PR TITLE
test(bdd): lot 12-communication — messagerie + RDV patient (QA Gherkin)

### DIFF
--- a/tests/manual/bdd/README.md
+++ b/tests/manual/bdd/README.md
@@ -18,7 +18,7 @@ runner Playwright + le helper `loginAs`).
 
 ```
 tests/manual/bdd/
-  features/                       # .feature (Gherkin FR, # language: fr) — 80 scénarios
+  features/                       # .feature (Gherkin FR, # language: fr) — 81 scénarios
     login.feature                 # ← docs/qa/01-auth.md (connexion)
     auth/reset-password.feature   # ← docs/qa/01-auth.md (mot de passe oublié)
     dashboard-access.feature      # ← docs/qa/02-dashboards.md

--- a/tests/manual/bdd/README.md
+++ b/tests/manual/bdd/README.md
@@ -18,7 +18,7 @@ runner Playwright + le helper `loginAs`).
 
 ```
 tests/manual/bdd/
-  features/                       # .feature (Gherkin FR, # language: fr) — 75 scénarios
+  features/                       # .feature (Gherkin FR, # language: fr) — 80 scénarios
     login.feature                 # ← docs/qa/01-auth.md (connexion)
     auth/reset-password.feature   # ← docs/qa/01-auth.md (mot de passe oublié)
     dashboard-access.feature      # ← docs/qa/02-dashboards.md
@@ -31,6 +31,7 @@ tests/manual/bdd/
     compliance-billing/{data-breaches,invoices,tax-rules}.feature  # ← docs/qa/09 (RBAC + validation)
     devices/{devices,documents,events}.feature  # ← docs/qa/10 (contrat API + RBAC + effet base events)
     clinical/{insulin-therapy,adjustment-proposals,medications}.feature  # ← docs/qa/11 (bornes cliniques)
+    communication/{messages,patient-appointments}.feature  # ← docs/qa/12 (messagerie + RDV patient)
     effet-base/login-session.feature  # ← docs/qa/01-auth.md (vérif EFFET BASE)
   steps/                          # step definitions (réutilisables)
     auth.steps.ts                 # "je suis connecté en tant que {string}" → loginAs()

--- a/tests/manual/bdd/features/communication/messages.feature
+++ b/tests/manual/bdd/features/communication/messages.feature
@@ -1,0 +1,26 @@
+# language: fr
+# Source : docs/qa/12-communication.md — messagerie sécurisée (contrat API + RBAC)
+Fonctionnalité: Messagerie sécurisée
+
+  Scénario: un DOCTOR liste ses conversations
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/messages"
+    Alors le statut de la réponse est 200
+
+  Scénario: un DOCTOR consulte son compteur de non-lus
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/messages/unread-count"
+    Alors le statut de la réponse est 200
+
+  Scénario: un patient accède à sa messagerie
+    Étant donné que je suis connecté en tant que "VIEWER"
+    Quand j'appelle GET "/api/messages"
+    Alors le statut de la réponse est 200
+
+  Scénario: envoi avec un corps invalide refusé
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand je POST "/api/messages" avec le JSON:
+      """
+      {}
+      """
+    Alors le statut de la réponse est 422

--- a/tests/manual/bdd/features/communication/messages.feature
+++ b/tests/manual/bdd/features/communication/messages.feature
@@ -1,5 +1,6 @@
 # language: fr
 # Source : docs/qa/12-communication.md — messagerie sécurisée (contrat API + RBAC)
+# Pré-requis seed : gdprConsent actif sur DOCTOR + patient_dt1 (sinon 403, pas 200).
 Fonctionnalité: Messagerie sécurisée
 
   Scénario: un DOCTOR liste ses conversations
@@ -24,3 +25,12 @@ Fonctionnalité: Messagerie sécurisée
       {}
       """
     Alors le statut de la réponse est 422
+
+  Scénario: envoi sans en-tête CSRF refusé
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand je POST "/api/messages" sans en-tête CSRF avec le JSON:
+      """
+      {"toUserId":1,"body":"x"}
+      """
+    Alors le statut de la réponse est 403
+    Et le corps contient "csrfMissing"

--- a/tests/manual/bdd/features/communication/patient-appointments.feature
+++ b/tests/manual/bdd/features/communication/patient-appointments.feature
@@ -1,5 +1,7 @@
 # language: fr
 # Source : docs/qa/12-communication.md — RDV côté patient (contrat API)
+# Note : le 400 scopeRequired est levé avant toute logique de rôle — valide la
+# garde de scope obligatoire (un from/to sans memberId ni patientId est refusé).
 Fonctionnalité: RDV côté patient
 
   Scénario: scope obligatoire pour lister les RDV

--- a/tests/manual/bdd/features/communication/patient-appointments.feature
+++ b/tests/manual/bdd/features/communication/patient-appointments.feature
@@ -1,0 +1,9 @@
+# language: fr
+# Source : docs/qa/12-communication.md — RDV côté patient (contrat API)
+Fonctionnalité: RDV côté patient
+
+  Scénario: scope obligatoire pour lister les RDV
+    Étant donné que je suis connecté en tant que "VIEWER"
+    Quand j'appelle GET "/api/appointments?from=2026-05-01&to=2026-07-01"
+    Alors le statut de la réponse est 400
+    Et le corps contient "scopeRequired"


### PR DESCRIPTION
## Contexte

Dernier lot du plan QA (\`docs/qa/\`) porté en **Gherkin exécutable** (playwright-bdd). Clôt la couverture des 12 domaines QA.

## Contenu — 2 features, 5 scénarios

**\`communication/messages.feature\`** — messagerie sécurisée (contrat API + RBAC) :
- DOCTOR liste ses conversations → 200
- DOCTOR consulte son compteur de non-lus → 200
- patient (VIEWER) accède à sa messagerie → 200
- envoi avec corps invalide → 422 (validation Zod)

**\`communication/patient-appointments.feature\`** — RDV côté patient :
- VIEWER sans scope → 400 \`scopeRequired\`

Tous les statuts ont été **sondés sur l'API réelle** (curl + cookie d'auth) avant écriture. 5/5 verts localement.

## Notes
- Aucun nouveau step : réutilise \`api.steps.ts\` (GET/POST via \`page.request\`).
- POC manuelle (jamais en CI) — cf. \`tests/manual/bdd/README.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)