### PR TITLE
fix(appointments): en-tête du calendrier transperçait le modal "Nouveau rendez-vous"

### DIFF
--- a/src/components/diabeo/appointments/AppointmentCalendar.tsx
+++ b/src/components/diabeo/appointments/AppointmentCalendar.tsx
@@ -760,7 +760,14 @@ export function AppointmentCalendar({
             : t("calendarMainLabel")
         }
         aria-busy={isInitialLoading}
-        className="rounded-lg border border-border bg-card overflow-hidden min-h-[640px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+        // `isolate` — confine le stacking context du calendrier. L'en-tête sticky
+        // de Schedule-X (`.sx__week-header`, z-index 100) dépassait le z-index 50
+        // de l'overlay du modal shadcn (`<Dialog>` "Nouveau rendez-vous", rendu
+        // sur la même page) → l'axe des dates / bandeau "événements journée"
+        // transperçaient le modal par le haut. En isolant ici, le z-index 100
+        // reste interne au calendrier ; l'overlay (z-50, portalé au body) repasse
+        // au-dessus. Fix non-invasif (impossible de modifier components/ui/dialog).
+        className="isolate rounded-lg border border-border bg-card overflow-hidden min-h-[640px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
         tabIndex={-1}
       >
         <ScheduleXCalendar calendarApp={calendar} />

--- a/src/components/diabeo/appointments/AppointmentCalendar.tsx
+++ b/src/components/diabeo/appointments/AppointmentCalendar.tsx
@@ -751,6 +751,14 @@ export function AppointmentCalendar({
        * Pour V1, l'alternative a11y du drag&drop est le bouton "Déplacer"
        * dans le modal détail iter 5 (Fix FE-2 PR #435 WCAG 2.5.7).
        */}
+      {/* `isolate` (className) — confine le stacking context du calendrier.
+          L'en-tête sticky de Schedule-X (`.sx__week-header`, z-index 100)
+          dépassait le z-index 50 de l'overlay du modal shadcn (`<Dialog>`
+          "Nouveau rendez-vous", rendu sur la même page) → l'axe des dates /
+          bandeau "événements journée" transperçaient le modal par le haut. En
+          isolant ici, le z-index 100 reste interne au calendrier ; l'overlay
+          (z-50, portalé au body) repasse au-dessus. Fix non-invasif
+          (impossible de modifier components/ui/dialog). */}
       <div
         id="appointment-calendar-main"
         role="region"
@@ -760,13 +768,6 @@ export function AppointmentCalendar({
             : t("calendarMainLabel")
         }
         aria-busy={isInitialLoading}
-        // `isolate` — confine le stacking context du calendrier. L'en-tête sticky
-        // de Schedule-X (`.sx__week-header`, z-index 100) dépassait le z-index 50
-        // de l'overlay du modal shadcn (`<Dialog>` "Nouveau rendez-vous", rendu
-        // sur la même page) → l'axe des dates / bandeau "événements journée"
-        // transperçaient le modal par le haut. En isolant ici, le z-index 100
-        // reste interne au calendrier ; l'overlay (z-50, portalé au body) repasse
-        // au-dessus. Fix non-invasif (impossible de modifier components/ui/dialog).
         className="isolate rounded-lg border border-border bg-card overflow-hidden min-h-[640px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
         tabIndex={-1}
       >


### PR DESCRIPTION
## 🐛 Bug

À l'ouverture du modal **« Nouveau rendez-vous »**, des éléments visuels apparaissent **au-dessus** du modal, par le haut : l'**en-tête sticky du calendrier Schedule-X** — l'axe des dates (`sx__week-header`, `sx__week-grid__date-axis`) et le bandeau « événements journée » (`sx__date-grid`).

### Cause racine — conflit de `z-index`

| Élément | `z-index` |
|---|---|
| `.sx__week-header` (Schedule-X, `position: sticky`) | **100** (`--sx-z-index-week-header`) |
| Overlay + contenu `<Dialog>` shadcn | **50** (`z-50`) |

`AppointmentCalendar` rend **à la fois** le calendrier **et** le `AppointmentCreateModal` sur la même page. L'en-tête sticky (z-index 100) participe au stacking context racine et **dépasse l'overlay du modal** (z-index 50) → il transperce le modal.

## ✅ Fix

Ajout de la classe **`isolate`** sur le conteneur `#appointment-calendar-main` : cela crée un **nouveau stacking context** qui **confine** le `z-index:100` interne au calendrier. L'overlay du modal (z-50, portalé au `body`) repasse alors au-dessus de tout le calendrier.

- ✅ Non-invasif : `components/ui/dialog.tsx` (shadcn, interdit de modification) **intouché**.
- ✅ N'altère pas le comportement sticky de l'en-tête **à l'intérieur** du calendrier.
- ✅ Confine aussi les autres couches Schedule-X (event-modal z101, popup z102).

## 🧪 Vérification

- `tsc --noEmit` exit 0, `eslint` clean.
- `appointments-a11y` : 13 tests verts.
- ⚠️ **À valider visuellement** en ouvrant le modal « Nouveau rendez-vous » depuis la page calendrier (le rendu Schedule-X n'est pas testable en headless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)