### PR TITLE
docs(us): Domaine 24 — environnement de test mocké + fixtures QA (13 US)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -202,6 +202,29 @@
 |----|-------|--------|---------------|
 | US-2171 | Base médicamenteuse BDPM | DONE | `bdpm.service.ts`, `atc.service.ts`, modèles Prisma |
 
+### Domaine 24 — QA & Environnement de test (13 US, 41 SP, 🆕 À démarrer)
+
+> Rendre l'app exécutable **offline & déterministe** + fixtures couvrant **tous
+> les états** des 12 domaines QA (`docs/qa/`). Voir
+> [README](../UserStory/pro-user-stories/24-qa-test-environment/README.md).
+> **US-2270 (socle)** est prérequis de toutes les autres.
+
+| US | Titre | SP | Statut |
+|----|-------|---:|--------|
+| [US-2270](../UserStory/pro-user-stories/24-qa-test-environment/US-2270-socle-dev-mocke.md) | Socle dev mocké (stubs email/firebase/antivirus + redis revocation fallback + `.env.mock.dev`) | 5 | 🆕 |
+| [US-2271](../UserStory/pro-user-stories/24-qa-test-environment/US-2271-fixtures-qa-auth.md) | Fixtures 01-auth (MFA, suspendu/archivé, verrouillé) | 3 | 🆕 |
+| [US-2272](../UserStory/pro-user-stories/24-qa-test-environment/US-2272-fixtures-qa-dashboards.md) | Fixtures 02-dashboards (à-risque, urgences, KPI) | 3 | 🆕 |
+| [US-2273](../UserStory/pro-user-stories/24-qa-test-environment/US-2273-fixtures-qa-patients.md) | Fixtures 03-patients (états vides, soft-delete) | 2 | 🆕 |
+| [US-2274](../UserStory/pro-user-stories/24-qa-test-environment/US-2274-fixtures-qa-appointments.md) | Fixtures 04-appointments (statuts, conflits, indispo) | 3 | 🆕 |
+| [US-2275](../UserStory/pro-user-stories/24-qa-test-environment/US-2275-fixtures-qa-settings.md) | Fixtures 05-settings (RGPD, langue, unités) | 2 | 🆕 |
+| [US-2276](../UserStory/pro-user-stories/24-qa-test-environment/US-2276-fixtures-qa-admin.md) | Fixtures 06-admin (délégations, data breach, fiscalité) | 3 | 🆕 |
+| [US-2277](../UserStory/pro-user-stories/24-qa-test-environment/US-2277-fixtures-qa-analytics.md) | Fixtures 07-analytics (multi-patients, données insuffisantes) | 3 | 🆕 |
+| [US-2278](../UserStory/pro-user-stories/24-qa-test-environment/US-2278-fixtures-qa-admin-ops.md) | Fixtures 08-admin-ops (backups, system-health, cron) | 3 | 🆕 |
+| [US-2279](../UserStory/pro-user-stories/24-qa-test-environment/US-2279-fixtures-qa-compliance-billing.md) | Fixtures 09-compliance-billing (cycle facture, relances, RGPD) | 3 | 🆕 |
+| [US-2280](../UserStory/pro-user-stories/24-qa-test-environment/US-2280-fixtures-qa-devices-documents-events.md) | Fixtures 10-devices-documents-events (upload/scan, appairage) | 5 | 🆕 |
+| [US-2281](../UserStory/pro-user-stories/24-qa-test-environment/US-2281-fixtures-qa-clinical.md) | Fixtures 11-clinical (propositions, bolus, alertes) | 5 | 🆕 |
+| [US-2282](../UserStory/pro-user-stories/24-qa-test-environment/US-2282-fixtures-qa-communication.md) | Fixtures 12-communication (push, livraison, annonces) | 3 | 🆕 |
+
 ### Mirror MVP (9 US — DONE PR #343)
 
 | US | Titre | Statut | Domaine |

