### PR TITLE
feat(dev): US-2270 — socle dev mocké (stubs email/push/antivirus + profil offline)

### DIFF
--- a/.env.mock.dev.example
+++ b/.env.mock.dev.example
@@ -1,0 +1,56 @@
+# =============================================================================
+# US-2270 — Profil d'environnement « dev mocké complet » (offline)
+# =============================================================================
+# Copier en `.env.mock.dev` (gitignoré) puis lancer :
+#   docker compose --profile local up         # PostgreSQL + MinIO (S3 local)
+#   pnpm dev --env-file .env.mock.dev          # (ou sourcer ce fichier)
+#
+# Objectif : faire tourner l'app SANS aucun service externe (email/push/Redis
+# cloud), pour la QA. Les services concernés basculent sur des STUBS/fallbacks
+# (jamais en production — voir src/lib/mocks/dev-mock.ts).
+# =============================================================================
+
+NODE_ENV=development
+
+# --- Bascule globale (optionnelle) ------------------------------------------
+# true = force les stubs même si une clé est présente. Sinon, le stub s'active
+# automatiquement quand la clé du service est absente (ci-dessous laissées vides).
+MOCK_MODE=true
+
+# --- Base de données (docker compose --profile local) -----------------------
+DATABASE_URL=postgresql://diabeo:diabeo@localhost:5432/diabeo?schema=public
+
+# --- Crypto / Auth (clés de DEV — JAMAIS en prod) ---------------------------
+# 32 octets hex (64 caractères) pour le chiffrement AES-256-GCM.
+HEALTH_DATA_ENCRYPTION_KEY=a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2
+HMAC_SECRET=dev-hmac-secret-32-bytes-long!!!
+CONVERSATION_KEY_PEPPER=f1e2d3c4b5a6978869504132f1e2d3c4b5a6978869504132f1e2d3c4b5a69788
+AUDIT_PEPPER=aa00bb11cc22dd33ee44ff55aa00bb11cc22dd33ee44ff55aa00bb11cc22dd33
+CRON_SECRET=cccc0011dddd2233eeee4455ffff6677cccc0011dddd2233eeee4455ffff6677
+# JWT RS256 — générer une paire locale (openssl) et coller ici (PEM).
+JWT_PRIVATE_KEY=
+JWT_PUBLIC_KEY=
+
+# --- S3 documents → MinIO local (docker compose --profile local) ------------
+OVH_S3_ENDPOINT=http://localhost:9000
+OVH_S3_ACCESS_KEY=minioadmin
+OVH_S3_SECRET_KEY=minioadmin
+OVH_S3_BUCKET=diabeo-documents
+
+# --- Antivirus : neutralisé (clean) en dev ----------------------------------
+MOCK_ANTIVIRUS=true
+
+# --- Services laissés VIDES → bascule automatique sur stub/fallback ----------
+# Email (Resend) absent  → emailService.send() loggue et renvoie un id mock.
+RESEND_API_KEY=
+# Push (Firebase) absent → fcm envoie vers une file mémoire (getPushLog()).
+FIREBASE_SERVICE_ACCOUNT_KEY=
+FIREBASE_PROJECT_ID=
+# Redis (Upstash) absent → cache/idempotency basculent sur un fallback mémoire.
+# NB : la révocation de session est un NO-OP offline (le logout vide le cookie ;
+#      le JWT reste techniquement valide jusqu'à expiration — acceptable en dev).
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+
+# --- MyDiabby : non appelable hors staging (gardé par staging-guard) ---------
+# Pour tester un import local : DIABEO_ALLOW_LOCAL_MYDIABBY=1 (sinon 404).

--- a/.env.mock.dev.example
+++ b/.env.mock.dev.example
@@ -18,7 +18,7 @@ NODE_ENV=development
 MOCK_MODE=true
 
 # --- Base de données (docker compose --profile local) -----------------------
-DATABASE_URL=postgresql://diabeo:diabeo@localhost:5432/diabeo?schema=public
+DATABASE_URL=postgresql://diabeo:password@localhost:5432/diabeo?schema=public
 
 # --- Crypto / Auth (à GÉNÉRER localement — JAMAIS committer de clé réelle) ---
 # Laissées VIDES volontairement : ne pas committer de matériel cryptographique,

--- a/.env.mock.dev.example
+++ b/.env.mock.dev.example
@@ -20,14 +20,18 @@ MOCK_MODE=true
 # --- Base de données (docker compose --profile local) -----------------------
 DATABASE_URL=postgresql://diabeo:diabeo@localhost:5432/diabeo?schema=public
 
-# --- Crypto / Auth (clés de DEV — JAMAIS en prod) ---------------------------
-# 32 octets hex (64 caractères) pour le chiffrement AES-256-GCM.
-HEALTH_DATA_ENCRYPTION_KEY=a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2
-HMAC_SECRET=dev-hmac-secret-32-bytes-long!!!
-CONVERSATION_KEY_PEPPER=f1e2d3c4b5a6978869504132f1e2d3c4b5a6978869504132f1e2d3c4b5a69788
-AUDIT_PEPPER=aa00bb11cc22dd33ee44ff55aa00bb11cc22dd33ee44ff55aa00bb11cc22dd33
-CRON_SECRET=cccc0011dddd2233eeee4455ffff6677cccc0011dddd2233eeee4455ffff6677
+# --- Crypto / Auth (à GÉNÉRER localement — JAMAIS committer de clé réelle) ---
+# Laissées VIDES volontairement : ne pas committer de matériel cryptographique,
+# même « de dev » (risque de réutilisation prod par copier-coller + faux positifs
+# scanners de secrets). Générer chacune avec :
+#   openssl rand -hex 32     # 32 octets hex (64 caractères)
+HEALTH_DATA_ENCRYPTION_KEY=
+HMAC_SECRET=
+CONVERSATION_KEY_PEPPER=
+AUDIT_PEPPER=
+CRON_SECRET=
 # JWT RS256 — générer une paire locale (openssl) et coller ici (PEM).
+#   openssl genrsa -out jwt.key 2048 && openssl rsa -in jwt.key -pubout -out jwt.pub
 JWT_PRIVATE_KEY=
 JWT_PUBLIC_KEY=
 

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ yarn-error.log*
 # env files
 .env*
 !.env.example
