### PR TITLE
docs(roadmap): US-2112b — préférence de langue utilisateur (V1)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -16,11 +16,11 @@
 | Priorité | Total | DONE | PARTIAL | NOT STARTED | % Done |
 |----------|-------|------|---------|-------------|--------|
 | **MVP**  | 68    | 68   | 0       | 0           | **100%** |
-| **V1**   | 98    | 98   | 0       | 0           | **100%** |
+| **V1**   | 99    | 98   | 0       | 1           | **99%** |
 | **V2**   | 93    | 0    | 0       | 93          | **0%**  |
 | **V3**   | 10    | 0    | 0       | 10          | **0%**  |
 | **V4**   | 16    | 0    | 0       | 16          | **0%**  |
-| **TOTAL**| **285** | **166** | **0**   | **119**     | **58%** |
+| **TOTAL**| **286** | **166** | **0**   | **120**     | **58%** |
 
 > **V1 nettoyé 2026-05-16** : 19 US reclassées V2 retirées des sections V1
 > (Groupes 1/3/7/8 i18n/9/9b/10) pour cohérence du compte. Ces US restent
@@ -349,7 +349,7 @@ tous corrigés. Migration `20260513230000_groupe5_review_fixes` (FK + unique + p
 
 > Note : US-2104 (Abonnement DZ), US-2106 (Webhooks Stripe), US-2109 (Remboursements) reclassées V2 — voir section V2 ci-dessous.
 
-### Groupe 8 — i18n & Interopérabilité (4 US, 6 SP, 100% DONE V1)
+### Groupe 8 — i18n & Interopérabilité (5 US, 9 SP — 4 DONE + 1 à démarrer)
 
 > **Batch 1 (4 US, 6 SP) — DONE PR #393** : US-2113 + US-2114 + US-2116 + US-2123 scaffold.
 
@@ -359,8 +359,11 @@ tous corrigés. Migration `20260513230000_groupe5_review_fixes` (FK + unique + p
 | US-2114 | Règles fiscales par pays (CountryTaxRule, date-bounded, overlap-rejected) | 1 | ✅ DONE |
 | US-2116 | Réglementation santé par pays (HealthcareRegulation : RPPS/ADELI/INS/HDS/RGPD/MSSANTE) | 1 | ✅ DONE |
 | US-2123 | HL7 FHIR R4 scaffold (FhirInteroperability + FhirAllowedSystem + retry queue + AES-256-GCM payload + SSRF guard + DPA allowlist + kill-switch) | 3 | ✅ DONE |
+| [US-2112b](../UserStory/pro-user-stories/13-multi-pays-i18n/US-2112b-preference-langue-utilisateur.md) | Préférence de langue utilisateur — switcher sur écrans non-auth + persistance `User.language` en base + alerte de confirmation si langue session ≠ préférence au login (follow-up US-2112) | 3 | 🆕 À démarrer |
 
 > Note : US-2124 (DMP), US-2125 (MSSanté backend), US-2126 (INSi), US-2127 (PSC) reclassées V2 (bloqué procurement ANS / Mailiz / Apicrypt) — voir section V2 ci-dessous.
+>
+> **US-2112b** (V1, 3 SP) ajoutée le 2026-06-09 : US-2112 (moteur i18n) est DONE mais le `LocaleSwitcher` n'est exposé sur aucun écran de l'app vivante, la langue n'est pas persistée en base (colonne `User.language` déjà présente mais non câblée), et aucun écart langue-session/préférence n'est signalé au login. 3 AC : (1) switcher sur écrans non authentifiés, (2) changement persisté en base via Settings, (3) alerte de confirmation au login.
 
 ### Groupe 9 — Admin & Ops (4 US, 100% DONE V1)
 

--- a/docs/UserStory/pro-user-stories/13-multi-pays-i18n/US-2112b-preference-langue-utilisateur.md
+++ b/docs/UserStory/pro-user-stories/13-multi-pays-i18n/US-2112b-preference-langue-utilisateur.md
@@ -1,0 +1,237 @@
+# US-2112b — Préférence de langue utilisateur (switcher hors-auth + persistance + confirmation au login)
+
+> Follow-up de [US-2112](./US-2112-internationalisation-fr-ar.md) (i18n FR/EN/AR, DONE).
+> US-2112 a livré le moteur i18n (next-intl, `LocaleSwitcher`, cookie `diabeo_locale`,
+> `dir="rtl"` pour AR). Cette US comble trois manques d'**accès** et de **persistance**
+> identifiés en revue : le switcher n'est exposé sur aucun écran de l'app vivante, la
+> langue n'est pas enregistrée comme préférence durable, et un écart langue-session vs
+> préférence n'est pas signalé à la connexion.
+
+---
+
+## 📊 Métadonnées
+
+| Champ | Valeur |
+|-------|--------|
+| **ID** | `US-2112b` |
+| **Référence inventaire** | `FN-112` (extension) |
+| **Domaine** | 13. Multi-pays & i18n |
+| **Priorité** | **V1** |
+| **Pays cible** | Universel |
+| **Intégration externe** | Non |
+| **Service / Standard** | Interne (next-intl) |
+| **Modèle économique** | Interne |
+| **Coût estimé** | — |
+| **Statut** | 🆕 À démarrer |
+| **Story points** | **3** (Fibonacci) |
+| **Dépendances** | US-2112 (i18n FR/EN/AR, DONE) · US-2101 (préférences compte) |
+| **Sprint cible** | À définir lors du planning |
+| **Owner** | À assigner |
+
+---
+
+## 📋 Contexte métier
+
+### Pourquoi cette fonctionnalité ?
+
+Le moteur i18n (US-2112) est fonctionnel mais **inatteignable en pratique** :
+
+1. **Écrans non authentifiés** (login, mot de passe oublié, reset, invitation, MFA) :
+   aucun moyen de changer la langue. Un utilisateur arabophone ou anglophone arrive
+   sur un écran de connexion en français sans recours.
+2. **Persistance** : le composant `LocaleSwitcher` n'écrit qu'un **cookie**
+   (`diabeo_locale`). La colonne `User.language` (enum `fr|en|ar`, défaut `fr`) existe
+   déjà en base mais **n'est pas alimentée** : la préférence est perdue au changement
+   de device / navigateur / vidage de cookies. Par ailleurs le seul `LocaleSwitcher`
+   est monté dans `components/diabeo/Sidebar.tsx`, composant **non rendu** par le shell
+   actif (`NavigationShell`) → invisible pour l'utilisateur final.
+3. **Cohérence au login** : un utilisateur peut se connecter depuis un appareil dont le
+   cookie locale diffère de sa préférence enregistrée (ex. préférence `ar` en base,
+   cookie `fr` sur un poste partagé). Aucune réconciliation n'est proposée.
+
+### Personas concernés
+
+- **Tous les rôles** (ADMIN / DOCTOR / NURSE / VIEWER) et **les visiteurs non
+  authentifiés** (écrans `(auth)`).
+
+### Valeur produit
+
+- **Accessibilité & inclusion** : choix de langue dès le premier écran (RGAA / marché DZ arabophone).
+- **Continuité** : la langue suit l'utilisateur entre appareils (préférence serveur).
+- **Confiance** : pas de bascule de langue silencieuse et déroutante au login.
+
+---
+
+## ✅ Critères d'acceptation
+
+### AC-1 — Switcher de langue sur les écrans NON authentifiés
+- **Étant donné** un visiteur non connecté sur `/login` (ou reset / forgot / invitation / MFA),
+- **Quand** il ouvre le sélecteur de langue rendu dans le layout `(auth)`,
+- **Alors** il peut choisir FR / EN / AR ; la sélection pose le cookie `diabeo_locale`
+  (pas d'appel authentifié requis), recharge la page, applique les messages et
+  `dir="rtl"` pour AR.
+- Le composant respecte l'accessibilité (label associé, `aria-label`, restauration du
+  focus post-reload — déjà géré par `LocaleSwitcher`).
+
+### AC-2 — Changement de langue persisté en base (écrans authentifiés / Settings)
+- **Étant donné** un utilisateur authentifié sur `/settings`,
+- **Quand** il change sa langue dans une section dédiée,
+- **Alors** la préférence est **enregistrée en base** dans `User.language` **ET** le
+  cookie `diabeo_locale` est synchronisé (affichage immédiat), avec un audit
+  `UPDATE / USER` (`metadata.setting = "locale"`, sans PHI).
+- **Et** à la prochaine connexion depuis n'importe quel appareil, c'est `User.language`
+  qui fait foi pour initialiser la langue (le cookie est (re)posé à partir de la
+  préférence au login).
+
+### AC-3 — Alerte de confirmation si langue de session ≠ préférence enregistrée
+- **Étant donné** un utilisateur dont `User.language` diffère de la locale active
+  (cookie `diabeo_locale`) au moment du login,
+- **Quand** la session est établie,
+- **Alors** une **alerte non bloquante** (`role="alert"`, dismissible) lui demande de
+  **confirmer le changement de langue** : « Vous étiez en {langueSession}, votre
+  préférence est {languePréférée}. Continuer en {langueSession} / Revenir à
+  {languePréférée} ? »
+- **Confirmer (langueSession)** met à jour `User.language` = langue de session (AC-2).
+  **Revenir (préférence)** repose le cookie sur `User.language` et recharge.
+- L'alerte ne s'affiche **pas** quand cookie == préférence (cas nominal).
+
+---
+
+## 📐 Règles métier
+
+- **RM-1** — Source de vérité : pour un utilisateur authentifié, `User.language` est la
+  préférence durable ; le cookie `diabeo_locale` est le véhicule d'affichage (rechargé
+  depuis la préférence au login). Pour un visiteur non authentifié, seul le cookie existe.
+- **RM-2** — Langues supportées : `fr`, `en`, `ar` (enum `Language`). Toute valeur hors
+  enum est rejetée (Zod) et retombe sur `defaultLocale = fr`.
+- **RM-3** — L'écriture de `User.language` exige une session authentifiée ; le switcher
+  hors-auth (AC-1) ne touche jamais la base (cookie uniquement).
+- **RM-4** — L'alerte AC-3 est **non bloquante** : l'utilisateur peut l'ignorer sans
+  perdre l'accès ; à défaut de choix, la langue de session (cookie) reste active et la
+  préférence en base est inchangée.
+- **RM-5** — Aucune donnée de santé : la langue n'est pas une donnée sensible ; elle est
+  toutefois incluse dans l'export RGPD Art. 15 et la suppression Art. 17 (déjà couvert
+  par `User`).
+
+---
+
+## 🗄️ Modèle de données
+
+### Schéma Prisma indicatif
+
+La colonne **existe déjà** — aucune migration nécessaire :
+
+```prisma
+enum Language {
+  fr
+  en
+  ar
+}
+
+model User {
+  // ...
+  language Language? @default(fr) // préférence de langue (AC-2) — déjà présent
+}
+```
+
+### Notes de migration
+
+- **Aucune migration** : `User.language` (enum `Language`, défaut `fr`) est déjà dans
+  `prisma/schema.prisma`. L'US ne fait que **câbler** la lecture/écriture de ce champ.
+- Cohérence iOS : aligner le mapping `Language` ↔ locale app patient (`fr`/`en`/`ar`)
+  avec le dépôt Swift (modèles de données partagés).
+
+---
+
+## 🔌 API & contrats
+
+### Routes exposées
+
+| Méthode | Endpoint | Auth | Rôles | Description |
+|---------|----------|------|-------|-------------|
+| PUT | `/api/account/locale` | JWT | Tous | **Étendu** : pose le cookie `diabeo_locale` **+** persiste `User.language` (aujourd'hui : cookie seul). |
+| GET | `/api/account/locale` | JWT | Tous | (nouveau) Renvoie `{ preference: User.language, active: cookieLocale }` pour la détection d'écart AC-3. |
+
+> Le switcher hors-auth (AC-1) **n'appelle pas** ces routes : il pose le cookie
+> directement côté client (aucun endpoint public n'est créé — pas de surface non
+> authentifiée nouvelle).
+
+### Validation des entrées (Zod)
+
+```ts
+const putLocaleSchema = z.object({ locale: z.enum(["fr", "en", "ar"]) })
+```
+
+### Format de réponse standard
+
+```jsonc
+// PUT /api/account/locale → 200
+{ "locale": "ar", "persisted": true }
+// GET /api/account/locale → 200
+{ "preference": "ar", "active": "fr", "mismatch": true }
+```
+
+---
+
+## ⚠️ Scénarios d'erreur
+
+| HTTP | Code applicatif | Message utilisateur | Comportement |
+|------|-----------------|---------------------|--------------|
+| 400 | `validationFailed` | Langue non supportée | Locale hors enum `fr/en/ar` |
+| 401 | `unauthenticated` | Veuillez vous connecter | PUT/GET `/api/account/locale` sans JWT (le switcher hors-auth, lui, n'appelle pas l'API) |
+| 500 | `serverError` | Erreur interne | Échec persistance → le cookie reste posé (dégradation gracieuse), log + retry |
+
+---
+
+## 🔒 Sécurité & conformité HDS
+
+- **Cookie** `diabeo_locale` : `httpOnly:false` (lisible par le switcher client), `SameSite=Lax`, `Secure` en prod, pas de donnée sensible.
+- **Audit** : changement de préférence loggé `UPDATE / USER` (`metadata.setting="locale"`), sans PHI.
+- **RGPD** : `User.language` inclus dans l'export Art. 15 et la suppression Art. 17.
+- **Pas de nouvelle route publique** : l'AC-1 reste 100 % côté client (cookie), aucune surface non authentifiée ajoutée.
+- **Anti-spoof** : `User.language` n'est écrit que via session JWT valide (RM-3).
+
+---
+
+## 🧪 Plan de test 3 niveaux
+
+### Tests unitaires (Vitest)
+- [ ] `LocaleSwitcher` : changement → pose cookie + reload ; valeur hors enum ignorée ; focus restauré post-reload (sentinel TTL).
+- [ ] Helper de détection d'écart (AC-3) : `mismatch` vrai ssi `cookie !== preference` et préférence non nulle.
+- [ ] Zod `putLocaleSchema` accepte fr/en/ar, rejette le reste.
+
+### Tests d'intégration (Vitest + Prisma)
+- [ ] `PUT /api/account/locale` persiste `User.language` **et** pose le cookie + audit `UPDATE/USER`.
+- [ ] `GET /api/account/locale` renvoie `{ preference, active, mismatch }`.
+- [ ] Login : le cookie `diabeo_locale` est (re)posé depuis `User.language`.
+- [ ] 401 sans JWT ; 400 locale invalide.
+
+### Tests E2E (Playwright)
+- [ ] Écran `/login` non authentifié : le switcher change la langue (FR→AR), `dir="rtl"` appliqué.
+- [ ] Settings : changement langue persiste après logout/login sur un cookie vidé.
+- [ ] Login avec cookie ≠ préférence : l'alerte AC-3 s'affiche ; « Revenir » restaure la préférence ; « Continuer » met à jour la base.
+
+---
+
+## 🏁 Définition de Done
+
+- [ ] AC-1/2/3 satisfaits, 3 niveaux de tests verts (couverture ≥ 80 % sur le code ajouté).
+- [ ] `LocaleSwitcher` exposé dans le layout `(auth)` **et** dans `NavigationShell` (variant `compact`) — le composant `Sidebar` mort n'est plus la seule porte.
+- [ ] `PUT /api/account/locale` persiste `User.language` ; login repose le cookie depuis la préférence.
+- [ ] i18n des nouveaux libellés (alerte AC-3, section langue Settings) en fr/en/ar + `dir=rtl`.
+- [ ] Accessibilité : `role="alert"` dismissible, labels ARIA, focus management (WCAG 2.4.3 / 4.1.2).
+- [ ] Audit + export/suppression RGPD couvrent `language`.
+- [ ] Revue code-reviewer + (si surface auth touchée) healthcare-security-auditor.
+
+---
+
+## 📎 Ressources
+
+- `src/components/diabeo/LocaleSwitcher.tsx` (composant existant, US-2112)
+- `src/components/diabeo/NavigationShell.tsx` (shell actif — à enrichir du switcher)
+- `src/app/(auth)/layout.tsx` (layout non authentifié — cible AC-1)
+- `src/app/api/account/locale/route.ts` (PUT cookie — à étendre vers `User.language`)
+- `src/i18n/request.ts` (résolution serveur via cookie `diabeo_locale`)
+- `prisma/schema.prisma` → `enum Language`, `User.language`
+- [US-2112 — Internationalisation FR/AR](./US-2112-internationalisation-fr-ar.md)
+- [US-2101 — Préférences de compte](../03-profil-preferences/) (préférences utilisateur)

--- a/docs/UserStory/pro-user-stories/README.md
+++ b/docs/UserStory/pro-user-stories/README.md
@@ -200,11 +200,12 @@ définition de Done, ressources.
 | [US-2110](12-facturation/US-2110-tva-multi-pays.md) | TVA multi-pays | V1 | FR+DZ | Partiel |
 | [US-2111](12-facturation/US-2111-comptabilite-export.md) | Comptabilité export | V2 | FR | Non |
 
-### 13. Multi-pays & i18n (5 US)
+### 13. Multi-pays & i18n (6 US)
 
 | ID | Titre | Priorité | Pays | Externe |
 |----|-------|---------:|------|---------|
 | [US-2112](13-multi-pays-i18n/US-2112-internationalisation-fr-ar.md) | Internationalisation FR/AR | MVP | FR+DZ | Non |
+| [US-2112b](13-multi-pays-i18n/US-2112b-preference-langue-utilisateur.md) | Préférence de langue utilisateur (switcher hors-auth + persistance + confirmation login) | V1 | Universel | Non |
 | [US-2113](13-multi-pays-i18n/US-2113-devises-eur-dzd.md) | Devises EUR / DZD | V1 | FR+DZ | Non |
 | [US-2114](13-multi-pays-i18n/US-2114-regles-fiscales-par-pays.md) | Règles fiscales par pays | V1 | FR+DZ | Non |
 | [US-2115](13-multi-pays-i18n/US-2115-formats-date-nombre-localises.md) | Formats date/nombre localisés | MVP | FR+DZ | Non |

--- a/docs/qa/01-auth.md
+++ b/docs/qa/01-auth.md
@@ -97,6 +97,39 @@ Feature: Connexion au backoffice
   vers `/register` (page inexistante → 404). L'inscription patient se fait par le
   personnel via `/patients/new` ; il n'y a pas d'auto-inscription publique.
 
+### 🔵 Planifié — Langue sur les écrans non authentifiés + confirmation au login ([US-2112b](../UserStory/pro-user-stories/13-multi-pays-i18n/US-2112b-preference-langue-utilisateur.md), V1)
+
+> **Non encore implémenté.** Aujourd'hui aucun sélecteur de langue n'est exposé
+> sur `/login` (ni les autres écrans `(auth)`). AC-1 + AC-3 ci-dessous.
+
+```gherkin
+Feature: Langue à la connexion (US-2112b — planifié V1)
+
+  # AC-1 — switcher sur écran non authentifié (cookie uniquement, pas d'API auth)
+  Scenario: un visiteur change la langue depuis l'écran de connexion
+    Given je suis sur "/login" (non authentifié)
+    When je choisis "العربية" dans le sélecteur de langue
+    Then "/login" se recharge en arabe avec dir="rtl"
+    # Effet base: AUCUN — cookie diabeo_locale=ar uniquement (aucun appel authentifié)
+
+  # AC-3 — alerte de confirmation si langue de session ≠ préférence enregistrée
+  Scenario: alerte quand la langue active diffère de la préférence au login
+    Given ma préférence "User.language" = "ar"
+    And mon cookie "diabeo_locale" = "fr" (poste partagé)
+    When je me connecte avec des identifiants valides
+    Then je vois une alerte de confirmation de changement de langue (role="alert", non bloquante)
+    When je clique "Revenir à l'arabe"
+    Then l'interface se recharge en arabe
+    # Effet base: cookie diabeo_locale reposé depuis users.language (aucune écriture base)
+
+  Scenario: pas d'alerte quand langue active == préférence
+    Given ma préférence "User.language" = "fr" et le cookie "diabeo_locale" = "fr"
+    When je me connecte
+    Then aucune alerte de changement de langue n'est affichée
+```
+
+**Cas limites (cible)** : alerte non bloquante (ignorable) ; « Continuer en {langue session} » met à jour `User.language` (cf. `05-settings.md` AC-2) ; pas d'alerte si `User.language` NULL.
+
 ---
 
 ## Écran : Mot de passe oublié (`/reset-password`) 🟢

--- a/docs/qa/05-settings.md
+++ b/docs/qa/05-settings.md
@@ -103,3 +103,57 @@ Feature: Paramètres du compte
   prochaine création de RDV / accès données = 422/403.
 - **Double-save** : bouton désactivé pendant l'envoi (`loading`).
 - **Non authentifié** → `redirect("/login")`.
+
+---
+
+## 🔵 Planifié — Préférence de langue ([US-2112b](../UserStory/pro-user-stories/13-multi-pays-i18n/US-2112b-preference-langue-utilisateur.md), V1 — à implémenter)
+
+> **Non encore implémenté.** Spécification de test du follow-up US-2112b.
+> Aujourd'hui : le moteur i18n (US-2112) existe mais le `LocaleSwitcher` n'est
+> exposé sur aucun écran de l'app vivante, et la langue n'est **pas** persistée
+> en base (colonne `User.language` présente mais non câblée). AC-2 ci-dessous.
+
+### Affichage attendu (cible)
+
+| Section | Visibilité | Contenu |
+|---|---|---|
+| **Langue** | tous | Sélecteur FR / EN / AR (valeur courante = `User.language`, défaut `fr`) · application immédiate (reload) · `dir="rtl"` pour AR |
+
+### Actions & effets (cible)
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Changer la langue | `PUT /api/account/locale` (étendu) | reload localisé + toast | **UPDATE `users.language`** + cookie `diabeo_locale` synchronisé · audit UPDATE/USER (`metadata.setting=locale`, sans PHI) |
+
+### Scénarios (Gherkin — cible)
+
+```gherkin
+Feature: Préférence de langue (US-2112b — planifié V1)
+
+  Scenario: changer la langue dans les paramètres la persiste en base
+    Given je suis connecté en tant que "VIEWER"
+    And je suis sur "/settings" section "Langue"
+    When je choisis "العربية" (ar)
+    Then l'interface se recharge en arabe avec dir="rtl"
+    # Effet base: UPDATE users SET language='ar' WHERE id=? + cookie diabeo_locale=ar
+    #             + audit_logs(UPDATE/USER, metadata.setting=locale, value=ar)
+
+  Scenario: la préférence survit au changement d'appareil (cookie vidé)
+    Given ma préférence "User.language" = "ar"
+    And mon cookie "diabeo_locale" est absent (nouveau navigateur)
+    When je me connecte
+    Then l'interface s'affiche en arabe
+    # Effet base: le login (re)pose le cookie diabeo_locale depuis users.language
+
+  Scenario: langue non supportée rejetée
+    Given je suis connecté en tant que "VIEWER"
+    When je PUT "/api/account/locale" avec {"locale":"zz"}
+    Then le statut de la réponse est 400
+    # Validation Zod z.enum(["fr","en","ar"])
+```
+
+### Cas limites (cible)
+
+- Échec persistance base → le cookie reste posé (dégradation gracieuse), pas de blocage UX.
+- `User.language` NULL (jamais choisi) → défaut `fr`.
+- Écran non authentifié : la langue se change par cookie uniquement (cf. `01-auth.md`).


### PR DESCRIPTION
## Contexte

US-2112 (moteur i18n FR/EN/AR) est **DONE**, mais une revue a identifié 3 manques d'**accès** et de **persistance** — formalisés ici en une nouvelle US **V1**.

## Contenu (docs uniquement)

- **`US-2112b`** (nouvelle US, format standard complet) — `docs/UserStory/pro-user-stories/13-multi-pays-i18n/US-2112b-preference-langue-utilisateur.md` :
  1. **AC-1** — switcher de langue sur les écrans **non authentifiés** (login/reset/forgot/MFA), cookie-based, sans appel authentifié.
  2. **AC-2** — changement dans les **Settings** persisté en base (`User.language`, colonne **déjà présente** → aucune migration) + cookie synchronisé + audit.
  3. **AC-3** — **alerte de confirmation** au login si la langue de session ≠ préférence enregistrée.
- **`docs/ROADMAP.md`** — ajout au Groupe 8 i18n V1 (🆕 à démarrer, 3 SP) + compteurs (V1 98→99 / 99 %, TOTAL 285→286).
- **README index** Domaine 13 (5→6 US).

## Notes
- **Aucune migration** : `enum Language {fr,en,ar}` + `User.language @default(fr)` existent déjà ; l'US ne fait que **câbler** lecture/écriture.
- Les AC-2/AC-3 portent sur des écrans **authentifiés** (Settings/login) — j'ai interprété « sans authentification » comme une coquille pour ces deux points (ils impliquent une session + une préférence en base). À confirmer si l'intention était autre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)