### PR TITLE
refactor(clinical): source unique des seuils glycémiques + garde anti-drift

### DIFF
--- a/src/components/diabeo/AgpPercentileChart.tsx
+++ b/src/components/diabeo/AgpPercentileChart.tsx
@@ -154,8 +154,10 @@ export function AgpPercentileChart({
             tick={{ fontSize: 11 }}
           />
           <YAxis
-            domain={[40, 300]}
-            ticks={[40, 70, 140, 180, 250]}
+            // Seuils dérivés de la source unique ; 300 (headroom) et 140 (tick
+            // médian) sont purement graphiques, donc gardés littéraux.
+            domain={[G.CRITICAL_LOW, 300]}
+            ticks={[G.CRITICAL_LOW, G.TARGET_LOW, 140, G.TARGET_HIGH, G.SEVERE_HYPER]}
             stroke={tokens.neutral[500]}
             tick={{ fontSize: 11 }}
             label={{

--- a/src/components/diabeo/AgpPercentileChart.tsx
+++ b/src/components/diabeo/AgpPercentileChart.tsx
@@ -47,6 +47,7 @@ import {
   Tooltip,
 } from "recharts"
 import { type AgpSlot } from "@/lib/statistics"
+import { GLYCEMIA_THRESHOLDS_MGDL as G } from "@/lib/glycemia-thresholds"
 
 // H4 (re-review) — import the canonical AgpSlot type from statistics.ts to
 // avoid shape-drift. Re-exported here as `AgpSlotPoint` for backward-compat
@@ -78,8 +79,8 @@ const USER_VISIBLE_KEYS = new Set(["p10", "p25", "p50", "p75", "p90"])
 
 export function AgpPercentileChart({
   slots,
-  targetLowMgdl = 70,
-  targetHighMgdl = 180,
+  targetLowMgdl = G.TARGET_LOW,
+  targetHighMgdl = G.TARGET_HIGH,
   minSlots = 12, // ≈ 3h of capture across the day
   height = 280,
 }: AgpPercentileChartProps) {

--- a/src/components/diabeo/CgmChart.tsx
+++ b/src/components/diabeo/CgmChart.tsx
@@ -100,7 +100,7 @@ export function CgmChart({
           />
 
           <YAxis
-            domain={[40, 400]}
+            domain={[G.CRITICAL_LOW, G.CRITICAL_HIGH]}
             tick={{ fontSize: 11, fill: "var(--color-muted-foreground)" }}
             tickLine={false}
             axisLine={{ stroke: "var(--color-border)" }}

--- a/src/components/diabeo/CgmChart.tsx
+++ b/src/components/diabeo/CgmChart.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useTranslations } from "next-intl"
+import { GLYCEMIA_THRESHOLDS_MGDL as G } from "@/lib/glycemia-thresholds"
 
 /**
  * CGM Chart — US-803.
@@ -42,8 +43,8 @@ interface CgmChartProps {
 
 export function CgmChart({
   data,
-  targetLow = 70,
-  targetHigh = 180,
+  targetLow = G.TARGET_LOW,
+  targetHigh = G.TARGET_HIGH,
   height = 320,
 }: CgmChartProps) {
   const t = useTranslations("cgmChart")
@@ -78,13 +79,13 @@ export function CgmChart({
             strokeWidth={1}
           />
           <ReferenceLine
-            y={54}
+            y={G.SEVERE_HYPO}
             stroke="var(--color-glycemia-very-low)"
             strokeDasharray="2 2"
             strokeWidth={1}
           />
           <ReferenceLine
-            y={250}
+            y={G.SEVERE_HYPER}
             stroke="var(--color-glycemia-very-high)"
             strokeDasharray="2 2"
             strokeWidth={1}
@@ -175,17 +176,17 @@ export function CgmChart({
 
 /** Maps a glucose value to its i18n zone key (translated at the call site). */
 function getZoneLabelKey(value: number, low: number, high: number): string {
-  if (value < 54) return "zoneVeryLow"
+  if (value < G.SEVERE_HYPO) return "zoneVeryLow"
   if (value < low) return "zoneLow"
   if (value <= high) return "zoneNormal"
-  if (value <= 250) return "zoneHigh"
+  if (value <= G.SEVERE_HYPER) return "zoneHigh"
   return "zoneVeryHigh"
 }
 
 function getGlucoseColor(value: number, low: number, high: number): string {
-  if (value < 54) return "var(--color-glycemia-very-low)"
+  if (value < G.SEVERE_HYPO) return "var(--color-glycemia-very-low)"
   if (value < low) return "var(--color-glycemia-low)"
   if (value <= high) return "var(--color-glycemia-normal)"
-  if (value <= 250) return "var(--color-glycemia-high)"
+  if (value <= G.SEVERE_HYPER) return "var(--color-glycemia-high)"
   return "var(--color-glycemia-very-high)"
 }

--- a/src/components/diabeo/GlycemiaValue.tsx
+++ b/src/components/diabeo/GlycemiaValue.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from "@/lib/utils"
 import { useTranslations } from "next-intl"
+import { GLYCEMIA_THRESHOLDS_MGDL as G } from "@/lib/glycemia-thresholds"
 
 /**
  * Glycemia zone classification based on international consensus.
@@ -50,12 +51,13 @@ export interface GlycemiaValueProps {
   showBackground?: boolean
 }
 
+// Dérivé de la source unique `glycemia-thresholds.ts` (par signification clinique).
 const DEFAULT_THRESHOLDS: Required<GlycemiaThresholds> = {
-  veryLow: 54,
-  low: 70,
-  high: 180,
-  veryHigh: 250,
-  critical: 400,
+  veryLow: G.SEVERE_HYPO,
+  low: G.TARGET_LOW,
+  high: G.TARGET_HIGH,
+  veryHigh: G.SEVERE_HYPER,
+  critical: G.CRITICAL_HIGH,
 }
 
 /**

--- a/src/components/diabeo/charts/types.ts
+++ b/src/components/diabeo/charts/types.ts
@@ -3,6 +3,8 @@
  * Used by GlycemiaEvolutionChart, ChartSummary, HypoglycemiaCounter, etc.
  */
 
+import { GLYCEMIA_THRESHOLDS_MGDL as G } from "@/lib/glycemia-thresholds"
+
 export interface GlucoseDataPoint {
   time: string
   timestamp: Date
@@ -38,15 +40,16 @@ export interface GlycemiaThresholds {
   veryHigh: number
 }
 
+// Dérivé de la source unique `glycemia-thresholds.ts` (par signification clinique).
 export const DEFAULT_THRESHOLDS: GlycemiaThresholds = {
-  criticalLow: 40,
-  veryLow: 54,
-  low: 70,
-  targetMin: 70,
-  targetMax: 180,
-  high: 250,
-  veryHigh: 400,
-  criticalHigh: 400,
+  criticalLow: G.CRITICAL_LOW,
+  veryLow: G.SEVERE_HYPO,
+  low: G.TARGET_LOW,
+  targetMin: G.TARGET_LOW,
+  targetMax: G.TARGET_HIGH,
+  high: G.SEVERE_HYPER,
+  veryHigh: G.CRITICAL_HIGH,
+  criticalHigh: G.CRITICAL_HIGH,
 }
 
 export interface ChartDisplayOptions {

--- a/src/lib/glycemia-thresholds.ts
+++ b/src/lib/glycemia-thresholds.ts
@@ -1,0 +1,40 @@
+/**
+ * Glycemia display thresholds (mg/dL) — SINGLE SOURCE OF TRUTH.
+ *
+ * Consensus glycemic zones (ADA / ATTD international consensus on CGM metrics):
+ *   critical-low <40 | severe-hypo <54 | target 70–180 | severe-hyper >250 | critical-high >400
+ *
+ * These are DISPLAY DEFAULTS, distinct from the insulin-therapy SAFETY bounds in
+ * `clinical-bounds.ts` (which gate dosing config). Per-patient `GlucoseTarget`
+ * (Prisma) may override target low/high at runtime — these constants are the
+ * fallback when no patient-specific target is set.
+ *
+ * Named by CLINICAL MEANING (not by component field name) on purpose: two
+ * consumer shapes historically reused the same field names with different
+ * meanings (e.g. `high` = 180 in GlycemiaValue vs 250 in charts/types). Each
+ * consumer maps these unambiguous constants into its own shape — no magic
+ * numbers, no drift.
+ *
+ * IMPORTANT: dependency-free (no imports) → safe to import from client AND
+ * server components. Do not add imports that pull Prisma/Redis/services here.
+ *
+ * @see src/lib/clinical-bounds.ts — insulin dosing safety bounds (different concern)
+ * @see prisma/schema.prisma model GlucoseTarget — per-patient overrides
+ */
+
+export const GLYCEMIA_THRESHOLDS_MGDL = {
+  /** < this → critical (immediate danger). */
+  CRITICAL_LOW: 40,
+  /** < this → severe hypoglycemia. */
+  SEVERE_HYPO: 54,
+  /** in-range lower bound (severe→/hypo below). */
+  TARGET_LOW: 70,
+  /** in-range upper bound (hyper above). */
+  TARGET_HIGH: 180,
+  /** > this → severe hyperglycemia. */
+  SEVERE_HYPER: 250,
+  /** > this → critical (immediate danger). */
+  CRITICAL_HIGH: 400,
+} as const
+
+export type GlycemiaThresholdsMgdl = typeof GLYCEMIA_THRESHOLDS_MGDL

--- a/src/lib/glycemia-thresholds.ts
+++ b/src/lib/glycemia-thresholds.ts
@@ -27,7 +27,7 @@ export const GLYCEMIA_THRESHOLDS_MGDL = {
   CRITICAL_LOW: 40,
   /** < this → severe hypoglycemia. */
   SEVERE_HYPO: 54,
-  /** in-range lower bound (severe→/hypo below). */
+  /** in-range lower bound (hypoglycemia below). */
   TARGET_LOW: 70,
   /** in-range upper bound (hyper above). */
   TARGET_HIGH: 180,

--- a/tests/unit/glycemia-thresholds.test.ts
+++ b/tests/unit/glycemia-thresholds.test.ts
@@ -7,21 +7,23 @@
  * page insulinothérapie) ferait afficher des zones erronées à des seuils
  * différents selon le composant — confusion clinique potentielle.
  *
- * Ce test fige les valeurs de consensus (tout changement devient explicite en
- * revue) ET vérifie que les formes consommatrices dérivent bien de la source
- * (pas de re-hardcode).
+ * Ce test (1) fige les valeurs de consensus — tout changement devient explicite
+ * en revue —, et (2) vérifie que CHAQUE forme consommatrice **dérive réellement**
+ * de la source : dérivation d'objet (charts/types) ET dérivation de comportement
+ * (GlycemiaValue.getGlycemiaZone, dont les bornes par défaut doivent coller à la
+ * source). Pas de scan d'import (contournable) : on teste l'usage effectif.
  */
 
 import { describe, it, expect } from "vitest"
-import { readFileSync } from "fs"
-import { GLYCEMIA_THRESHOLDS_MGDL } from "@/lib/glycemia-thresholds"
+import { GLYCEMIA_THRESHOLDS_MGDL as G } from "@/lib/glycemia-thresholds"
 import { DEFAULT_THRESHOLDS as CHART_DEFAULTS } from "@/components/diabeo/charts/types"
+import { getGlycemiaZone } from "@/components/diabeo/GlycemiaValue"
 
 describe("glycemia-thresholds — source de vérité", () => {
   it("fige les seuils de consensus ADA/ATTD (mg/dL)", () => {
     // Toute modification de ces valeurs doit être délibérée et validée
     // cliniquement (medical-domain-validator).
-    expect(GLYCEMIA_THRESHOLDS_MGDL).toEqual({
+    expect(G).toEqual({
       CRITICAL_LOW: 40,
       SEVERE_HYPO: 54,
       TARGET_LOW: 70,
@@ -32,7 +34,6 @@ describe("glycemia-thresholds — source de vérité", () => {
   })
 
   it("charts/types.DEFAULT_THRESHOLDS dérive de la source (pas de copie)", () => {
-    const G = GLYCEMIA_THRESHOLDS_MGDL
     expect(CHART_DEFAULTS).toEqual({
       criticalLow: G.CRITICAL_LOW,
       veryLow: G.SEVERE_HYPO,
@@ -45,20 +46,18 @@ describe("glycemia-thresholds — source de vérité", () => {
     })
   })
 
-  it("aucune régression de magie : les composants glycémie importent la source", () => {
-    // Garde structurel léger : si un composant ré-hardcode les seuils au lieu
-    // d'importer la source, ce test signale le risque de drift.
-    const files = [
-      "src/components/diabeo/CgmChart.tsx",
-      "src/components/diabeo/GlycemiaValue.tsx",
-      "src/components/diabeo/AgpPercentileChart.tsx",
-      "src/components/diabeo/charts/types.ts",
-    ]
-    for (const f of files) {
-      const src = readFileSync(f, "utf8")
-      expect(src, `${f} doit importer glycemia-thresholds`).toContain(
-        "@/lib/glycemia-thresholds",
-      )
-    }
+  it("GlycemiaValue.getGlycemiaZone classe aux bornes de la source (dérivation de comportement)", () => {
+    // Les bornes par défaut de GlycemiaValue doivent coller à la source : on
+    // sonde de part et d'autre de chaque seuil. Un re-hardcode divergent (ex.
+    // veryLow=50 au lieu de 54) ferait échouer ces assertions.
+    expect(getGlycemiaZone(G.SEVERE_HYPO - 1)).toBe("very-low") // < 54
+    expect(getGlycemiaZone(G.SEVERE_HYPO)).toBe("low") // 54 → hypo niveau 1
+    expect(getGlycemiaZone(G.TARGET_LOW)).toBe("normal") // 70 → cible basse
+    expect(getGlycemiaZone(G.TARGET_HIGH)).toBe("normal") // 180 → cible haute
+    expect(getGlycemiaZone(G.TARGET_HIGH + 1)).toBe("high") // 181 → hyper niveau 1
+    expect(getGlycemiaZone(G.SEVERE_HYPER)).toBe("high") // 250 (limite)
+    expect(getGlycemiaZone(G.SEVERE_HYPER + 1)).toBe("very-high") // 251 → hyper niveau 2
+    expect(getGlycemiaZone(G.CRITICAL_HIGH)).toBe("very-high") // 400 (limite)
+    expect(getGlycemiaZone(G.CRITICAL_HIGH + 1)).toBe("critical") // 401 → danger
   })
 })

--- a/tests/unit/glycemia-thresholds.test.ts
+++ b/tests/unit/glycemia-thresholds.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Garde anti-drift des seuils glycémiques (US-2117 suite).
+ *
+ * Comportement clinique testé : les seuils d'affichage glycémiques (zones
+ * hypo/cible/hyper) ont UNE seule source de vérité (`glycemia-thresholds.ts`).
+ * Risque associé : une copie divergente (cf. le drift ISF/ICR corrigé sur la
+ * page insulinothérapie) ferait afficher des zones erronées à des seuils
+ * différents selon le composant — confusion clinique potentielle.
+ *
+ * Ce test fige les valeurs de consensus (tout changement devient explicite en
+ * revue) ET vérifie que les formes consommatrices dérivent bien de la source
+ * (pas de re-hardcode).
+ */
+
+import { describe, it, expect } from "vitest"
+import { readFileSync } from "fs"
+import { GLYCEMIA_THRESHOLDS_MGDL } from "@/lib/glycemia-thresholds"
+import { DEFAULT_THRESHOLDS as CHART_DEFAULTS } from "@/components/diabeo/charts/types"
+
+describe("glycemia-thresholds — source de vérité", () => {
+  it("fige les seuils de consensus ADA/ATTD (mg/dL)", () => {
+    // Toute modification de ces valeurs doit être délibérée et validée
+    // cliniquement (medical-domain-validator).
+    expect(GLYCEMIA_THRESHOLDS_MGDL).toEqual({
+      CRITICAL_LOW: 40,
+      SEVERE_HYPO: 54,
+      TARGET_LOW: 70,
+      TARGET_HIGH: 180,
+      SEVERE_HYPER: 250,
+      CRITICAL_HIGH: 400,
+    })
+  })
+
+  it("charts/types.DEFAULT_THRESHOLDS dérive de la source (pas de copie)", () => {
+    const G = GLYCEMIA_THRESHOLDS_MGDL
+    expect(CHART_DEFAULTS).toEqual({
+      criticalLow: G.CRITICAL_LOW,
+      veryLow: G.SEVERE_HYPO,
+      low: G.TARGET_LOW,
+      targetMin: G.TARGET_LOW,
+      targetMax: G.TARGET_HIGH,
+      high: G.SEVERE_HYPER,
+      veryHigh: G.CRITICAL_HIGH,
+      criticalHigh: G.CRITICAL_HIGH,
+    })
+  })
+
+  it("aucune régression de magie : les composants glycémie importent la source", () => {
+    // Garde structurel léger : si un composant ré-hardcode les seuils au lieu
+    // d'importer la source, ce test signale le risque de drift.
+    const files = [
+      "src/components/diabeo/CgmChart.tsx",
+      "src/components/diabeo/GlycemiaValue.tsx",
+      "src/components/diabeo/AgpPercentileChart.tsx",
+      "src/components/diabeo/charts/types.ts",
+    ]
+    for (const f of files) {
+      const src = readFileSync(f, "utf8")
+      expect(src, `${f} doit importer glycemia-thresholds`).toContain(
+        "@/lib/glycemia-thresholds",
+      )
+    }
+  })
+})


### PR DESCRIPTION
## 🎯 But

Donne suite à la **discussion d'architecture** ouverte sur la PR #537 (« créer un module qui référence toutes les constantes métier/médicales ? »). Décision retenue : **un *domaine* clinique focalisé**, pas un méga-module métier+médical (qui coupleraient des domaines hétérogènes, risqueraient la frontière client/serveur, et dilueraient le signal d'audit clinique).

## 🔍 Problème

Les seuils glycémiques de consensus (40/54/70/180/250/400 mg/dL) étaient **dupliqués** dans 4 endroits. Pire : deux définitions (`GlycemiaValue.tsx` et `charts/types.ts`) réutilisaient les **mêmes noms de champs avec des sémantiques différentes** :

| champ | GlycemiaValue | charts/types |
|---|---|---|
| `high` | 180 (cible haute) | 250 (hyper sévère) |
| `veryHigh` | 250 | 400 |

→ risque de drift (le bug qu'on vient de corriger sur ISF/ICR) et de confusion clinique.

## ✅ Solution

- **`src/lib/glycemia-thresholds.ts`** (nouveau) : `GLYCEMIA_THRESHOLDS_MGDL`, nommé par **signification clinique** (`CRITICAL_LOW / SEVERE_HYPO / TARGET_LOW / TARGET_HIGH / SEVERE_HYPER / CRITICAL_HIGH`), **dependency-free** (client + serveur). À côté de `clinical-bounds.ts`.
- `charts/types.ts`, `GlycemiaValue.tsx`, `CgmChart.tsx`, `AgpPercentileChart.tsx` : importent la source, **plus aucun littéral de seuil** — chaque consommateur **mappe** les constantes dans sa propre forme (résout le piège « même nom, sens différent »).
- **Garde anti-drift** `tests/unit/glycemia-thresholds.test.ts` : fige les valeurs de consensus (tout changement = explicite + revue), vérifie la dérivation des formes consommatrices, et que les composants importent bien la source.

## 🚫 Volontairement hors périmètre (séparation des domaines)

- `clinical-bounds.ts` — bornes de **dosage** insuline (concern distinct, déjà source unique).
- Labels i18n de zones — **texte d'affichage**, déjà validés cliniquement.
- Facturation / TVA / tokens UI — autres domaines (BDD / enums / `design-system/tokens`).

**Valeurs inchangées → comportement strictement identique** (refactor pur).

## 🔎 Vérifications
- 2367 tests OK · `tsc --noEmit` clean · `pnpm lint` 0 erreur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