--- a/docs/UserStory/pro-user-stories/24-qa-test-environment/README.md
+++ b/docs/UserStory/pro-user-stories/24-qa-test-environment/README.md
@@ -1,0 +1,38 @@
+# Domaine 24 — QA & Environnement de test
+
+Jeu de User Stories pour **pousser la QA à fond** : rendre l'application
+entièrement exécutable **hors-ligne et de façon déterministe**, puis garantir
+que **chaque domaine QA** (`docs/qa/NN-*.md`) dispose des fixtures couvrant
+**tous ses états** (nominal, vides, erreurs, refus RBAC, cas limites).
+
+## Structure
+
+| US | Portée | SP |
+|----|--------|---:|
+| [US-2270](US-2270-socle-dev-mocke.md) | **Socle** — env mocké (stubs email/firebase/antivirus + redis revocation fallback + profil `.env.mock.dev`) | 5 |
+| [US-2271](US-2271-fixtures-qa-auth.md) | Fixtures **01-auth** (MFA, suspendu/archivé, verrouillé, reset) | 3 |
+| [US-2272](US-2272-fixtures-qa-dashboards.md) | Fixtures **02-dashboards** (patients à risque, urgences, propositions, KPI) | 3 |
+| [US-2273](US-2273-fixtures-qa-patients.md) | Fixtures **03-patients** (sans medical data / sans thérapie, soft-delete) | 2 |
+| [US-2274](US-2274-fixtures-qa-appointments.md) | Fixtures **04-appointments** (tous statuts + motif, conflits, indispo) | 3 |
+| [US-2275](US-2275-fixtures-qa-settings.md) | Fixtures **05-settings** (RGPD opt-out, langue, unités, notifs) | 2 |
+| [US-2276](US-2276-fixtures-qa-admin.md) | Fixtures **06-admin** (suspendu/archivé, délégations, data breach, fiscalité) | 3 |
+| [US-2277](US-2277-fixtures-qa-analytics.md) | Fixtures **07-analytics** (multi-patients, données insuffisantes, compare) | 3 |
+| [US-2278](US-2278-fixtures-qa-admin-ops.md) | Fixtures **08-admin-ops** (backups, system-health, cron, audit) | 3 |
+| [US-2279](US-2279-fixtures-qa-compliance-billing.md) | Fixtures **09-compliance-billing** (cycle facture, relances, RGPD) | 3 |
+| [US-2280](US-2280-fixtures-qa-devices-documents-events.md) | Fixtures **10-devices-documents-events** (upload/scan/download, appairage, events) | 5 |
+| [US-2281](US-2281-fixtures-qa-clinical.md) | Fixtures **11-clinical** (propositions, bolus log, alertes) | 5 |
+| [US-2282](US-2282-fixtures-qa-communication.md) | Fixtures **12-communication** (push, livraison, annonces) | 3 |
+
+**Total : 41 SP.** US-2270 (socle) est prérequis de toutes les autres.
+
+## Principes
+- **Déterministe** : PRNG seedé, idempotent (upsert), reproductible (captures QA stables).
+- **Offline** : aucun service externe requis (stubs + fallbacks mémoire + MinIO).
+- **Sécurité conservée** : PII chiffrées AES-256-GCM même en fixtures ; secrets de dev marqués `DEV-ONLY`, jamais en prod.
+- **Couverture états** : chaque écran de `docs/qa/` doit avoir une fixture pour son état nominal **et** ses états vides/erreur/refus.
+
+## Ordre de réalisation conseillé
+1. **US-2270** (débloque l'app offline).
+2. Domaines aujourd'hui **vides** au seed (impact QA max) : US-2281 (clinical), US-2279 (billing), US-2278 (admin-ops), US-2280 (devices/docs).
+3. Domaines **partiels** : US-2271, 2272, 2274, 2277, 2276, 2275, 2282, 2273.
+4. Lancer la campagne via le skill `/qa` (interactif) ou Playwright BDD (headless).

--- a/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2270-socle-dev-mocke.md
+++ b/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2270-socle-dev-mocke.md
@@ -1,0 +1,56 @@
+# US-2270 — Socle : environnement de dev entièrement mocké (offline, déterministe)
+
+> Permettre de lancer l'application **100 % hors-ligne** (aucun service externe
+> requis) pour dérouler la QA sur tous les domaines. Aujourd'hui ~70 % marche
+> déjà en local (PostgreSQL + MinIO via `docker compose --profile local`,
+> fallbacks mémoire Redis cache/idempotency, antivirus skip en dev). Cette US
+> comble les 3 services qui **plantent en dur** sans credentials et pose un
+> profil d'environnement mocké unique.
+
+## 📊 Métadonnées
+
+| Champ | Valeur |
+|-------|--------|
+| **ID** | `US-2270` |
+| **Domaine** | 24. QA & Environnement de test |
+| **Priorité** | **V1** |
+| **Statut** | 🆕 À démarrer |
+| **Story points** | **5** (Fibonacci) |
+| **Dépendances** | docker-compose profil local · MinIO · clés crypto locales (tests/helpers/setup.ts) |
+
+---
+
+
+## 📋 Contexte
+
+Services sans fallback (throw si env absent) → bloquent le dev offline :
+- **Resend (email)** — `src/lib/services/email.service.ts` : throw `RESEND_API_KEY not configured`.
+- **Firebase FCM (push)** — `src/lib/firebase/admin.ts` : throw si `FIREBASE_SERVICE_ACCOUNT_KEY` absent.
+- **Redis revocation** — `src/lib/auth/revocation.ts` : pas de fallback mémoire (skip silencieux), ≠ cache/idempotency qui ont déjà un `memoryFallback`.
+
+Déjà offline-capables (à conserver) : S3→MinIO, Redis cache/idempotency (Map mémoire), ClamAV (skip dev), crypto/JWT (clés locales).
+
+## ✅ Critères d'acceptation
+
+```gherkin
+Scenario: démarrage 100 % offline sans aucun service externe
+  Given docker compose --profile local (PostgreSQL + MinIO) lancé
+  And un profil d'env "mock" (sans clés Resend/Firebase/Upstash)
+  When je lance `pnpm dev`
+  Then aucune route n'échoue en 500 faute de service externe
+  And les emails partent vers un STUB (loggés, jamais envoyés)
+  And les push FCM partent vers un STUB (file mémoire inspectable)
+  And l'upload de document va sur MinIO (consultable + téléchargeable)
+  And l'antivirus est neutralisé (clean=true) hors production
+```
+
+## 🛠️ Implémentation
+- **Profil env** `.env.mock.dev` (gitignoré) : clés Resend/Firebase/Upstash vides → déclenche les fallbacks ; `OVH_S3_*` → MinIO localhost ; clés crypto de dev partagées avec `tests/helpers/setup.ts`.
+- **Stubs** (gate `MOCK_MODE`/env absente, jamais en prod) : `email-stub` (console + messageId mock), `firebase-stub` (file mémoire + `getPushLog()` pour les tests), gate `MOCK_ANTIVIRUS`.
+- **Redis revocation** : aligner sur le `memoryFallback` (cache/idempotency) pour un comportement déterministe offline.
+- **Factory** `getEmailService()/getFirebaseService()` : vrai client si credentials, sinon stub.
+- Doc `docs/local-development.md` : section « mode mocké complet ».
+
+## 🔭 Hors périmètre
+Enrichissement des données de seed par domaine → US-2271…US-2282 (une par domaine QA).
+

