### PR TITLE
docs(qa): settings — langue 🟢 + scénarios persistance round-trip

### DIFF
--- a/docs/qa/03-patients.md
+++ b/docs/qa/03-patients.md
@@ -36,7 +36,7 @@ via `PatientService → HealthcareService`. Patients soft-deleted exclus.
 |---|---|---|---|
 | Recherche par nom | (demo : filtre client) · réel : `GET /api/patients/search?search=…` | liste filtrée | **lecture** · audit READ (`resourceId:"search"`) · `Cache-Control: no-store` · match **HMAC exact** sur `firstnameHmac`/`lastnameHmac` |
 | Filtre pathologie | (demo : filtre client) | bouton actif + liste filtrée | aucun |
-| Clic ligne | — | `/patients/{id}` | (déclenche le détail) |
+| Clic ligne (ou Entrée/Espace) | `POST /api/consultation/open` | **ouvre le workspace de consultation en overlay** (US-2018b) ; **aucune navigation**, l'URL reste `/patients` | INSERT jeton éphémère Redis + audit READ/PATIENT (`metadata.patientId`) — voir section « Consultation patient » ci-dessous |
 | Clic « Ajouter patient » | — | `/patients/new` | aucun |
 
 ### Scénarios (Gherkin)
@@ -78,6 +78,81 @@ Feature: Liste des patients
 
 ---
 
