### PR TITLE
fix(auth-i18n): bouton fermer + countdown lockout localisés (run QA 01-auth)

### DIFF
--- a/docs/qa/01-auth.md
+++ b/docs/qa/01-auth.md
@@ -96,14 +96,20 @@ Feature: Connexion au backoffice
 - ✅ **Lien « Créer un compte » retiré** (anomalie A1, corrigée) : il pointait
   vers `/register` (page inexistante → 404). L'inscription patient se fait par le
   personnel via `/patients/new` ; il n'y a pas d'auto-inscription publique.
+- **Login réussi → réinitialise le compteur d'échecs** (`clearAttempts` au succès) :
+  comportement **intentionnel** (standard + sûr : un mot de passe correct prouve
+  la légitimité, on lève le lockout). Confirmé au run QA 2026-06-09.
+- ✅ **Sélecteur de langue présent sur `/login` et `/reset-password`** (US-2112b
+  AC-1, livré PR #513) — combobox FR/EN/AR, cookie client, sans appel authentifié.
 
-### 🔵 Planifié — Langue sur les écrans non authentifiés + confirmation au login ([US-2112b](../UserStory/pro-user-stories/13-multi-pays-i18n/US-2112b-preference-langue-utilisateur.md), V1)
+### 🟢 Réel — Langue sur les écrans non authentifiés + confirmation au login ([US-2112b](../UserStory/pro-user-stories/13-multi-pays-i18n/US-2112b-preference-langue-utilisateur.md), livré PR #513)
 
-> **Non encore implémenté.** Aujourd'hui aucun sélecteur de langue n'est exposé
-> sur `/login` (ni les autres écrans `(auth)`). AC-1 + AC-3 ci-dessous.
+> **Livré et confirmé** au run QA 2026-06-09 (AR/RTL) : switcher visible sur
+> `/login` + `/reset-password` ; alerte de réconciliation affichée après login
+> quand le cookie diffère de `User.language`.
 
 ```gherkin
-Feature: Langue à la connexion (US-2112b — planifié V1)
+Feature: Langue à la connexion (US-2112b)
 
   # AC-1 — switcher sur écran non authentifié (cookie uniquement, pas d'API auth)
   Scenario: un visiteur change la langue depuis l'écran de connexion
@@ -128,7 +134,7 @@ Feature: Langue à la connexion (US-2112b — planifié V1)
     Then aucune alerte de changement de langue n'est affichée
 ```
 
-**Cas limites (cible)** : alerte non bloquante (ignorable) ; « Continuer en {langue session} » met à jour `User.language` (cf. `05-settings.md` AC-2) ; pas d'alerte si `User.language` NULL.
+**Cas limites** : alerte non bloquante (ignorable) ; « Continuer en {langue session} » met à jour `User.language` (cf. `05-settings.md` AC-2) ; pas d'alerte si `User.language` NULL.
 
 ---
 

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -28,7 +28,8 @@
     "hourShort": "{count}س",
     "dayShort": "{count}ي",
     "noEvent": "لا توجد أحداث",
-    "eventCount": "{count} حدث(أحداث)"
+    "eventCount": "{count} حدث(أحداث)",
+    "alertClose": "إغلاق التنبيه"
   },
   "nav": {
     "dashboard": "لوحة القيادة",
@@ -154,7 +155,8 @@
     "resetPasswordButton": "إرسال الرابط",
     "resetPasswordSending": "جاري الإرسال...",
     "resetPasswordSuccess": "إذا كان هناك حساب بهذا العنوان، فقد تم إرسال بريد إعادة التعيين.",
-    "resetPasswordBack": "العودة إلى تسجيل الدخول"
+    "resetPasswordBack": "العودة إلى تسجيل الدخول",
+    "lockoutCountdown": "{minutes, plural, =0 {{seconds} ث} other {# د {seconds} ث}}"
   },
   "dashboard": {
     "title": "لوحة القيادة",

--- a/messages/en.json
+++ b/messages/en.json
@@ -28,7 +28,8 @@
     "hourShort": "{count}h",
     "dayShort": "{count}d",
     "noEvent": "no event",
-    "eventCount": "{count} event(s)"
+    "eventCount": "{count} event(s)",
+    "alertClose": "Dismiss alert"
   },
   "nav": {
     "dashboard": "Dashboard",
@@ -154,7 +155,8 @@
     "resetPasswordButton": "Send reset link",
     "resetPasswordSending": "Sending...",
     "resetPasswordSuccess": "If an account exists with this address, a reset email has been sent.",
-    "resetPasswordBack": "Back to login"
+    "resetPasswordBack": "Back to login",
+    "lockoutCountdown": "{minutes, plural, =0 {{seconds} s} other {# min {seconds} s}}"
   },
   "dashboard": {
     "title": "Dashboard",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -28,7 +28,8 @@
     "hourShort": "{count}h",
     "dayShort": "{count}j",
     "noEvent": "aucun evenement",
-    "eventCount": "{count} evenement(s)"
+    "eventCount": "{count} evenement(s)",
+    "alertClose": "Fermer l'alerte"
   },
   "nav": {
     "dashboard": "Tableau de bord",
@@ -154,7 +155,8 @@
     "resetPasswordButton": "Envoyer le lien",
     "resetPasswordSending": "Envoi en cours...",
     "resetPasswordSuccess": "Si un compte existe avec cette adresse, un e-mail de reinitialisation a ete envoye.",
-    "resetPasswordBack": "Retour a la connexion"
+    "resetPasswordBack": "Retour a la connexion",
+    "lockoutCountdown": "{minutes, plural, =0 {{seconds} s} other {# min {seconds} s}}"
   },
   "dashboard": {
     "title": "Tableau de bord",

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -28,6 +28,7 @@ import Link from "next/link"
 
 export default function LoginPage() {
   const t = useTranslations("auth")
+  const tCommon = useTranslations("common")
   const { login, isLoading, error, setError } = useAuth()
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
@@ -86,11 +87,12 @@ export default function LoginPage() {
     }
   }
 
+  // i18n-3 — countdown localisé : unités + chiffres rendus dans la locale active
+  // via la clé ICU `auth.lockoutCountdown` (ex. AR → « ٤ د ٢٤ ث »).
   function formatLockoutTime(seconds: number): string {
-    const min = Math.floor(seconds / 60)
+    const minutes = Math.floor(seconds / 60)
     const sec = seconds % 60
-    if (min > 0) return `${min}min ${sec.toString().padStart(2, "0")}s`
-    return `${sec}s`
+    return t("lockoutCountdown", { minutes, seconds: sec })
   }
 
   return (
@@ -117,6 +119,7 @@ export default function LoginPage() {
             severity="warning"
             title={error}
             dismissible
+            dismissLabel={tCommon("alertClose")}
             onDismiss={() => setError(null)}
           />
         </div>


### PR DESCRIPTION
Corrige 2 anomalies i18n du run QA `01-auth.md` (AR/RTL, 2026-06-09) + met la doc QA à jour.

## Corrections
- **i18n-2** : l'`AlertBanner` d'erreur de `/login` passe désormais `dismissLabel={t("common.alertClose")}` (fr/en/ar) → le bouton de fermeture n'est plus « Fermer l'alerte » en dur pour un lecteur d'écran AR/EN.
- **i18n-3** : `formatLockoutTime` rend le compte à rebours via la clé ICU `auth.lockoutCountdown` (`{minutes, plural, …}`) → unités et chiffres dans la locale active (AR → « د / ث », chiffres arabo-indiens).
- **doc** : `docs/qa/01-auth.md` — US-2112b **🔵 Planifié → 🟢 Réel** (AC-1 switcher + AC-3 alerte confirmés livrés PR #513) ; note documentant que le **login réussi réinitialise le compteur de lockout** (intentionnel).

## Hors scope (suivi séparé)
- **i18n-1** (fuite FR du dashboard `/medecin` + infirmier/admin) = US dédiée (gros chantier multi-écrans).
- Backlog : compte seed MFA, step `db.steps.ts` effet-base.

Validation : `tsc` 0 · `eslint` 0 · parité i18n verte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)