--- a/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2271-fixtures-qa-auth.md
+++ b/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2271-fixtures-qa-auth.md
@@ -1,0 +1,51 @@
+# US-2271 — fixtures QA — Authentification (rendre le domaine QA-testable offline)
+
+> Enrichir les données de seed pour que **tous les scénarios Gherkin de
+> `docs/qa/01-auth.md`** soient exécutables hors-ligne contre l'environnement
+> mocké (US-2270), y compris les **états limites** (vides, erreurs, refus RBAC).
+
+## 📊 Métadonnées
+
+| Champ | Valeur |
+|-------|--------|
+| **ID** | `US-2271` |
+| **Domaine** | 24. QA & Environnement de test |
+| **Priorité** | **V1** |
+| **Statut** | 🆕 À démarrer |
+| **Story points** | **3** (Fibonacci) |
+| **Dépendances** | **US-2270** (socle dev mocké) · `prisma/seed.ts` · `docs/qa/01-auth.md` |
+
+---
+
+
+## 📋 Contexte — états manquants au seed actuel
+- compte avec **MFA activée** (secret TOTP de dev documenté)
+- compte **suspendu** (status≠active) et compte **archivé**
+- compte **verrouillé** (état lockout — via helper seed ou Redis mémoire)
+- jeton de reset password valide (+ email via stub US-2270)
+
+## ✅ Critères d'acceptation
+
+```gherkin
+Feature: QA 01-auth exécutable offline
+
+  Scenario: un compte MFA permet de dérouler login→challenge OTP
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: un compte suspendu renvoie 401 générique sans incrément rate-limit
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: tous les scénarios de docs/qa/01-auth.md sont atteignables
+    Given l'env mocké (US-2270) + le seed enrichi de ce domaine
+    Then chaque écran/état décrit dans docs/qa/01-auth.md a une donnée
+         de fixture permettant de le rendre (y compris états vides/erreur)
+```
+
+## 🛠️ Implémentation
+- Ajouts dans `prisma/seed.ts` (ou module `prisma/seed/01-auth.ts` dédié), **déterministes** (PRNG seedé), idempotents (upsert), PII chiffrées comme l'existant.
+- Mettre à jour la ligne « # Effet base » des scénarios concernés dans `docs/qa/01-auth.md` si besoin.
+- Revue `prisma-specialist` (+ `medical-domain-validator` pour les domaines cliniques 07/11).
+
+## 🔭 Hors périmètre
+Stubs de services externes → US-2270. Exécution effective de la campagne → skill `/qa`.
+

--- a/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2272-fixtures-qa-dashboards.md
+++ b/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2272-fixtures-qa-dashboards.md
@@ -1,0 +1,51 @@
+# US-2272 — fixtures QA — Dashboards (médecin/infirmier/admin) (rendre le domaine QA-testable offline)
+
+> Enrichir les données de seed pour que **tous les scénarios Gherkin de
+> `docs/qa/02-dashboards.md`** soient exécutables hors-ligne contre l'environnement
+> mocké (US-2270), y compris les **états limites** (vides, erreurs, refus RBAC).
+
+## 📊 Métadonnées
+
+| Champ | Valeur |
+|-------|--------|
+| **ID** | `US-2272` |
+| **Domaine** | 24. QA & Environnement de test |
+| **Priorité** | **V1** |
+| **Statut** | 🆕 À démarrer |
+| **Story points** | **3** (Fibonacci) |
+| **Dépendances** | **US-2270** (socle dev mocké) · `prisma/seed.ts` · `docs/qa/02-dashboards.md` |
+
+---
+
+
+## 📋 Contexte — états manquants au seed actuel
+- ≥2 **patients à risque** (flags variés) pour la carte « Patients à suivre »
+- **urgences en cours** (EmergencyAlert) pour la carte urgences
+- **propositions en attente** (compteur)
+- données KPI 14j non vides (TIR moyen, actifs, urgences sem)
+
+## ✅ Critères d'acceptation
+
+```gherkin
+Feature: QA 02-dashboards exécutable offline
+
+  Scenario: le dashboard médecin affiche urgences, RDV, patients à suivre et KPI non vides
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: l'état vide de chaque carte est aussi atteignable (patient sans alerte)
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: tous les scénarios de docs/qa/02-dashboards.md sont atteignables
+    Given l'env mocké (US-2270) + le seed enrichi de ce domaine
+    Then chaque écran/état décrit dans docs/qa/02-dashboards.md a une donnée
+         de fixture permettant de le rendre (y compris états vides/erreur)
+```
+
+## 🛠️ Implémentation
+- Ajouts dans `prisma/seed.ts` (ou module `prisma/seed/02-dashboards.ts` dédié), **déterministes** (PRNG seedé), idempotents (upsert), PII chiffrées comme l'existant.
+- Mettre à jour la ligne « # Effet base » des scénarios concernés dans `docs/qa/02-dashboards.md` si besoin.
+- Revue `prisma-specialist` (+ `medical-domain-validator` pour les domaines cliniques 07/11).
+
+## 🔭 Hors périmètre
+Stubs de services externes → US-2270. Exécution effective de la campagne → skill `/qa`.
+

