### PR TITLE
fix(appointments): combobox patient RDV — faux "Aucun patient ne correspond" + recherche backend >50

### DIFF
--- a/docs/security/xff-trusted-proxy.md
+++ b/docs/security/xff-trusted-proxy.md
@@ -1,0 +1,53 @@
+# Résolution de l'IP client (X-Forwarded-For) — durcissement transverse
+
+> **Statut** : backlog sécurité (MEDIUM). Identifié en revue PR #531 (round 3) par
+> le `healthcare-security-auditor`. **Pré-existant** — non introduit par cette PR.
+
+## Problème
+
+`extractRequestContext` (`src/lib/services/audit.service.ts`) résout l'IP client ainsi :
+
+```ts
+const ipAddress =
+  headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+  headers.get("x-real-ip") ??
+  "unknown"
+```
+
+Le **premier** segment de `x-forwarded-for` (hop **le plus à gauche**) est la valeur
+**que le client contrôle** : seul le hop ajouté par notre proxy de confiance (OVH GRA
+reverse proxy) en bout de chaîne est fiable. Conséquences :
+
+1. **Rate-limit per-IP évadable** — un attaquant authentifié peut envoyer
+   `X-Forwarded-For: 1.2.3.4` différent à chaque requête → chaque IP usurpée =
+   budget neuf (bucket `patientDataReadIp`). Le bucket per-IP devient une
+   défense en profondeur partielle. *Le bucket per-**user** (60/60s) borne la
+   menace réaliste (1 compte PS compromis qui scrape).*
+2. **IP des audit logs spoofable** — impact **forensique HDS/CNIL/ANS** : l'IP
+   tracée dans `audit_logs` n'est pas fiable tant que ce point n'est pas corrigé.
+
+## Pourquoi ce n'est PAS corrigé dans la PR #531
+
+La correction touche la résolution d'IP de **tout** le backoffice (toutes les
+routes + tous les audit logs), et dépend de la **topologie proxy réelle** (nombre
+de hops de confiance devant l'app, OVH positionne-t-il `x-real-ip` ?). La corriger
+à l'aveugle risquerait de **corrompre la forensique d'audit de toute l'application**.
+C'est un chantier transverse, hors du périmètre « combobox RDV ».
+
+## Correction recommandée (ticket dédié)
+
+1. Confirmer la topologie OVH GRA : nombre de proxies de confiance, présence et
+   fiabilité de `x-real-ip`.
+2. Résoudre l'IP depuis le **hop de confiance** (rightmost trusted hop) via un
+   `TRUSTED_PROXY_COUNT` configurable, **de façon cohérente pour l'audit ET le
+   rate-limit** (point unique dans `extractRequestContext`).
+3. Ajouter un test : un `X-Forwarded-For` client-supplied ne doit pas changer
+   l'IP résolue derrière N proxies de confiance.
+
+## Mitigations en place en attendant
+
+- Bucket rate-limit **per-user** (borne la menace post-auth réaliste).
+- Bucket per-IP en **fail-open** + **skip** quand l'IP = `"unknown"` (pas de
+  bucket partagé `ip:unknown`), cf. `src/app/api/patients/search/route.ts`.
+- La **confidentialité** ne repose pas sur le rate-limit mais sur le **RBAC**
+  (`accessibleIds`) — non affecté par le spoofing d'IP.

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -526,6 +526,7 @@
     "patientListError": "تعذر تحميل قائمة المرضى.",
     "patientSelected": "تم اختيار المريض",
     "patientNoResults": "لا يوجد مريض يطابق بحثك.",
+    "patientSearching": "جارٍ البحث…",
     "patientHint": "{count, plural, =0 {لا يوجد مريض متاح} one {مريض واحد متاح} two {مريضان متاحان} few {# مرضى متاحون} many {# مريضاً متاحاً} other {# مريض متاح}}",
     "scopeMissingChooseFirst": "يرجى اختيار عضو العيادة أولاً لإنشاء موعد.",
     "dndErrorConflict": "الموعد المستهدف محجوز بالفعل — تمت إعادة الموعد إلى موقعه الأصلي.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -526,6 +526,7 @@
     "patientListError": "Could not load patient list.",
     "patientSelected": "Patient selected",
     "patientNoResults": "No patient matches your search.",
+    "patientSearching": "Searching…",
     "patientHint": "{count, plural, =0 {No patient available} one {1 patient available} other {# patients available}}",
     "scopeMissingChooseFirst": "Please select a practice member first to create an appointment.",
     "dndErrorConflict": "Target slot already taken — appointment reverted to original position.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -526,6 +526,7 @@
     "patientListError": "Impossible de charger la liste des patients.",
     "patientSelected": "Patient sélectionné",
     "patientNoResults": "Aucun patient ne correspond à votre recherche.",
+    "patientSearching": "Recherche en cours…",
     "patientHint": "{count, plural, =0 {Aucun patient disponible} one {1 patient disponible} other {# patients disponibles}}",
     "scopeMissingChooseFirst": "Sélectionnez d'abord un membre cabinet pour créer un RDV.",
     "dndErrorConflict": "Le créneau cible est déjà pris — le RDV est revenu à sa position d'origine.",

