### PR TITLE
test(bdd): lot 08-admin-ops — santé système + backups (QA Gherkin)

### DIFF
--- a/tests/manual/bdd/README.md
+++ b/tests/manual/bdd/README.md
@@ -18,7 +18,7 @@ runner Playwright + le helper `loginAs`).
 
 ```
 tests/manual/bdd/
-  features/                       # .feature (Gherkin FR, # language: fr) — 81 scénarios
+  features/                       # .feature (Gherkin FR, # language: fr) — 85 scénarios
     login.feature                 # ← docs/qa/01-auth.md (connexion)
     auth/reset-password.feature   # ← docs/qa/01-auth.md (mot de passe oublié)
     dashboard-access.feature      # ← docs/qa/02-dashboards.md
@@ -26,7 +26,8 @@ tests/manual/bdd/
     settings/rbac.feature         # ← docs/qa/05-settings.md (PS vs patient)
     patients/{list,detail,create}.feature      # ← docs/qa/03-patients.md (contrat API + effet base)
     appointments/{list,create,cancel}.feature  # ← docs/qa/04-appointments.md (contrat API + effet base)
-    admin/{users,cabinets,audit}.feature        # ← docs/qa/06-admin.md + 08 (RBAC ADMIN, contrat API)
+    admin/{users,cabinets,audit}.feature        # ← docs/qa/06-admin.md (RBAC ADMIN, contrat API)
+    admin-ops/{system-health,backups}.feature   # ← docs/qa/08-admin-ops.md (RBAC ADMIN, lecture seule)
     analytics/{dashboards,glycemia}.feature     # ← docs/qa/07-dashboards-analytics.md (contrat API + RBAC)
     compliance-billing/{data-breaches,invoices,tax-rules}.feature  # ← docs/qa/09 (RBAC + validation)
     devices/{devices,documents,events}.feature  # ← docs/qa/10 (contrat API + RBAC + effet base events)

--- a/tests/manual/bdd/features/admin-ops/backups.feature
+++ b/tests/manual/bdd/features/admin-ops/backups.feature
@@ -1,0 +1,19 @@
+# language: fr
+# Source : docs/qa/08-admin-ops.md — Backups PostgreSQL (/admin/backups)
+# Dette (itération ultérieure) : le déclenchement (POST -> 202), le concurrency
+# guard (409) et le rate-limit (429, 3/h user) exigent des préconditions d'état
+# (un backup déjà running / 3 déjà déclenchés dans l'heure) + ont des effets de
+# bord (pg_dump). Couverts par les tests unitaires ; ici on porte le contrat
+# lecture seule + RBAC, robuste et sans pollution.
+Fonctionnalité: Backups PostgreSQL
+
+  Scénario: un ADMIN liste les backups
+    Étant donné que je suis connecté en tant que "ADMIN"
+    Quand j'appelle GET "/api/admin/backups"
+    Alors le statut de la réponse est 200
+    Et le corps contient "items"
+
+  Scénario: un non-ADMIN ne peut pas lister les backups
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/admin/backups"
+    Alors le statut de la réponse est 403

--- a/tests/manual/bdd/features/admin-ops/system-health.feature
+++ b/tests/manual/bdd/features/admin-ops/system-health.feature
@@ -1,5 +1,9 @@
 # language: fr
 # Source : docs/qa/08-admin-ops.md — Santé système (/admin/system-health)
+# Dette (itération ultérieure) : le scénario QA « alerte tentatives élevées »
+# (highlight UI quand unauthorizedAttempts24h > 100) n'est pas porté ici — c'est
+# une assertion d'affichage + un état difficile à seeder. On porte le snapshot
+# (présence des sections) et le RBAC, robustes et sans état.
 Fonctionnalité: Santé système
 
   Scénario: snapshot santé pour un ADMIN

--- a/tests/manual/bdd/features/admin-ops/system-health.feature
+++ b/tests/manual/bdd/features/admin-ops/system-health.feature
@@ -1,0 +1,15 @@
+# language: fr
+# Source : docs/qa/08-admin-ops.md — Santé système (/admin/system-health)
+Fonctionnalité: Santé système
+
+  Scénario: snapshot santé pour un ADMIN
+    Étant donné que je suis connecté en tant que "ADMIN"
+    Quand j'appelle GET "/api/admin/system-health"
+    Alors le statut de la réponse est 200
+    Et le corps contient "components"
+    Et le corps contient "unauthorizedAttempts24h"
+
+  Scénario: un non-ADMIN ne voit pas la santé système
+    Étant donné que je suis connecté en tant que "DOCTOR"
+    Quand j'appelle GET "/api/admin/system-health"
+    Alors le statut de la réponse est 403


### PR DESCRIPTION
## Contexte

Porte le dernier domaine QA non couvert (\`docs/qa/08-admin-ops.md\`) en Gherkin exécutable. **Avec ce lot, les 12 domaines du plan QA sont portés.**

## Contenu — 2 features, 4 scénarios

**\`admin-ops/system-health.feature\`** :
- ADMIN snapshot → 200 (corps contient \`components\` + métrique \`unauthorizedAttempts24h\`)
- DOCTOR → 403

**\`admin-ops/backups.feature\`** :
- ADMIN liste → 200 (corps contient \`items\`)
- DOCTOR → 403

Statuts sondés sur l'API réelle. 4/4 verts.

## Dette documentée (non portée à dessein)
Le **déclenchement** de backup (POST → 202), le **concurrency guard** (409) et le **rate-limit** (429, 3/h user) exigent des préconditions d'état (backup déjà *running* / 3 déjà déclenchés) **et** ont des effets de bord (\`pg_dump\`). Déjà couverts par les tests unitaires ; ici on porte le contrat lecture seule + RBAC (robuste, sans pollution). Voir le commentaire d'en-tête de \`backups.feature\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)