--- a/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2273-fixtures-qa-patients.md
+++ b/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2273-fixtures-qa-patients.md
@@ -1,0 +1,51 @@
+# US-2273 — fixtures QA — Patients (rendre le domaine QA-testable offline)
+
+> Enrichir les données de seed pour que **tous les scénarios Gherkin de
+> `docs/qa/03-patients.md`** soient exécutables hors-ligne contre l'environnement
+> mocké (US-2270), y compris les **états limites** (vides, erreurs, refus RBAC).
+
+## 📊 Métadonnées
+
+| Champ | Valeur |
+|-------|--------|
+| **ID** | `US-2273` |
+| **Domaine** | 24. QA & Environnement de test |
+| **Priorité** | **V1** |
+| **Statut** | 🆕 À démarrer |
+| **Story points** | **2** (Fibonacci) |
+| **Dépendances** | **US-2270** (socle dev mocké) · `prisma/seed.ts` · `docs/qa/03-patients.md` |
+
+---
+
+
+## 📋 Contexte — états manquants au seed actuel
+- 1 patient **sans données médicales**
+- 1 patient **sans paramètres d'insulinothérapie**
+- palette de flags de risque (cardio, pondéral…) variée
+- 1 patient en **soft-delete** (deletedAt) pour vérifier l'exclusion
+
+## ✅ Critères d'acceptation
+
+```gherkin
+Feature: QA 03-patients exécutable offline
+
+  Scenario: la fiche d'un patient sans medical data s'affiche sans erreur (états vides)
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: un patient soft-deleted n'apparaît pas dans la liste
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: tous les scénarios de docs/qa/03-patients.md sont atteignables
+    Given l'env mocké (US-2270) + le seed enrichi de ce domaine
+    Then chaque écran/état décrit dans docs/qa/03-patients.md a une donnée
+         de fixture permettant de le rendre (y compris états vides/erreur)
+```
+
+## 🛠️ Implémentation
+- Ajouts dans `prisma/seed.ts` (ou module `prisma/seed/03-patients.ts` dédié), **déterministes** (PRNG seedé), idempotents (upsert), PII chiffrées comme l'existant.
+- Mettre à jour la ligne « # Effet base » des scénarios concernés dans `docs/qa/03-patients.md` si besoin.
+- Revue `prisma-specialist` (+ `medical-domain-validator` pour les domaines cliniques 07/11).
+
+## 🔭 Hors périmètre
+Stubs de services externes → US-2270. Exécution effective de la campagne → skill `/qa`.
+

--- a/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2274-fixtures-qa-appointments.md
+++ b/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2274-fixtures-qa-appointments.md
@@ -1,0 +1,51 @@
+# US-2274 — fixtures QA — Rendez-vous (rendre le domaine QA-testable offline)
+
+> Enrichir les données de seed pour que **tous les scénarios Gherkin de
+> `docs/qa/04-appointments.md`** soient exécutables hors-ligne contre l'environnement
+> mocké (US-2270), y compris les **états limites** (vides, erreurs, refus RBAC).
+
+## 📊 Métadonnées
+
+| Champ | Valeur |
+|-------|--------|
+| **ID** | `US-2274` |
+| **Domaine** | 24. QA & Environnement de test |
+| **Priorité** | **V1** |
+| **Statut** | 🆕 À démarrer |
+| **Story points** | **3** (Fibonacci) |
+| **Dépendances** | **US-2270** (socle dev mocké) · `prisma/seed.ts` · `docs/qa/04-appointments.md` |
+
+---
+
+
+## 📋 Contexte — états manquants au seed actuel
+- RDV de **chaque statut** (completed/no_show/scheduled/pending_validation/confirmed/cancelled) AVEC `motifEncrypted`
+- RDV **sans motif** (test affichage vide)
+- **conflit** (double-booking) + précédence d'une indisponibilité membre
+- 1 membre **sans aucun RDV** (liste vide)
+
+## ✅ Critères d'acceptation
+
+```gherkin
+Feature: QA 04-appointments exécutable offline
+
+  Scenario: le modal détail RDV affiche le motif déchiffré quand présent
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: un créneau en conflit est signalé
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: tous les scénarios de docs/qa/04-appointments.md sont atteignables
+    Given l'env mocké (US-2270) + le seed enrichi de ce domaine
+    Then chaque écran/état décrit dans docs/qa/04-appointments.md a une donnée
+         de fixture permettant de le rendre (y compris états vides/erreur)
+```
+
+## 🛠️ Implémentation
+- Ajouts dans `prisma/seed.ts` (ou module `prisma/seed/04-appointments.ts` dédié), **déterministes** (PRNG seedé), idempotents (upsert), PII chiffrées comme l'existant.
+- Mettre à jour la ligne « # Effet base » des scénarios concernés dans `docs/qa/04-appointments.md` si besoin.
+- Revue `prisma-specialist` (+ `medical-domain-validator` pour les domaines cliniques 07/11).
+
+## 🔭 Hors périmètre
+Stubs de services externes → US-2270. Exécution effective de la campagne → skill `/qa`.
+

