### PR TITLE
feat(design-system): US-2269 — source de tokens unique (TS) + gate anti-drift

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -44,6 +44,33 @@ const eslintConfig = defineConfig([
       "@typescript-eslint/no-explicit-any": "off",
     },
   },
+  // US-2269 — Gate anti-drift design system : interdit les couleurs hex en dur.
+  // En `warn` pour le MVP (migration incrémentale des ~call-sites existants ;
+  // `pnpm lint` n'a pas `--max-warnings`, la CI ne casse donc pas). Les charts
+  // doivent importer `tokens` de `@/design-system/tokens` ; les composants
+  // doivent utiliser des classes Tailwind sémantiques (var(--color-*)).
+  // Exclu : `components/ui/` (shadcn auto-généré), `email.service` (HTML d'email
+  // — les clients mail n'ont pas accès aux variables CSS), `design-system/` et
+  // `styles/` (la SOURCE des tokens).
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    ignores: [
+      "src/components/ui/**",
+      "src/design-system/**",
+      "src/styles/**",
+      "src/lib/services/email.service.ts",
+    ],
+    rules: {
+      "no-restricted-syntax": [
+        "warn",
+        {
+          selector: "Literal[value=/^#[0-9a-fA-F]{3,8}$/]",
+          message:
+            "Couleur hex en dur interdite (US-2269 anti-drift). Importez `tokens` depuis @/design-system/tokens (charts/SVG) ou utilisez une classe Tailwind sémantique (var(--color-*)).",
+        },
+      ],
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/src/components/diabeo/AgpPercentileChart.tsx
+++ b/src/components/diabeo/AgpPercentileChart.tsx
@@ -16,7 +16,7 @@
 "use client"
 
 import { useEffect, useMemo, useState } from "react"
-import { tokens } from "@/design-system/tokens"
+import { tokens, withAlpha } from "@/design-system/tokens"
 
 /** L1/H7 (re-review) — observe `prefers-reduced-motion` so a mid-session
  *  preference change re-applies to the animation prop. */
@@ -202,7 +202,8 @@ export function AgpPercentileChart({
       <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-2 text-xs text-gray-600">
         <span className="flex items-center gap-1">
           <span
-            className="w-3 h-1 bg-teal-700 inline-block"
+            className="w-3 h-1 inline-block"
+            style={{ backgroundColor: tokens.brand.primary[700] }}
             aria-label="Ligne médiane (50ème percentile)"
             role="img"
           />
@@ -210,7 +211,8 @@ export function AgpPercentileChart({
         </span>
         <span className="flex items-center gap-1">
           <span
-            className="w-3 h-3 bg-teal-600/30 inline-block"
+            className="w-3 h-3 inline-block"
+            style={{ backgroundColor: withAlpha(tokens.brand.primary[600], 0.28) }}
             aria-label="Bande percentile 25-75 (teinte moyenne)"
             role="img"
           />
@@ -218,7 +220,8 @@ export function AgpPercentileChart({
         </span>
         <span className="flex items-center gap-1">
           <span
-            className="w-3 h-3 bg-teal-500/15 inline-block"
+            className="w-3 h-3 inline-block"
+            style={{ backgroundColor: withAlpha(tokens.brand.primary[600], 0.12) }}
             aria-label="Bande percentile 10-90 (teinte claire)"
             role="img"
           />
@@ -226,7 +229,8 @@ export function AgpPercentileChart({
         </span>
         <span className="flex items-center gap-1">
           <span
-            className="w-3 h-3 bg-emerald-500/15 inline-block"
+            className="w-3 h-3 inline-block"
+            style={{ backgroundColor: withAlpha(tokens.glycemia.normal, 0.08) }}
             aria-label="Zone glycémique cible"
             role="img"
           />

--- a/src/components/diabeo/AgpPercentileChart.tsx
+++ b/src/components/diabeo/AgpPercentileChart.tsx
@@ -16,6 +16,7 @@
 "use client"
 
 import { useEffect, useMemo, useState } from "react"
+import { tokens } from "@/design-system/tokens"
 
 /** L1/H7 (re-review) — observe `prefers-reduced-motion` so a mid-session
  *  preference change re-applies to the animation prop. */
@@ -137,31 +138,31 @@ export function AgpPercentileChart({
     <div className="w-full" role="figure" aria-label="Profil ambulatoire de glycémie sur 7 jours">
       <ResponsiveContainer width="100%" height={height}>
         <ComposedChart data={data} margin={{ top: 10, right: 12, bottom: 24, left: 12 }}>
-          <CartesianGrid strokeDasharray="3 3" stroke="#E5E7EB" />
+          <CartesianGrid strokeDasharray="3 3" stroke={tokens.neutral[200]} />
           <XAxis
             dataKey="minute"
             type="number"
             domain={[0, 1440]}
             ticks={[0, 240, 480, 720, 960, 1200, 1440]}
             tickFormatter={(m) => formatHour(m)}
-            stroke="#6B7280"
+            stroke={tokens.neutral[500]}
             tick={{ fontSize: 11 }}
           />
           <YAxis
             domain={[40, 300]}
             ticks={[40, 70, 140, 180, 250]}
-            stroke="#6B7280"
+            stroke={tokens.neutral[500]}
             tick={{ fontSize: 11 }}
             label={{
               value: "mg/dL", angle: -90,
               position: "insideLeft", offset: 0,
-              style: { textAnchor: "middle", fontSize: 11, fill: "#6B7280" },
+              style: { textAnchor: "middle", fontSize: 11, fill: tokens.neutral[500] },
             }}
           />
           {/* Target range band — green tint */}
           <ReferenceArea
             y1={targetLowMgdl} y2={targetHighMgdl}
-            fill="#10B981" fillOpacity={0.08}
+            fill={tokens.glycemia.normal} fillOpacity={0.08}
             ifOverflow="extendDomain"
           />
           {/* Stacked percentile bands. Floor (transparent) lifts the visible
@@ -170,17 +171,17 @@ export function AgpPercentileChart({
                 stroke="none" fill="transparent"
                 isAnimationActive={!prefersReducedMotion} />
           <Area type="monotone" dataKey="bandLow" stackId="agp"
-                stroke="none" fill="#0D9488" fillOpacity={0.12}
+                stroke="none" fill={tokens.brand.primary[600]} fillOpacity={0.12}
                 isAnimationActive={!prefersReducedMotion} />
           <Area type="monotone" dataKey="bandMid" stackId="agp"
-                stroke="none" fill="#0D9488" fillOpacity={0.28}
+                stroke="none" fill={tokens.brand.primary[600]} fillOpacity={0.28}
                 isAnimationActive={!prefersReducedMotion} />
           <Area type="monotone" dataKey="bandHigh" stackId="agp"
-                stroke="none" fill="#0D9488" fillOpacity={0.12}
+                stroke="none" fill={tokens.brand.primary[600]} fillOpacity={0.12}
                 isAnimationActive={!prefersReducedMotion} />
           {/* Median line */}
           <Line type="monotone" dataKey="p50"
-                stroke="#0F766E" strokeWidth={2} dot={false}
+                stroke={tokens.brand.primary[700]} strokeWidth={2} dot={false}
                 isAnimationActive={!prefersReducedMotion} />
           <Tooltip
             formatter={(value, name) => {

--- a/src/components/diabeo/loaders/ChartLoader.tsx
+++ b/src/components/diabeo/loaders/ChartLoader.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils"
-import { tokens } from "@/design-system/tokens"
+import { tokens, withAlpha } from "@/design-system/tokens"
 
 type ChartLoaderProps = {
   variant?: "line" | "agp" | "bars" | "donut"
@@ -83,7 +83,7 @@ export function ChartLoader({
 function LineSkeleton() {
   return (
     <svg viewBox="0 0 600 200" className="w-full h-48" aria-hidden>
-      <rect x="0" y="70" width="600" height="70" fill="rgba(16,185,129,0.06)" />
+      <rect x="0" y="70" width="600" height="70" fill={withAlpha(tokens.glycemia.normal, 0.06)} />
       <line x1="0" y1="70" x2="600" y2="70" stroke={tokens.neutral[200]} strokeDasharray="3 3" />
       <line x1="0" y1="140" x2="600" y2="140" stroke={tokens.neutral[200]} strokeDasharray="3 3" />
       <path
@@ -101,15 +101,15 @@ function LineSkeleton() {
 function AgpSkeleton() {
   return (
     <svg viewBox="0 0 600 200" className="w-full h-48" aria-hidden>
-      <rect x="0" y="70" width="600" height="70" fill="rgba(16,185,129,0.06)" />
+      <rect x="0" y="70" width="600" height="70" fill={withAlpha(tokens.glycemia.normal, 0.06)} />
       <path
         d="M0,140 L100,155 L200,125 L300,80 L400,100 L500,135 L600,140 L600,50 L500,45 L400,30 L300,15 L200,40 L100,75 L0,90 Z"
-        fill="rgba(13,148,136,0.12)"
+        fill={withAlpha(tokens.brand.primary[600], 0.12)}
         className="animate-pulse"
       />
       <path
         d="M0,130 L100,140 L200,115 L300,85 L400,100 L500,125 L600,130 L600,65 L500,60 L400,50 L300,40 L200,55 L100,85 L0,95 Z"
-        fill="rgba(13,148,136,0.22)"
+        fill={withAlpha(tokens.brand.primary[600], 0.22)}
         className="animate-pulse"
       />
       <path

--- a/src/components/diabeo/loaders/ChartLoader.tsx
+++ b/src/components/diabeo/loaders/ChartLoader.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils"
+import { tokens } from "@/design-system/tokens"
 
 type ChartLoaderProps = {
   variant?: "line" | "agp" | "bars" | "donut"
@@ -83,13 +84,13 @@ function LineSkeleton() {
   return (
     <svg viewBox="0 0 600 200" className="w-full h-48" aria-hidden>
       <rect x="0" y="70" width="600" height="70" fill="rgba(16,185,129,0.06)" />
-      <line x1="0" y1="70" x2="600" y2="70" stroke="#E5E7EB" strokeDasharray="3 3" />
-      <line x1="0" y1="140" x2="600" y2="140" stroke="#E5E7EB" strokeDasharray="3 3" />
+      <line x1="0" y1="70" x2="600" y2="70" stroke={tokens.neutral[200]} strokeDasharray="3 3" />
+      <line x1="0" y1="140" x2="600" y2="140" stroke={tokens.neutral[200]} strokeDasharray="3 3" />
       <path
         className="chart-draw"
         d="M0,120 L50,110 L100,95 L150,80 L200,100 L250,130 L300,145 L350,130 L400,115 L450,95 L500,105 L550,120 L600,115"
         fill="none"
-        stroke="#0D9488"
+        stroke={tokens.brand.primary[600]}
         strokeWidth="2.5"
         strokeLinecap="round"
       />
@@ -115,7 +116,7 @@ function AgpSkeleton() {
         className="chart-draw"
         d="M0,115 L100,125 L200,110 L300,88 L400,95 L500,115 L600,120"
         fill="none"
-        stroke="#0D9488"
+        stroke={tokens.brand.primary[600]}
         strokeWidth="2"
       />
     </svg>
@@ -136,7 +137,7 @@ function BarsSkeleton() {
             width="28"
             height={h}
             rx="4"
-            fill="#CCFBF1"
+            fill={tokens.brand.primary[100]}
             className="animate-pulse"
             style={{ animationDelay: `${i * 80}ms` }}
           />
@@ -150,13 +151,13 @@ function DonutSkeleton() {
   return (
     <div className="flex items-center justify-center py-4">
       <svg viewBox="0 0 120 120" className="w-36 h-36" aria-hidden>
-        <circle cx="60" cy="60" r="48" fill="none" stroke="#F3F4F6" strokeWidth="14" />
+        <circle cx="60" cy="60" r="48" fill="none" stroke={tokens.neutral[100]} strokeWidth="14" />
         <circle
           cx="60"
           cy="60"
           r="48"
           fill="none"
-          stroke="#0D9488"
+          stroke={tokens.brand.primary[600]}
           strokeWidth="14"
           strokeDasharray="60 302"
           strokeLinecap="round"

--- a/src/design-system/tokens.ts
+++ b/src/design-system/tokens.ts
@@ -102,13 +102,28 @@ export const COLOR_TOKEN_CSS = {
   "dt2-bg": "#EFF6FF",
   "gd": "#EC4899",
   "gd-bg": "#FDF2F8",
+  // Pur blanc — fonds de masquage des bandes de charts (≠ neutral-50 #FAFAFA).
+  "white": "#FFFFFF",
 } as const
 
 export type ColorTokenName = keyof typeof COLOR_TOKEN_CSS
 
-/** Récupère la valeur hex d'un token de couleur (helper typé). */
-export function color(name: ColorTokenName): string {
+/** Récupère la valeur hex d'un token de couleur — préserve le type littéral. */
+export function color<K extends ColorTokenName>(name: K): (typeof COLOR_TOKEN_CSS)[K] {
   return COLOR_TOKEN_CSS[name]
+}
+
+/**
+ * Applique une opacité à une couleur hex de token → `rgba(r,g,b,a)`. Évite les
+ * `rgba(...)` en dur qui dupliquent un token (anti-drift pour les bandes/halos
+ * de charts). Ex. `withAlpha(tokens.brand.primary[600], 0.12)`.
+ */
+export function withAlpha(hex: string, alpha: number): string {
+  const h = hex.replace("#", "")
+  const r = parseInt(h.slice(0, 2), 16)
+  const g = parseInt(h.slice(2, 4), 16)
+  const b = parseInt(h.slice(4, 6), 16)
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
 }
 
 const C = COLOR_TOKEN_CSS
@@ -154,6 +169,6 @@ export const tokens = {
   pathology: {
     DT1: C["dt1"], DT2: C["dt2"], GD: C["gd"],
   },
-  /** Blanc pur — fonds de bandes/segments de charts (≡ neutral-50 visuel). */
-  white: "#FFFFFF",
+  /** Pur blanc (#FFFFFF) — fonds de masquage des bandes de charts. */
+  white: C["white"],
 } as const

--- a/src/design-system/tokens.ts
+++ b/src/design-system/tokens.ts
@@ -8,9 +8,10 @@
  * dur (anti-drift).
  *
  * ⚠️ NE PAS DIVERGER de `src/styles/tokens.css` : `tests/unit/design-tokens.test.ts`
- * vérifie que chaque entrée de {@link COLOR_TOKEN_CSS} égale la variable
- * `--diabeo-*` correspondante du CSS (gate CI). Toute modif d'une couleur DOIT
- * se faire dans les deux (ou la CI échoue).
+ * vérifie la parité **bidirectionnelle** — chaque entrée de {@link COLOR_TOKEN_CSS}
+ * égale la variable `--diabeo-*` du CSS (TS→CSS) ET toute variable hex du CSS a
+ * un pendant ici (CSS→TS). Toute modif/ajout/suppression d'une couleur DOIT se
+ * faire dans les deux fichiers (ou la CI échoue).
  *
  * @see src/styles/tokens.css — source CSS consommée par Tailwind @theme
  * @see docs/design-system/colors.md — documentation
@@ -117,13 +118,21 @@ export function color<K extends ColorTokenName>(name: K): (typeof COLOR_TOKEN_CS
  * Applique une opacité à une couleur hex de token → `rgba(r,g,b,a)`. Évite les
  * `rgba(...)` en dur qui dupliquent un token (anti-drift pour les bandes/halos
  * de charts). Ex. `withAlpha(tokens.brand.primary[600], 0.12)`.
+ *
+ * Défensif : n'accepte qu'un hex **6 chiffres** (`#RRGGBB`, le format de tous
+ * les tokens) — lève sur une entrée invalide plutôt que d'émettre un
+ * `rgba(NaN, …)` silencieux. `alpha` est clampé dans `[0, 1]`.
  */
 export function withAlpha(hex: string, alpha: number): string {
   const h = hex.replace("#", "")
+  if (!/^[0-9a-fA-F]{6}$/.test(h)) {
+    throw new Error(`withAlpha: hex 6 chiffres attendu, reçu "${hex}"`)
+  }
+  const a = Math.min(1, Math.max(0, alpha))
   const r = parseInt(h.slice(0, 2), 16)
   const g = parseInt(h.slice(2, 4), 16)
   const b = parseInt(h.slice(4, 6), 16)
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+  return `rgba(${r}, ${g}, ${b}, ${a})`
 }
 
 const C = COLOR_TOKEN_CSS

--- a/src/design-system/tokens.ts
+++ b/src/design-system/tokens.ts
@@ -1,0 +1,159 @@
+/**
+ * Diabeo Design System — Design tokens (miroir TypeScript de `src/styles/tokens.css`).
+ *
+ * US-2269 — SOURCE DE VÉRITÉ unique côté JS. Les composants utilisent les
+ * classes Tailwind sémantiques (`text-foreground`, `text-glycemia-critical`…)
+ * qui pointent sur les variables `@theme` ; mais les **charts/SVG** (Recharts)
+ * ont besoin de valeurs JS — ils importent `tokens` au lieu d'écrire des hex en
+ * dur (anti-drift).
+ *
+ * ⚠️ NE PAS DIVERGER de `src/styles/tokens.css` : `tests/unit/design-tokens.test.ts`
+ * vérifie que chaque entrée de {@link COLOR_TOKEN_CSS} égale la variable
+ * `--diabeo-*` correspondante du CSS (gate CI). Toute modif d'une couleur DOIT
+ * se faire dans les deux (ou la CI échoue).
+ *
+ * @see src/styles/tokens.css — source CSS consommée par Tailwind @theme
+ * @see docs/design-system/colors.md — documentation
+ */
+
+/**
+ * Map plat `<nom-sans-prefixe-diabeo> → hex`. UNIQUE endroit où les hex sont
+ * écrits côté JS ; validé contre `tokens.css` par le gate de parité.
+ */
+export const COLOR_TOKEN_CSS = {
+  // Brand — Primary (teal)
+  "primary-50": "#F0FDFA",
+  "primary-100": "#CCFBF1",
+  "primary-200": "#99F6E4",
+  "primary-300": "#5EEAD4",
+  "primary-400": "#2DD4BF",
+  "primary-500": "#14B8A6",
+  "primary-600": "#0D9488",
+  "primary-700": "#0F766E",
+  "primary-800": "#115E59",
+  "primary-900": "#134E4A",
+  "primary-950": "#042F2E",
+  // Brand — Secondary (coral)
+  "secondary-50": "#FFF7ED",
+  "secondary-100": "#FFEDD5",
+  "secondary-200": "#FED7AA",
+  "secondary-300": "#FDBA74",
+  "secondary-400": "#FB923C",
+  "secondary-500": "#F97316",
+  "secondary-600": "#EA580C",
+  "secondary-700": "#C2410C",
+  "secondary-800": "#9A3412",
+  "secondary-900": "#7C2D12",
+  "secondary-950": "#431407",
+  // Neutral (gray)
+  "neutral-50": "#FAFAFA",
+  "neutral-100": "#F3F4F6",
+  "neutral-200": "#E5E7EB",
+  "neutral-300": "#D1D5DB",
+  "neutral-400": "#9CA3AF",
+  "neutral-500": "#6B7280",
+  "neutral-600": "#4B5563",
+  "neutral-700": "#374151",
+  "neutral-800": "#1F2937",
+  "neutral-900": "#111827",
+  "neutral-950": "#030712",
+  // Glycemia (clinical)
+  "glycemia-very-low": "#991B1B",
+  "glycemia-very-low-bg": "#FEF2F2",
+  "glycemia-very-low-border": "#FECACA",
+  "glycemia-low": "#EF4444",
+  "glycemia-low-bg": "#FEF2F2",
+  "glycemia-low-border": "#FCA5A5",
+  "glycemia-normal": "#10B981",
+  "glycemia-normal-bg": "#ECFDF5",
+  "glycemia-normal-border": "#A7F3D0",
+  "glycemia-high": "#F59E0B",
+  "glycemia-high-bg": "#FFFBEB",
+  "glycemia-high-border": "#FDE68A",
+  "glycemia-very-high": "#EF4444",
+  "glycemia-very-high-bg": "#FEF2F2",
+  "glycemia-very-high-border": "#FECACA",
+  "glycemia-critical": "#DC2626",
+  "glycemia-critical-bg": "#FEE2E2",
+  "glycemia-critical-border": "#F87171",
+  // TIR zones (5-zone)
+  "tir-very-low": "#991B1B",
+  "tir-low": "#EF4444",
+  "tir-in-range": "#10B981",
+  "tir-high": "#F59E0B",
+  "tir-very-high": "#F97316",
+  // Semantic
+  "success": "#10B981",
+  "success-bg": "#ECFDF5",
+  "success-border": "#A7F3D0",
+  "warning": "#F59E0B",
+  "warning-bg": "#FFFBEB",
+  "warning-border": "#FDE68A",
+  "error": "#EF4444",
+  "error-bg": "#FEF2F2",
+  "error-border": "#FCA5A5",
+  "info": "#3B82F6",
+  "info-bg": "#EFF6FF",
+  "info-border": "#BFDBFE",
+  // Pathology badges
+  "dt1": "#7C3AED",
+  "dt1-bg": "#F5F3FF",
+  "dt2": "#2563EB",
+  "dt2-bg": "#EFF6FF",
+  "gd": "#EC4899",
+  "gd-bg": "#FDF2F8",
+} as const
+
+export type ColorTokenName = keyof typeof COLOR_TOKEN_CSS
+
+/** Récupère la valeur hex d'un token de couleur (helper typé). */
+export function color(name: ColorTokenName): string {
+  return COLOR_TOKEN_CSS[name]
+}
+
+const C = COLOR_TOKEN_CSS
+
+/**
+ * Vue ergonomique pour les consommateurs JS (charts/SVG). Construite À PARTIR de
+ * {@link COLOR_TOKEN_CSS} → ne peut pas diverger de la source.
+ */
+export const tokens = {
+  brand: {
+    primary: {
+      50: C["primary-50"], 100: C["primary-100"], 200: C["primary-200"],
+      300: C["primary-300"], 400: C["primary-400"], 500: C["primary-500"],
+      600: C["primary-600"], 700: C["primary-700"], 800: C["primary-800"],
+      900: C["primary-900"], 950: C["primary-950"],
+    },
+    secondary: {
+      50: C["secondary-50"], 100: C["secondary-100"], 200: C["secondary-200"],
+      300: C["secondary-300"], 400: C["secondary-400"], 500: C["secondary-500"],
+      600: C["secondary-600"], 700: C["secondary-700"], 800: C["secondary-800"],
+      900: C["secondary-900"], 950: C["secondary-950"],
+    },
+  },
+  neutral: {
+    50: C["neutral-50"], 100: C["neutral-100"], 200: C["neutral-200"],
+    300: C["neutral-300"], 400: C["neutral-400"], 500: C["neutral-500"],
+    600: C["neutral-600"], 700: C["neutral-700"], 800: C["neutral-800"],
+    900: C["neutral-900"], 950: C["neutral-950"],
+  },
+  glycemia: {
+    veryLow: C["glycemia-very-low"], low: C["glycemia-low"],
+    normal: C["glycemia-normal"], high: C["glycemia-high"],
+    veryHigh: C["glycemia-very-high"], critical: C["glycemia-critical"],
+  },
+  /** Couleurs des 5 zones Time-in-Range (charts). */
+  tir: {
+    veryLow: C["tir-very-low"], low: C["tir-low"], inRange: C["tir-in-range"],
+    high: C["tir-high"], veryHigh: C["tir-very-high"],
+  },
+  semantic: {
+    success: C["success"], warning: C["warning"], error: C["error"], info: C["info"],
+  },
+  pathology: {
+    DT1: C["dt1"], DT2: C["dt2"], GD: C["gd"],
+  },
+  /** Blanc pur — fonds de bandes/segments de charts (≡ neutral-50 visuel). */
+  white: "#FFFFFF",
+} as const

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -54,6 +54,9 @@
   --diabeo-neutral-900: #111827;
   --diabeo-neutral-950: #030712;
 
+  /* Pure white — chart band masking (distinct from neutral-50 #FAFAFA) */
+  --diabeo-white: #FFFFFF;
+
   /* ----------------------------------------------------------------
    * 2. COLOR TOKENS — Glycemia (clinical)
    * ---------------------------------------------------------------- */

--- a/tests/unit/design-tokens.test.ts
+++ b/tests/unit/design-tokens.test.ts
@@ -18,7 +18,7 @@
 import { describe, it, expect } from "vitest"
 import { readFileSync } from "fs"
 import { resolve } from "path"
-import { COLOR_TOKEN_CSS } from "@/design-system/tokens"
+import { COLOR_TOKEN_CSS, withAlpha, tokens } from "@/design-system/tokens"
 
 /** Parse `src/styles/tokens.css` → map `--diabeo-<name>` (UPPER hex). */
 function readCssTokens(): Record<string, string> {
@@ -72,5 +72,23 @@ describe("design tokens — parité tokens.ts ↔ tokens.css", () => {
       expect(COLOR_TOKEN_CSS[k]).toBeDefined()
       expect(cssTokens[k]).toBe(COLOR_TOKEN_CSS[k].toUpperCase())
     }
+  })
+})
+
+describe("withAlpha", () => {
+  it("convertit un token hex 6-chiffres en rgba", () => {
+    expect(withAlpha(tokens.brand.primary[600], 0.12)).toBe("rgba(13, 148, 136, 0.12)")
+    expect(withAlpha(tokens.glycemia.normal, 0.08)).toBe("rgba(16, 185, 129, 0.08)")
+  })
+
+  it("clampe alpha dans [0, 1]", () => {
+    expect(withAlpha(tokens.brand.primary[600], 1.5)).toBe("rgba(13, 148, 136, 1)")
+    expect(withAlpha(tokens.brand.primary[600], -0.2)).toBe("rgba(13, 148, 136, 0)")
+  })
+
+  it("lève sur un hex invalide (pas de rgba(NaN) silencieux)", () => {
+    expect(() => withAlpha("#FFF", 0.5)).toThrow()
+    expect(() => withAlpha("not-a-hex", 0.5)).toThrow()
+    expect(() => withAlpha("#0D944880", 0.5)).toThrow() // 8-digits rejeté
   })
 })

--- a/tests/unit/design-tokens.test.ts
+++ b/tests/unit/design-tokens.test.ts
@@ -40,7 +40,7 @@ describe("design tokens — parité tokens.ts ↔ tokens.css", () => {
     expect(cssTokens["primary-600"]).toBe("#0D9488")
   })
 
-  it("chaque token TS correspond EXACTEMENT à la variable CSS --diabeo-*", () => {
+  it("chaque token TS correspond EXACTEMENT à la variable CSS --diabeo-* (TS → CSS)", () => {
     const mismatches: string[] = []
     for (const [name, hex] of Object.entries(COLOR_TOKEN_CSS)) {
       const cssHex = cssTokens[name]
@@ -51,6 +51,15 @@ describe("design tokens — parité tokens.ts ↔ tokens.css", () => {
       }
     }
     expect(mismatches).toEqual([])
+  })
+
+  it("chaque variable CSS couleur a un pendant dans tokens.ts (CSS → TS, anti-drift inverse)", () => {
+    // `cssTokens` ne contient QUE les variables `--diabeo-*` à valeur hex (le
+    // regex filtre déjà sur `#...`) → toute couleur ajoutée côté CSS sans miroir
+    // TS est détectée ici. (Les tokens non-couleur — spacing, radius… — n'ont
+    // pas de valeur hex et ne sont donc pas concernés.)
+    const missingInTs = Object.keys(cssTokens).filter((name) => !(name in COLOR_TOKEN_CSS))
+    expect(missingInTs).toEqual([])
   })
 
   it("couvre les couleurs cliniques critiques (glycémie + TIR)", () => {

--- a/tests/unit/design-tokens.test.ts
+++ b/tests/unit/design-tokens.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @vitest-environment node
+ */
+
+/**
+ * US-2269 — Gate anti-drift du design system.
+ *
+ * Garantit que le miroir TypeScript `src/design-system/tokens.ts`
+ * ({@link COLOR_TOKEN_CSS}) reste STRICTEMENT synchrone avec la source CSS
+ * `src/styles/tokens.css` (variables `--diabeo-*`). Toute couleur modifiée dans
+ * l'un sans l'autre fait échouer la CI — même esprit que `clinical-bounds.test.ts`.
+ *
+ * Comportement « clinique » couvert : les couleurs glycémie/TIR (sévérité d'un
+ * état patient) ne doivent jamais diverger entre la doc/CSS et le code des
+ * graphes — un vert/rouge incohérent induirait le praticien en erreur.
+ */
+
+import { describe, it, expect } from "vitest"
+import { readFileSync } from "fs"
+import { resolve } from "path"
+import { COLOR_TOKEN_CSS } from "@/design-system/tokens"
+
+/** Parse `src/styles/tokens.css` → map `--diabeo-<name>` (UPPER hex). */
+function readCssTokens(): Record<string, string> {
+  const css = readFileSync(resolve(process.cwd(), "src/styles/tokens.css"), "utf8")
+  const map: Record<string, string> = {}
+  const re = /--diabeo-([\w-]+):\s*(#[0-9A-Fa-f]{3,8})\s*;/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(css)) !== null) {
+    map[m[1]] = m[2].toUpperCase()
+  }
+  return map
+}
+
+describe("design tokens — parité tokens.ts ↔ tokens.css", () => {
+  const cssTokens = readCssTokens()
+
+  it("la source CSS expose bien des tokens couleur", () => {
+    expect(Object.keys(cssTokens).length).toBeGreaterThan(20)
+    expect(cssTokens["primary-600"]).toBe("#0D9488")
+  })
+
+  it("chaque token TS correspond EXACTEMENT à la variable CSS --diabeo-*", () => {
+    const mismatches: string[] = []
+    for (const [name, hex] of Object.entries(COLOR_TOKEN_CSS)) {
+      const cssHex = cssTokens[name]
+      if (cssHex === undefined) {
+        mismatches.push(`${name}: absent de tokens.css`)
+      } else if (cssHex !== hex.toUpperCase()) {
+        mismatches.push(`${name}: tokens.ts=${hex.toUpperCase()} ≠ tokens.css=${cssHex}`)
+      }
+    }
+    expect(mismatches).toEqual([])
+  })
+
+  it("couvre les couleurs cliniques critiques (glycémie + TIR)", () => {
+    for (const k of [
+      "glycemia-normal",
+      "glycemia-critical",
+      "tir-in-range",
+      "tir-very-low",
+    ] as const) {
+      expect(COLOR_TOKEN_CSS[k]).toBeDefined()
+      expect(cssTokens[k]).toBe(COLOR_TOKEN_CSS[k].toUpperCase())
+    }
+  })
+})


### PR DESCRIPTION
Implémente **[US-2269](docs/UserStory/pro-user-stories/18-admin-systeme/US-2269-design-system-source-de-verite-anti-drift.md)** (spec mergée séparément).

## Problème
Le design system est tokenisé en CSS (`src/styles/tokens.css`) mais **les charts/SVG utilisent des couleurs hex en dur** (Recharts a besoin de valeurs JS, pas de classes Tailwind) → drift : si la palette change, les graphes ne suivent pas, et la doc peut diverger du code.

## Solution (MVP)
1. **`src/design-system/tokens.ts`** — miroir TypeScript importable de `tokens.css`. Map plat `COLOR_TOKEN_CSS` (**unique** endroit où les hex vivent côté JS) + vue ergonomique `tokens` (`brand`/`neutral`/`glycemia`/`tir`/`semantic`/`pathology`) construite à partir du map → cohérence interne garantie.
2. **Gate de parité** `tests/unit/design-tokens.test.ts` — parse `tokens.css` et **assert que chaque token TS == la variable `--diabeo-*`** (anti-drift, même pattern que `clinical-bounds.test.ts`). Couleurs cliniques (glycémie/TIR) explicitement couvertes.
3. **Migration charts** — `AgpPercentileChart` + `ChartLoader` importent `tokens` (0 hex résiduel).
4. **Règle ESLint** `no-restricted-syntax` (**warn**) interdisant les hex en dur dans `src/**` — exclus : `components/ui/` (shadcn), `email.service` (HTML d'email), `design-system/`, `styles/`. `pnpm lint` n'a pas `--max-warnings` → **CI non bloquée** ; les **~67 hex call-sites** restants sont signalés en warning pour migration incrémentale.

## Comment ça empêche la dérive
- Changer une couleur dans `tokens.css` sans mettre à jour `tokens.ts` (ou l'inverse) → **le test de parité casse la CI**.
- Écrire un nouveau hex en dur dans un composant → **warning ESLint** pointant vers `tokens`.

## Validation
`tsc` 0 · `eslint` **0 error** (67 warnings = backlog hex documenté) · **2976 tests verts** (gate inclus).

## Hors périmètre (suite incrémentale, cf. US)
Migration exhaustive des call-sites + `rgba()`, génération de `globals.css @theme` depuis la source, export W3C `design-tokens.json`, check contraste WCAG automatisé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)