--- a/prisma/migrations/20260612090000_us2500_patient_search_lastname_hmac_index/migration.sql
+++ b/prisma/migrations/20260612090000_us2500_patient_search_lastname_hmac_index/migration.sql
@@ -1,0 +1,17 @@
+-- PR #531 (US-2500) — Index dédié sur users.lastname_hmac.
+--
+-- La recherche patient tokenisée (patient.service → search) génère la branche
+-- `lastname_hmac = ANY($1)` SANS contrainte sur firstname_hmac. L'index composite
+-- existant "users_firstname_hmac_lastname_hmac_idx" ne peut PAS la servir
+-- (lastname_hmac est la 2e colonne) → seq scan sur "users". Cet index dédié
+-- rétablit un lookup indexé. firstname_hmac reste couvert par l'index composite
+-- (colonne de tête).
+--
+-- IF NOT EXISTS : idempotence si la migration est rejouée à la main (runbook
+-- incident) ; `migrate deploy` reste idempotent via son journal.
+-- Pas de CONCURRENTLY : `prisma migrate deploy` enveloppe chaque migration dans
+-- UNE transaction où `CREATE INDEX CONCURRENTLY` est interdit. Env non peuplé
+-- (ADR US-2267) → lock de build négligeable. Pour un env DÉJÀ peuplé : pré-créer
+-- l'index hors-bande en CONCURRENTLY (cf. docs/runbook/migrations.md) AVANT le
+-- deploy, le IF NOT EXISTS le sautera ensuite.
+CREATE INDEX IF NOT EXISTS "users_lastname_hmac_idx" ON "users"("lastname_hmac");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -291,87 +291,87 @@ enum EmergencyAlertActionType {
 // ═══════════════════════════════════════════════════════════════
 
 model User {
-  id                       Int        @id @default(autoincrement())
+  id                       Int               @id @default(autoincrement())
   email                    String // chiffre AES-256-GCM en production
-  emailHmac                String     @unique @map("email_hmac") // HMAC-SHA256 pour lookup unique
-  passwordHash             String     @map("password_hash")
+  emailHmac                String            @unique @map("email_hmac") // HMAC-SHA256 pour lookup unique
+  passwordHash             String            @map("password_hash")
   title                    String? // 'M.' | 'Mme' | 'Dr' | 'Prof'
   firstname                String? // chiffre
-  firstnameHmac            String?    @map("firstname_hmac") // HMAC-SHA256 pour recherche
+  firstnameHmac            String?           @map("firstname_hmac") // HMAC-SHA256 pour recherche
   firstnames               String? // chiffre
-  usedFirstname            String?    @map("used_firstname") // chiffre
+  usedFirstname            String?           @map("used_firstname") // chiffre
   lastname                 String? // chiffre
-  lastnameHmac             String?    @map("lastname_hmac") // HMAC-SHA256 pour recherche
-  usedLastname             String?    @map("used_lastname") // chiffre
-  birthday                 DateTime?  @db.Date // NON chiffre — type DATE natif PG, stocke en clair (cf. src/types/user.ts). Donnee directe : classification a documenter en DPIA (F9 review).
+  lastnameHmac             String?           @map("lastname_hmac") // HMAC-SHA256 pour recherche
+  usedLastname             String?           @map("used_lastname") // chiffre
+  birthday                 DateTime?         @db.Date // NON chiffre — type DATE natif PG, stocke en clair (cf. src/types/user.ts). Donnee directe : classification a documenter en DPIA (F9 review).
   sex                      Sex?
-  codeBirthPlace           String?    @map("code_birth_place") // chiffre
-  timezone                 String?    @default("Europe/Paris")
+  codeBirthPlace           String?           @map("code_birth_place") // chiffre
+  timezone                 String?           @default("Europe/Paris")
   phone                    String? // chiffre
   address1                 String? // chiffre
   address2                 String? // chiffre
   cp                       String? // chiffre
   city                     String? // chiffre
-  country                  String?    @db.Char(2)
+  country                  String?           @db.Char(2)
   pic                      String?
-  language                 Language?  @default(fr)
-  role                     Role       @default(VIEWER)
+  language                 Language?         @default(fr)
+  role                     Role              @default(VIEWER)
   /// US-2148 — Statut compte (active/suspended/archived). Suspension bloque
   /// le login dans /api/auth/login (vérification post-bcrypt).
-  status                   UserStatus @default(active)
+  status                   UserStatus        @default(active)
   /// US-2148 — Date de suspension/archivage. Set au moment de la transition.
-  statusChangedAt          DateTime?  @map("status_changed_at") @db.Timestamptz()
+  statusChangedAt          DateTime?         @map("status_changed_at") @db.Timestamptz()
   /// US-2148 — User-ID de l'admin ayant effectué la transition (audit + rollback).
   /// FK Restrict : empêche la suppression DELETE d'un admin qui a effectué des
   /// transitions. RGPD Art. 17 utilise l'anonymisation (non-DELETE) — la trace
   /// reste en colonne, le user est anonymisé via `deletion.service`.
-  statusChangedBy          Int?       @map("status_changed_by")
-  mfaSecret                String?    @map("mfa_secret")
-  mfaEnabled               Boolean    @default(false) @map("mfa_enabled")
+  statusChangedBy          Int?              @map("status_changed_by")
+  mfaSecret                String?           @map("mfa_secret")
+  mfaEnabled               Boolean           @default(false) @map("mfa_enabled")
   /// Last accepted TOTP time step (RFC 6238 T counter). Prevents replay of
   /// a code within its ±1 step window. Set atomically on successful verify.
-  mfaLastUsedStep          Int?       @map("mfa_last_used_step")
-  hasSignedTerms           Boolean    @default(false) @map("has_signed_terms")
-  profileComplete          Boolean    @default(false) @map("profile_complete")
-  needDataPolicyUpdate     Boolean    @default(false) @map("need_data_policy_update")
-  dataPolicyUpdate         DateTime?  @map("data_policy_update")
-  needPasswordUpdate       Boolean    @default(false) @map("need_password_update")
-  needOnboarding           Boolean    @default(false) @map("need_onboarding")
-  debug                    Boolean    @default(false)
+  mfaLastUsedStep          Int?              @map("mfa_last_used_step")
+  hasSignedTerms           Boolean           @default(false) @map("has_signed_terms")
+  profileComplete          Boolean           @default(false) @map("profile_complete")
+  needDataPolicyUpdate     Boolean           @default(false) @map("need_data_policy_update")
+  dataPolicyUpdate         DateTime?         @map("data_policy_update")
+  needPasswordUpdate       Boolean           @default(false) @map("need_password_update")
+  needOnboarding           Boolean           @default(false) @map("need_onboarding")
+  debug                    Boolean           @default(false)
   nirpp                    String? // chiffre — TRES SENSIBLE
-  nirppType                String?    @map("nirpp_type") // 'nir' | 'nia' | 'nir_key'
-  nirppPolicyholder        String?    @map("nirpp_policyholder") // chiffre
-  nirppPolicyholderType    String?    @map("nirpp_policyholder_type")
+  nirppType                String?           @map("nirpp_type") // 'nir' | 'nia' | 'nir_key'
+  nirppPolicyholder        String?           @map("nirpp_policyholder") // chiffre
+  nirppPolicyholderType    String?           @map("nirpp_policyholder_type")
   oid                      String? // interne — jamais expose
   ins                      String? // Identite Nationale de Sante, chiffre AES-256-GCM
   /// US-2026 — HMAC-SHA256 hex de l'INS plaintext (lookup unique anti-
   /// doublon RNIPP). NULL si pas d'INS renseigne. UNIQUE index avec
   /// NULLS DISTINCT (PG 16 default — plusieurs NULL autorises).
   /// Aligne `TEXT` avec emailHmac/firstnameHmac/lastnameHmac (M4 review).
-  insHmac                  String?    @map("ins_hmac")
+  insHmac                  String?           @map("ins_hmac")
   /// US-2026 C1 review — Statut de qualite INS conforme Referentiel ANS v3.
   /// V1 force `saisi_non_verifie` (INSi reste V2 US-2126 procurement-bloque).
   insQualityStatus         InsQualityStatus? @map("ins_quality_status")
   /// US-2026 C1 review — Timestamp de set INS (forensique HDS Art. L.1111-8).
-  insSetAt                 DateTime?  @map("ins_set_at") @db.Timestamptz()
+  insSetAt                 DateTime?         @map("ins_set_at") @db.Timestamptz()
   /// US-2026 H5 review — User qui a saisi l'INS (FK SetNull si anonymisation
   /// RGPD du saisisseur). Permet "INS saisi par DOCTOR.123 vs VIEWER auto".
   /// Index partiel `users_ins_set_by_user_id_idx WHERE ins_set_by_user_id
   /// IS NOT NULL` defini en SQL uniquement (Prisma ne supporte pas partial
   /// WHERE dans `@@index` cote schema — cf. messaging.thread idem).
-  insSetByUserId           Int?       @map("ins_set_by_user_id")
+  insSetByUserId           Int?              @map("ins_set_by_user_id")
   /// US-2026 C1 review — Hash SHA-256 des traits d'identite au moment du
   /// set (nom+prenom+dob+sex+lieu naissance). Permet de detecter qu'un
   /// trait a change post-set (declenche re-verification INSi futur V2).
-  insTraitsHash            String?    @map("ins_traits_hash")
-  intercomHash             String?    @map("intercom_hash") // interne — jamais expose
-  deploymentKey            String?    @map("deployment_key") // interne — jamais expose
+  insTraitsHash            String?           @map("ins_traits_hash")
+  intercomHash             String?           @map("intercom_hash") // interne — jamais expose
+  deploymentKey            String?           @map("deployment_key") // interne — jamais expose
   pro                      String? // interne
-  photoUrl                 String?    @map("photo_url") @db.VarChar(500)
-  displayModalTlsMutual    Boolean    @default(false) @map("display_modal_tls_mutual")
-  displayModalTlsMandatory Boolean    @default(false) @map("display_modal_tls_mandatory")
-  createdAt                DateTime   @default(now()) @map("created_at")
-  updatedAt                DateTime   @updatedAt @map("updated_at")
+  photoUrl                 String?           @map("photo_url") @db.VarChar(500)
+  displayModalTlsMutual    Boolean           @default(false) @map("display_modal_tls_mutual")
+  displayModalTlsMandatory Boolean           @default(false) @map("display_modal_tls_mandatory")
+  createdAt                DateTime          @default(now()) @map("created_at")
+  updatedAt                DateTime          @updatedAt @map("updated_at")
 
   // Relations
   patient                           Patient?
@@ -444,14 +444,20 @@ model User {
   insSetByUser                      User?                             @relation("InsSetter", fields: [insSetByUserId], references: [id], onDelete: SetNull)
   insSetForUsers                    User[]                            @relation("InsSetter")
 
-  @@index([createdAt])
-  @@index([firstnameHmac, lastnameHmac])
-  /// US-2148 — supporte le count anti-lockout `count(active ADMIN)` et le
-  /// filtre admin de la liste users.
-  @@index([status, role])
   /// US-2026 — INS unique anti-doublon RNIPP. PG default NULLS DISTINCT
   /// autorise plusieurs NULL (PS / ADMIN sans INS renseigne).
   @@unique([insHmac], map: "users_ins_hmac_key")
+  @@index([createdAt])
+  @@index([firstnameHmac, lastnameHmac])
+  /// PR #531 — recherche patient tokenisée : la branche `lastnameHmac = ANY(...)`
+  /// (sans contrainte sur firstnameHmac) ne peut PAS utiliser l'index composite
+  /// ci-dessus (lastnameHmac est la 2e colonne). Index dédié pour éviter le
+  /// seq-scan sur `users`. firstnameHmac reste couvert par l'index composite
+  /// (colonne de tête).
+  @@index([lastnameHmac])
+  /// US-2148 — supporte le count anti-lockout `count(active ADMIN)` et le
+  /// filtre admin de la liste users.
+  @@index([status, role])
   @@map("users")
 }
 
@@ -476,13 +482,13 @@ model Account {
 }
 
 model Session {
-  id           String   @id @default(cuid())
-  sessionToken String   @unique @map("session_token")
-  userId       Int      @map("user_id")
-  expires      DateTime
+  id                String    @id @default(cuid())
+  sessionToken      String    @unique @map("session_token")
+  userId            Int       @map("user_id")
+  expires           DateTime
   /// True if this session was created via MFA challenge. HDS forensics:
   /// "which live sessions were second-factor-verified vs password-only".
-  mfaVerified  Boolean  @default(false) @map("mfa_verified")
+  mfaVerified       Boolean   @default(false) @map("mfa_verified")
   /// Plan B follow-up A2 — Step-up MFA freshness timestamp. Bumped à chaque
   /// MFA challenge réussi (login OU step-up). `requireFreshMfa` exige que ce
   /// timestamp soit < `STEP_UP_WINDOW_SECONDS` (5min) pour les actions
@@ -492,11 +498,11 @@ model Session {
   /// US-2007 (Groupe 9) — metadata pour la vue "Sessions multiples" UI :
   /// le user identifie chaque session par device/localisation et peut
   /// la révoquer. Pas de PHI — IP et UA déjà persistés en AuditLog.
-  createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz()
-  ipAddress    String?  @map("ip_address") @db.VarChar(45)
-  userAgent    String?  @map("user_agent") @db.VarChar(500)
+  createdAt         DateTime  @default(now()) @map("created_at") @db.Timestamptz()
+  ipAddress         String?   @map("ip_address") @db.VarChar(45)
+  userAgent         String?   @map("user_agent") @db.VarChar(500)
   /// Dernière activité (bumpé à chaque vérification token).
-  lastSeenAt   DateTime @default(now()) @map("last_seen_at") @db.Timestamptz()
+  lastSeenAt        DateTime  @default(now()) @map("last_seen_at") @db.Timestamptz()
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -670,10 +676,10 @@ model Patient {
   /// US-2076 scope A — Messages liés au patient (pivot audit US-2268).
   messages               Message[]
 
-  @@index([deletedAt])
   /// US-2076bis-V2 (Issue #442) — lookup `publicRef → patientId` interne
   /// (résolve quand UI envoie ref opaque). UNIQUE empêche collision UUID v4.
   @@unique([publicRef], map: "patients_public_ref_key")
+  @@index([deletedAt])
   @@map("patients")
 }
 
@@ -1509,16 +1515,16 @@ model SupportedDevice {
 
   /// Unicité par (brand, model, category) : un même device n'a qu'une entrée.
   @@unique([brand, model, category])
-  /// Index pour search par brand + category (UI filter pairing).
-  /// CI drift fix — `map:` explicite car migration originale a nommé l'index
-  /// `_active_idx` (vs Prisma auto-name `_is_active_idx`).
-  @@index([category, isActive], map: "supported_devices_category_active_idx")
   /// CR L4 / HSA L3 — model_identifier unique quand renseigné
   /// (USB VID:PID ou BLE UUID = identifiant matériel global). PG défaut
   /// NULLS DISTINCT permet multiples NULL (legacy devices).
   /// (Prisma auto-name = `supported_devices_model_identifier_key` —
   /// L6 round 2 review : `map:` redondant retiré.)
   @@unique([modelIdentifier])
+  /// Index pour search par brand + category (UI filter pairing).
+  /// CI drift fix — `map:` explicite car migration originale a nommé l'index
+  /// `_active_idx` (vs Prisma auto-name `_is_active_idx`).
+  @@index([category, isActive], map: "supported_devices_category_active_idx")
   @@map("supported_devices")
 }
 
@@ -1540,44 +1546,44 @@ model DeviceDataSync {
 // ═══════════════════════════════════════════════════════════════
 
 model HealthcareService {
-  id            Int         @id @default(autoincrement())
-  name          String      @db.VarChar(255)
-  establishment String?     @db.VarChar(255)
+  id               Int         @id @default(autoincrement())
+  name             String      @db.VarChar(255)
+  establishment    String?     @db.VarChar(255)
   /// US-2117 — Adresse complète (chiffrée AES-256-GCM si contient des PII
   /// identifiables ; ici champ de rue donc plain). Utile pour annuaire,
   /// envoi documents postaux, etc.
-  addressLine1  String?     @map("address_line1") @db.VarChar(255)
-  addressLine2  String?     @map("address_line2") @db.VarChar(255)
-  postalCode    String?     @map("postal_code") @db.VarChar(10)
-  city          String?     @db.VarChar(100)
-  country       String?     @db.Char(2)
+  addressLine1     String?     @map("address_line1") @db.VarChar(255)
+  addressLine2     String?     @map("address_line2") @db.VarChar(255)
+  postalCode       String?     @map("postal_code") @db.VarChar(10)
+  city             String?     @db.VarChar(100)
+  country          String?     @db.Char(2)
   /// US-2117 — Coordonnées de contact (publiques cabinet).
-  phone         String?     @db.VarChar(30)
-  email         String?     @db.VarChar(255)
-  website       String?     @db.VarChar(500)
+  phone            String?     @db.VarChar(30)
+  email            String?     @db.VarChar(255)
+  website          String?     @db.VarChar(500)
   /// US-2117 — Horaires d'ouverture format JSON :
   /// { mon: [["09:00","12:00"],["14:00","18:00"]], tue: [...], ..., sun: [] }
   /// Tableau vide = fermé. Validation côté service (Zod).
-  openingHours  Json?       @map("opening_hours")
+  openingHours     Json?       @map("opening_hours")
   /// US-2117 — Spécialités cliniques (libellés libres ou codes CIM).
   /// Ex: ["diabetologie", "endocrinologie", "pediatrie"]. Cardinalité 0-N.
-  specialties   String[]    @default([])
+  specialties      String[]    @default([])
   /// US-2117 — Capacité (lits / box / postes consultation). Optionnel.
-  capacity      Int?
+  capacity         Int?
   /// US-2117 — Manager responsable (User backoffice). Différent du référent
   /// patient (qui est par patient). Le manager voit tous les patients du
   /// service via PatientService (relation existante).
-  managerId     Int?        @map("manager_id")
+  managerId        Int?        @map("manager_id")
   /// `Restrict` cohérent avec le reste du schéma (statusChangedBy, BackupLog.triggeredBy) :
   /// la suppression d'un User manager d'un service échoue côté DB, forçant un
   /// admin à réassigner explicitement avant deletion. Évite l'orphelinage silencieux
   /// d'une structure dont le manager a été supprimé.
-  manager       User?       @relation("HealthcareServiceManager", fields: [managerId], references: [id], onDelete: Restrict)
-  noVideos      Boolean     @default(false) @map("no_videos")
-  noFood        Boolean     @default(false) @map("no_food")
-  logo          String?     @db.VarChar(500)
+  manager          User?       @relation("HealthcareServiceManager", fields: [managerId], references: [id], onDelete: Restrict)
+  noVideos         Boolean     @default(false) @map("no_videos")
+  noFood           Boolean     @default(false) @map("no_food")
+  logo             String?     @db.VarChar(500)
   /// US-2118 — Type de structure (cabinet, hôpital, praticien libéral).
-  type          ServiceType @default(clinic)
+  type             ServiceType @default(clinic)
   /// US-2118 — Numéro RPPS (11 digits) / ADELI (9 digits) pour praticiens
   /// libéraux. Validation Luhn + format côté service. Optionnel pour
   /// cabinets / hôpitaux.
@@ -1587,22 +1593,22 @@ model HealthcareService {
   /// contrainte unique inline rejetterait la création du nouveau cabinet
   /// avant suppression de l'ancien. La validation business (warning
   /// "RPPS déjà utilisé") est appliquée au service layer si besoin futur.
-  licenseNumber String?     @map("license_number") @db.VarChar(11)
+  licenseNumber    String?     @map("license_number") @db.VarChar(11)
   /// Groupe 7 Batch 1 — Mentions légales obligatoires sur facture FR
   /// (art. 242 nonies A CGI, art. L441-9 Code de commerce). Stockés sur
   /// HealthcareService pour snapshot atomique à l'issuance Invoice.
   /// SIRET = 14 digits, validation Luhn côté service (US-2118 patron).
-  siret         String?     @db.VarChar(14)
+  siret            String?     @db.VarChar(14)
   /// Numéro TVA intracommunautaire (FR : FR + 2 cipher + SIREN = 13 chars).
-  tvaIntra      String?     @map("tva_intra") @db.VarChar(15)
+  tvaIntra         String?     @map("tva_intra") @db.VarChar(15)
   /// IBAN pour paiement par virement (US-2102). Standard ISO 13616.
-  iban          String?     @db.VarChar(34)
+  iban             String?     @db.VarChar(34)
   /// US-2506 V1 mock — Feature flag SMS active par cabinet (admin toggle).
   /// Real provider (Twilio/OVH) reportee V3 sous US-2506bis.
-  smsEnabled        Boolean @default(false) @map("sms_enabled")
+  smsEnabled       Boolean     @default(false) @map("sms_enabled")
   /// US-2506 V1 mock — Credits SMS prepayes (decrement par envoi reussi).
   /// Alerte ops si <10. Mock V1 = on n'achete pas vraiment.
-  smsCreditBalance  Int     @default(0) @map("sms_credit_balance")
+  smsCreditBalance Int         @default(0) @map("sms_credit_balance")
 
   members                    HealthcareMember[]
   patientServices            PatientService[]
@@ -3172,19 +3178,19 @@ enum InvoiceReminderStatus {
 }
 
 model InvoiceReminder {
-  id             Int                  @id @default(autoincrement())
-  invoiceId      Int                  @map("invoice_id")
+  id             Int                   @id @default(autoincrement())
+  invoiceId      Int                   @map("invoice_id")
   step           InvoiceReminderStep
-  sentAt         DateTime             @default(now()) @map("sent_at") @db.Timestamptz()
+  sentAt         DateTime              @default(now()) @map("sent_at") @db.Timestamptz()
   status         InvoiceReminderStatus @default(sent)
   /// Email destinataire chiffre AES-256-GCM (base64) — forensique sans
   /// exposer mail patient en clair en BDD. Optional car certaines step
   /// `skipped` arrivent avant qu'on ait pu dechiffrer.
-  sentToEnc      String?              @map("sent_to_enc")
+  sentToEnc      String?               @map("sent_to_enc")
   /// ID Resend (data.id) — debug rebonds via Resend dashboard.
-  emailMessageId String?              @map("email_message_id") @db.VarChar(100)
+  emailMessageId String?               @map("email_message_id") @db.VarChar(100)
   /// Message d'erreur Resend (pas de PHI — code/timeout). Cap 500 chars.
-  errorMessage   String?              @map("error_message") @db.VarChar(500)
+  errorMessage   String?               @map("error_message") @db.VarChar(500)
 
   invoice Invoice @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
 
@@ -3420,25 +3426,25 @@ enum SmsStatus {
 /// par defaut). V3 = real Twilio/OVH (status=sent/failed). Le mock est
 /// utilise par US-2502 pour les rappels RDV J-1.
 model SmsLog {
-  id                  Int       @id @default(autoincrement())
-  cabinetId           Int       @map("cabinet_id")
+  id                Int       @id @default(autoincrement())
+  cabinetId         Int       @map("cabinet_id")
   /// Numero destinataire chiffre AES-256-GCM base64 (defensive vs dump
   /// BDD). Optional pour status='skipped' (avant decryption).
-  toEnc               String?   @map("to_enc")
+  toEnc             String?   @map("to_enc")
   /// Apercu 120 premiers chars du message (forensique sans plaintext
   /// complet contre leak PHI).
-  messageExcerpt      String?   @map("message_excerpt") @db.VarChar(120)
-  status              SmsStatus @default(mock)
+  messageExcerpt    String?   @map("message_excerpt") @db.VarChar(120)
+  status            SmsStatus @default(mock)
   /// Provider : 'mock' (V1) | 'twilio' (V3) | 'ovh' (V3).
-  provider            String    @default("mock") @db.VarChar(30)
+  provider          String    @default("mock") @db.VarChar(30)
   /// ID Twilio/OVH si real ; UUID mock-* si V1.
-  providerMessageId   String?   @map("provider_message_id") @db.VarChar(100)
+  providerMessageId String?   @map("provider_message_id") @db.VarChar(100)
   /// Cout en credits (1 SMS standard = 1 credit V1).
-  creditCost          Int       @default(1) @map("credit_cost")
-  errorMessage        String?   @map("error_message") @db.VarChar(500)
-  sentAt              DateTime  @default(now()) @map("sent_at") @db.Timestamptz()
+  creditCost        Int       @default(1) @map("credit_cost")
+  errorMessage      String?   @map("error_message") @db.VarChar(500)
+  sentAt            DateTime  @default(now()) @map("sent_at") @db.Timestamptz()
   /// Contexte d'envoi : 'appointment_reminder' (US-2502) | futurs.
-  contextKind         String    @map("context_kind") @db.VarChar(50)
+  contextKind       String    @map("context_kind") @db.VarChar(50)
 
   /// M7 round 2 — Restrict pour préserver l'historique audit SMS forensique
   /// (HealthcareService n'est jamais hard-deleted en pratique, mais CASCADE
@@ -3486,20 +3492,20 @@ enum AppointmentReminderStatus {
 /// Idempotence absolue : `@@unique([appointmentId, channel, step])`
 /// empeche envoi double si cron rejoue.
 model AppointmentReminder {
-  id                  Int                          @id @default(autoincrement())
-  appointmentId       Int                          @map("appointment_id")
-  channel             AppointmentReminderChannel
-  step                AppointmentReminderStep
+  id                Int                        @id @default(autoincrement())
+  appointmentId     Int                        @map("appointment_id")
+  channel           AppointmentReminderChannel
+  step              AppointmentReminderStep
   /// M6 round 2 — default `skipped` (vs `sent` trompeur). Le caller doit
   /// marquer explicitement `sent` après envoi réussi (defense-in-depth
   /// si bulk insert futur omet le statut).
-  status              AppointmentReminderStatus    @default(skipped)
-  sentAt              DateTime                     @default(now()) @map("sent_at") @db.Timestamptz()
+  status            AppointmentReminderStatus  @default(skipped)
+  sentAt            DateTime                   @default(now()) @map("sent_at") @db.Timestamptz()
   /// Destinataire chiffre AES-256-GCM (email pour channel=email, phone
   /// pour channel=sms, fcmToken pour channel=push).
-  sentToEnc           String?                      @map("sent_to_enc")
-  providerMessageId   String?                      @map("provider_message_id") @db.VarChar(100)
-  errorMessage        String?                      @map("error_message") @db.VarChar(500)
+  sentToEnc         String?                    @map("sent_to_enc")
+  providerMessageId String?                    @map("provider_message_id") @db.VarChar(100)
+  errorMessage      String?                    @map("error_message") @db.VarChar(500)
 
   appointment Appointment @relation(fields: [appointmentId], references: [id], onDelete: Cascade)
 

--- a/src/app/api/patients/search/route.ts
+++ b/src/app/api/patients/search/route.ts
@@ -60,21 +60,35 @@ const querySchema = z.object({
 export async function GET(req: NextRequest) {
   try {
     const user = requireRole(req, "NURSE")
+    const ctx = extractRequestContext(req)
 
-    // Rate-limit endpoint PHI (aligné avec /analytics, /glycemia, /meal-photos).
+    // Rate-limit endpoint PHI (aligné /analytics, /glycemia, /meal-photos).
     // Borne l'énumération `#1 #2 #3…` + la récolte de noms déchiffrés au débit
-    // d'un autocomplete légitime. Fail-open (availability-first) via le bucket.
-    const rl = await checkApiRateLimit(String(user.id), RATE_LIMITS.patientDataRead)
-    if (!rl.allowed) {
+    // d'un autocomplete légitime. Double bucket per-user + per-IP (cohérent
+    // avec les autres endpoints exfil-sensibles) : le per-IP couvre le fan-out
+    // credential-stuffing depuis un seul hôte. Fail-open — la confidentialité
+    // repose sur le RBAC `accessibleIds`, pas le limiter.
+    const rlUser = await checkApiRateLimit(String(user.id), RATE_LIMITS.patientDataRead)
+    if (!rlUser.allowed) {
       return setPatientsSearchSecurityHeaders(
         NextResponse.json(
           { error: "rateLimitExceeded" },
-          { status: 429, headers: { "Retry-After": String(rl.retryAfterSec) } },
+          { status: 429, headers: { "Retry-After": String(rlUser.retryAfterSec) } },
         ),
       )
     }
-
-    const ctx = extractRequestContext(req)
+    const rlIp = await checkApiRateLimit(
+      `ip:${ctx.ipAddress ?? "unknown-ip"}`,
+      RATE_LIMITS.patientDataReadIp,
+    )
+    if (!rlIp.allowed) {
+      return setPatientsSearchSecurityHeaders(
+        NextResponse.json(
+          { error: "rateLimitExceeded" },
+          { status: 429, headers: { "Retry-After": String(rlIp.retryAfterSec) } },
+        ),
+      )
+    }
 
     const parsed = querySchema.safeParse(
       Object.fromEntries(req.nextUrl.searchParams.entries()),

--- a/src/app/api/patients/search/route.ts
+++ b/src/app/api/patients/search/route.ts
@@ -77,17 +77,26 @@ export async function GET(req: NextRequest) {
         ),
       )
     }
-    const rlIp = await checkApiRateLimit(
-      `ip:${ctx.ipAddress ?? "unknown-ip"}`,
-      RATE_LIMITS.patientDataReadIp,
-    )
-    if (!rlIp.allowed) {
-      return setPatientsSearchSecurityHeaders(
-        NextResponse.json(
-          { error: "rateLimitExceeded" },
-          { status: 429, headers: { "Retry-After": String(rlIp.retryAfterSec) } },
-        ),
+    // Bucket per-IP : on SKIP quand l'IP n'est pas résolue (`extractRequestContext`
+    // renvoie la sentinelle "unknown"). Sinon toutes les requêtes sans
+    // `x-forwarded-for` (proxy contourné, health-checks) tomberaient dans UN
+    // seul bucket partagé `ip:unknown` → DoS auto-infligé (revue round 3). Le
+    // bucket per-user reste appliqué dans tous les cas. NB : l'IP vient du hop
+    // XFF le plus à gauche (spoofable) — durcissement transverse suivi dans
+    // docs/security/xff-trusted-proxy.md.
+    if (ctx.ipAddress && ctx.ipAddress !== "unknown") {
+      const rlIp = await checkApiRateLimit(
+        `ip:${ctx.ipAddress}`,
+        RATE_LIMITS.patientDataReadIp,
       )
+      if (!rlIp.allowed) {
+        return setPatientsSearchSecurityHeaders(
+          NextResponse.json(
+            { error: "rateLimitExceeded" },
+            { status: 429, headers: { "Retry-After": String(rlIp.retryAfterSec) } },
+          ),
+        )
+      }
     }
 
     const parsed = querySchema.safeParse(

--- a/src/app/api/patients/search/route.ts
+++ b/src/app/api/patients/search/route.ts
@@ -1,15 +1,22 @@
 /**
- * US-2019 — Recherche patient (full-text exact match sur HMAC + filtres).
+ * US-2019 — Recherche patient (HMAC tokenisé + filtres).
  *
  * Query params:
- *  - `search`     — nom OU prénom EXACT (case-insensitive). HMAC déterministe
- *                   sur User.firstnameHmac / User.lastnameHmac.
+ *  - `search`     — nom et/ou prénom. La saisie est **tokenisée par mot** côté
+ *                   service : chaque token COMPLET est matché par HMAC exact sur
+ *                   User.firstnameHmac / lastnameHmac (les noms chiffrés ne
+ *                   permettent pas de `LIKE %fragment%`). Un token `#<id>`
+ *                   résout directement l'id patient (désambiguïsation homonymes).
  *  - `pathology`  — DT1 / DT2 / GD (exact match).
  *  - `cursor`     — id patient (pagination).
  *  - `limit`      — page size (1..50, défaut 25).
  *
  * Scoping RBAC : ADMIN voit tout, DOCTOR/NURSE limités aux patients de leurs
- * services, VIEWER → own patient. Le `search` ne contourne JAMAIS la scope.
+ * services, VIEWER → own patient. Le `search` ne contourne JAMAIS la scope
+ * (le `id IN accessibleIds` top-level est ANDé avec le OR de recherche).
+ *
+ * Rate-limit : `patientDataRead` (60/60s/user, fail-open) — endpoint PHI
+ * (noms déchiffrés) appelé par l'autocomplete + recherche `#id` énumérable.
  *
  * Audit : `READ` sur `PATIENT` (`resourceId="search"`) avec le count + flags.
  */
@@ -18,6 +25,7 @@ import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
 import { Pathology } from "@prisma/client"
 import { requireRole, AuthError } from "@/lib/auth"
+import { checkApiRateLimit, RATE_LIMITS } from "@/lib/auth/api-rate-limit"
 import { getAccessiblePatientIds } from "@/lib/access-control"
 import { patientService } from "@/lib/services/patient.service"
 import { extractRequestContext } from "@/lib/services/audit.service"
@@ -52,6 +60,20 @@ const querySchema = z.object({
 export async function GET(req: NextRequest) {
   try {
     const user = requireRole(req, "NURSE")
+
+    // Rate-limit endpoint PHI (aligné avec /analytics, /glycemia, /meal-photos).
+    // Borne l'énumération `#1 #2 #3…` + la récolte de noms déchiffrés au débit
+    // d'un autocomplete légitime. Fail-open (availability-first) via le bucket.
+    const rl = await checkApiRateLimit(String(user.id), RATE_LIMITS.patientDataRead)
+    if (!rl.allowed) {
+      return setPatientsSearchSecurityHeaders(
+        NextResponse.json(
+          { error: "rateLimitExceeded" },
+          { status: 429, headers: { "Retry-After": String(rl.retryAfterSec) } },
+        ),
+      )
+    }
+
     const ctx = extractRequestContext(req)
 
     const parsed = querySchema.safeParse(

--- a/src/components/diabeo/appointments/PatientCombobox.tsx
+++ b/src/components/diabeo/appointments/PatientCombobox.tsx
@@ -12,8 +12,10 @@
  *     2 patients homonymes "Jean Martin" deviennent "Jean Martin #42" vs
  *     "Jean Martin #43" → médecin distingue visuellement, élimine le risque
  *     clinique de RDV créé pour le mauvais patient)
- *   - debounce 250ms via `useDeferredValue` React 19 (Fix FE-2 round 1 :
- *     plus de setState-in-effect anti-pattern)
+ *   - **filtrage 100% client-side** sur la liste large (≤ 50) fetchée une seule
+ *     fois : le backend `search=` fait un match HMAC EXACT (prénom/nom complet)
+ *     incompatible avec une recherche au fil de la frappe, donc on ne l'appelle
+ *     pas par keystroke (sinon `items` se vide → faux "aucun patient").
  *
  * **Stratégie** : V1 simple — `<input>` + `<datalist>` natif HTML5 pour éviter
  * d'ajouter Command/Popover shadcn. UX : autocomplete navigateur natif (Chrome,
@@ -35,7 +37,7 @@
 
 import { useCallback, useDeferredValue, useMemo, useState } from "react"
 import { useTranslations } from "next-intl"
-import { usePatientList } from "./usePatientList"
+import { usePatientList, type PatientListItem } from "./usePatientList"
 
 export interface PatientComboboxProps {
   /** id input DOM pour association `<Label>`. */
@@ -84,16 +86,42 @@ function normalize(s: string): string {
 export function PatientCombobox({ id, value, onChange, disabled }: PatientComboboxProps) {
   const t = useTranslations("appointments")
   const [inputValue, setInputValue] = useState("")
-  // Fix FE-2 round 1 review PR #434 — `useDeferredValue` React 19 (vs ancien
-  // pattern setState-in-effect + setTimeout custom). Le rendu utilise la valeur
-  // "fraîche" pour l'input mais la valeur "deferred" pour le fetch backend.
-  // React 19 ajuste automatiquement le délai selon la charge CPU.
-  const deferredInput = useDeferredValue(inputValue)
 
-  const { items, loading, error } = usePatientList({
-    enabled: true, // composant n'est rendu que dans modal ouvert (parent gate)
-    search: deferredInput.trim().length > 0 ? deferredInput.trim() : undefined,
+  // ── Liste base (stable) ────────────────────────────────────────────────
+  // Fetch large (≤ 50) UNE seule fois, jamais piloté par la frappe. Sert de
+  // socle au filtrage client-side accent-aware. Le backend `search=` étant un
+  // match HMAC **exact**, l'alimenter au fil de la frappe viderait la liste
+  // (fragment "Jea" → 0 match) → faux "Aucun patient ne correspond" + input
+  // disabled. Le composant n'est rendu que dans un modal ouvert (parent gate).
+  const base = usePatientList({ enabled: true })
+
+  // ── Recherche backend complémentaire (cabinets > 50 patients) ──────────
+  // Un patient absent des 50 premiers devient trouvable en tapant son nom OU
+  // prénom COMPLET (le backend tokenise + matche par HMAC exact, cf.
+  // patient.service → search). Débounce via `useDeferredValue` (React 19). Ses
+  // résultats AUGMENTENT la liste (merge ci-dessous) au lieu de la remplacer :
+  //   - pas de collapse de la liste base,
+  //   - input jamais désactivé par cette recherche (seul `base.loading` gate),
+  //   - la sélection reste possible (le patient surfacé reste dans `items`).
+  const deferredSearch = useDeferredValue(inputValue.trim())
+  const searchActive = deferredSearch.length > 0
+  const search = usePatientList({
+    enabled: searchActive,
+    search: searchActive ? deferredSearch : undefined,
   })
+
+  // Union dédupliquée par id (base d'abord → ordre stable, hits de recherche
+  // ajoutés ensuite). `items` est la liste affichée + filtrée client-side.
+  const items = useMemo<PatientListItem[]>(() => {
+    const byId = new Map<number, PatientListItem>()
+    for (const p of base.items) byId.set(p.id, p)
+    for (const p of search.items) if (!byId.has(p.id)) byId.set(p.id, p)
+    return [...byId.values()]
+  }, [base.items, search.items])
+
+  const loading = base.loading
+  const error = base.error ?? search.error
+  const searching = searchActive && search.loading
 
   // Filtre client-side fallback (utile pour les 50 premiers sans search backend).
   // Accent-aware via `normalize()` — couvre "Müller" tapé "muller".
@@ -128,11 +156,15 @@ export function PatientCombobox({ id, value, onChange, disabled }: PatientCombob
   // Fix FE-7 round 1 review PR #434 — états distincts du hint :
   //   - loading → "Chargement…"
   //   - error → role=alert
+  //   - searching → recherche backend complémentaire en cours (anti-flicker :
+  //     on n'affiche pas "aucun résultat" tant qu'un fetch peut encore remonter
+  //     un patient hors des 50 premiers)
   //   - no-results (user a tapé + filter vide) → "Aucun patient trouvé"
   //   - selected (value !== null) → "Patient sélectionné"
   //   - idle (default) → "X patient(s) disponible(s)" avec total backend
   const isSearching = inputValue.trim().length > 0
-  const noResults = !loading && !error && isSearching && filtered.length === 0
+  const noResults =
+    !loading && !error && !searching && isSearching && filtered.length === 0
 
   return (
     <div className="grid gap-1">
@@ -163,12 +195,15 @@ export function PatientCombobox({ id, value, onChange, disabled }: PatientCombob
             {t("patientListError")}
           </span>
         )}
+        {searching && !loading && !error && (
+          <span role="status">{t("patientSearching")}</span>
+        )}
         {noResults && (
           <span role="status" className="text-amber-700">
             {t("patientNoResults")}
           </span>
         )}
-        {!loading && !error && !noResults && (
+        {!loading && !error && !searching && !noResults && (
           value !== null
             ? t("patientSelected")
             // Fix FE-9 round 1 review PR #434 — count NON-filtré (`items.length`)

--- a/src/components/diabeo/appointments/PatientCombobox.tsx
+++ b/src/components/diabeo/appointments/PatientCombobox.tsx
@@ -83,6 +83,12 @@ function normalize(s: string): string {
   return s.normalize("NFD").replace(/\p{Diacritic}/gu, "").toLowerCase()
 }
 
+/**
+ * Longueur minimale avant de solliciter la recherche backend complémentaire.
+ * Évite de marteler un endpoint PHI sur chaque 1re lettre (revue PR #531).
+ */
+const MIN_BACKEND_SEARCH_LEN = 2
+
 export function PatientCombobox({ id, value, onChange, disabled }: PatientComboboxProps) {
   const t = useTranslations("appointments")
   const [inputValue, setInputValue] = useState("")
@@ -98,13 +104,16 @@ export function PatientCombobox({ id, value, onChange, disabled }: PatientCombob
   // ── Recherche backend complémentaire (cabinets > 50 patients) ──────────
   // Un patient absent des 50 premiers devient trouvable en tapant son nom OU
   // prénom COMPLET (le backend tokenise + matche par HMAC exact, cf.
-  // patient.service → search). Débounce via `useDeferredValue` (React 19). Ses
-  // résultats AUGMENTENT la liste (merge ci-dessous) au lieu de la remplacer :
-  //   - pas de collapse de la liste base,
-  //   - input jamais désactivé par cette recherche (seul `base.loading` gate),
-  //   - la sélection reste possible (le patient surfacé reste dans `items`).
+  // patient.service → search). Ses résultats AUGMENTENT la liste (merge
+  // ci-dessous) au lieu de la remplacer → pas de collapse, sélection préservée.
+  //
+  // ⚠️ `useDeferredValue` n'est PAS un debounce réseau : il diffère seulement la
+  // priorité de RENDU, donc le fetch part dès que la valeur déférée se stabilise.
+  // On gate sur `MIN_BACKEND_SEARCH_LEN` pour ne pas frapper l'endpoint PHI sur
+  // chaque 1re lettre ; `usePatientList` annule la requête précédente
+  // (AbortController) à chaque changement de `search`.
   const deferredSearch = useDeferredValue(inputValue.trim())
-  const searchActive = deferredSearch.length > 0
+  const searchActive = deferredSearch.length >= MIN_BACKEND_SEARCH_LEN
   const search = usePatientList({
     enabled: searchActive,
     search: searchActive ? deferredSearch : undefined,
@@ -120,7 +129,11 @@ export function PatientCombobox({ id, value, onChange, disabled }: PatientCombob
   }, [base.items, search.items])
 
   const loading = base.loading
-  const error = base.error ?? search.error
+  // Seul l'échec de la liste BASE bloque. Un échec de la recherche
+  // complémentaire (token bizarre → 500) ne doit PAS transformer un combobox
+  // fonctionnel en bandeau d'erreur : il se traduit juste par une absence
+  // d'augmentation (revue PR #531).
+  const error = base.error
   const searching = searchActive && search.loading
 
   // Filtre client-side fallback (utile pour les 50 premiers sans search backend).
@@ -155,10 +168,10 @@ export function PatientCombobox({ id, value, onChange, disabled }: PatientCombob
 
   // Fix FE-7 round 1 review PR #434 — états distincts du hint :
   //   - loading → "Chargement…"
-  //   - error → role=alert
-  //   - searching → recherche backend complémentaire en cours (anti-flicker :
-  //     on n'affiche pas "aucun résultat" tant qu'un fetch peut encore remonter
-  //     un patient hors des 50 premiers)
+  //   - error → région role=alert dédiée (séparée du live region polite)
+  //   - searching → recherche complémentaire en vol : signalée via `aria-busy`
+  //     sur l'input (PAS annoncée en texte, anti-spam SR) + anti-flicker (on
+  //     n'affiche pas "aucun résultat" tant qu'un fetch peut remonter un >50)
   //   - no-results (user a tapé + filter vide) → "Aucun patient trouvé"
   //   - selected (value !== null) → "Patient sélectionné"
   //   - idle (default) → "X patient(s) disponible(s)" avec total backend
@@ -179,36 +192,51 @@ export function PatientCombobox({ id, value, onChange, disabled }: PatientCombob
         spellCheck={false}
         aria-required="true"
         aria-invalid={value === null && isSearching ? "true" : undefined}
+        // Recherche complémentaire en vol → `aria-busy` (état "occupé") plutôt
+        // qu'un texte annoncé à chaque frappe dans le live region (revue a11y).
+        aria-busy={searching ? "true" : undefined}
         className="border border-input rounded-md p-2 text-sm bg-background disabled:opacity-50"
         placeholder={t("patientPlaceholder")}
-        aria-describedby={`${id}-help`}
+        aria-describedby={error ? `${id}-error ${id}-help` : `${id}-help`}
       />
       <datalist id={`${id}-options`}>
         {filtered.map((p) => (
           <option key={p.id} value={patientLabel(p)} />
         ))}
       </datalist>
-      <p id={`${id}-help`} className="text-xs text-muted-foreground" aria-live="polite">
+
+      {/* Erreur — région ASSERTIVE dédiée (role=alert). Sortie du live region
+          "polite" ci-dessous pour éviter le conflit d'assertivité d'un alert
+          imbriqué dans un polite (revue a11y PR #531). N'apparaît que sur
+          échec de la liste BASE. */}
+      {error && (
+        <p id={`${id}-error`} role="alert" className="text-xs text-red-600">
+          {t("patientListError")}
+        </p>
+      )}
+
+      {/* Statut/hint — région POLITE atomique, états STABLES uniquement. Le
+          "searching" transitoire reste visible mais `aria-hidden` (non annoncé :
+          c'est `aria-busy` sur l'input qui porte l'info pour les SR). */}
+      <p
+        id={`${id}-help`}
+        className="text-xs text-muted-foreground"
+        aria-live="polite"
+        aria-atomic="true"
+      >
         {loading && t("loading")}
-        {error && (
-          <span role="alert" className="text-red-600">
-            {t("patientListError")}
-          </span>
-        )}
         {searching && !loading && !error && (
-          <span role="status">{t("patientSearching")}</span>
+          <span aria-hidden="true">{t("patientSearching")}</span>
         )}
         {noResults && (
-          <span role="status" className="text-amber-700">
-            {t("patientNoResults")}
-          </span>
+          <span className="text-amber-700">{t("patientNoResults")}</span>
         )}
         {!loading && !error && !searching && !noResults && (
           value !== null
             ? t("patientSelected")
             // Fix FE-9 round 1 review PR #434 — count NON-filtré (`items.length`)
-            // pour ne pas mentir : "50 patients disponibles" reflète le total
-            // backend, pas le filtre client-side trompeur.
+            // pour ne pas mentir : reflète le total chargé (base ∪ recherche),
+            // pas le filtre client-side trompeur.
             : t("patientHint", { count: items.length })
         )}
       </p>

--- a/src/components/diabeo/appointments/PatientCombobox.tsx
+++ b/src/components/diabeo/appointments/PatientCombobox.tsx
@@ -195,9 +195,16 @@ export function PatientCombobox({ id, value, onChange, disabled }: PatientCombob
         // Recherche complémentaire en vol → `aria-busy` (état "occupé") plutôt
         // qu'un texte annoncé à chaque frappe dans le live region (revue a11y).
         aria-busy={searching ? "true" : undefined}
+        // `aria-controls` vers la datalist : compense l'absence d'aria-expanded
+        // (impossible sur `<input list>` natif — l'ouverture est gérée par le
+        // navigateur, non détectable en JS). Revue a11y round 2.
+        aria-controls={`${id}-options`}
         className="border border-input rounded-md p-2 text-sm bg-background disabled:opacity-50"
         placeholder={t("patientPlaceholder")}
-        aria-describedby={error ? `${id}-error ${id}-help` : `${id}-help`}
+        // `aria-describedby` STABLE (help seul) : l'erreur est déjà annoncée par
+        // sa région `role="alert"` (assertive). Éviter de basculer 1↔2 ids
+        // (référence ARIA orpheline au démontage de l'erreur — revue a11y r2).
+        aria-describedby={`${id}-help`}
       />
       <datalist id={`${id}-options`}>
         {filtered.map((p) => (
@@ -205,24 +212,24 @@ export function PatientCombobox({ id, value, onChange, disabled }: PatientCombob
         ))}
       </datalist>
 
-      {/* Erreur — région ASSERTIVE dédiée (role=alert). Sortie du live region
-          "polite" ci-dessous pour éviter le conflit d'assertivité d'un alert
-          imbriqué dans un polite (revue a11y PR #531). N'apparaît que sur
-          échec de la liste BASE. */}
+      {/* Erreur — région ASSERTIVE dédiée (role=alert), hors du live region
+          "polite" (évite l'alert imbriqué dans un polite — revue a11y r1).
+          Annoncée d'elle-même à l'apparition ; pas référencée par
+          aria-describedby (évite la référence orpheline au démontage — r2). */}
       {error && (
-        <p id={`${id}-error`} role="alert" className="text-xs text-red-600">
+        <p role="alert" className="text-xs text-red-600">
           {t("patientListError")}
         </p>
       )}
 
-      {/* Statut/hint — région POLITE atomique, états STABLES uniquement. Le
-          "searching" transitoire reste visible mais `aria-hidden` (non annoncé :
-          c'est `aria-busy` sur l'input qui porte l'info pour les SR). */}
+      {/* Statut/hint — région POLITE. PAS `aria-atomic` (sinon chaque mutation
+          relit toute la région → sur-annonce sur les transitions — revue a11y
+          r2). Le "searching" transitoire reste visible mais `aria-hidden`
+          (l'info SR est portée par `aria-busy` sur l'input). */}
       <p
         id={`${id}-help`}
         className="text-xs text-muted-foreground"
         aria-live="polite"
-        aria-atomic="true"
       >
         {loading && t("loading")}
         {searching && !loading && !error && (

--- a/src/components/diabeo/appointments/usePatientList.ts
+++ b/src/components/diabeo/appointments/usePatientList.ts
@@ -13,8 +13,9 @@
  *
  * **Usage** : `<PatientCombobox>` instancie ce hook DEUX fois — une liste
  * "base" (`enabled:true`, sans `search`) fetchée une fois, et une instance de
- * recherche complémentaire (`search` débouncé) dont les résultats sont mergés
- * à la base. Chaque instance gère son propre `AbortController`.
+ * recherche complémentaire (`search` différé via `useDeferredValue` + gate
+ * min-length côté composant — PAS un debounce réseau) dont les résultats sont
+ * mergés à la base. Chaque instance gère son propre `AbortController`.
  *
  * Endpoint : `GET /api/patients/search?limit=50` (US-2019).
  * Réponse : `{ items: [{ id, user: { firstname, lastname, ... } }], nextCursor }`.
@@ -27,7 +28,7 @@
  *
  * **Lifecycle** :
  *   - `enabled=false` (modal fermé) → idle, pas de fetch
- *   - `enabled=true` → fetch initial + refetch sur `search` change (debounced)
+ *   - `enabled=true` → fetch initial + refetch sur `search` change (différé)
  *
  * @see src/app/api/patients/search/route.ts
  * @see src/lib/services/patient.service.ts → search
@@ -51,7 +52,8 @@ export interface UsePatientListResult {
 export interface UsePatientListParams {
   /** Active le fetch (false = modal fermé, hook idle). */
   enabled: boolean
-  /** Search exact match (HMAC backend) — débouncing fait par le composant parent. */
+  /** Search exact match (HMAC backend) — différé via useDeferredValue + gate
+   * min-length côté composant parent (pas un debounce réseau). */
   search?: string
 }
 

--- a/src/components/diabeo/appointments/usePatientList.ts
+++ b/src/components/diabeo/appointments/usePatientList.ts
@@ -7,8 +7,14 @@
  * US-2500-UI iter 6 — alimente le `<PatientCombobox>` autocomplete.
  *
  * **Stratégie** : fetch `limit=50` initial (cabinet typique < 50 patients
- * actifs), filtrage côté client par nom/prénom. Si > 50 patients, le user
- * tape le nom EXACT pour déclencher un fetch ciblé (param `search` HMAC).
+ * actifs), filtrage côté client par nom/prénom. Si > 50 patients, taper un
+ * nom/prénom **complet** déclenche un fetch ciblé : le backend tokenise la
+ * saisie et matche chaque mot par HMAC exact (`search`), cf. patient.service.
+ *
+ * **Usage** : `<PatientCombobox>` instancie ce hook DEUX fois — une liste
+ * "base" (`enabled:true`, sans `search`) fetchée une fois, et une instance de
+ * recherche complémentaire (`search` débouncé) dont les résultats sont mergés
+ * à la base. Chaque instance gère son propre `AbortController`.
  *
  * Endpoint : `GET /api/patients/search?limit=50` (US-2019).
  * Réponse : `{ items: [{ id, user: { firstname, lastname, ... } }], nextCursor }`.

--- a/src/lib/auth/api-rate-limit.ts
+++ b/src/lib/auth/api-rate-limit.ts
@@ -158,6 +158,19 @@ export const RATE_LIMITS = {
     max: 60,
     failMode: "open",
   } satisfies ApiRateLimitConfig,
+  /**
+   * PR #531 — recherche patient par IP : 120 req/60 s. Double le quota user
+   * (autocomplete + recherche `#id`) pour ne pas pénaliser plusieurs PS
+   * légitimes derrière un même NAT cabinet, tout en bornant un fan-out
+   * credential-stuffing depuis un seul hôte. Fail-open (cohérent patientDataRead
+   * — la confidentialité repose sur le RBAC `accessibleIds`, pas le limiter).
+   */
+  patientDataReadIp: {
+    bucket: "patient-data-read-ip",
+    windowSec: 60,
+    max: 120,
+    failMode: "open",
+  } satisfies ApiRateLimitConfig,
   /** Export RGPD per user: 3 req/h. Fail-closed — HDS data-exfiltration guard. */
   exportUser: {
     bucket: "export-rgpd-user",

--- a/src/lib/services/audit.service.ts
+++ b/src/lib/services/audit.service.ts
@@ -327,6 +327,10 @@ export function extractRequestContext(req: Request): {
   requestId: string
 } {
   const headers = req.headers
+  // ⚠️ Le hop XFF le plus à gauche est client-contrôlé (spoofable) → l'IP
+  // résolue ici n'est pas fiable derrière un proxy (rate-limit per-IP évadable
+  // + IP audit spoofable). Durcissement transverse (résolution depuis le hop de
+  // confiance) tracké dans docs/security/xff-trusted-proxy.md. Pré-existant.
   const ipAddress =
     headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
     headers.get("x-real-ip") ??

--- a/src/lib/services/patient.service.ts
+++ b/src/lib/services/patient.service.ts
@@ -886,7 +886,11 @@ export const patientService = {
     const searchOr = ((): Prisma.PatientWhereInput[] | undefined => {
       const raw = input.search?.trim()
       if (!raw) return undefined
-      const tokens = raw.split(/\s+/).filter(Boolean)
+      // Cap défensif sur le nombre de tokens. L'input est déjà borné à 100 car.
+      // par Zod (route), mais on évite tout HMAC-SHA256 × N non borné + `IN`
+      // qui gonfle sur un endpoint PHI. 8 tokens couvrent largement un nom
+      // composé ("Jean-Pierre De La Fontaine #42").
+      const tokens = raw.split(/\s+/).filter(Boolean).slice(0, 8)
       const idTokens = tokens
         .filter((tok) => /^#\d+$/.test(tok))
         .map((tok) => Number(tok.slice(1)))
@@ -909,10 +913,18 @@ export const patientService = {
 
     const where: Prisma.PatientWhereInput = {
       deletedAt: null,
-      // H1 — exclude patients who revoked sharing or never accepted GDPR.
-      // Matches the same filter applied in `population-analytics.service`
-      // (RGPD Art. 7.3 — revocation effective on all aggregations).
-      user: { privacySettings: { gdprConsent: true, shareWithProviders: true } },
+      // RGPD Art. 7.3 (révocation) + défaut implicite — ALIGNÉ sur `listByDoctor`
+      // (HSA H1 + PR #418 round 3) : un patient nouvellement créé n'a PAS encore
+      // de row `UserPrivacySettings` → il doit rester trouvable (sinon le PS qui
+      // vient de le créer ne le voit dans son portefeuille mais pas au combobox
+      // RDV). L'opt-out explicite (row présente avec un flag false) reste honoré.
+      //   OR (pas encore de row)  OR (gdprConsent && shareWithProviders confirmés)
+      user: {
+        OR: [
+          { privacySettings: null },
+          { privacySettings: { gdprConsent: true, shareWithProviders: true } },
+        ],
+      },
       ...(input.accessibleIds !== null && { id: { in: input.accessibleIds } }),
       ...(input.pathology && { pathology: input.pathology }),
       ...(searchOr && { OR: searchOr }),
@@ -927,6 +939,11 @@ export const patientService = {
           select: { id: true, firstname: true, lastname: true },
         },
       },
+      // NB pagination : avec une branche `#id` dans le `OR`, le résultat n'est
+      // pas une fenêtre triée *stricte* (un patient ciblé par `#id` est inclus
+      // quelle que soit sa position vs le curseur). Pas de perte ni de doublon
+      // (le curseur exclut un seul id via skip:1) — l'autocomplete consomme la
+      // 1re page sans paginer. Comportement assumé, documenté ici.
       orderBy: { id: "desc" },
       take: limit + 1,
       ...(input.cursor && { cursor: { id: input.cursor }, skip: 1 }),

--- a/src/lib/services/patient.service.ts
+++ b/src/lib/services/patient.service.ts
@@ -148,6 +148,34 @@ function localDecryptField(value: string): string {
 const LIST_BY_DOCTOR_MAX = 2000
 const LIST_BY_DOCTOR_WARN_AT = 1000
 
+/**
+ * Prédicat de visibilité "côté soignant" partagé par `listByDoctor` et `search`
+ * (review round 2 — HSA M : éviter la divergence accidentelle entre deux
+ * surfaces qui doivent appliquer la MÊME règle de consentement).
+ *
+ * ⚠️ DPIA — posture *fail-open* sur l'absence de row `UserPrivacySettings` :
+ *   - OR (pas encore de row)  → patient nouvellement créé, wizard de
+ *     consentement pas encore passé : il DOIT rester visible/trouvable par le
+ *     soignant de son portefeuille (sinon le PS qui vient de le créer ne peut
+ *     ni le consulter ni lui poser un RDV). RGPD Art. 6.1.b/9.2.h — base légale
+ *     "prise en charge", pas le consentement Art. 7.
+ *   - OR (gdprConsent && shareWithProviders confirmés) → opt-in explicite.
+ *   - L'opt-out explicite (row présente avec un flag false) tombe dans aucune
+ *     branche → EXCLU (Art. 21 honoré dès qu'une row existe).
+ *
+ * ⚠️ NE PAS réutiliser pour l'AGRÉGATION population (`population-analytics`,
+ * `consent.ts`, `team-workflow`) qui sont délibérément *fail-closed* (absence
+ * de row = pas de consentement) : agréger des données d'un patient sans
+ * consentement explicite n'a pas la même base légale que l'identifier dans le
+ * portefeuille de son propre soignant. Cf. DPIA patient-search.
+ */
+const PROVIDER_VISIBLE_USER_WHERE: Prisma.UserWhereInput = {
+  OR: [
+    { privacySettings: null },
+    { privacySettings: { gdprConsent: true, shareWithProviders: true } },
+  ],
+}
+
 const DECRYPT_WARN_WINDOW_MS = 60_000
 const DECRYPT_SUPPRESSED_CAP = 10_000_000
 /**
@@ -886,18 +914,24 @@ export const patientService = {
     const searchOr = ((): Prisma.PatientWhereInput[] | undefined => {
       const raw = input.search?.trim()
       if (!raw) return undefined
-      // Cap défensif sur le nombre de tokens. L'input est déjà borné à 100 car.
-      // par Zod (route), mais on évite tout HMAC-SHA256 × N non borné + `IN`
-      // qui gonfle sur un endpoint PHI. 8 tokens couvrent largement un nom
-      // composé ("Jean-Pierre De La Fontaine #42").
-      const tokens = raw.split(/\s+/).filter(Boolean).slice(0, 8)
-      const idTokens = tokens
+      const allTokens = raw.split(/\s+/).filter(Boolean)
+      // Les tokens `#id` (désambiguïsation homonymes) sont extraits AVANT tout
+      // cap — sinon un `#42` en fin de saisie multi-mots serait silencieusement
+      // perdu (review round 2 LOW-2). Bornés à 8 par défense en profondeur.
+      const idTokens = allTokens
         .filter((tok) => /^#\d+$/.test(tok))
         .map((tok) => Number(tok.slice(1)))
         .filter((n) => Number.isSafeInteger(n) && n > 0)
+        .slice(0, 8)
+      // Cap défensif sur les tokens-NOMS : input déjà borné à 100 car. par Zod
+      // (route), mais on évite tout HMAC-SHA256 × N non borné + `IN` qui gonfle
+      // sur un endpoint PHI. 8 mots couvrent un nom composé large.
       const nameHmacs = [
         ...new Set(
-          tokens.filter((tok) => !/^#\d+$/.test(tok)).map((tok) => hmacField(tok)),
+          allTokens
+            .filter((tok) => !/^#\d+$/.test(tok))
+            .slice(0, 8)
+            .map((tok) => hmacField(tok)),
         ),
       ]
       const or: Prisma.PatientWhereInput[] = []
@@ -911,20 +945,17 @@ export const patientService = {
       return or.length > 0 ? or : undefined
     })()
 
+    // Note perf (review round 2 — backlog) : `where.user` (consentement) +
+    // `where.OR[].user` (HMAC noms) génèrent 2-3 sous-requêtes `EXISTS`
+    // indépendantes sur `users`. SQL correct ; invisible à l'échelle POC, mais
+    // à surveiller > 50k users (cf. ROADMAP scaling). Pas d'N+1 (`include`
+    // reste un JOIN batché unique).
     const where: Prisma.PatientWhereInput = {
       deletedAt: null,
-      // RGPD Art. 7.3 (révocation) + défaut implicite — ALIGNÉ sur `listByDoctor`
-      // (HSA H1 + PR #418 round 3) : un patient nouvellement créé n'a PAS encore
-      // de row `UserPrivacySettings` → il doit rester trouvable (sinon le PS qui
-      // vient de le créer ne le voit dans son portefeuille mais pas au combobox
-      // RDV). L'opt-out explicite (row présente avec un flag false) reste honoré.
-      //   OR (pas encore de row)  OR (gdprConsent && shareWithProviders confirmés)
-      user: {
-        OR: [
-          { privacySettings: null },
-          { privacySettings: { gdprConsent: true, shareWithProviders: true } },
-        ],
-      },
+      // Consentement RGPD — règle partagée avec `listByDoctor` (cf.
+      // PROVIDER_VISIBLE_USER_WHERE + sa note DPIA). Fail-open sur l'absence de
+      // row ; opt-out explicite honoré.
+      user: PROVIDER_VISIBLE_USER_WHERE,
       ...(input.accessibleIds !== null && { id: { in: input.accessibleIds } }),
       ...(input.pathology && { pathology: input.pathology }),
       ...(searchOr && { OR: searchOr }),
@@ -1007,21 +1038,11 @@ export const patientService = {
         pro: { userId: doctorUserId },
         patient: {
           deletedAt: null,
-          // HSA H1 + review round 2 C1 — RGPD Art. 7.3 (révocation) tout en
-          // respectant le défaut implicite : un patient nouvellement créé n'a
-          // PAS encore de row UserPrivacySettings (pas créée par le wizard) →
-          // il doit rester visible (sinon le PS qui le crée ne le voit jamais
-          // dans son portefeuille). Pattern aligné PR #418 round 3 :
-          //   OR (no settings row yet) (opt-out explicit not yet expressed)
-          //   OR (gdprConsent && shareWithProviders)  (opt-in confirmé)
-          // L'opt-out Art. 21 (révocation explicite via /api/account/privacy)
-          // est honoré dès qu'une row existe avec un flag false.
-          user: {
-            OR: [
-              { privacySettings: null },
-              { privacySettings: { gdprConsent: true, shareWithProviders: true } },
-            ],
-          },
+          // HSA H1 + review round 2 — règle de visibilité soignant partagée
+          // avec `search` (cf. PROVIDER_VISIBLE_USER_WHERE + sa note DPIA).
+          // Fail-open sur l'absence de row (patient nouvellement créé) ;
+          // opt-out explicite Art. 21 honoré dès qu'une row existe.
+          user: PROVIDER_VISIBLE_USER_WHERE,
         },
       },
       select: {

--- a/src/lib/services/patient.service.ts
+++ b/src/lib/services/patient.service.ts
@@ -169,12 +169,18 @@ const LIST_BY_DOCTOR_WARN_AT = 1000
  * consentement explicite n'a pas la même base légale que l'identifier dans le
  * portefeuille de son propre soignant. Cf. DPIA patient-search.
  */
-const PROVIDER_VISIBLE_USER_WHERE: Prisma.UserWhereInput = {
-  OR: [
+// `Object.freeze` (deep) — la constante est partagée par référence entre
+// `search` et `listByDoctor` ; on gèle (objet + tableau `OR`) pour qu'un futur
+// `.OR.push(...)` échoue bruyamment au runtime au lieu de corrompre
+// silencieusement les deux surfaces (revue round 3). Le cast final efface le
+// `readonly` côté types (Prisma attend un tableau mutable) ; seule la garde
+// runtime importe ici.
+const PROVIDER_VISIBLE_USER_WHERE = Object.freeze({
+  OR: Object.freeze([
     { privacySettings: null },
     { privacySettings: { gdprConsent: true, shareWithProviders: true } },
-  ],
-}
+  ]),
+}) as Prisma.UserWhereInput
 
 const DECRYPT_WARN_WINDOW_MS = 60_000
 const DECRYPT_SUPPRESSED_CAP = 10_000_000

--- a/src/lib/services/patient.service.ts
+++ b/src/lib/services/patient.service.ts
@@ -873,25 +873,49 @@ export const patientService = {
       return { items: [], nextCursor: null as number | null }
     }
 
-    const userFilter: Prisma.UserWhereInput | undefined = input.search?.trim()
-      // hmacField internally normalizes (lowercase + trim).
-      ? (() => {
-          const hmac = hmacField(input.search!)
-          return { OR: [{ firstnameHmac: hmac }, { lastnameHmac: hmac }] }
-        })()
-      : undefined
+    // Recherche autocomplete patient. Les noms étant chiffrés, le HMAC est un
+    // match EXACT par token : impossible de faire un "LIKE %fragment%". On
+    // découpe donc la saisie en tokens (mots) et on matche chaque token COMPLET
+    // contre `firstnameHmac` OU `lastnameHmac` (`in` HMAC déterministe,
+    // hmacField normalise lowercase+trim). Sémantique OR volontairement large
+    // (surensemble affiné côté client) : taper "Jean Dupont" remonte les Jean
+    // ET les Dupont, le combobox filtre ensuite. Les tokens `#42`
+    // (désambiguïsation homonymes émise par `<PatientCombobox>`) sont résolus
+    // en match direct sur l'`id` patient — toujours borné par le scope RBAC
+    // `accessibleIds` ci-dessous (le `id: { in }` top-level reste ANDé).
+    const searchOr = ((): Prisma.PatientWhereInput[] | undefined => {
+      const raw = input.search?.trim()
+      if (!raw) return undefined
+      const tokens = raw.split(/\s+/).filter(Boolean)
+      const idTokens = tokens
+        .filter((tok) => /^#\d+$/.test(tok))
+        .map((tok) => Number(tok.slice(1)))
+        .filter((n) => Number.isSafeInteger(n) && n > 0)
+      const nameHmacs = [
+        ...new Set(
+          tokens.filter((tok) => !/^#\d+$/.test(tok)).map((tok) => hmacField(tok)),
+        ),
+      ]
+      const or: Prisma.PatientWhereInput[] = []
+      if (nameHmacs.length > 0) {
+        or.push({ user: { firstnameHmac: { in: nameHmacs } } })
+        or.push({ user: { lastnameHmac: { in: nameHmacs } } })
+      }
+      if (idTokens.length > 0) {
+        or.push({ id: { in: idTokens } })
+      }
+      return or.length > 0 ? or : undefined
+    })()
 
     const where: Prisma.PatientWhereInput = {
       deletedAt: null,
       // H1 — exclude patients who revoked sharing or never accepted GDPR.
       // Matches the same filter applied in `population-analytics.service`
       // (RGPD Art. 7.3 — revocation effective on all aggregations).
-      user: {
-        privacySettings: { gdprConsent: true, shareWithProviders: true },
-        ...(userFilter ?? {}),
-      },
+      user: { privacySettings: { gdprConsent: true, shareWithProviders: true } },
       ...(input.accessibleIds !== null && { id: { in: input.accessibleIds } }),
       ...(input.pathology && { pathology: input.pathology }),
+      ...(searchOr && { OR: searchOr }),
     }
 
     const items = await prisma.patient.findMany({

--- a/tests/unit/PatientCombobox.test.tsx
+++ b/tests/unit/PatientCombobox.test.tsx
@@ -249,23 +249,40 @@ describe("<PatientCombobox>", () => {
     expect(alert.textContent).toContain("patientListError")
   })
 
-  it("searching state : recherche backend en vol → hint 'patientSearching', pas de faux 'aucun résultat'", () => {
+  it("searching state : recherche backend en vol → aria-busy sur l'input + pas de faux 'aucun résultat'", () => {
     // base (sans search) peuplée + non-loading ; instance search en vol (loading)
     // pour une saisie qui ne matche encore rien → anti-flicker : on n'affiche
-    // PAS "patientNoResults" tant que le fetch peut remonter un patient >50.
+    // PAS "patientNoResults" tant que le fetch peut remonter un patient >50, et
+    // l'état "occupé" est porté par aria-busy (pas un texte annoncé par frappe).
     mockUsePatientList.mockImplementation((args: { search?: string }) =>
       args?.search
         ? { items: [], loading: true, error: null, refetch: vi.fn() }
         : { items: baseItems, loading: false, error: null, refetch: vi.fn() },
     )
     render(<PatientCombobox id="test-combobox" value={null} onChange={vi.fn()} />)
+    const input = screen.getByRole("combobox")
 
-    fireEvent.change(screen.getByRole("combobox"), {
-      target: { value: "Inexistant" },
-    })
+    fireEvent.change(input, { target: { value: "Inexistant" } })
 
+    expect(input.getAttribute("aria-busy")).toBe("true")
     expect(document.body.textContent).toContain("patientSearching")
     expect(document.body.textContent).not.toContain("patientNoResults")
+  })
+
+  it("min-length : une saisie d'1 caractère ne déclenche PAS la recherche backend", () => {
+    // Anti-flooding endpoint PHI : l'instance de recherche reste désactivée
+    // (enabled:false, search:undefined) sous le seuil MIN_BACKEND_SEARCH_LEN.
+    // `mockClear()` — l'historique d'appels s'accumule sur tout le fichier
+    // (afterEach restoreAllMocks ne vide pas .mock.calls).
+    mockUsePatientList.mockClear()
+    render(<PatientCombobox id="test-combobox" value={null} onChange={vi.fn()} />)
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "J" } })
+
+    // Aucun appel du hook avec un `search` défini pour une saisie d'1 caractère.
+    const searchCalls = mockUsePatientList.mock.calls.filter(
+      (c) => (c[0] as { search?: string }).search !== undefined,
+    )
+    expect(searchCalls).toHaveLength(0)
   })
 
   it("autoComplete='off' + spellCheck=false (anti history input + anti spell check PHI)", () => {

--- a/tests/unit/PatientCombobox.test.tsx
+++ b/tests/unit/PatientCombobox.test.tsx
@@ -66,6 +66,68 @@ afterEach(() => {
 })
 
 describe("<PatientCombobox>", () => {
+  it("REGRESSION — la recherche backend AUGMENTE la liste base, ne la vide pas", () => {
+    // Le endpoint /api/patients/search fait un match HMAC EXACT : un fragment
+    // ("Jea") ne matche personne. AVANT le fix, ce résultat vide remplaçait la
+    // liste → faux "Aucun patient ne correspond" + input disabled. Désormais la
+    // recherche AUGMENTE une liste base stable (merge dédupliqué).
+    mockUsePatientList.mockImplementation((args: { search?: string }) =>
+      args?.search
+        ? // backend HMAC exact : vide sur un fragment "Jea"
+          { items: [], loading: false, error: null, refetch: vi.fn() }
+        : // liste base (sans search) : reste peuplée
+          { items: baseItems, loading: false, error: null, refetch: vi.fn() },
+    )
+
+    render(<PatientCombobox id="cb" value={null} onChange={vi.fn()} />)
+    const input = screen.getByRole("combobox") as HTMLInputElement
+
+    fireEvent.change(input, { target: { value: "Jea" } })
+
+    // L'input n'est jamais désactivé par la recherche complémentaire.
+    expect(input.disabled).toBe(false)
+    // La liste base n'est PAS vidée : les options "Jean*" restent filtrées.
+    const labels = Array.from(
+      document.querySelectorAll("#cb-options option"),
+    ).map((o) => (o as HTMLOptionElement).value)
+    expect(labels).toContain("Jean Durand #1")
+    expect(labels).toContain("Jean Martin #42")
+    // Pas de faux "aucun patient".
+    expect(document.body.textContent).not.toContain("patientNoResults")
+
+    // La liste base reste fetchée indépendamment de la frappe (instance sans search).
+    expect(
+      mockUsePatientList.mock.calls.some(
+        (c) => (c[0] as { enabled: boolean; search?: string }).enabled === true
+          && (c[0] as { search?: string }).search === undefined,
+      ),
+    ).toBe(true)
+  })
+
+  it("MERGE — un patient hors des 50 premiers, remonté par la recherche, devient sélectionnable", () => {
+    // base = 50 premiers (sans #99) ; search exact "Zoé Xavier" → remonte #99.
+    const extra = { id: 99, firstname: "Zoé", lastname: "Xavier" }
+    mockUsePatientList.mockImplementation((args: { search?: string }) =>
+      args?.search
+        ? { items: [extra], loading: false, error: null, refetch: vi.fn() }
+        : { items: baseItems, loading: false, error: null, refetch: vi.fn() },
+    )
+    const onChange = vi.fn()
+    render(<PatientCombobox id="cb" value={null} onChange={onChange} />)
+    const input = screen.getByRole("combobox")
+
+    // L'option mergée apparaît dans la datalist.
+    fireEvent.change(input, { target: { value: "Zoé Xavier" } })
+    const labels = Array.from(
+      document.querySelectorAll("#cb-options option"),
+    ).map((o) => (o as HTMLOptionElement).value)
+    expect(labels).toContain("Zoé Xavier #99")
+
+    // Sélection du label complet → onChange remonte l'id mergé.
+    fireEvent.change(input, { target: { value: "Zoé Xavier #99" } })
+    expect(onChange).toHaveBeenCalledWith(99, "Zoé Xavier #99")
+  })
+
   it("render initial : input + datalist + hint count total backend (FE-9)", () => {
     const onChange = vi.fn()
     render(<PatientCombobox id="test-combobox" value={null} onChange={onChange} />)

--- a/tests/unit/PatientCombobox.test.tsx
+++ b/tests/unit/PatientCombobox.test.tsx
@@ -249,6 +249,25 @@ describe("<PatientCombobox>", () => {
     expect(alert.textContent).toContain("patientListError")
   })
 
+  it("searching state : recherche backend en vol → hint 'patientSearching', pas de faux 'aucun résultat'", () => {
+    // base (sans search) peuplée + non-loading ; instance search en vol (loading)
+    // pour une saisie qui ne matche encore rien → anti-flicker : on n'affiche
+    // PAS "patientNoResults" tant que le fetch peut remonter un patient >50.
+    mockUsePatientList.mockImplementation((args: { search?: string }) =>
+      args?.search
+        ? { items: [], loading: true, error: null, refetch: vi.fn() }
+        : { items: baseItems, loading: false, error: null, refetch: vi.fn() },
+    )
+    render(<PatientCombobox id="test-combobox" value={null} onChange={vi.fn()} />)
+
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "Inexistant" },
+    })
+
+    expect(document.body.textContent).toContain("patientSearching")
+    expect(document.body.textContent).not.toContain("patientNoResults")
+  })
+
   it("autoComplete='off' + spellCheck=false (anti history input + anti spell check PHI)", () => {
     render(<PatientCombobox id="test-combobox" value={null} onChange={vi.fn()} />)
     const input = screen.getByRole("combobox")

--- a/tests/unit/PatientCombobox.test.tsx
+++ b/tests/unit/PatientCombobox.test.tsx
@@ -13,7 +13,7 @@
  *   - aria-required + aria-invalid (FE-15/16)
  *   - Loading state
  *   - Error state (role=alert)
- *   - useDeferredValue debouncing (smoke — vérifie pas de setState in effect)
+ *   - useDeferredValue (différé, PAS un debounce) — smoke : pas de setState in effect
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
@@ -78,6 +78,10 @@ describe("<PatientCombobox>", () => {
         : // liste base (sans search) : reste peuplée
           { items: baseItems, loading: false, error: null, refetch: vi.fn() },
     )
+    // `mockClear()` — l'historique d'appels s'accumule sur tout le fichier
+    // (afterEach restoreAllMocks ne vide pas .mock.calls) ; on isole pour que
+    // l'assertion finale porte sur CE rendu, pas un appel d'un test précédent.
+    mockUsePatientList.mockClear()
 
     render(<PatientCombobox id="cb" value={null} onChange={vi.fn()} />)
     const input = screen.getByRole("combobox") as HTMLInputElement
@@ -202,7 +206,7 @@ describe("<PatientCombobox>", () => {
 
     fireEvent.change(screen.getByRole("combobox"), { target: { value: "Inexistant" } })
 
-    // Le hint affiche "patientNoResults" via role=status
+    // Le hint affiche "patientNoResults" dans la région aria-live="polite"
     expect(document.body.textContent).toContain("patientNoResults")
   })
 

--- a/tests/unit/patient-search.service.test.ts
+++ b/tests/unit/patient-search.service.test.ts
@@ -30,15 +30,55 @@ describe("patientService.search", () => {
     expect(prismaMock.patient.findMany).not.toHaveBeenCalled()
   })
 
-  it("uses OR on firstnameHmac/lastnameHmac when search is provided", async () => {
+  it("uses OR on firstnameHmac/lastnameHmac (in) when a single name token is provided", async () => {
     await patientService.search(
       { search: "Dupont", accessibleIds: null },
       9,
     )
     const call = prismaMock.patient.findMany.mock.calls[0][0] as any
-    expect(call.where.user.OR).toHaveLength(2)
-    expect(call.where.user.OR[0]).toHaveProperty("firstnameHmac")
-    expect(call.where.user.OR[1]).toHaveProperty("lastnameHmac")
+    // La recherche est portée par `where.OR` (patient-level), pas `where.user`.
+    expect(call.where.OR).toHaveLength(2)
+    expect(call.where.OR[0].user.firstnameHmac.in).toHaveLength(1)
+    expect(call.where.OR[1].user.lastnameHmac.in).toHaveLength(1)
+    // `where.user` ne porte que le filtre privacy (consentement RGPD).
+    expect(call.where.user).toEqual({
+      privacySettings: { gdprConsent: true, shareWithProviders: true },
+    })
+  })
+
+  it("tokenise une saisie multi-mots → un HMAC par mot dans le `in`", async () => {
+    await patientService.search(
+      { search: "Jean Dupont", accessibleIds: null },
+      9,
+    )
+    const call = prismaMock.patient.findMany.mock.calls[0][0] as any
+    expect(call.where.OR).toHaveLength(2)
+    // 2 mots distincts → 2 HMAC sur firstnameHmac ET lastnameHmac.
+    expect(call.where.OR[0].user.firstnameHmac.in).toHaveLength(2)
+    expect(call.where.OR[1].user.lastnameHmac.in).toHaveLength(2)
+  })
+
+  it("résout un token `#id` (désambiguïsation homonymes) en match direct sur l'id", async () => {
+    await patientService.search(
+      { search: "Jean Martin #42", accessibleIds: null },
+      9,
+    )
+    const call = prismaMock.patient.findMany.mock.calls[0][0] as any
+    // 2 branches noms + 1 branche id.
+    expect(call.where.OR).toHaveLength(3)
+    const idBranch = call.where.OR.find((b: any) => b.id)
+    expect(idBranch).toEqual({ id: { in: [42] } })
+    // Les mots-noms ne contiennent jamais le token `#42`.
+    expect(call.where.OR[0].user.firstnameHmac.in).toHaveLength(2)
+  })
+
+  it("token `#id` seul → uniquement la branche id (pas de HMAC vide)", async () => {
+    await patientService.search(
+      { search: "#7", accessibleIds: null },
+      9,
+    )
+    const call = prismaMock.patient.findMany.mock.calls[0][0] as any
+    expect(call.where.OR).toEqual([{ id: { in: [7] } }])
   })
 
   it("filters out patients without gdprConsent + shareWithProviders (H1)", async () => {

--- a/tests/unit/patient-search.service.test.ts
+++ b/tests/unit/patient-search.service.test.ts
@@ -81,6 +81,22 @@ describe("patientService.search", () => {
     expect(call.where.OR).toEqual([{ id: { in: [7] } }])
   })
 
+  it("SECURITY — un token `#id` ne contourne PAS le scope RBAC (id-in top-level ANDé)", async () => {
+    // Un PS sonde `#99` alors que son périmètre = [1, 2]. Le match `#id` est
+    // dans `where.OR`, mais `where.id = { in: accessibleIds }` reste top-level
+    // → Prisma applique `id ∈ [1,2] AND (… OR id ∈ [99])` : #99 hors périmètre
+    // ne peut pas être exfiltré.
+    await patientService.search(
+      { search: "#99", accessibleIds: [1, 2] },
+      9,
+    )
+    const call = prismaMock.patient.findMany.mock.calls[0][0] as any
+    // Scope top-level conservé (ANDé avec le OR).
+    expect(call.where.id).toEqual({ in: [1, 2] })
+    // La branche id de la recherche existe mais reste contrainte par le scope.
+    expect(call.where.OR).toEqual([{ id: { in: [99] } }])
+  })
+
   it("filters out patients without gdprConsent + shareWithProviders (H1)", async () => {
     await patientService.search(
       { accessibleIds: [1] },

--- a/tests/unit/patient-search.service.test.ts
+++ b/tests/unit/patient-search.service.test.ts
@@ -40,9 +40,13 @@ describe("patientService.search", () => {
     expect(call.where.OR).toHaveLength(2)
     expect(call.where.OR[0].user.firstnameHmac.in).toHaveLength(1)
     expect(call.where.OR[1].user.lastnameHmac.in).toHaveLength(1)
-    // `where.user` ne porte que le filtre privacy (consentement RGPD).
+    // `where.user` ne porte que le filtre privacy (consentement RGPD), aligné
+    // sur listByDoctor : OR (pas de row) OR (consentement confirmé).
     expect(call.where.user).toEqual({
-      privacySettings: { gdprConsent: true, shareWithProviders: true },
+      OR: [
+        { privacySettings: null },
+        { privacySettings: { gdprConsent: true, shareWithProviders: true } },
+      ],
     })
   })
 
@@ -97,15 +101,51 @@ describe("patientService.search", () => {
     expect(call.where.OR).toEqual([{ id: { in: [99] } }])
   })
 
-  it("filters out patients without gdprConsent + shareWithProviders (H1)", async () => {
+  it("filters consent (H1) en autorisant les patients sans row privacySettings (aligné listByDoctor)", async () => {
     await patientService.search(
       { accessibleIds: [1] },
       9,
     )
     const call = prismaMock.patient.findMany.mock.calls[0][0] as any
-    expect(call.where.user.privacySettings).toEqual({
-      gdprConsent: true, shareWithProviders: true,
-    })
+    // OR (pas encore de row — patient fraîchement créé) OR (consentement confirmé).
+    // Un patient avec une row présente mais un flag false reste exclu (opt-out).
+    expect(call.where.user.OR).toEqual([
+      { privacySettings: null },
+      { privacySettings: { gdprConsent: true, shareWithProviders: true } },
+    ])
+  })
+
+  it("cap défensif : au-delà de 8 tokens, seuls les 8 premiers sont matchés", async () => {
+    // 10 mots distincts → tokenisation tronquée à 8 → 8 HMAC max dans le `in`.
+    await patientService.search(
+      { search: "a b c d e f g h i j", accessibleIds: null },
+      9,
+    )
+    const call = prismaMock.patient.findMany.mock.calls[0][0] as any
+    expect(call.where.OR[0].user.firstnameHmac.in).toHaveLength(8)
+    expect(call.where.OR[1].user.lastnameHmac.in).toHaveLength(8)
+  })
+
+  it("fallback : saisie blancs-only → pas de branche `OR` de recherche", async () => {
+    await patientService.search(
+      { search: "   ", accessibleIds: [1] },
+      9,
+    )
+    const call = prismaMock.patient.findMany.mock.calls[0][0] as any
+    expect(call.where.OR).toBeUndefined()
+  })
+
+  it("fallback : `#id` non-safe-integer → token ignoré, pas de branche `OR`", async () => {
+    // `#99999999999999999999` matche /^#\d+$/ (donc exclu des noms) mais échoue
+    // Number.isSafeInteger → idTokens vide → searchOr undefined (liste scopée
+    // renvoyée, JAMAIS hors scope car `id IN accessibleIds` reste top-level).
+    await patientService.search(
+      { search: "#99999999999999999999", accessibleIds: [1] },
+      9,
+    )
+    const call = prismaMock.patient.findMany.mock.calls[0][0] as any
+    expect(call.where.OR).toBeUndefined()
+    expect(call.where.id).toEqual({ in: [1] })
   })
 
   it("response trims to id/firstname/lastname (data-minimization)", async () => {


### PR DESCRIPTION
## 🐛 Bug

Dans le modal **« Ajouter un RDV »**, le `<PatientCombobox>` affichait **« Aucun patient ne correspond à votre recherche »** dès qu'on tapait, **et même en sélectionnant un patient dans la liste**. L'input se désactivait aussi à chaque touche.

### Cause racine

Le combobox envoyait **chaque frappe** au backend comme paramètre `search`, or `/api/patients/search` fait un **match HMAC exact** sur prénom/nom complet (`patient.service.ts`) — contrainte de chiffrement : les noms sont chiffrés, impossible de faire un `LIKE %fragment%`.

```ts
const hmac = hmacField(input.search!)
return { OR: [{ firstnameHmac: hmac }, { lastnameHmac: hmac }] }
```

Conséquence : un fragment (« Jea ») ou le label désambiguïsé (« Jean Martin #42 ») ne matchent **jamais** → `items` se vide → le filtre client-side aussi → faux message + input `disabled` via `loading`.

> ⚠️ Invisible aux tests unitaires : ils **mockent** `usePatientList` (retour constant quel que soit `search`).

## ✅ Fix

**Frontend** — la liste large (≤ 50) est fetchée **une seule fois** et filtrée **client-side** (accent-aware, déjà en place). Plus aucune frappe ne pilote le backend sur cette liste → plus de collapse, plus d'input désactivé.

## 🔎 Recherche backend (cabinets > 50 patients)

Implémentée à la demande, en respectant la contrainte de chiffrement :

- **Backend** (`patient.service.search`) : **tokenisation** de la saisie → match HMAC exact **par mot** sur `firstnameHmac`/`lastnameHmac` (`in`), + résolution des tokens `#id` (désambiguïsation homonymes) en **match direct sur l'id** patient. Le tout **toujours borné par le scope RBAC** `accessibleIds` (ANDé).
- **Frontend** : 2ᵉ instance `usePatientList` (débounce `useDeferredValue` React 19) dont les résultats **augmentent** la liste base (merge dédupliqué par id) au lieu de la remplacer :
  - pas de collapse de la liste base,
  - input jamais désactivé par la recherche complémentaire (seul le load initial gate),
  - un patient **hors des 50 premiers** devient trouvable en tapant son nom/prénom complet, **et reste sélectionnable**.
- Hint `patientSearching` (FR/EN/AR) + anti-flicker du « aucun résultat » pendant une recherche en vol.

## 🧪 Tests

- `PatientCombobox` : test de régression (la recherche **augmente**, ne vide pas, input jamais disabled) + test **merge** (patient hors 50 premiers remonté par la recherche → sélectionnable).
- `patient-search.service` : tokenisation multi-mots, résolution `#id`, `#id` seul, nouvelle structure `where.OR` patient-level.
- **63 tests verts**, `tsc --noEmit` exit 0, `eslint` clean.

## 🔐 Sécurité / conformité

- Aucun PHI déchiffré exposé côté recherche (HMAC déterministe only).
- Scope RBAC `accessibleIds` préservé sur **toutes** les branches (noms ET id).
- Audit `READ` / `resourceId="search"` inchangé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)