--- a/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2275-fixtures-qa-settings.md
+++ b/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2275-fixtures-qa-settings.md
@@ -1,0 +1,51 @@
+# US-2275 — fixtures QA — Paramètres (rendre le domaine QA-testable offline)
+
+> Enrichir les données de seed pour que **tous les scénarios Gherkin de
+> `docs/qa/05-settings.md`** soient exécutables hors-ligne contre l'environnement
+> mocké (US-2270), y compris les **états limites** (vides, erreurs, refus RBAC).
+
+## 📊 Métadonnées
+
+| Champ | Valeur |
+|-------|--------|
+| **ID** | `US-2275` |
+| **Domaine** | 24. QA & Environnement de test |
+| **Priorité** | **V1** |
+| **Statut** | 🆕 À démarrer |
+| **Story points** | **2** (Fibonacci) |
+| **Dépendances** | **US-2270** (socle dev mocké) · `prisma/seed.ts` · `docs/qa/05-settings.md` |
+
+---
+
+
+## 📋 Contexte — états manquants au seed actuel
+- états de **consentement RGPD** (opt-in / opt-out explicite)
+- préférences de **langue** (fr/en/ar) + préférence ≠ cookie (alerte réconciliation)
+- préférences d'**unités** et de **notifications** variées
+- liste d'appareils **MFA** (si MFA activée, cf. US-2271)
+
+## ✅ Critères d'acceptation
+
+```gherkin
+Feature: QA 05-settings exécutable offline
+
+  Scenario: un opt-out RGPD est reflété dans les écrans concernés
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: changer la langue persiste la préférence (User.language)
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: tous les scénarios de docs/qa/05-settings.md sont atteignables
+    Given l'env mocké (US-2270) + le seed enrichi de ce domaine
+    Then chaque écran/état décrit dans docs/qa/05-settings.md a une donnée
+         de fixture permettant de le rendre (y compris états vides/erreur)
+```
+
+## 🛠️ Implémentation
+- Ajouts dans `prisma/seed.ts` (ou module `prisma/seed/05-settings.ts` dédié), **déterministes** (PRNG seedé), idempotents (upsert), PII chiffrées comme l'existant.
+- Mettre à jour la ligne « # Effet base » des scénarios concernés dans `docs/qa/05-settings.md` si besoin.
+- Revue `prisma-specialist` (+ `medical-domain-validator` pour les domaines cliniques 07/11).
+
+## 🔭 Hors périmètre
+Stubs de services externes → US-2270. Exécution effective de la campagne → skill `/qa`.
+

--- a/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2276-fixtures-qa-admin.md
+++ b/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2276-fixtures-qa-admin.md
@@ -1,0 +1,51 @@
+# US-2276 — fixtures QA — Admin (users, délégations) (rendre le domaine QA-testable offline)
+
+> Enrichir les données de seed pour que **tous les scénarios Gherkin de
+> `docs/qa/06-admin.md`** soient exécutables hors-ligne contre l'environnement
+> mocké (US-2270), y compris les **états limites** (vides, erreurs, refus RBAC).
+
+## 📊 Métadonnées
+
+| Champ | Valeur |
+|-------|--------|
+| **ID** | `US-2276` |
+| **Domaine** | 24. QA & Environnement de test |
+| **Priorité** | **V1** |
+| **Statut** | 🆕 À démarrer |
+| **Story points** | **3** (Fibonacci) |
+| **Dépendances** | **US-2270** (socle dev mocké) · `prisma/seed.ts` · `docs/qa/06-admin.md` |
+
+---
+
+
+## 📋 Contexte — états manquants au seed actuel
+- utilisateurs **suspendu/archivé** + multi-rôles
+- **demande de délégation** (pending → approved/rejected)
+- enregistrement de **violation de données** (data breach, US-2137)
+- règles **fiscales** par pays (US-2114) non vides
+
+## ✅ Critères d'acceptation
+
+```gherkin
+Feature: QA 06-admin exécutable offline
+
+  Scenario: un admin suspend/réactive un utilisateur (effet base + audit)
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: une délégation pending peut être approuvée
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: tous les scénarios de docs/qa/06-admin.md sont atteignables
+    Given l'env mocké (US-2270) + le seed enrichi de ce domaine
+    Then chaque écran/état décrit dans docs/qa/06-admin.md a une donnée
+         de fixture permettant de le rendre (y compris états vides/erreur)
+```
+
+## 🛠️ Implémentation
+- Ajouts dans `prisma/seed.ts` (ou module `prisma/seed/06-admin.ts` dédié), **déterministes** (PRNG seedé), idempotents (upsert), PII chiffrées comme l'existant.
+- Mettre à jour la ligne « # Effet base » des scénarios concernés dans `docs/qa/06-admin.md` si besoin.
+- Revue `prisma-specialist` (+ `medical-domain-validator` pour les domaines cliniques 07/11).
+
+## 🔭 Hors périmètre
+Stubs de services externes → US-2270. Exécution effective de la campagne → skill `/qa`.
+