+!.env.mock.dev.example
 
 # vercel
 .vercel

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -293,8 +293,13 @@ pnpm dev --env-file .env.mock.dev         # (ou sourcer le fichier)
 ```
 
 ### Ce qui bascule en stub/fallback (jamais en production)
-Gate : `src/lib/mocks/dev-mock.ts` (`isDevMocked(key)` → vrai si `NODE_ENV≠production`
-et (`MOCK_MODE=true` ou clé du service absente)).
+Gate : `src/lib/mocks/dev-mock.ts`. Un stub ne s'active **que** si `NODE_ENV` vaut
+`development` ou `test` (`isDevMocked` : + `MOCK_MODE=true` ou clé du service absente).
+**Fail-safe** : tout autre `NODE_ENV` — production, **staging** (le VPS de recette
+tourne en `NODE_ENV=production` + `APP_ENV=staging`), ou `NODE_ENV` absent/inconnu —
+refuse le mock. Donc **la recette utilise les vrais services** (Resend, FCM, ClamAV).
+Au boot prod, `assertRequiredEnv()` **refuse même de démarrer** si un `MOCK_MODE`/
+`MOCK_ANTIVIRUS=true` résiduel traîne dans la config (defense-in-depth).
 
 | Service | Comportement offline | Inspection |
 |---|---|---|

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -277,3 +277,37 @@ dans `docker-compose.yml` (mais alors aussi dans `.env`).
 - Roadmap : [docs/ROADMAP.md](./ROADMAP.md)
 - Migrations Prisma : [docs/runbook/migrations.md](./runbook/migrations.md)
 - Partitioning CGM (à activer quand le volume justifie) : [docs/runbook/postgres-partitioning.md](./runbook/postgres-partitioning.md)
+
+---
+
+## 🧪 Mode dev mocké complet (offline, pour la QA) — US-2270
+
+Pour faire tourner l'app **sans aucun service externe** (email, push, Redis
+cloud) — utile pour dérouler la QA de façon déterministe :
+
+```bash
+cp .env.mock.dev.example .env.mock.dev   # gitignoré ; ajuster les clés JWT
+docker compose --profile local up        # PostgreSQL + MinIO (S3 local)
+pnpm prisma db seed                       # données de test
+pnpm dev --env-file .env.mock.dev         # (ou sourcer le fichier)
+```
+
+### Ce qui bascule en stub/fallback (jamais en production)
+Gate : `src/lib/mocks/dev-mock.ts` (`isDevMocked(key)` → vrai si `NODE_ENV≠production`
+et (`MOCK_MODE=true` ou clé du service absente)).
+
+| Service | Comportement offline | Inspection |
+|---|---|---|
+| **Email (Resend)** | `emailService.send()` loggue + renvoie `{sent:true, id:"mock-…"}` | logs |
+| **Push (Firebase)** | capturé dans une file mémoire, jamais envoyé | `getPushLog()` (fcm.service) |
+| **Antivirus (ClamAV)** | `MOCK_ANTIVIRUS=true` → `{scanned:false, clean:true}` | — |
+| **S3 documents** | redirigé vers **MinIO** (`OVH_S3_ENDPOINT=localhost:9000`) | console MinIO |
+| **Redis cache / idempotency** | fallback `Map` mémoire (déjà en place) | — |
+
+### Limite connue (offline)
+La **révocation de session** (`src/lib/auth/revocation.ts`) est vérifiée en
+**runtime Edge** : un fallback mémoire Node ne serait pas atteignable et l'archi
+a justement abandonné le `Map` pour le cross-runtime. Offline, la révocation est
+donc un **no-op** — le logout vide le cookie client, mais le JWT reste
+techniquement valide jusqu'à expiration. Acceptable en dev/QA ; en prod, Redis
+(Upstash) est requis.

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -341,6 +341,21 @@ export function assertRequiredEnv(): void {
   assertSpecs(REQUIRED_FULL)
   // US-2123 — fail-fast on misconfigured FHIR feature flag.
   assertOptionalBoolean("FHIR_ENABLED")
+  // US-2270 — defense-in-depth : le gate runtime (dev-mock.ts) neutralise déjà
+  // les flags de mock en prod, mais un flag résiduel est un signal de misconfig
+  // qui doit remonter (ANSSI). On refuse le boot prod plutôt que de neutraliser
+  // silencieusement.
+  if (process.env.NODE_ENV === "production") {
+    const leakedMockFlags = ["MOCK_MODE", "MOCK_ANTIVIRUS"].filter(
+      (key) => process.env[key] === "true",
+    )
+    if (leakedMockFlags.length > 0) {
+      throw new Error(
+        `Mock flags forbidden in production: ${leakedMockFlags.join(", ")}=true. ` +
+          "Remove them from the production environment (cf. src/lib/mocks/dev-mock.ts).",
+      )
+    }
+  }
 }
 
 /**

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -26,6 +26,7 @@
  */
 
 import { createPrivateKey, createPublicKey } from "node:crypto"
+import { isFlagTrue } from "@/lib/mocks/dev-mock"
 
 interface EnvSpec {
   name: string
@@ -346,8 +347,10 @@ export function assertRequiredEnv(): void {
   // qui doit remonter (ANSSI). On refuse le boot prod plutôt que de neutraliser
   // silencieusement.
   if (process.env.NODE_ENV === "production") {
-    const leakedMockFlags = ["MOCK_MODE", "MOCK_ANTIVIRUS"].filter(
-      (key) => process.env[key] === "true",
+    // isFlagTrue (partagé avec le gate dev-mock) capte aussi TRUE/1/yes : une
+    // faute de casse ne doit pas échapper au signal de misconfig.
+    const leakedMockFlags = ["MOCK_MODE", "MOCK_ANTIVIRUS"].filter((key) =>
+      isFlagTrue(process.env[key]),
     )
     if (leakedMockFlags.length > 0) {
       throw new Error(

--- a/src/lib/mocks/dev-mock.ts
+++ b/src/lib/mocks/dev-mock.ts
@@ -1,0 +1,21 @@
+/**
+ * US-2270 — Gate du mode dev mocké.
+ *
+ * Décide si un **stub** doit remplacer un service externe (email, push, …) :
+ * - **JAMAIS en production** (un service non configuré en prod doit échouer fort
+ *   pour être détecté) ;
+ * - `MOCK_MODE=true` force le stub (hors prod) ;
+ * - en **`development`**, on stub si la variable d'env du credential est absente
+ *   (dev offline sans clés) ;
+ * - en **`test`** (et autres), on ne stube PAS par défaut : les tests unitaires
+ *   mockent eux-mêmes les clients et asservissent le vrai chemin (ils activent
+ *   `MOCK_MODE`/`development` explicitement pour tester un stub).
+ *
+ * Pur (lecture d'env uniquement) → importable côté serveur sans dépendance.
+ */
+export function isDevMocked(credEnvKey: string): boolean {
+  if (process.env.NODE_ENV === "production") return false
+  if (process.env.MOCK_MODE === "true") return true
+  if (process.env.NODE_ENV === "development") return !process.env[credEnvKey]
+  return false
+}

--- a/src/lib/mocks/dev-mock.ts
+++ b/src/lib/mocks/dev-mock.ts
@@ -4,12 +4,18 @@
  * Décide si un **stub** doit remplacer un service externe (email, push, …) :
  * - **JAMAIS en production** (un service non configuré en prod doit échouer fort
  *   pour être détecté) ;
- * - `MOCK_MODE=true` force le stub (hors prod) ;
+ * - `MOCK_MODE=true` force le stub (en dev/test uniquement) ;
  * - en **`development`**, on stub si la variable d'env du credential est absente
  *   (dev offline sans clés) ;
- * - en **`test`** (et autres), on ne stube PAS par défaut : les tests unitaires
- *   mockent eux-mêmes les clients et asservissent le vrai chemin (ils activent
- *   `MOCK_MODE`/`development` explicitement pour tester un stub).
+ * - en **`test`** (sans `MOCK_MODE`), on ne stube PAS par défaut : les tests
+ *   unitaires mockent eux-mêmes les clients et asservissent le vrai chemin.
+ *
+ * **Fail-safe environnement** : seuls `development` et `test` peuvent activer un
+ * stub. Tout autre cas — production, **staging** (le VPS de recette tourne avec
+ * `NODE_ENV=production` + `APP_ENV=staging`, cf. `staging-guard.ts`), ou un
+ * `NODE_ENV` absent/inconnu — est traité comme la prod et **refuse** le mock.
+ * Conséquence assumée : **la recette utilise les vrais services** (Resend, FCM,
+ * ClamAV), pas les stubs. Le mode mocké est réservé au dev local.
  *
  * Pur (lecture d'env uniquement) → importable côté serveur sans dépendance.
  *
@@ -18,20 +24,29 @@
  * idempotency/service.ts), indépendant de ce gate — ne pas supposer que tout le
  * « mock » passe par ici.
  */
+/**
+ * Environnements où un stub peut s'activer. Tout le reste (prod, staging,
+ * `NODE_ENV` absent/inconnu) = refus fail-safe. Point de vérité unique partagé
+ * par {@link isDevMocked} et {@link isMockFlagOn}.
+ */
+function isMockableEnv(): boolean {
+  return process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test"
+}
+
 export function isDevMocked(credEnvKey: string): boolean {
-  if (process.env.NODE_ENV === "production") return false
+  if (!isMockableEnv()) return false
   if (process.env.MOCK_MODE === "true") return true
   if (process.env.NODE_ENV === "development") return !process.env[credEnvKey]
-  return false
+  return false // test sans MOCK_MODE → vrai chemin (les tests mockent les clients)
 }
 
 /**
  * Variante pour les services pilotés par un **flag booléen explicite** (ex.
- * `MOCK_ANTIVIRUS`) plutôt que par l'absence d'un credential. **Jamais en prod**
- * (point de vérité unique partagé avec {@link isDevMocked}) ; `MOCK_MODE=true`
- * l'active aussi.
+ * `MOCK_ANTIVIRUS`) plutôt que par l'absence d'un credential. Même fail-safe
+ * environnement que {@link isDevMocked} (jamais en prod/staging/`NODE_ENV`
+ * absent) ; `MOCK_MODE=true` l'active aussi.
  */
 export function isMockFlagOn(flagEnvKey: string): boolean {
-  if (process.env.NODE_ENV === "production") return false
+  if (!isMockableEnv()) return false
   return process.env.MOCK_MODE === "true" || process.env[flagEnvKey] === "true"
 }

--- a/src/lib/mocks/dev-mock.ts
+++ b/src/lib/mocks/dev-mock.ts
@@ -33,9 +33,21 @@ function isMockableEnv(): boolean {
   return process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test"
 }
 
+/**
+ * Interprète une variable d'env comme un booléen « vrai » (`true`/`1`/`yes`,
+ * insensible à la casse et aux espaces). Mutualisé pour qu'une faute de frappe
+ * (`MOCK_MODE=TRUE`, `MOCK_ANTIVIRUS=1`) ne puisse PAS diverger entre le gate
+ * runtime et le fail-fast de boot (`assertRequiredEnv`) — une telle valeur doit
+ * remonter comme misconfig en prod plutôt que d'être silencieusement ignorée.
+ */
+export function isFlagTrue(value: string | undefined): boolean {
+  if (!value) return false
+  return ["true", "1", "yes"].includes(value.trim().toLowerCase())
+}
+
 export function isDevMocked(credEnvKey: string): boolean {
   if (!isMockableEnv()) return false
-  if (process.env.MOCK_MODE === "true") return true
+  if (isFlagTrue(process.env.MOCK_MODE)) return true
   if (process.env.NODE_ENV === "development") return !process.env[credEnvKey]
   return false // test sans MOCK_MODE → vrai chemin (les tests mockent les clients)
 }
@@ -48,5 +60,5 @@ export function isDevMocked(credEnvKey: string): boolean {
  */
 export function isMockFlagOn(flagEnvKey: string): boolean {
   if (!isMockableEnv()) return false
-  return process.env.MOCK_MODE === "true" || process.env[flagEnvKey] === "true"
+  return isFlagTrue(process.env.MOCK_MODE) || isFlagTrue(process.env[flagEnvKey])
 }

--- a/src/lib/mocks/dev-mock.ts
+++ b/src/lib/mocks/dev-mock.ts
@@ -12,10 +12,26 @@
  *   `MOCK_MODE`/`development` explicitement pour tester un stub).
  *
  * Pur (lecture d'env uniquement) → importable côté serveur sans dépendance.
+ *
+ * NB : ce gate couvre les **stubs d'appels externes** (email/push/antivirus). Le
+ * cache et l'idempotency ont leur PROPRE fail-open mémoire (cf. redis-cache.ts /
+ * idempotency/service.ts), indépendant de ce gate — ne pas supposer que tout le
+ * « mock » passe par ici.
  */
 export function isDevMocked(credEnvKey: string): boolean {
   if (process.env.NODE_ENV === "production") return false
   if (process.env.MOCK_MODE === "true") return true
   if (process.env.NODE_ENV === "development") return !process.env[credEnvKey]
   return false
+}
+
+/**
+ * Variante pour les services pilotés par un **flag booléen explicite** (ex.
+ * `MOCK_ANTIVIRUS`) plutôt que par l'absence d'un credential. **Jamais en prod**
+ * (point de vérité unique partagé avec {@link isDevMocked}) ; `MOCK_MODE=true`
+ * l'active aussi.
+ */
+export function isMockFlagOn(flagEnvKey: string): boolean {
+  if (process.env.NODE_ENV === "production") return false
+  return process.env.MOCK_MODE === "true" || process.env[flagEnvKey] === "true"
 }

--- a/src/lib/services/antivirus.service.ts
+++ b/src/lib/services/antivirus.service.ts
@@ -3,6 +3,7 @@ import { existsSync } from "fs"
 import { writeFile, rm, mkdtemp } from "fs/promises"
 import { join } from "path"
 import { tmpdir } from "os"
+import { isMockFlagOn } from "@/lib/mocks/dev-mock"
 
 let clamInstance: NodeClam | null = null
 
@@ -43,8 +44,8 @@ export async function scanFile(filePath: string): Promise<ScanResult> {
   }
 
   // US-2270 — dev mocké : antivirus neutralisé de façon déterministe (clean),
-  // même si ClamAV est installé localement. Jamais en production.
-  if (process.env.NODE_ENV !== "production" && process.env.MOCK_ANTIVIRUS === "true") {
+  // même si ClamAV est installé localement. Jamais en production (gate partagé).
+  if (isMockFlagOn("MOCK_ANTIVIRUS")) {
     return { scanned: false, clean: true, viruses: [] }
   }
 

--- a/src/lib/services/antivirus.service.ts
+++ b/src/lib/services/antivirus.service.ts
@@ -42,6 +42,12 @@ export async function scanFile(filePath: string): Promise<ScanResult> {
     throw new Error("File not found for scan")
   }
 
+  // US-2270 — dev mocké : antivirus neutralisé de façon déterministe (clean),
+  // même si ClamAV est installé localement. Jamais en production.
+  if (process.env.NODE_ENV !== "production" && process.env.MOCK_ANTIVIRUS === "true") {
+    return { scanned: false, clean: true, viruses: [] }
+  }
+
   const clam = await getClamAV()
 
   if (!clam) {

--- a/src/lib/services/antivirus.service.ts
+++ b/src/lib/services/antivirus.service.ts
@@ -3,6 +3,7 @@ import { existsSync } from "fs"
 import { writeFile, rm, mkdtemp } from "fs/promises"
 import { join } from "path"
 import { tmpdir } from "os"
+import { logger } from "@/lib/logger"
 import { isMockFlagOn } from "@/lib/mocks/dev-mock"
 
 let clamInstance: NodeClam | null = null
@@ -27,7 +28,7 @@ async function getClamAV(): Promise<NodeClam | null> {
     })
     return clamInstance
   } catch {
-    console.warn("[antivirus] ClamAV not available — scans will be skipped")
+    logger.warn("antivirus", "ClamAV not available — scans will be skipped")
     return null
   }
 }
@@ -63,7 +64,8 @@ export async function scanFile(filePath: string): Promise<ScanResult> {
     const isClean = result.isInfected === false
 
     if (!isClean) {
-      console.error("[antivirus] INFECTED file detected:", result.viruses?.join(", "))
+      // Noms de signatures virales (pas de PII) — gardés en clair pour le SOC.
+      logger.error("antivirus", `INFECTED file detected: ${result.viruses?.join(", ") ?? "unknown"}`)
     }
 
     return {
@@ -73,7 +75,7 @@ export async function scanFile(filePath: string): Promise<ScanResult> {
     }
   } catch (err) {
     const msg = err instanceof Error ? err.message : "Unknown error"
-    console.error("[antivirus] Scan failed:", msg)
+    logger.error("antivirus", `Scan failed: ${msg}`)
     return { scanned: false, clean: false, viruses: ["SCAN_ERROR"] }
   }
 }

--- a/src/lib/services/email.service.ts
+++ b/src/lib/services/email.service.ts
@@ -1,5 +1,7 @@
+import { randomUUID } from "crypto"
 import { Resend } from "resend"
 import { logger } from "@/lib/logger"
+import { isDevMocked } from "@/lib/mocks/dev-mock"
 
 function escapeHtml(str: string): string {
   return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#x27;")
@@ -156,6 +158,12 @@ interface EmailResult {
 
 export const emailService = {
   async send(input: SendEmailInput): Promise<EmailResult> {
+    // US-2270 — dev mocké : email non envoyé, succès simulé (jamais en prod).
+    // (Pas de destinataire/sujet dans les logs — PII.)
+    if (isDevMocked("RESEND_API_KEY")) {
+      logger.info("email", "STUB dev — email non envoyé (mode mocké)")
+      return { sent: true, id: `mock-${randomUUID()}` }
+    }
     try {
       const client = getClient()
       const { data, error } = await client.emails.send({

--- a/src/lib/services/email.service.ts
+++ b/src/lib/services/email.service.ts
@@ -143,14 +143,14 @@ const REMINDER_I18N: Record<"fr" | "en" | "ar", ReminderI18n> = {
   },
 }
 
-interface SendEmailInput {
+export interface SendEmailInput {
   to: string
   subject: string
   html: string
   text?: string
 }
 
-interface EmailResult {
+export interface EmailResult {
   sent: boolean
   id?: string
   error?: string

--- a/src/lib/services/fcm.service.ts
+++ b/src/lib/services/fcm.service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto"
 import { getFcm } from "@/lib/firebase/admin"
 import { prisma } from "@/lib/db/client"
 import { auditService } from "./audit.service"
@@ -15,14 +16,22 @@ export interface MockedPush {
   platform: PushPlatform
   title: string
   body: string
+  /** Payload de données (templateId, variables) — utile pour l'inspection QA. */
+  data?: Record<string, string>
   at: string
 }
 /** Borne du buffer (ring) : évite toute croissance non bornée en dev long-running. */
 const PUSH_LOG_MAX = 500
 const pushStubLog: MockedPush[] = []
-/** Renvoie les push capturés par le stub (mode dev mocké). */
+/**
+ * Renvoie une **copie** des push capturés par le stub (mode dev mocké).
+ *
+ * ⚠️ Le contenu (`title`/`body`/`token`) peut être nominatif/PII : ce buffer est
+ * **dev/QA uniquement** et ne doit JAMAIS être sérialisé vers une route API, même
+ * en dev (aucune ACL). La copie empêche toute mutation du buffer interne via cast.
+ */
 export function getPushLog(): readonly MockedPush[] {
-  return pushStubLog
+  return [...pushStubLog]
 }
 /** Vide le journal des push stub. Test/dev uniquement (no-op en prod). */
 export function _clearPushLog(): void {
@@ -47,7 +56,7 @@ const INVALID_TOKEN_CODES = new Set([
   "messaging/invalid-registration-token",
 ])
 
-interface SendInput {
+export interface SendInput {
   userId: number
   /**
    * Acteur qui déclenche l'envoi. `null` accepté pour les acteurs système
@@ -61,7 +70,7 @@ interface SendInput {
   data?: Record<string, string>
 }
 
-interface SendResult {
+export interface SendResult {
   sent: number
   failed: number
   results: { registrationId: string; platform: PushPlatform; status: "sent" | "failed"; error?: string }[]
@@ -104,9 +113,21 @@ async function sendWithRetry(
 ): Promise<{ messageId?: string; error?: string }> {
   // US-2270 — dev mocké : push capturé en mémoire, jamais envoyé (jamais en prod).
   if (isDevMocked("FIREBASE_SERVICE_ACCOUNT_KEY")) {
-    pushStubLog.push({ token, platform, title: payload.title, body: payload.body, at: new Date().toISOString() })
-    if (pushStubLog.length > PUSH_LOG_MAX) pushStubLog.shift() // ring-buffer
-    return { messageId: `mock-${crypto.randomUUID()}` }
+    // Defense-in-depth : ne JAMAIS écrire de PII dans le buffer en prod, même si
+    // le gate était contourné (le gate isDevMocked l'exclut déjà — ceinture +
+    // bretelles, cohérent avec _clearPushLog).
+    if (process.env.NODE_ENV !== "production") {
+      pushStubLog.push({
+        token,
+        platform,
+        title: payload.title,
+        body: payload.body,
+        data: payload.data,
+        at: new Date().toISOString(),
+      })
+      if (pushStubLog.length > PUSH_LOG_MAX) pushStubLog.shift() // ring-buffer
+    }
+    return { messageId: `mock-${randomUUID()}` }
   }
   const fcm = getFcm()
 
@@ -177,7 +198,7 @@ export const fcmService = {
       return { sent: 0, failed: 0, results: [] }
     }
 
-    const idempotencyKey = crypto.randomUUID()
+    const idempotencyKey = randomUUID()
 
     const sendPromises = registrations.map(async (reg) => {
       const { messageId, error } = await sendWithRetry(

--- a/src/lib/services/fcm.service.ts
+++ b/src/lib/services/fcm.service.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "crypto"
 import { getFcm } from "@/lib/firebase/admin"
 import { prisma } from "@/lib/db/client"
 import { auditService } from "./audit.service"
@@ -11,20 +10,23 @@ import type { AuditContext } from "./patient.service"
  * US-2270 — file d'attente mémoire des push en mode dev mocké (Firebase absent).
  * Permet d'inspecter ce qui « aurait été envoyé » (QA / tests) sans FCM réel.
  */
-interface MockedPush {
+export interface MockedPush {
   token: string
   platform: PushPlatform
   title: string
   body: string
   at: string
 }
+/** Borne du buffer (ring) : évite toute croissance non bornée en dev long-running. */
+const PUSH_LOG_MAX = 500
 const pushStubLog: MockedPush[] = []
 /** Renvoie les push capturés par le stub (mode dev mocké). */
 export function getPushLog(): readonly MockedPush[] {
   return pushStubLog
 }
-/** Vide le journal des push stub. Test-only. */
+/** Vide le journal des push stub. Test/dev uniquement (no-op en prod). */
 export function _clearPushLog(): void {
+  if (process.env.NODE_ENV === "production") return
   pushStubLog.length = 0
 }
 
@@ -103,7 +105,8 @@ async function sendWithRetry(
   // US-2270 — dev mocké : push capturé en mémoire, jamais envoyé (jamais en prod).
   if (isDevMocked("FIREBASE_SERVICE_ACCOUNT_KEY")) {
     pushStubLog.push({ token, platform, title: payload.title, body: payload.body, at: new Date().toISOString() })
-    return { messageId: `mock-${randomUUID()}` }
+    if (pushStubLog.length > PUSH_LOG_MAX) pushStubLog.shift() // ring-buffer
+    return { messageId: `mock-${crypto.randomUUID()}` }
   }
   const fcm = getFcm()
 

--- a/src/lib/services/fcm.service.ts
+++ b/src/lib/services/fcm.service.ts
@@ -1,9 +1,32 @@
+import { randomUUID } from "crypto"
 import { getFcm } from "@/lib/firebase/admin"
 import { prisma } from "@/lib/db/client"
 import { auditService } from "./audit.service"
 import { logger } from "@/lib/logger"
+import { isDevMocked } from "@/lib/mocks/dev-mock"
 import type { PushPlatform } from "@prisma/client"
 import type { AuditContext } from "./patient.service"
+
+/**
+ * US-2270 — file d'attente mémoire des push en mode dev mocké (Firebase absent).
+ * Permet d'inspecter ce qui « aurait été envoyé » (QA / tests) sans FCM réel.
+ */
+interface MockedPush {
+  token: string
+  platform: PushPlatform
+  title: string
+  body: string
+  at: string
+}
+const pushStubLog: MockedPush[] = []
+/** Renvoie les push capturés par le stub (mode dev mocké). */
+export function getPushLog(): readonly MockedPush[] {
+  return pushStubLog
+}
+/** Vide le journal des push stub. Test-only. */
+export function _clearPushLog(): void {
+  pushStubLog.length = 0
+}
 
 const MAX_RETRIES = 3
 const RETRY_DELAY_MS = 1000
@@ -77,6 +100,11 @@ async function sendWithRetry(
   platform: PushPlatform,
   idempotencyKey: string,
 ): Promise<{ messageId?: string; error?: string }> {
+  // US-2270 — dev mocké : push capturé en mémoire, jamais envoyé (jamais en prod).
+  if (isDevMocked("FIREBASE_SERVICE_ACCOUNT_KEY")) {
+    pushStubLog.push({ token, platform, title: payload.title, body: payload.body, at: new Date().toISOString() })
+    return { messageId: `mock-${randomUUID()}` }
+  }
   const fcm = getFcm()
 
   const dataPayload = {

--- a/src/lib/services/fcm.service.ts
+++ b/src/lib/services/fcm.service.ts
@@ -24,16 +24,20 @@ export interface MockedPush {
 const PUSH_LOG_MAX = 500
 const pushStubLog: MockedPush[] = []
 /**
- * Renvoie une **copie** des push capturés par le stub (mode dev mocké).
+ * Renvoie une **copie défensive** des push capturés par le stub (mode dev mocké).
  *
  * ⚠️ Le contenu (`title`/`body`/`token`) peut être nominatif/PII : ce buffer est
  * **dev/QA uniquement** et ne doit JAMAIS être sérialisé vers une route API, même
- * en dev (aucune ACL). La copie empêche toute mutation du buffer interne via cast.
+ * en dev (aucune ACL). La copie (incluant un clone de `data`) empêche toute
+ * mutation du buffer interne via la valeur retournée.
  */
 export function getPushLog(): readonly MockedPush[] {
-  return [...pushStubLog]
+  return pushStubLog.map((p) => ({ ...p, data: p.data ? { ...p.data } : undefined }))
 }
-/** Vide le journal des push stub. Test/dev uniquement (no-op en prod). */
+/**
+ * Vide le journal des push stub. Test/dev uniquement (no-op en prod).
+ * @internal — exposé pour les tests ; ne pas appeler depuis le code applicatif.
+ */
 export function _clearPushLog(): void {
   if (process.env.NODE_ENV === "production") return
   pushStubLog.length = 0
@@ -113,9 +117,10 @@ async function sendWithRetry(
 ): Promise<{ messageId?: string; error?: string }> {
   // US-2270 — dev mocké : push capturé en mémoire, jamais envoyé (jamais en prod).
   if (isDevMocked("FIREBASE_SERVICE_ACCOUNT_KEY")) {
-    // Defense-in-depth : ne JAMAIS écrire de PII dans le buffer en prod, même si
-    // le gate était contourné (le gate isDevMocked l'exclut déjà — ceinture +
-    // bretelles, cohérent avec _clearPushLog).
+    // Defense-in-depth (HDS) : garde volontairement redondante. `isDevMocked`
+    // exclut déjà la prod, donc cette branche est normalement inatteignable en
+    // prod — on la garde comme 2ᵉ verrou pour qu'aucune PII n'atterrisse dans le
+    // buffer mémoire si le gate venait à régresser (cohérent avec _clearPushLog).
     if (process.env.NODE_ENV !== "production") {
       pushStubLog.push({
         token,

--- a/tests/unit/antivirus-stub.test.ts
+++ b/tests/unit/antivirus-stub.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @vitest-environment node
+ */
+
+/**
+ * Tests — stub antivirus du mode dev mocké (US-2270).
+ *
+ * Comportement clinique/sécurité testé : un document uploadé doit TOUJOURS être
+ * scanné en production. Le bypass `MOCK_ANTIVIRUS` ne doit JAMAIS neutraliser le
+ * scan en prod, et le fail-closed prod (refus si ClamAV indisponible) doit tenir.
+ * Risque couvert : un faux `clean:true` = malware stocké → faille HDS.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from "vitest"
+import { writeFileSync, rmSync } from "fs"
+import { join } from "path"
+import { tmpdir } from "os"
+
+// ClamAV indisponible de façon déterministe (init rejette) → getClamAV() = null.
+vi.mock("clamscan", () => ({
+  default: class {
+    init() {
+      return Promise.reject(new Error("ClamAV not available in test env"))
+    }
+  },
+}))
+
+import { scanFile } from "@/lib/services/antivirus.service"
+
+const tmpFile = join(tmpdir(), "diabeo-av-stub-test.txt")
+
+beforeAll(() => writeFileSync(tmpFile, "harmless content"))
+afterAll(() => rmSync(tmpFile, { force: true }))
+afterEach(() => vi.unstubAllEnvs())
+
+describe("scanFile — mode dev mocké", () => {
+  it("dev + MOCK_ANTIVIRUS=true → scan neutralisé (clean, non scanné)", async () => {
+    vi.stubEnv("NODE_ENV", "development")
+    vi.stubEnv("MOCK_ANTIVIRUS", "true")
+    const res = await scanFile(tmpFile)
+    expect(res).toEqual({ scanned: false, clean: true, viruses: [] })
+  })
+
+  it("PRODUCTION + MOCK_ANTIVIRUS=true → bypass IGNORÉ, ClamAV indispo → throw (fail-closed)", async () => {
+    vi.stubEnv("NODE_ENV", "production")
+    vi.stubEnv("MOCK_ANTIVIRUS", "true")
+    await expect(scanFile(tmpFile)).rejects.toThrow(/ClamAV unavailable in production/)
+  })
+
+  it("dev SANS flag + ClamAV indispo → skip toléré (clean, non scanné)", async () => {
+    vi.stubEnv("NODE_ENV", "development")
+    vi.stubEnv("MOCK_ANTIVIRUS", "")
+    const res = await scanFile(tmpFile)
+    expect(res).toEqual({ scanned: false, clean: true, viruses: [] })
+  })
+
+  it("fichier inexistant → throw", async () => {
+    vi.stubEnv("NODE_ENV", "development")
+    vi.stubEnv("MOCK_ANTIVIRUS", "true")
+    await expect(scanFile(join(tmpdir(), "does-not-exist-xyz.bin"))).rejects.toThrow(/File not found/)
+  })
+})

--- a/tests/unit/dev-mock.test.ts
+++ b/tests/unit/dev-mock.test.ts
@@ -5,13 +5,35 @@
 /** Tests — gate du mode dev mocké (US-2270). */
 
 import { describe, it, expect, vi, afterEach } from "vitest"
-import { isDevMocked } from "@/lib/mocks/dev-mock"
+import { isDevMocked, isMockFlagOn } from "@/lib/mocks/dev-mock"
 
 afterEach(() => vi.unstubAllEnvs())
 
 describe("isDevMocked", () => {
   it("JAMAIS en production (même clé absente)", () => {
     vi.stubEnv("NODE_ENV", "production")
+    vi.stubEnv("RESEND_API_KEY", "")
+    expect(isDevMocked("RESEND_API_KEY")).toBe(false)
+  })
+
+  it("JAMAIS en production même si MOCK_MODE=true (flag résiduel)", () => {
+    vi.stubEnv("NODE_ENV", "production")
+    vi.stubEnv("MOCK_MODE", "true")
+    vi.stubEnv("RESEND_API_KEY", "")
+    expect(isDevMocked("RESEND_API_KEY")).toBe(false)
+  })
+
+  it("JAMAIS sur staging (NODE_ENV=production + APP_ENV=staging) → vrais services", () => {
+    vi.stubEnv("NODE_ENV", "production")
+    vi.stubEnv("APP_ENV", "staging")
+    vi.stubEnv("MOCK_MODE", "true")
+    vi.stubEnv("RESEND_API_KEY", "")
+    expect(isDevMocked("RESEND_API_KEY")).toBe(false)
+  })
+
+  it("fail-safe : NODE_ENV absent → pas de stub (traité comme prod)", () => {
+    vi.stubEnv("NODE_ENV", undefined)
+    vi.stubEnv("MOCK_MODE", "true")
     vi.stubEnv("RESEND_API_KEY", "")
     expect(isDevMocked("RESEND_API_KEY")).toBe(false)
   })
@@ -40,5 +62,45 @@ describe("isDevMocked", () => {
     vi.stubEnv("NODE_ENV", "test")
     vi.stubEnv("RESEND_API_KEY", "")
     expect(isDevMocked("RESEND_API_KEY")).toBe(false)
+  })
+})
+
+describe("isMockFlagOn", () => {
+  it("JAMAIS en production même si le flag est présent", () => {
+    vi.stubEnv("NODE_ENV", "production")
+    vi.stubEnv("MOCK_ANTIVIRUS", "true")
+    expect(isMockFlagOn("MOCK_ANTIVIRUS")).toBe(false)
+  })
+
+  it("JAMAIS en production même si MOCK_MODE=true", () => {
+    vi.stubEnv("NODE_ENV", "production")
+    vi.stubEnv("MOCK_MODE", "true")
+    expect(isMockFlagOn("MOCK_ANTIVIRUS")).toBe(false)
+  })
+
+  it("fail-safe : NODE_ENV absent → false (traité comme prod)", () => {
+    vi.stubEnv("NODE_ENV", undefined)
+    vi.stubEnv("MOCK_ANTIVIRUS", "true")
+    expect(isMockFlagOn("MOCK_ANTIVIRUS")).toBe(false)
+  })
+
+  it("development + flag=true → actif", () => {
+    vi.stubEnv("NODE_ENV", "development")
+    vi.stubEnv("MOCK_ANTIVIRUS", "true")
+    expect(isMockFlagOn("MOCK_ANTIVIRUS")).toBe(true)
+  })
+
+  it("development + MOCK_MODE=true (flag absent) → actif", () => {
+    vi.stubEnv("NODE_ENV", "development")
+    vi.stubEnv("MOCK_MODE", "true")
+    vi.stubEnv("MOCK_ANTIVIRUS", "")
+    expect(isMockFlagOn("MOCK_ANTIVIRUS")).toBe(true)
+  })
+
+  it("development sans aucun flag → inactif (vrai scan)", () => {
+    vi.stubEnv("NODE_ENV", "development")
+    vi.stubEnv("MOCK_MODE", "")
+    vi.stubEnv("MOCK_ANTIVIRUS", "")
+    expect(isMockFlagOn("MOCK_ANTIVIRUS")).toBe(false)
   })
 })

--- a/tests/unit/dev-mock.test.ts
+++ b/tests/unit/dev-mock.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @vitest-environment node
+ */
+
+/** Tests — gate du mode dev mocké (US-2270). */
+
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { isDevMocked } from "@/lib/mocks/dev-mock"
+
+afterEach(() => vi.unstubAllEnvs())
+
+describe("isDevMocked", () => {
+  it("JAMAIS en production (même clé absente)", () => {
+    vi.stubEnv("NODE_ENV", "production")
+    vi.stubEnv("RESEND_API_KEY", "")
+    expect(isDevMocked("RESEND_API_KEY")).toBe(false)
+  })
+
+  it("development + clé absente → mocké", () => {
+    vi.stubEnv("NODE_ENV", "development")
+    vi.stubEnv("RESEND_API_KEY", "")
+    expect(isDevMocked("RESEND_API_KEY")).toBe(true)
+  })
+
+  it("MOCK_MODE=true (hors prod) → mocké même si la clé est présente", () => {
+    vi.stubEnv("NODE_ENV", "development")
+    vi.stubEnv("MOCK_MODE", "true")
+    vi.stubEnv("RESEND_API_KEY", "re_real_key")
+    expect(isDevMocked("RESEND_API_KEY")).toBe(true)
+  })
+
+  it("development + clé présente sans MOCK_MODE → service réel", () => {
+    vi.stubEnv("NODE_ENV", "development")
+    vi.stubEnv("MOCK_MODE", "")
+    vi.stubEnv("RESEND_API_KEY", "re_real_key")
+    expect(isDevMocked("RESEND_API_KEY")).toBe(false)
+  })
+
+  it("env test (vitest) sans MOCK_MODE → PAS de stub (vrai chemin)", () => {
+    vi.stubEnv("NODE_ENV", "test")
+    vi.stubEnv("RESEND_API_KEY", "")
+    expect(isDevMocked("RESEND_API_KEY")).toBe(false)
+  })
+})

--- a/tests/unit/dev-mock.test.ts
+++ b/tests/unit/dev-mock.test.ts
@@ -5,7 +5,7 @@
 /** Tests — gate du mode dev mocké (US-2270). */
 
 import { describe, it, expect, vi, afterEach } from "vitest"
-import { isDevMocked, isMockFlagOn } from "@/lib/mocks/dev-mock"
+import { isDevMocked, isMockFlagOn, isFlagTrue } from "@/lib/mocks/dev-mock"
 
 afterEach(() => vi.unstubAllEnvs())
 
@@ -102,5 +102,34 @@ describe("isMockFlagOn", () => {
     vi.stubEnv("MOCK_MODE", "")
     vi.stubEnv("MOCK_ANTIVIRUS", "")
     expect(isMockFlagOn("MOCK_ANTIVIRUS")).toBe(false)
+  })
+
+  it("env test + flag=true → actif (asymétrie assumée vs isDevMocked)", () => {
+    vi.stubEnv("NODE_ENV", "test")
+    vi.stubEnv("MOCK_ANTIVIRUS", "true")
+    expect(isMockFlagOn("MOCK_ANTIVIRUS")).toBe(true)
+  })
+
+  it("capte les variantes de casse/format (TRUE, 1, yes)", () => {
+    vi.stubEnv("NODE_ENV", "development")
+    vi.stubEnv("MOCK_MODE", "")
+    for (const v of ["TRUE", "True", " true ", "1", "yes", "YES"]) {
+      vi.stubEnv("MOCK_ANTIVIRUS", v)
+      expect(isMockFlagOn("MOCK_ANTIVIRUS")).toBe(true)
+    }
+  })
+})
+
+describe("isFlagTrue", () => {
+  it("vrai pour true/1/yes insensible à la casse et aux espaces", () => {
+    for (const v of ["true", "TRUE", " True ", "1", "yes", "YES"]) {
+      expect(isFlagTrue(v)).toBe(true)
+    }
+  })
+
+  it("faux pour absent/vide/valeurs non vraies", () => {
+    for (const v of [undefined, "", "false", "0", "no", "off", "2"]) {
+      expect(isFlagTrue(v)).toBe(false)
+    }
   })
 })

--- a/tests/unit/email-stub.test.ts
+++ b/tests/unit/email-stub.test.ts
@@ -1,0 +1,31 @@
+/**
+ * @vitest-environment node
+ */
+
+/** Tests — stub email du mode dev mocké (US-2270). */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { emailService } from "@/lib/services/email.service"
+
+beforeEach(() => {
+  vi.stubEnv("NODE_ENV", "development")
+  vi.stubEnv("MOCK_MODE", "")
+  vi.stubEnv("RESEND_API_KEY", "")
+})
+afterEach(() => vi.unstubAllEnvs())
+
+describe("emailService.send — mode dev mocké", () => {
+  it("sans RESEND_API_KEY en dev → succès simulé (id mock-, aucun envoi réseau)", async () => {
+    const res = await emailService.send({ to: "a@b.test", subject: "x", html: "<p>x</p>" })
+    expect(res.sent).toBe(true)
+    expect(res.id).toMatch(/^mock-/)
+  })
+
+  it("en production sans clé → ne stube PAS (échoue fort)", async () => {
+    vi.stubEnv("NODE_ENV", "production")
+    vi.stubEnv("RESEND_API_KEY", "")
+    await expect(
+      emailService.send({ to: "a@b.test", subject: "x", html: "<p>x</p>" }),
+    ).rejects.toThrow(/RESEND_API_KEY/)
+  })
+})

--- a/tests/unit/email-stub.test.ts
+++ b/tests/unit/email-stub.test.ts
@@ -5,9 +5,16 @@
 /** Tests — stub email du mode dev mocké (US-2270). */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+const { infoMock } = vi.hoisted(() => ({ infoMock: vi.fn() }))
+vi.mock("@/lib/logger", () => ({
+  logger: { info: infoMock, error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}))
+
 import { emailService } from "@/lib/services/email.service"
 
 beforeEach(() => {
+  vi.clearAllMocks()
   vi.stubEnv("NODE_ENV", "development")
   vi.stubEnv("MOCK_MODE", "")
   vi.stubEnv("RESEND_API_KEY", "")
@@ -15,10 +22,20 @@ beforeEach(() => {
 afterEach(() => vi.unstubAllEnvs())
 
 describe("emailService.send — mode dev mocké", () => {
-  it("sans RESEND_API_KEY en dev → succès simulé (id mock-, aucun envoi réseau)", async () => {
-    const res = await emailService.send({ to: "a@b.test", subject: "x", html: "<p>x</p>" })
+  it("succès simulé (id mock-, aucun envoi) ET aucune PII loggée", async () => {
+    const res = await emailService.send({
+      to: "secret@patient.test",
+      subject: "RDV cardiologie",
+      html: "<p>x</p>",
+    })
     expect(res.sent).toBe(true)
-    expect(res.id).toMatch(/^mock-/)
+    expect(res.id).toBeDefined()
+    expect(res.id!).toMatch(/^mock-/)
+
+    // HDS/RGPD : ni le destinataire ni le sujet ne doivent apparaître dans les logs.
+    const logged = infoMock.mock.calls.flat().map(String).join(" ")
+    expect(logged).not.toContain("secret@patient.test")
+    expect(logged).not.toContain("RDV cardiologie")
   })
 
   it("en production sans clé → ne stube PAS (échoue fort)", async () => {

--- a/tests/unit/email-stub.test.ts
+++ b/tests/unit/email-stub.test.ts
@@ -30,7 +30,7 @@ describe("emailService.send — mode dev mocké", () => {
     })
     expect(res.sent).toBe(true)
     expect(res.id).toBeDefined()
-    expect(res.id!).toMatch(/^mock-/)
+    expect(res.id).toMatch(/^mock-/)
 
     // HDS/RGPD : ni le destinataire ni le sujet ne doivent apparaître dans les logs.
     const logged = infoMock.mock.calls.flat().map(String).join(" ")

--- a/tests/unit/env.test.ts
+++ b/tests/unit/env.test.ts
@@ -232,4 +232,31 @@ describe("assertRequiredEnv", () => {
     expect(() => assertRequiredEnv()).not.toThrow()
     expect(() => assertRequiredEnv()).not.toThrow()
   })
+
+  // US-2270 — defense-in-depth : un flag de mock résiduel en prod doit refuser
+  // le boot (misconfig tracée plutôt que neutralisée silencieusement).
+  it("rejects MOCK_MODE=true in production", () => {
+    vi.stubEnv("NODE_ENV", "production")
+    vi.stubEnv("MOCK_MODE", "true")
+    expect(() => assertRequiredEnv()).toThrow(/Mock flags forbidden in production/)
+  })
+
+  it("rejects MOCK_ANTIVIRUS=true in production", () => {
+    vi.stubEnv("NODE_ENV", "production")
+    vi.stubEnv("MOCK_ANTIVIRUS", "true")
+    expect(() => assertRequiredEnv()).toThrow(/MOCK_ANTIVIRUS/)
+  })
+
+  it("catches case/format variants (TRUE, 1) in production", () => {
+    vi.stubEnv("NODE_ENV", "production")
+    vi.stubEnv("MOCK_MODE", "TRUE")
+    expect(() => assertRequiredEnv()).toThrow(/Mock flags forbidden in production/)
+  })
+
+  it("does NOT reject mock flags outside production", () => {
+    vi.stubEnv("NODE_ENV", "development")
+    vi.stubEnv("MOCK_MODE", "true")
+    vi.stubEnv("MOCK_ANTIVIRUS", "true")
+    expect(() => assertRequiredEnv()).not.toThrow()
+  })
 })

--- a/tests/unit/fcm-stub.test.ts
+++ b/tests/unit/fcm-stub.test.ts
@@ -90,10 +90,21 @@ describe("fcmService.sendToUser — mode dev mocké", () => {
     findManyMock.mockResolvedValue([
       { id: "reg-1", pushToken: "tok-1", platform: "web", userId: 1, isActive: true },
     ])
-    await fcmService.sendToUser({ userId: 1, senderId: 1, title: "A", body: "1" })
+    await fcmService.sendToUser({
+      userId: 1,
+      senderId: 1,
+      title: "A",
+      body: "1",
+      data: { templateId: "t1" },
+    })
     const snapshot = getPushLog() as MockedPush[]
+    // (a) ajout d'élément au tableau retourné → sans effet
     snapshot.push({ token: "x", platform: "web", title: "INJECTED", body: "z", at: "" })
-    expect(getPushLog()).toHaveLength(1) // le buffer interne n'a pas bougé
+    // (b) mutation de l'objet `data` d'un élément capturé → sans effet (deep-clone)
+    snapshot[0].data!["injected"] = "x"
+    const after = getPushLog()
+    expect(after).toHaveLength(1)
+    expect(after[0].data).toEqual({ templateId: "t1" }) // pas de clé "injected"
   })
 
   it("MOCK_MODE=true stube même si une clé Firebase est présente", async () => {

--- a/tests/unit/fcm-stub.test.ts
+++ b/tests/unit/fcm-stub.test.ts
@@ -25,7 +25,7 @@ vi.mock("@/lib/db/client", () => ({
 vi.mock("@/lib/firebase/admin", () => ({ getFcm: getFcmMock }))
 vi.mock("@/lib/services/audit.service", () => ({ auditService: { log: auditMock } }))
 
-import { fcmService, getPushLog, _clearPushLog } from "@/lib/services/fcm.service"
+import { fcmService, getPushLog, _clearPushLog, type MockedPush } from "@/lib/services/fcm.service"
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -70,6 +70,30 @@ describe("fcmService.sendToUser — mode dev mocké", () => {
     const log = getPushLog()
     expect(log).toHaveLength(2)
     expect(log.map((p) => p.title)).toEqual(["A", "B"])
+  })
+
+  it("borne le buffer à 500 (ring-buffer FIFO, pas de croissance non bornée)", async () => {
+    findManyMock.mockResolvedValue([
+      { id: "reg-1", pushToken: "tok-1", platform: "web", userId: 1, isActive: true },
+    ])
+    // 501 envois → la 1re entrée doit avoir été évincée (shift), taille plafonnée.
+    for (let i = 0; i < 501; i++) {
+      await fcmService.sendToUser({ userId: 1, senderId: 1, title: `n-${i}`, body: "x" })
+    }
+    const log = getPushLog()
+    expect(log).toHaveLength(500)
+    expect(log[0].title).toBe("n-1") // n-0 évincé
+    expect(log[log.length - 1].title).toBe("n-500")
+  })
+
+  it("getPushLog() renvoie une copie défensive (mutation sans effet sur le buffer)", async () => {
+    findManyMock.mockResolvedValue([
+      { id: "reg-1", pushToken: "tok-1", platform: "web", userId: 1, isActive: true },
+    ])
+    await fcmService.sendToUser({ userId: 1, senderId: 1, title: "A", body: "1" })
+    const snapshot = getPushLog() as MockedPush[]
+    snapshot.push({ token: "x", platform: "web", title: "INJECTED", body: "z", at: "" })
+    expect(getPushLog()).toHaveLength(1) // le buffer interne n'a pas bougé
   })
 
   it("MOCK_MODE=true stube même si une clé Firebase est présente", async () => {

--- a/tests/unit/fcm-stub.test.ts
+++ b/tests/unit/fcm-stub.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @vitest-environment node
+ */
+
+/** Tests — stub push (FCM) du mode dev mocké (US-2270). */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+const { findManyMock, logCreateMock, auditMock, getFcmMock } = vi.hoisted(() => ({
+  findManyMock: vi.fn(),
+  logCreateMock: vi.fn().mockResolvedValue({}),
+  auditMock: vi.fn().mockResolvedValue({}),
+  getFcmMock: vi.fn(() => {
+    throw new Error("getFcm ne doit PAS être appelé en mode mocké")
+  }),
+}))
+
+vi.mock("@/lib/db/client", () => ({
+  prisma: {
+    pushDeviceRegistration: { findMany: findManyMock, update: vi.fn(), findFirst: vi.fn() },
+    pushNotificationLog: { create: logCreateMock },
+    pushNotificationTemplate: { findUnique: vi.fn() },
+  },
+}))
+vi.mock("@/lib/firebase/admin", () => ({ getFcm: getFcmMock }))
+vi.mock("@/lib/services/audit.service", () => ({ auditService: { log: auditMock } }))
+
+import { fcmService, getPushLog, _clearPushLog } from "@/lib/services/fcm.service"
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  _clearPushLog()
+  vi.stubEnv("NODE_ENV", "development")
+  vi.stubEnv("MOCK_MODE", "")
+  vi.stubEnv("FIREBASE_SERVICE_ACCOUNT_KEY", "")
+})
+afterEach(() => vi.unstubAllEnvs())
+
+describe("fcmService.sendToUser — mode dev mocké", () => {
+  it("capture le push en mémoire (getPushLog) sans appeler Firebase", async () => {
+    findManyMock.mockResolvedValue([
+      { id: "reg-1", pushToken: "tok-1", platform: "web", userId: 1, isActive: true },
+    ])
+
+    const res = await fcmService.sendToUser({ userId: 1, senderId: 1, title: "Rappel", body: "RDV demain" })
+
+    expect(res).toEqual(expect.objectContaining({ sent: 1, failed: 0 }))
+    expect(getFcmMock).not.toHaveBeenCalled() // Firebase jamais sollicité
+    const log = getPushLog()
+    expect(log).toHaveLength(1)
+    expect(log[0]).toEqual(expect.objectContaining({ token: "tok-1", platform: "web", title: "Rappel", body: "RDV demain" }))
+    expect(auditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "CREATE", resource: "PUSH_NOTIFICATION" }),
+    )
+  })
+
+  it("sans device enregistré → aucun envoi", async () => {
+    findManyMock.mockResolvedValue([])
+    const res = await fcmService.sendToUser({ userId: 1, senderId: 1, title: "x", body: "y" })
+    expect(res).toEqual({ sent: 0, failed: 0, results: [] })
+    expect(getPushLog()).toHaveLength(0)
+  })
+})

--- a/tests/unit/fcm-stub.test.ts
+++ b/tests/unit/fcm-stub.test.ts
@@ -60,4 +60,26 @@ describe("fcmService.sendToUser — mode dev mocké", () => {
     expect(res).toEqual({ sent: 0, failed: 0, results: [] })
     expect(getPushLog()).toHaveLength(0)
   })
+
+  it("accumule les push successifs dans le buffer", async () => {
+    findManyMock.mockResolvedValue([
+      { id: "reg-1", pushToken: "tok-1", platform: "web", userId: 1, isActive: true },
+    ])
+    await fcmService.sendToUser({ userId: 1, senderId: 1, title: "A", body: "1" })
+    await fcmService.sendToUser({ userId: 1, senderId: 1, title: "B", body: "2" })
+    const log = getPushLog()
+    expect(log).toHaveLength(2)
+    expect(log.map((p) => p.title)).toEqual(["A", "B"])
+  })
+
+  it("MOCK_MODE=true stube même si une clé Firebase est présente", async () => {
+    vi.stubEnv("MOCK_MODE", "true")
+    vi.stubEnv("FIREBASE_SERVICE_ACCOUNT_KEY", "present")
+    findManyMock.mockResolvedValue([
+      { id: "reg-1", pushToken: "tok-1", platform: "web", userId: 1, isActive: true },
+    ])
+    const res = await fcmService.sendToUser({ userId: 1, senderId: 1, title: "x", body: "y" })
+    expect(res.sent).toBe(1)
+    expect(getFcmMock).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
Implémente **[US-2270](docs/UserStory/pro-user-stories/24-qa-test-environment/US-2270-socle-dev-mocke.md)** (socle du Domaine 24, prérequis des fixtures QA). Permet de lancer l'app **100 % offline** (sans Resend/Firebase/Upstash) pour dérouler la QA.

## Changements
- **`src/lib/mocks/dev-mock.ts`** — gate `isDevMocked(key)` : **jamais en prod** ; `MOCK_MODE=true` force le stub (hors prod) ; en `development` stub si la clé du service est absente ; en **`test`** pas de stub par défaut (les tests asservissent le vrai chemin).
- **Email** (`email.service`) : sans `RESEND_API_KEY` → `{sent:true, id:"mock-…"}`, aucun envoi, pas de PII loggée.
- **Push** (`fcm.service`) : sans `FIREBASE_SERVICE_ACCOUNT_KEY` → capturé dans une file mémoire **`getPushLog()`**, Firebase jamais sollicité.
- **Antivirus** (`antivirus.service`) : `MOCK_ANTIVIRUS=true` → clean déterministe (hors prod).
- **`.env.mock.dev.example`** (commité via exception `.gitignore`) + section **« mode dev mocké complet »** dans `docs/local-development.md`.

## Déjà offline (inchangé, rappelé dans la doc)
S3 → MinIO (`OVH_S3_ENDPOINT=localhost:9000`), Redis cache/idempotency → fallback `Map`, crypto/JWT → clés locales.

## Décision documentée (hors périmètre code)
La **révocation de session** (`revocation.ts`) reste un **no-op offline** : elle est vérifiée en **runtime Edge**, un fallback mémoire Node ne serait pas atteignable (l'archi a justement abandonné le `Map` pour le cross-runtime). Le logout vide le cookie ; Redis requis en prod. (Tracé dans la doc.)

## Tests
`isDevMocked` (gate, incl. `test`→pas de stub), stub email (mock vs prod hard-fail), stub push (capture mémoire + Firebase non sollicité). **tsc 0 · eslint 0 · 3001 tests verts** (les tests email/fcm existants passent : le gate exclut l'env `test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)