+## Écran : Consultation patient — overlay éphémère (`/patients` → overlay) 🟢
+
+**Rôle / RBAC** : NURSE+ (DOCTOR/NURSE/ADMIN). VIEWER n'y accède jamais (il n'a
+pas la liste pro). **Statut impl.** : 🟢 Réel ([US-2018b](../UserStory/pro-user-stories/02-patients/US-2018b-consultation-patient-overlay-ephemere.md), PR #523).
+
+> Depuis la liste, un clic ouvre un **workspace patient en overlay** (drawer,
+> extensible plein écran) avec une **référence patient éphémère** : aucun id
+> patient dans l'URL (reste `/patients`), jeton serveur `cTok` (en-tête
+> `x-consultation-token`) **non partageable**, détruit à la fermeture.
+
+### Affichage attendu
+
+| Élément | État attendu |
+|---|---|
+| Drawer | panneau latéral (bouton **Agrandir** → plein écran) ; sidebar + header **grisés/inertes** dessous |
+| Bandeau éphémère | « Consultation éphémère — référence détruite à la fermeture » (texte coral lisible) |
+| En-tête patient | initiales (décoratives) + nom + pathologie · `role="dialog"` `aria-modal` |
+| Onglets (horizontaux) | Vue d'ensemble · Profil glycémique · Glycémie · Traitements · Documents (clavier ←/→/Home/End) |
+| Boutons | Agrandir/Réduire · Fermer (✕) |
+| URL | reste `/patients` (aucun id patient) |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Ouvrir (clic ligne) | `POST /api/consultation/open` `{patientRef}` (publicRef UUID) | drawer s'ouvre, sidebar inerte | jeton `cTok` (Redis, TTL 15 min glissant, plafond 60 min, lié à {user,patient}) · audit READ/PATIENT (`metadata.patientId, kind=consultation.open`) |
+| Charger un onglet | `GET /api/{patient,analytics/*,cgm,patient/insulin-settings,documents}` **en-tête `x-consultation-token`** | données réelles du patient | lecture santé auditée · **id patient jamais dans l'URL** (résolu serveur via jeton) |
+| Agrandir / Réduire | — (client) | drawer ↔ plein écran | aucun |
+| Fermer (✕ / clic dehors / Échap) | `POST /api/consultation/close` | overlay disparaît, focus rendu à la ligne | jeton **détruit** (non rejouable) ; sidebar réactivée |
+
+### Scénarios (Gherkin)
+
+```gherkin
+Feature: Consultation patient en overlay éphémère
+
+  Scenario: ouvrir un patient depuis la liste
+    Given je suis connecté en tant que "DOCTOR" sur "/patients"
+    When je clique une ligne patient
+    Then un overlay s'ouvre avec les onglets du dossier
+    And l'URL reste "/patients" (aucun id patient)
+    # Effet base: POST /api/consultation/open → cTok (Redis) + audit READ/PATIENT(metadata.patientId)
+
+  Scenario: la consultation n'est pas partageable par URL
+    Given une consultation ouverte
+    When je copie l'URL de la page
+    Then l'URL est "/patients" et ne mène à aucun patient
+
+  Scenario: F5 referme la consultation (référence éphémère)
+    Given une consultation ouverte
+    When je rafraîchis la page
+    Then je reviens à la liste "/patients" (overlay fermé)
+    # Effet base: cTok détruit (sendBeacon /api/consultation/close) ou expiré (TTL) — non rejouable
+
+  Scenario: les 5 onglets chargent les vraies données via le jeton
+    Given une consultation ouverte
+    When j'ouvre l'onglet "Profil glycémique"
+    Then les métriques (moyenne/GMI/TIR/hypos) s'affichent
+    # Effet base: GET /api/analytics/* avec en-tête x-consultation-token (pas de ?patientId dans l'URL)
+
+  Scenario: un VIEWER n'accède jamais à la consultation pro
+    Given je suis connecté en tant que "VIEWER"
+    When je vais sur "/patients"
+    Then je suis redirigé vers "/patient/dashboard" (pas de liste, pas d'overlay)
+```
+
+### Cas limites
+
+- **Jeton lié à l'utilisateur** : un `cTok` présenté par un autre utilisateur est refusé (anti-partage) ; fermer le jeton d'autrui est un no-op (pas de DoS inter-utilisateur).
+- **Single-active** : ouvrir un 2e patient invalide le jeton du 1er.
+- **Jeton expiré** (TTL glissant 15 min dépassé, ou plafond absolu 60 min) → l'onglet affiche l'état d'erreur ; rouvrir le patient.
+- **Patient hors portefeuille** : `open` renvoie 404 neutre (même réponse qu'un patient inexistant — anti-énumération).
+- **Conversion glycémie** : `valueGl` (g/L) → mg/dL via `glToMgdl` (× 100), jamais × 18.
+
+---
+
 ## Écran : Détail patient (`/patients/[id]`) 🟡
 
 **Rôle / RBAC** : NURSE+ avec `canAccessPatient(user, role, patientId)`. 403
@@ -85,6 +160,11 @@ Feature: Liste des patients
 `invalidPatientId` si non numérique.
 **Statut impl.** : 🟡 DEMO_DATA pour l'affichage · 🟢 `GET /api/patients/[id]`,
 `PUT/PATCH /api/patient/objectives` réels.
+
+> ℹ️ Depuis [US-2018b](../UserStory/pro-user-stories/02-patients/US-2018b-consultation-patient-overlay-ephemere.md) (PR #523), le **clic depuis la liste**
+> n'ouvre plus cette page mais le **workspace de consultation en overlay**
+> (section ci-dessus). Cette page reste accessible par URL directe (fallback,
+> encore en données démo pour certains onglets) — chemin secondaire.
 
 ### Affichage attendu
 

--- a/docs/qa/05-settings.md
+++ b/docs/qa/05-settings.md
@@ -45,6 +45,7 @@ PS = sous-ensemble. Le rôle est lu côté serveur (`x-user-role`) ; fail-closed
 | Modifier moments | `PUT /api/account/day-moments` | toast | UPSERT `user_day_moments` (par type) |
 | Modifier notifications | `PUT /api/account/notifications` | toggles + toast | UPSERT `user_notification_preferences` · audit |
 | Modifier confidentialité | `PUT /api/account/privacy` | toggles + toast | UPSERT `user_privacy_settings` (gdprConsent → `consentDate` auto) · **invalide le cache de consentement** · audit |
+| Changer la langue | `PUT /api/account/locale` | reload localisé (RTL si AR) | UPDATE `users.language` + cookie `diabeo_locale` · audit UPDATE/USER (`metadata.setting=locale`, sans PHI) — voir section Langue 🟢 |
 | Gérer sessions | `GET /api/account/sessions` · `DELETE /api/account/sessions/[id]` | session retirée de la liste | DELETE `sessions` (révocation) |
 | Exporter (RGPD Art. 20) | `GET /api/account/export` | spinner → téléchargement | lecture agrégée · audit EXPORT · **rate-limit 3/h/user** |
 
@@ -92,6 +93,46 @@ Feature: Paramètres du compte
     When je clique "Déconnecter" sur l'autre session
     Then elle disparaît de la liste
     # Effet base: DELETE sessions WHERE id = {sessionId}
+
+  # ── Persistance round-trip : modifié → enregistré en base → relu au rechargement ──
+  # Garde-fou anti-régression : chaque champ éditable doit survivre à un reload
+  # (la valeur est rechargée depuis la base via les GET /api/account/*), pas
+  # seulement affichée en mémoire après le save.
+
+  Scenario: unités — la valeur modifiée est persistée et relue après rechargement
+    Given je suis connecté en tant que "VIEWER" sur "/settings" section "Unités"
+    When je change l'unité de glycémie en "mmol/L" et j'enregistre
+    Then je vois "✓ Enregistré"
+    When je recharge "/settings"
+    Then la section "Unités" affiche "mmol/L"
+    # Effet base: UPSERT user_unit_preferences(glycemia='mmol/L') ; valeur relue via GET /api/account/units
+
+  Scenario: notifications — un toggle modifié est persisté après rechargement
+    Given je suis sur "/settings" section "Notifications"
+    When je désactive "Rappels de rendez-vous" et j'enregistre
+    When je recharge "/settings"
+    Then le toggle "Rappels de rendez-vous" est toujours désactivé
+    # Effet base: UPSERT user_notification_preferences ; relu via GET /api/account/notifications
+
+  Scenario: contact — le téléphone modifié est persisté (chiffré) et relu
+    Given je suis sur "/settings" section "Contact"
+    When je modifie le téléphone en "+33611223344" et j'enregistre
+    When je recharge "/settings"
+    Then le champ téléphone affiche "+33611223344"
+    # Effet base: UPDATE users(phone chiffré AES-256-GCM) ; déchiffré à la lecture (GET /api/account)
+
+  Scenario: moments de la journée — l'horaire modifié est persisté
+    Given je suis connecté en tant que "VIEWER" sur "/settings" section "Moments de la journée"
+    When je change l'heure du "matin" et j'enregistre
+    When je recharge "/settings"
+    Then l'heure du "matin" reflète la nouvelle valeur
+    # Effet base: UPSERT user_day_moments(type='morning', startTime=...) ; relu via GET /api/account/day-moments
+
+  Scenario: champs obligatoires — un prénom vidé est refusé (pas d'écriture)
+    Given je suis sur "/settings" section "Informations personnelles"
+    When je vide le prénom et je clique "Enregistrer"
+    Then je vois une erreur de validation et rien n'est enregistré
+    # Effet base: AUCUNE (Zod rejette → 400, pas d'UPDATE users)
 ```
 
 ### Cas limites
@@ -106,29 +147,31 @@ Feature: Paramètres du compte
 
 ---
 
-## 🔵 Planifié — Préférence de langue ([US-2112b](../UserStory/pro-user-stories/13-multi-pays-i18n/US-2112b-preference-langue-utilisateur.md), V1 — à implémenter)
+## 🟢 Réel — Préférence de langue ([US-2112b](../UserStory/pro-user-stories/13-multi-pays-i18n/US-2112b-preference-langue-utilisateur.md) PR #513 · [US-2112c](../UserStory/pro-user-stories/13-multi-pays-i18n/US-2112c-i18n-dashboard-medecin.md))
 
-> **Non encore implémenté.** Spécification de test du follow-up US-2112b.
-> Aujourd'hui : le moteur i18n (US-2112) existe mais le `LocaleSwitcher` n'est
-> exposé sur aucun écran de l'app vivante, et la langue n'est **pas** persistée
-> en base (colonne `User.language` présente mais non câblée). AC-2 ci-dessous.
+> **Implémenté.** La section « Langue » de `/settings` (tous rôles) expose le
+> `LocaleSwitcher` FR/EN/AR. Le choix est **persisté en base** (`User.language`)
+> **et** pose le cookie `diabeo_locale` (PUT renvoie `{locale, persisted}`). Un
+> écart langue active (cookie) vs préférence enregistrée au login déclenche une
+> **bannière de réconciliation** (AC-3, montée dans `NavigationShell`).
 
-### Affichage attendu (cible)
+### Affichage attendu
 
 | Section | Visibilité | Contenu |
 |---|---|---|
 | **Langue** | tous | Sélecteur FR / EN / AR (valeur courante = `User.language`, défaut `fr`) · application immédiate (reload) · `dir="rtl"` pour AR |
 
-### Actions & effets (cible)
+### Actions & effets
 
 | Action | Endpoint | Effet visuel | Effet base |
 |---|---|---|---|
-| Changer la langue | `PUT /api/account/locale` (étendu) | reload localisé + toast | **UPDATE `users.language`** + cookie `diabeo_locale` synchronisé · audit UPDATE/USER (`metadata.setting=locale`, sans PHI) |
+| Changer la langue (Settings) | `PUT /api/account/locale` | reload localisé (RTL si AR) | **UPDATE `users.language`** + cookie `diabeo_locale` (httpOnly:false, max-age 1 an) · audit UPDATE/USER (`metadata.setting=locale, value=...`, sans PHI) |
+| Vérifier l'écart langue/préférence | `GET /api/account/locale` | bannière réconciliation si mismatch | aucune écriture (lecture `{preference, active, mismatch}`) |
 
-### Scénarios (Gherkin — cible)
+### Scénarios (Gherkin)
 
 ```gherkin
-Feature: Préférence de langue (US-2112b — planifié V1)
+Feature: Préférence de langue (US-2112b/c — RÉEL)
 
   Scenario: changer la langue dans les paramètres la persiste en base
     Given je suis connecté en tant que "VIEWER"
@@ -138,22 +181,28 @@ Feature: Préférence de langue (US-2112b — planifié V1)
     # Effet base: UPDATE users SET language='ar' WHERE id=? + cookie diabeo_locale=ar
     #             + audit_logs(UPDATE/USER, metadata.setting=locale, value=ar)
 
-  Scenario: la préférence survit au changement d'appareil (cookie vidé)
-    Given ma préférence "User.language" = "ar"
-    And mon cookie "diabeo_locale" est absent (nouveau navigateur)
-    When je me connecte
+  Scenario: round-trip — la langue choisie est relue depuis la base à la reconnexion
+    Given j'ai choisi "ar" dans "/settings" section "Langue"
+    When je me déconnecte puis me reconnecte sur un navigateur au cookie vidé
     Then l'interface s'affiche en arabe
-    # Effet base: le login (re)pose le cookie diabeo_locale depuis users.language
+    # Effet base: le login (re)pose diabeo_locale depuis users.language (seedLocaleCookieIfAbsent)
+
+  Scenario: AC-3 — alerte de réconciliation si langue active ≠ préférence
+    Given ma préférence "User.language" = "ar" et mon cookie diabeo_locale = "fr"
+    When je me connecte
+    Then une bannière non bloquante propose « Revenir à l'arabe » / « Continuer en français »
+    # Effet base: « Continuer » → UPDATE users.language='fr' ; « Revenir » → cookie reposé sur 'ar'
 
   Scenario: langue non supportée rejetée
     Given je suis connecté en tant que "VIEWER"
     When je PUT "/api/account/locale" avec {"locale":"zz"}
     Then le statut de la réponse est 400
-    # Validation Zod z.enum(["fr","en","ar"])
+    # Validation Zod z.enum(["fr","en","ar"]) — aucune écriture
 ```
 
-### Cas limites (cible)
+### Cas limites
 
-- Échec persistance base → le cookie reste posé (dégradation gracieuse), pas de blocage UX.
-- `User.language` NULL (jamais choisi) → défaut `fr`.
-- Écran non authentifié : la langue se change par cookie uniquement (cf. `01-auth.md`).
+- Échec persistance base → le cookie reste posé (dégradation gracieuse, `persisted:false`), pas de blocage UX.
+- `User.language` NULL (jamais choisi) → défaut `fr` ; pas d'alerte de réconciliation.
+- Écran non authentifié : la langue se change par cookie uniquement (cf. `01-auth.md` — switcher sur `/login`).
+- Le cookie de locale n'est **jamais écrasé** par le login s'il est déjà présent (la divergence est gérée par la bannière, pas par un reset silencieux).


### PR DESCRIPTION
Complète la couverture QA de `/settings` suite à la demande (tester tous les champs · le changement de langue · la persistance en base).

## Changements (`docs/qa/05-settings.md`)
- **Section « Préférence de langue » : 🔵 Planifié → 🟢 RÉEL.** US-2112b (PR #513) + US-2112c sont mergées — le doc était stale (disait « non encore implémenté »). Mis à jour : switcher FR/EN/AR dans Settings, persistance `User.language` + cookie via `PUT /api/account/locale`, bannière de réconciliation AC-3 au login. Scénarios réécrits (persistance, round-trip reconnexion, réconciliation, rejet locale invalide) + ligne « Langue » dans la table d'actions.
- **Persistance round-trip (anti-régression)** — nouveaux scénarios « modifié → enregistré → **relu après rechargement depuis la base** » pour : unités, notifications, contact (chiffré), moments de la journée ; + rejet d'un champ obligatoire vidé (aucune écriture). Couvre « tester tous les champs » et « une valeur modifiée est persistée en base ».

## Ce qui était DÉJÀ couvert (non dupliqué)
- **Création de compte** : `03-patients.md` couvre déjà le wizard `/patients/new` + `POST /api/patients` (transaction, INSERT users/patients/medical_data/verification_token, 2× audit, email invitation).
- **Ajout de RDV** : `04-appointments.md` couvre déjà `POST /api/appointments` (+ confirm/cancel/propose/accept) avec # Effet base.

Tout est resté **fidèle au code réel** (endpoints, méthodes HTTP PUT, effets base vérifiés).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)