--- a/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2277-fixtures-qa-analytics.md
+++ b/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2277-fixtures-qa-analytics.md
@@ -1,0 +1,51 @@
+# US-2277 — fixtures QA — Analytics / reporting (rendre le domaine QA-testable offline)
+
+> Enrichir les données de seed pour que **tous les scénarios Gherkin de
+> `docs/qa/07-analytics.md`** soient exécutables hors-ligne contre l'environnement
+> mocké (US-2270), y compris les **états limites** (vides, erreurs, refus RBAC).
+
+## 📊 Métadonnées
+
+| Champ | Valeur |
+|-------|--------|
+| **ID** | `US-2277` |
+| **Domaine** | 24. QA & Environnement de test |
+| **Priorité** | **V1** |
+| **Statut** | 🆕 À démarrer |
+| **Story points** | **3** (Fibonacci) |
+| **Dépendances** | **US-2270** (socle dev mocké) · `prisma/seed.ts` · `docs/qa/07-analytics.md` |
+
+---
+
+
+## 📋 Contexte — états manquants au seed actuel
+- CGM sur **plusieurs patients** (DT1/DT2/GD), pas un seul
+- 1 patient avec **données insuffisantes** (< 7j → état « insufficientData »)
+- période de **comparaison** (2 fenêtres) pour le compare
+- cohorte population (tableau de bord population US-2094)
+
+## ✅ Critères d'acceptation
+
+```gherkin
+Feature: QA 07-analytics exécutable offline
+
+  Scenario: le profil glycémique affiche AGP/TIR/hypos sur ≥3 patients
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: un patient < 70 % de capture déclenche l'état données insuffisantes
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: tous les scénarios de docs/qa/07-analytics.md sont atteignables
+    Given l'env mocké (US-2270) + le seed enrichi de ce domaine
+    Then chaque écran/état décrit dans docs/qa/07-analytics.md a une donnée
+         de fixture permettant de le rendre (y compris états vides/erreur)
+```
+
+## 🛠️ Implémentation
+- Ajouts dans `prisma/seed.ts` (ou module `prisma/seed/07-analytics.ts` dédié), **déterministes** (PRNG seedé), idempotents (upsert), PII chiffrées comme l'existant.
+- Mettre à jour la ligne « # Effet base » des scénarios concernés dans `docs/qa/07-analytics.md` si besoin.
+- Revue `prisma-specialist` (+ `medical-domain-validator` pour les domaines cliniques 07/11).
+
+## 🔭 Hors périmètre
+Stubs de services externes → US-2270. Exécution effective de la campagne → skill `/qa`.
+

--- a/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2278-fixtures-qa-admin-ops.md
+++ b/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2278-fixtures-qa-admin-ops.md
@@ -1,0 +1,51 @@
+# US-2278 — fixtures QA — Admin Ops (backups, santé, cron) (rendre le domaine QA-testable offline)
+
+> Enrichir les données de seed pour que **tous les scénarios Gherkin de
+> `docs/qa/08-admin-ops.md`** soient exécutables hors-ligne contre l'environnement
+> mocké (US-2270), y compris les **états limites** (vides, erreurs, refus RBAC).
+
+## 📊 Métadonnées
+
+| Champ | Valeur |
+|-------|--------|
+| **ID** | `US-2278` |
+| **Domaine** | 24. QA & Environnement de test |
+| **Priorité** | **V1** |
+| **Statut** | 🆕 À démarrer |
+| **Story points** | **3** (Fibonacci) |
+| **Dépendances** | **US-2270** (socle dev mocké) · `prisma/seed.ts` · `docs/qa/08-admin-ops.md` |
+
+---
+
+
+## 📋 Contexte — états manquants au seed actuel
+- **backups** dans chaque état (pending/running/completed/failed)
+- probes **system-health** (Redis/DB/S3 ok/down — exploiter pingRedis)
+- historique de **jobs cron** (rappels, relances)
+- événements d'**audit** variés (LOGIN, UNAUTHORIZED, READ, EXPORT…)
+
+## ✅ Critères d'acceptation
+
+```gherkin
+Feature: QA 08-admin-ops exécutable offline
+
+  Scenario: la liste des backups affiche les différents statuts
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: le dashboard system-health distingue service ok vs down
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: tous les scénarios de docs/qa/08-admin-ops.md sont atteignables
+    Given l'env mocké (US-2270) + le seed enrichi de ce domaine
+    Then chaque écran/état décrit dans docs/qa/08-admin-ops.md a une donnée
+         de fixture permettant de le rendre (y compris états vides/erreur)
+```
+
+## 🛠️ Implémentation
+- Ajouts dans `prisma/seed.ts` (ou module `prisma/seed/08-admin-ops.ts` dédié), **déterministes** (PRNG seedé), idempotents (upsert), PII chiffrées comme l'existant.
+- Mettre à jour la ligne « # Effet base » des scénarios concernés dans `docs/qa/08-admin-ops.md` si besoin.
+- Revue `prisma-specialist` (+ `medical-domain-validator` pour les domaines cliniques 07/11).
+
+## 🔭 Hors périmètre
+Stubs de services externes → US-2270. Exécution effective de la campagne → skill `/qa`.
+

--- a/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2279-fixtures-qa-compliance-billing.md
+++ b/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2279-fixtures-qa-compliance-billing.md
@@ -1,0 +1,51 @@
+# US-2279 — fixtures QA — Conformité & Facturation (rendre le domaine QA-testable offline)
+
+> Enrichir les données de seed pour que **tous les scénarios Gherkin de
+> `docs/qa/09-compliance-billing.md`** soient exécutables hors-ligne contre l'environnement
+> mocké (US-2270), y compris les **états limites** (vides, erreurs, refus RBAC).
+
+## 📊 Métadonnées
+
+| Champ | Valeur |
+|-------|--------|
+| **ID** | `US-2279` |
+| **Domaine** | 24. QA & Environnement de test |
+| **Priorité** | **V1** |
+| **Statut** | 🆕 À démarrer |
+| **Story points** | **3** (Fibonacci) |
+| **Dépendances** | **US-2270** (socle dev mocké) · `prisma/seed.ts` · `docs/qa/09-compliance-billing.md` |
+
+---
+
+
+## 📋 Contexte — états manquants au seed actuel
+- **factures** dans tout le cycle (draft/issued/paid/overdue)
+- **relances** de facture (cron J+7/15/30, email via stub US-2270)
+- **règles fiscales** par pays + devises (EUR/DZD)
+- export RGPD (Art. 20) + notification de violation (Art. 33)
+
+## ✅ Critères d'acceptation
+
+```gherkin
+Feature: QA 09-compliance-billing exécutable offline
+
+  Scenario: une facture overdue déclenche une relance (email stub loggé)
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: l'export RGPD d'un patient produit l'archive attendue
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: tous les scénarios de docs/qa/09-compliance-billing.md sont atteignables
+    Given l'env mocké (US-2270) + le seed enrichi de ce domaine
+    Then chaque écran/état décrit dans docs/qa/09-compliance-billing.md a une donnée
+         de fixture permettant de le rendre (y compris états vides/erreur)
+```
+
+## 🛠️ Implémentation
+- Ajouts dans `prisma/seed.ts` (ou module `prisma/seed/09-compliance-billing.ts` dédié), **déterministes** (PRNG seedé), idempotents (upsert), PII chiffrées comme l'existant.
+- Mettre à jour la ligne « # Effet base » des scénarios concernés dans `docs/qa/09-compliance-billing.md` si besoin.
+- Revue `prisma-specialist` (+ `medical-domain-validator` pour les domaines cliniques 07/11).
+
+## 🔭 Hors périmètre
+Stubs de services externes → US-2270. Exécution effective de la campagne → skill `/qa`.
+

--- a/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2280-fixtures-qa-devices-documents-events.md
+++ b/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2280-fixtures-qa-devices-documents-events.md
@@ -1,0 +1,51 @@
+# US-2280 — fixtures QA — Appareils, documents, événements (rendre le domaine QA-testable offline)
+
+> Enrichir les données de seed pour que **tous les scénarios Gherkin de
+> `docs/qa/10-devices-documents-events.md`** soient exécutables hors-ligne contre l'environnement
+> mocké (US-2270), y compris les **états limites** (vides, erreurs, refus RBAC).
+
+## 📊 Métadonnées
+
+| Champ | Valeur |
+|-------|--------|
+| **ID** | `US-2280` |
+| **Domaine** | 24. QA & Environnement de test |
+| **Priorité** | **V1** |
+| **Statut** | 🆕 À démarrer |
+| **Story points** | **5** (Fibonacci) |
+| **Dépendances** | **US-2270** (socle dev mocké) · `prisma/seed.ts` · `docs/qa/10-devices-documents-events.md` |
+
+---
+
+
+## 📋 Contexte — états manquants au seed actuel
+- **documents** : upload (MinIO) → scan antivirus (stub) → téléchargement → suppression
+- appareils : **appairage** (QR/token) + appareil **révoqué**
+- **événements diabète** (DiabetesEvent multi-types : repas, activité, insuline…)
+- résultat antivirus **infecté** simulé (test du rejet)
+
+## ✅ Critères d'acceptation
+
+```gherkin
+Feature: QA 10-devices-documents-events exécutable offline
+
+  Scenario: un document uploadé est scanné (stub clean) puis téléchargeable
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: un appareil révoqué n'accepte plus de sync
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: tous les scénarios de docs/qa/10-devices-documents-events.md sont atteignables
+    Given l'env mocké (US-2270) + le seed enrichi de ce domaine
+    Then chaque écran/état décrit dans docs/qa/10-devices-documents-events.md a une donnée
+         de fixture permettant de le rendre (y compris états vides/erreur)
+```
+
+## 🛠️ Implémentation
+- Ajouts dans `prisma/seed.ts` (ou module `prisma/seed/10-devices-documents-events.ts` dédié), **déterministes** (PRNG seedé), idempotents (upsert), PII chiffrées comme l'existant.
+- Mettre à jour la ligne « # Effet base » des scénarios concernés dans `docs/qa/10-devices-documents-events.md` si besoin.
+- Revue `prisma-specialist` (+ `medical-domain-validator` pour les domaines cliniques 07/11).
+
+## 🔭 Hors périmètre
+Stubs de services externes → US-2270. Exécution effective de la campagne → skill `/qa`.
+

--- a/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2281-fixtures-qa-clinical.md
+++ b/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2281-fixtures-qa-clinical.md
@@ -1,0 +1,51 @@
+# US-2281 — fixtures QA — Clinique (propositions, bolus) (rendre le domaine QA-testable offline)
+
+> Enrichir les données de seed pour que **tous les scénarios Gherkin de
+> `docs/qa/11-clinical.md`** soient exécutables hors-ligne contre l'environnement
+> mocké (US-2270), y compris les **états limites** (vides, erreurs, refus RBAC).
+
+## 📊 Métadonnées
+
+| Champ | Valeur |
+|-------|--------|
+| **ID** | `US-2281` |
+| **Domaine** | 24. QA & Environnement de test |
+| **Priorité** | **V1** |
+| **Statut** | 🆕 À démarrer |
+| **Story points** | **5** (Fibonacci) |
+| **Dépendances** | **US-2270** (socle dev mocké) · `prisma/seed.ts` · `docs/qa/11-clinical.md` |
+
+---
+
+
+## 📋 Contexte — états manquants au seed actuel
+- **propositions d'ajustement** dans chaque statut (pending/accepted/rejected/expired)
+- **BolusCalculationLog** (immutable) + warnings cliniques
+- liste de **médicaments** / traitements variés
+- règles d'**alerte clinique** déclenchées (hypo/hyper/cétones)
+
+## ✅ Critères d'acceptation
+
+```gherkin
+Feature: QA 11-clinical exécutable offline
+
+  Scenario: une proposition pending peut être acceptée par un DOCTOR (jamais auto-appliquée)
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: un calcul de bolus produit un log immuable + propose un AdjustmentProposal
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: tous les scénarios de docs/qa/11-clinical.md sont atteignables
+    Given l'env mocké (US-2270) + le seed enrichi de ce domaine
+    Then chaque écran/état décrit dans docs/qa/11-clinical.md a une donnée
+         de fixture permettant de le rendre (y compris états vides/erreur)
+```
+
+## 🛠️ Implémentation
+- Ajouts dans `prisma/seed.ts` (ou module `prisma/seed/11-clinical.ts` dédié), **déterministes** (PRNG seedé), idempotents (upsert), PII chiffrées comme l'existant.
+- Mettre à jour la ligne « # Effet base » des scénarios concernés dans `docs/qa/11-clinical.md` si besoin.
+- Revue `prisma-specialist` (+ `medical-domain-validator` pour les domaines cliniques 07/11).
+
+## 🔭 Hors périmètre
+Stubs de services externes → US-2270. Exécution effective de la campagne → skill `/qa`.
+

--- a/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2282-fixtures-qa-communication.md
+++ b/docs/UserStory/pro-user-stories/24-qa-test-environment/US-2282-fixtures-qa-communication.md
@@ -1,0 +1,51 @@
+# US-2282 — fixtures QA — Communication (messagerie, push, annonces) (rendre le domaine QA-testable offline)
+
+> Enrichir les données de seed pour que **tous les scénarios Gherkin de
+> `docs/qa/12-communication.md`** soient exécutables hors-ligne contre l'environnement
+> mocké (US-2270), y compris les **états limites** (vides, erreurs, refus RBAC).
+
+## 📊 Métadonnées
+
+| Champ | Valeur |
+|-------|--------|
+| **ID** | `US-2282` |
+| **Domaine** | 24. QA & Environnement de test |
+| **Priorité** | **V1** |
+| **Statut** | 🆕 À démarrer |
+| **Story points** | **3** (Fibonacci) |
+| **Dépendances** | **US-2270** (socle dev mocké) · `prisma/seed.ts` · `docs/qa/12-communication.md` |
+
+---
+
+
+## 📋 Contexte — états manquants au seed actuel
+- **notifications push** (FCM stub US-2270) dans chaque état (envoyé/échec/lu)
+- messages avec **statut de livraison**, fils archivés, recherche
+- **annonces** (Announcement) actives/expirées
+- templates de notification (rappels RDV, alertes)
+
+## ✅ Critères d'acceptation
+
+```gherkin
+Feature: QA 12-communication exécutable offline
+
+  Scenario: l'envoi d'un push est capturé par le stub (getPushLog) sans Firebase réel
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: un fil de messages affiche le compteur non-lu correct
+    # exercé hors-ligne contre l'env mocké (US-2270)
+
+  Scenario: tous les scénarios de docs/qa/12-communication.md sont atteignables
+    Given l'env mocké (US-2270) + le seed enrichi de ce domaine
+    Then chaque écran/état décrit dans docs/qa/12-communication.md a une donnée
+         de fixture permettant de le rendre (y compris états vides/erreur)
+```
+
+## 🛠️ Implémentation
+- Ajouts dans `prisma/seed.ts` (ou module `prisma/seed/12-communication.ts` dédié), **déterministes** (PRNG seedé), idempotents (upsert), PII chiffrées comme l'existant.
+- Mettre à jour la ligne « # Effet base » des scénarios concernés dans `docs/qa/12-communication.md` si besoin.
+- Revue `prisma-specialist` (+ `medical-domain-validator` pour les domaines cliniques 07/11).
+
+## 🔭 Hors périmètre
+Stubs de services externes → US-2270. Exécution effective de la campagne → skill `/qa`.
+


### PR DESCRIPTION
Réponse à « peut-on construire des mocks complets pour le dev afin de pousser la QA ? » → **oui**, et voici le backlog structuré.

## Contenu
Nouveau domaine **24 — QA & Environnement de test** (`docs/UserStory/pro-user-stories/24-qa-test-environment/`, [README](docs/UserStory/pro-user-stories/24-qa-test-environment/README.md)) : **13 US, 41 SP**.

### Socle (prérequis)
- **US-2270** — env mocké : stubs **email/firebase/antivirus** + **redis revocation fallback** + profil `.env.mock.dev` → l'app tourne **100 % offline** (aujourd'hui ces 3 services *throw* sans credentials ; le reste — MinIO/S3, Redis cache/idempotency, ClamAV skip, crypto locale — est déjà offline).

### Fixtures par domaine (US-2271 → US-2282)
Une US par domaine QA, listant les **états manquants au seed actuel** et exigeant que **tous les scénarios de `docs/qa/NN-*.md`** soient exécutables offline (nominal + vides + erreurs + refus RBAC). Trous majeurs comblés : propositions d'ajustement (clinical), factures (billing), backups (admin-ops), documents/appairage (devices), MFA/suspendu/archivé (auth), données insuffisantes (analytics)…

## Ordre conseillé
1. US-2270 (débloque l'offline).
2. Domaines aujourd'hui **vides** au seed (impact QA max) : clinical, billing, admin-ops, devices/docs.
3. Domaines partiels.
4. Campagne via `/qa` (interactif) ou Playwright BDD (headless).

## Principes (rappelés dans chaque US)
Déterministe (PRNG seedé, idempotent) · offline · PII chiffrées même en fixtures (secrets `DEV-ONLY`, jamais en prod) · couverture des états vides/erreur.

Docs-only. Aucune implémentation ici — c'est le backlog ; chaque US sera ensuite déroulée par PR (socle puis domaines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)