### PR TITLE
feat(medecin): US-2602 « Ma journée » — enrichissement du dashboard médecin

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -75,6 +75,7 @@
   },
   "nav": {
     "dashboard": "لوحة القيادة",
+    "dashboardMedecin": "يومي",
     "patients": "المرضى",
     "appointments": "المواعيد",
     "users": "المستخدمون",
@@ -215,7 +216,7 @@
     "errorLoadingData": "تعذر تحميل بيانات الجلوكوز",
     "newEventAriaLabel": "فتح نموذج حدث جديد",
     "medecin": {
-      "pageTitle": "لوحة تحكم الطبيب",
+      "pageTitle": "يومي",
       "lastUpdate": "آخر تحديث {time}",
       "loading": "جارٍ التحميل…",
       "stale": "بيانات قديمة — في انتظار التحديث.",

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1472,8 +1472,10 @@
       "changeAria": "تغيّر بنسبة {percent}٪",
       "stale": "البيانات قديمة — في انتظار التحديث.",
       "unitBasalRate": "U/h",
-      "unitInsulinSensitivityFactor": "g/L/U",
-      "unitInsulinToCarbRatio": "g/U"
+      "unitInsulinToCarbRatio": "g/U",
+      "unitIsfGl": "g/L/U",
+      "unitIsfMgdl": "mg/dL/U",
+      "unitIsfMmol": "mmol/L/U"
     },
     "medecinMessages": {
       "title": "رسائل غير مقروءة",

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1470,6 +1470,16 @@
       "valueTransition": "{from} ← {to}",
       "changeAria": "تغيّر بنسبة {percent}٪"
     },
+    "medecinMessages": {
+      "title": "رسائل غير مقروءة",
+      "loading": "جارٍ التحميل…",
+      "loadError": "تعذّر تحميل الرسائل.",
+      "emptyTitle": "لا توجد رسائل غير مقروءة",
+      "emptyMessage": "صندوق الوارد محدّث.",
+      "previewFallback": "(رسالة مشفّرة)",
+      "unreadAria": "{count, plural, zero {# رسالة غير مقروءة} one {# رسالة غير مقروءة} two {# رسالتان غير مقروءتين} few {# رسائل غير مقروءة} many {# رسالة غير مقروءة} other {# رسالة غير مقروءة}}",
+      "openThread": "فتح المحادثة"
+    },
     "nurseTeamInbox": {
       "title": "تنسيق الفريق",
       "loading": "جارٍ التحميل…",

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1457,6 +1457,19 @@
       "reasonAppointmentUnconfirmed": "موعد غير مؤكّد",
       "reasonNeverSynced": "لم تتم المزامنة قط"
     },
+    "medecinProposals": {
+      "title": "المقترحات قيد الانتظار",
+      "loading": "جارٍ التحميل…",
+      "loadError": "تعذّر تحميل المقترحات.",
+      "emptyTitle": "لا توجد مقترحات",
+      "emptyMessage": "لا يوجد تعديل للمراجعة.",
+      "patientFallback": "مريض",
+      "paramBasalRate": "المعدل القاعدي",
+      "paramInsulinSensitivityFactor": "عامل حساسية الأنسولين (ISF)",
+      "paramInsulinToCarbRatio": "نسبة الأنسولين إلى الكربوهيدرات (ICR)",
+      "valueTransition": "{from} ← {to}",
+      "changeAria": "تغيّر بنسبة {percent}٪"
+    },
     "nurseTeamInbox": {
       "title": "تنسيق الفريق",
       "loading": "جارٍ التحميل…",

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1469,7 +1469,11 @@
       "paramInsulinSensitivityFactor": "عامل حساسية الأنسولين (ISF)",
       "paramInsulinToCarbRatio": "نسبة الأنسولين إلى الكربوهيدرات (ICR)",
       "valueTransition": "{from} ← {to}",
-      "changeAria": "تغيّر بنسبة {percent}٪"
+      "changeAria": "تغيّر بنسبة {percent}٪",
+      "stale": "البيانات قديمة — في انتظار التحديث.",
+      "unitBasalRate": "U/h",
+      "unitInsulinSensitivityFactor": "g/L/U",
+      "unitInsulinToCarbRatio": "g/U"
     },
     "medecinMessages": {
       "title": "رسائل غير مقروءة",
@@ -1479,7 +1483,7 @@
       "emptyMessage": "صندوق الوارد محدّث.",
       "previewFallback": "(رسالة مشفّرة)",
       "unreadAria": "{count, plural, zero {# رسالة غير مقروءة} one {# رسالة غير مقروءة} two {# رسالتان غير مقروءتين} few {# رسائل غير مقروءة} many {# رسالة غير مقروءة} other {# رسالة غير مقروءة}}",
-      "openThread": "فتح المحادثة"
+      "stale": "البيانات قديمة — في انتظار التحديث."
     },
     "nurseTeamInbox": {
       "title": "تنسيق الفريق",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1457,6 +1457,19 @@
       "reasonAppointmentUnconfirmed": "Unconfirmed appointment",
       "reasonNeverSynced": "Never synced"
     },
+    "medecinProposals": {
+      "title": "Pending proposals",
+      "loading": "Loading…",
+      "loadError": "Unable to load proposals.",
+      "emptyTitle": "No proposals",
+      "emptyMessage": "No adjustment to review.",
+      "patientFallback": "Patient",
+      "paramBasalRate": "Basal rate",
+      "paramInsulinSensitivityFactor": "Insulin sensitivity factor (ISF)",
+      "paramInsulinToCarbRatio": "Insulin-to-carb ratio (ICR)",
+      "valueTransition": "{from} → {to}",
+      "changeAria": "{percent}% change"
+    },
     "nurseTeamInbox": {
       "title": "Team coordination",
       "loading": "Loading…",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1472,8 +1472,10 @@
       "changeAria": "{percent}% change",
       "stale": "Data is stale — refresh pending.",
       "unitBasalRate": "U/h",
-      "unitInsulinSensitivityFactor": "g/L/U",
-      "unitInsulinToCarbRatio": "g/U"
+      "unitInsulinToCarbRatio": "g/U",
+      "unitIsfGl": "g/L/U",
+      "unitIsfMgdl": "mg/dL/U",
+      "unitIsfMmol": "mmol/L/U"
     },
     "medecinMessages": {
       "title": "Unread messages",

--- a/messages/en.json
+++ b/messages/en.json
@@ -75,6 +75,7 @@
   },
   "nav": {
     "dashboard": "Dashboard",
+    "dashboardMedecin": "My day",
     "patients": "Patients",
     "appointments": "Appointments",
     "users": "Users",
@@ -215,7 +216,7 @@
     "errorLoadingData": "Unable to load glycemia data",
     "newEventAriaLabel": "Open new event form",
     "medecin": {
-      "pageTitle": "Doctor dashboard",
+      "pageTitle": "My day",
       "lastUpdate": "Updated {time}",
       "loading": "Loading…",
       "stale": "Stale data — refresh pending.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1470,6 +1470,16 @@
       "valueTransition": "{from} → {to}",
       "changeAria": "{percent}% change"
     },
+    "medecinMessages": {
+      "title": "Unread messages",
+      "loading": "Loading…",
+      "loadError": "Unable to load messages.",
+      "emptyTitle": "No unread messages",
+      "emptyMessage": "Inbox up to date.",
+      "previewFallback": "(encrypted message)",
+      "unreadAria": "{count, plural, one {# unread message} other {# unread messages}}",
+      "openThread": "Open conversation"
+    },
     "nurseTeamInbox": {
       "title": "Team coordination",
       "loading": "Loading…",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1469,7 +1469,11 @@
       "paramInsulinSensitivityFactor": "Insulin sensitivity factor (ISF)",
       "paramInsulinToCarbRatio": "Insulin-to-carb ratio (ICR)",
       "valueTransition": "{from} → {to}",
-      "changeAria": "{percent}% change"
+      "changeAria": "{percent}% change",
+      "stale": "Data is stale — refresh pending.",
+      "unitBasalRate": "U/h",
+      "unitInsulinSensitivityFactor": "g/L/U",
+      "unitInsulinToCarbRatio": "g/U"
     },
     "medecinMessages": {
       "title": "Unread messages",
@@ -1479,7 +1483,7 @@
       "emptyMessage": "Inbox up to date.",
       "previewFallback": "(encrypted message)",
       "unreadAria": "{count, plural, one {# unread message} other {# unread messages}}",
-      "openThread": "Open conversation"
+      "stale": "Data is stale — refresh pending."
     },
     "nurseTeamInbox": {
       "title": "Team coordination",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1469,7 +1469,11 @@
       "paramInsulinSensitivityFactor": "Facteur de sensibilité à l'insuline (ISF)",
       "paramInsulinToCarbRatio": "Ratio insuline/glucides (ICR)",
       "valueTransition": "{from} → {to}",
-      "changeAria": "Variation de {percent} %"
+      "changeAria": "Variation de {percent} %",
+      "stale": "Données obsolètes — rafraîchissement en attente.",
+      "unitBasalRate": "U/h",
+      "unitInsulinSensitivityFactor": "g/L/U",
+      "unitInsulinToCarbRatio": "g/U"
     },
     "medecinMessages": {
       "title": "Messages non lus",
@@ -1479,7 +1483,7 @@
       "emptyMessage": "Boîte de réception à jour.",
       "previewFallback": "(message chiffré)",
       "unreadAria": "{count, plural, one {# message non lu} other {# messages non lus}}",
-      "openThread": "Ouvrir la conversation"
+      "stale": "Données obsolètes — rafraîchissement en attente."
     },
     "nurseTeamInbox": {
       "title": "Coordination équipe",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1470,6 +1470,16 @@
       "valueTransition": "{from} → {to}",
       "changeAria": "Variation de {percent} %"
     },
+    "medecinMessages": {
+      "title": "Messages non lus",
+      "loading": "Chargement…",
+      "loadError": "Impossible de charger les messages.",
+      "emptyTitle": "Aucun message non lu",
+      "emptyMessage": "Boîte de réception à jour.",
+      "previewFallback": "(message chiffré)",
+      "unreadAria": "{count, plural, one {# message non lu} other {# messages non lus}}",
+      "openThread": "Ouvrir la conversation"
+    },
     "nurseTeamInbox": {
       "title": "Coordination équipe",
       "loading": "Chargement…",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -75,6 +75,7 @@
   },
   "nav": {
     "dashboard": "Tableau de bord",
+    "dashboardMedecin": "Ma journée",
     "patients": "Patients",
     "appointments": "Rendez-vous",
     "users": "Utilisateurs",
@@ -215,7 +216,7 @@
     "errorLoadingData": "Impossible de charger les donnees de glycemie",
     "newEventAriaLabel": "Ouvrir le formulaire de saisie d'un nouvel evenement",
     "medecin": {
-      "pageTitle": "Tableau de bord médecin",
+      "pageTitle": "Ma journée",
       "lastUpdate": "Mise à jour {time}",
       "loading": "Chargement…",
       "stale": "Données obsolètes — rafraîchissement en attente.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1472,8 +1472,10 @@
       "changeAria": "Variation de {percent} %",
       "stale": "Données obsolètes — rafraîchissement en attente.",
       "unitBasalRate": "U/h",
-      "unitInsulinSensitivityFactor": "g/L/U",
-      "unitInsulinToCarbRatio": "g/U"
+      "unitInsulinToCarbRatio": "g/U",
+      "unitIsfGl": "g/L/U",
+      "unitIsfMgdl": "mg/dL/U",
+      "unitIsfMmol": "mmol/L/U"
     },
     "medecinMessages": {
       "title": "Messages non lus",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1457,6 +1457,19 @@
       "reasonAppointmentUnconfirmed": "Rendez-vous non confirmé",
       "reasonNeverSynced": "Jamais synchronisé"
     },
+    "medecinProposals": {
+      "title": "Propositions en attente",
+      "loading": "Chargement…",
+      "loadError": "Impossible de charger les propositions.",
+      "emptyTitle": "Aucune proposition",
+      "emptyMessage": "Aucun ajustement à examiner.",
+      "patientFallback": "Patient",
+      "paramBasalRate": "Débit basal",
+      "paramInsulinSensitivityFactor": "Facteur de sensibilité à l'insuline (ISF)",
+      "paramInsulinToCarbRatio": "Ratio insuline/glucides (ICR)",
+      "valueTransition": "{from} → {to}",
+      "changeAria": "Variation de {percent} %"
+    },
     "nurseTeamInbox": {
       "title": "Coordination équipe",
       "loading": "Chargement…",

--- a/src/app/(dashboard)/medecin/page.tsx
+++ b/src/app/(dashboard)/medecin/page.tsx
@@ -21,6 +21,8 @@ import { KpiSection } from "@/components/diabeo/dashboard/medecin/KpiSection"
 import { RecallListCard } from "@/components/diabeo/dashboard/infirmier/RecallListCard"
 // US-2602 (Ma journée) incr. 2 — Propositions d'ajustement en attente.
 import { PendingProposalsCard } from "@/components/diabeo/dashboard/medecin/PendingProposalsCard"
+// US-2602 (Ma journée) incr. 3 — Messages non lus (liste).
+import { UnreadMessagesCard } from "@/components/diabeo/dashboard/medecin/UnreadMessagesCard"
 
 const ALLOWED_ROLES = new Set(["DOCTOR", "NURSE", "ADMIN"])
 
@@ -43,6 +45,7 @@ export default async function MedecinDashboardPage() {
         <RecallListCard />
         <PendingProposalsCard />
       </div>
+      <UnreadMessagesCard />
       <KpiSection />
     </main>
   )

--- a/src/app/(dashboard)/medecin/page.tsx
+++ b/src/app/(dashboard)/medecin/page.tsx
@@ -19,6 +19,8 @@ import { KpiSection } from "@/components/diabeo/dashboard/medecin/KpiSection"
 // infirmier (`nurseRecallQuery`, scopée au portefeuille de l'appelant) + la
 // route `/api/dashboard/infirmier/recall-list` (minRole NURSE → DOCTOR éligible).
 import { RecallListCard } from "@/components/diabeo/dashboard/infirmier/RecallListCard"
+// US-2602 (Ma journée) incr. 2 — Propositions d'ajustement en attente.
+import { PendingProposalsCard } from "@/components/diabeo/dashboard/medecin/PendingProposalsCard"
 
 const ALLOWED_ROLES = new Set(["DOCTOR", "NURSE", "ADMIN"])
 
@@ -37,7 +39,10 @@ export default async function MedecinDashboardPage() {
         <AppointmentCard />
       </div>
       <PatientsAtRiskCard />
-      <RecallListCard />
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <RecallListCard />
+        <PendingProposalsCard />
+      </div>
       <KpiSection />
     </main>
   )

--- a/src/app/(dashboard)/medecin/page.tsx
+++ b/src/app/(dashboard)/medecin/page.tsx
@@ -1,8 +1,12 @@
 /**
- * US-2400 — Dashboard médecin (page conteneur).
+ * US-2400 / US-2602 — « Ma journée » (dashboard médecin, page conteneur).
  *
- * Layout responsive : 1 col mobile, 2 col grid lg+. Urgences + RDV top row
- * (parallel), Patients à suivre row 2 full-width, KPI section row 3.
+ * Vue jour du médecin. Layout responsive (1 col mobile, 2 col lg+) :
+ *   1. Urgences + Rendez-vous du jour (row 2 col)
+ *   2. Patients à suivre (full-width)
+ *   3. Relances en attente + Propositions d'ajustement en attente (row 2 col)
+ *   4. Messages non lus (full-width)
+ *   5. Indicateurs clés (KPI) du cabinet
  *
  * Server-side guard : redirect non-DOCTOR/NURSE/ADMIN to login. The
  * (dashboard)/layout.tsx already redirects VIEWER → /patient/dashboard.

--- a/src/app/(dashboard)/medecin/page.tsx
+++ b/src/app/(dashboard)/medecin/page.tsx
@@ -15,6 +15,10 @@ import { EmergencyCard } from "@/components/diabeo/dashboard/medecin/EmergencyCa
 import { AppointmentCard } from "@/components/diabeo/dashboard/medecin/AppointmentCard"
 import { PatientsAtRiskCard } from "@/components/diabeo/dashboard/medecin/PatientsAtRiskCard"
 import { KpiSection } from "@/components/diabeo/dashboard/medecin/KpiSection"
+// US-2602 (Ma journée) incr. 1 — Relances en attente. Réutilise la query
+// infirmier (`nurseRecallQuery`, scopée au portefeuille de l'appelant) + la
+// route `/api/dashboard/infirmier/recall-list` (minRole NURSE → DOCTOR éligible).
+import { RecallListCard } from "@/components/diabeo/dashboard/infirmier/RecallListCard"
 
 const ALLOWED_ROLES = new Set(["DOCTOR", "NURSE", "ADMIN"])
 
@@ -33,6 +37,7 @@ export default async function MedecinDashboardPage() {
         <AppointmentCard />
       </div>
       <PatientsAtRiskCard />
+      <RecallListCard />
       <KpiSection />
     </main>
   )

--- a/src/app/api/dashboard/medecin/pending-proposals/route.ts
+++ b/src/app/api/dashboard/medecin/pending-proposals/route.ts
@@ -1,0 +1,23 @@
+/**
+ * US-2602 (Ma journée) — Propositions d'ajustement en attente (médecin).
+ * GET — propositions `pending` du portefeuille du caller, scope RBAC.
+ * minRole NURSE (DOCTOR/ADMIN éligibles). Déterministe (aucun calcul front).
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { AuthError } from "@/lib/auth"
+import { pendingProposalsQuery } from "@/lib/services/doctor-dashboard.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+
+export async function GET(req: NextRequest) {
+  const ctx = extractRequestContext(req)
+  try {
+    const user = await auditedRequireRole(req, "NURSE", ctx, "ADJUSTMENT_PROPOSAL", "0")
+    const items = await pendingProposalsQuery.forCaller(user.id, user.role, user.id, ctx)
+    return NextResponse.json({ items })
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "dashboard/medecin/pending-proposals GET", ctx.requestId)
+  }
+}

--- a/src/app/api/dashboard/medecin/pending-proposals/route.ts
+++ b/src/app/api/dashboard/medecin/pending-proposals/route.ts
@@ -15,7 +15,8 @@ export async function GET(req: NextRequest) {
   try {
     const user = await auditedRequireRole(req, "NURSE", ctx, "ADJUSTMENT_PROPOSAL", "0")
     const items = await pendingProposalsQuery.forCaller(user.id, user.role, user.id, ctx)
-    return NextResponse.json({ items })
+    // PHI (prénom patient déchiffré) — pas de cache proxy intermédiaire.
+    return NextResponse.json({ items }, { headers: { "Cache-Control": "no-store, private" } })
   } catch (e) {
     if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
     return mapErrorToResponse(e, "dashboard/medecin/pending-proposals GET", ctx.requestId)

--- a/src/app/api/dashboard/medecin/unread-threads/route.ts
+++ b/src/app/api/dashboard/medecin/unread-threads/route.ts
@@ -1,0 +1,35 @@
+/**
+ * US-2602 (Ma journée) — Messages non lus (médecin).
+ * GET — threads avec ≥ 1 message non lu pour le caller (top 5, récence).
+ * minRole NURSE (DOCTOR/ADMIN éligibles).
+ *
+ * Audit : délégué à `messagingService.listThreads(..., "poll")` (1 row
+ * coalescé par fenêtre — pas de pollution sur le polling 60s). Pas de
+ * `auditedRequireRole` ici pour éviter un double audit.
+ *
+ * Consentement RGPD : messagerie = donnée santé Art. 9. Sans consentement
+ * du caller, la carte dégrade en liste vide (un dashboard ne hard-fail pas).
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { AuthError, requireRole } from "@/lib/auth"
+import { requireGdprConsent } from "@/lib/gdpr"
+import { unreadThreadsQuery } from "@/lib/services/doctor-dashboard.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { mapErrorToResponse } from "@/lib/team-route-helpers"
+
+export async function GET(req: NextRequest) {
+  const ctx = extractRequestContext(req)
+  try {
+    const user = requireRole(req, "NURSE")
+    const hasConsent = await requireGdprConsent(user.id)
+    if (!hasConsent) {
+      return NextResponse.json({ items: [] }, { headers: { "Cache-Control": "no-store, private" } })
+    }
+    const items = await unreadThreadsQuery.forCaller(user.id, ctx)
+    return NextResponse.json({ items }, { headers: { "Cache-Control": "no-store, private" } })
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "dashboard/medecin/unread-threads GET", ctx.requestId)
+  }
+}

--- a/src/app/api/dashboard/medecin/unread-threads/route.ts
+++ b/src/app/api/dashboard/medecin/unread-threads/route.ts
@@ -3,25 +3,36 @@
  * GET — threads avec ≥ 1 message non lu pour le caller (top 5, récence).
  * minRole NURSE (DOCTOR/ADMIN éligibles).
  *
- * Audit : délégué à `messagingService.listThreads(..., "poll")` (1 row
- * coalescé par fenêtre — pas de pollution sur le polling 60s). Pas de
- * `auditedRequireRole` ici pour éviter un double audit.
+ * Audit : succès délégué à `messagingService.listThreads(..., "poll")` (1 row
+ * coalescé par fenêtre — pas de pollution sur le polling 60s) ; les refus 403
+ * sont, eux, audités via `auditedRequireRole` (US-2265 burst detection).
  *
  * Consentement RGPD : messagerie = donnée santé Art. 9. Sans consentement
  * du caller, la carte dégrade en liste vide (un dashboard ne hard-fail pas).
+ *
+ * ⚠️ Indistinguabilité VOULUE : le cas « consentement absent/révoqué » renvoie
+ * exactement la même réponse (`{ items: [] }`, même `Cache-Control`) qu'une
+ * boîte de réception réellement vide. C'est délibéré (anti-signal open-space,
+ * RGPD Art. 5.1.f / Art. 9) — comme le badge non lus du `NavigationShell` :
+ * ne JAMAIS révéler l'état de consentement d'un PS à un tiers (open-space,
+ * partage d'écran). Ne pas « corriger » en différenciant les deux états.
  */
 
 import { NextResponse, type NextRequest } from "next/server"
-import { AuthError, requireRole } from "@/lib/auth"
+import { AuthError } from "@/lib/auth"
 import { requireGdprConsent } from "@/lib/gdpr"
 import { unreadThreadsQuery } from "@/lib/services/doctor-dashboard.service"
 import { extractRequestContext } from "@/lib/services/audit.service"
-import { mapErrorToResponse } from "@/lib/team-route-helpers"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
 
 export async function GET(req: NextRequest) {
   const ctx = extractRequestContext(req)
   try {
-    const user = requireRole(req, "NURSE")
+    // `auditedRequireRole` n'audite QUE le refus (403) — pas le succès, qui
+    // reste délégué à `listThreads("poll")` (audit coalescé, pas de double
+    // audit). Comble l'asymétrie de traçabilité des tentatives non autorisées
+    // (US-2265 burst detection) avec la route sœur pending-proposals.
+    const user = await auditedRequireRole(req, "NURSE", ctx, "MESSAGE", "0")
     const hasConsent = await requireGdprConsent(user.id)
     if (!hasConsent) {
       return NextResponse.json({ items: [] }, { headers: { "Cache-Control": "no-store, private" } })

--- a/src/components/diabeo/NavigationShell.tsx
+++ b/src/components/diabeo/NavigationShell.tsx
@@ -438,7 +438,14 @@ export function NavigationShell({
     .filter((item) => hasRoleAccess(userRole, item.minRole))
     .map((item) =>
       item.href === HOME_HREF_MARKER
-        ? { ...item, href: resolveHomeForRole(userRole) }
+        ? {
+            ...item,
+            href: resolveHomeForRole(userRole),
+            // US-2602 (Ma journée) — le home médecin est libellé « Ma journée »
+            // (vue jour : urgences, RDV, relances, propositions, messages).
+            // Les autres rôles gardent « Tableau de bord » (libellé générique).
+            labelKey: userRole === "DOCTOR" ? "dashboardMedecin" : item.labelKey,
+          }
         : item,
     )
 

--- a/src/components/diabeo/dashboard/medecin/PendingProposalsCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/PendingProposalsCard.tsx
@@ -1,0 +1,103 @@
+/**
+ * US-2602 (Ma journée) — Propositions d'ajustement en attente (médecin).
+ *
+ * Liste read-only, déterministe : les `AdjustmentProposal` sont produites
+ * côté backend (jamais auto-appliquées, jamais générées par le frontend).
+ * La revue accepter/rejeter se fait sur l'écran dédié — cette carte ne fait
+ * que signaler ce qui est en attente. Polling 60s.
+ */
+
+"use client"
+
+import { useTranslations } from "next-intl"
+import { DiabeoCard } from "@/components/diabeo/DiabeoCard"
+import { DiabeoEmptyState } from "@/components/diabeo/DiabeoEmptyState"
+import { StaleBanner, STALE_MESSAGE_FR } from "@/components/diabeo/dashboard/medecin/StaleBanner"
+import { Badge } from "@/components/ui/badge"
+import { usePollingFetch } from "@/hooks/usePollingFetch"
+import type { PendingProposalItem } from "@/lib/services/doctor-dashboard.service"
+
+type ApiResponse = { items: PendingProposalItem[] }
+
+/** parameterType → clé i18n du libellé (règle acronyme « Libellé (ACRONYME) »). */
+const PARAM_LABEL_KEY: Record<PendingProposalItem["parameterType"], string> = {
+  basalRate: "paramBasalRate",
+  insulinSensitivityFactor: "paramInsulinSensitivityFactor",
+  insulinToCarbRatio: "paramInsulinToCarbRatio",
+}
+
+/** Variante du badge selon l'ampleur de la variation (déterministe, |%|). */
+function changeVariant(percent: number): "destructive" | "secondary" {
+  return Math.abs(percent) >= 20 ? "destructive" : "secondary"
+}
+
+export function PendingProposalsCard() {
+  const t = useTranslations("dashboardCards.medecinProposals")
+  const { data, error, loading, isStale } = usePollingFetch<ApiResponse>(
+    "/api/dashboard/medecin/pending-proposals",
+    60_000,
+  )
+  const items = Array.isArray(data?.items) ? data!.items : []
+  const hasError = error !== null && data === null
+  return (
+    <DiabeoCard role="region" aria-labelledby="card-proposals-title">
+      <header className="flex items-center justify-between px-4 pt-4">
+        <h2 id="card-proposals-title" className="text-base font-semibold">
+          {t("title")}
+        </h2>
+        <span className="text-xs text-muted-foreground">{items.length}</span>
+      </header>
+      {isStale && <StaleBanner message={STALE_MESSAGE_FR} />}
+      <div className="px-4 pb-4">
+        {loading && items.length === 0 && (
+          <p className="text-sm text-muted-foreground">{t("loading")}</p>
+        )}
+        {hasError && (
+          <p className="text-sm text-glycemia-critical">{t("loadError")}</p>
+        )}
+        {!loading && !hasError && items.length === 0 && (
+          <DiabeoEmptyState
+            variant="noData"
+            title={t("emptyTitle")}
+            message={t("emptyMessage")}
+          />
+        )}
+        {items.length > 0 && (
+          <ul className="space-y-2">
+            {items.map((p) => {
+              const pct = Math.round(p.changePercent)
+              return (
+                <li
+                  key={p.id}
+                  className="flex items-center gap-3 rounded-md border border-border bg-card px-3 py-2"
+                >
+                  <span className="flex h-8 w-8 items-center justify-center rounded-full bg-muted text-sm font-semibold">
+                    {(p.patientFirstName || "?").charAt(0).toUpperCase()}
+                  </span>
+                  <span className="flex flex-1 flex-col truncate">
+                    <span className="truncate text-sm font-medium">
+                      {p.patientFirstName || t("patientFallback")}
+                      {p.pathology ? ` · ${p.pathology}` : ""}
+                    </span>
+                    <span className="truncate text-xs text-muted-foreground">
+                      {t(PARAM_LABEL_KEY[p.parameterType])}
+                    </span>
+                  </span>
+                  <span className="text-xs tabular-nums text-foreground">
+                    {t("valueTransition", { from: p.currentValue, to: p.proposedValue })}
+                  </span>
+                  <Badge
+                    variant={changeVariant(p.changePercent)}
+                    aria-label={t("changeAria", { percent: pct })}
+                  >
+                    {pct > 0 ? `+${pct}` : pct}&nbsp;%
+                  </Badge>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+    </DiabeoCard>
+  )
+}

--- a/src/components/diabeo/dashboard/medecin/PendingProposalsCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/PendingProposalsCard.tsx
@@ -9,12 +9,13 @@
 
 "use client"
 
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { DiabeoCard } from "@/components/diabeo/DiabeoCard"
 import { DiabeoEmptyState } from "@/components/diabeo/DiabeoEmptyState"
-import { StaleBanner, STALE_MESSAGE_FR } from "@/components/diabeo/dashboard/medecin/StaleBanner"
+import { StaleBanner } from "@/components/diabeo/dashboard/medecin/StaleBanner"
 import { Badge } from "@/components/ui/badge"
 import { usePollingFetch } from "@/hooks/usePollingFetch"
+import { bcp47 } from "@/i18n/config"
 import type { PendingProposalItem } from "@/lib/services/doctor-dashboard.service"
 
 type ApiResponse = { items: PendingProposalItem[] }
@@ -26,6 +27,13 @@ const PARAM_LABEL_KEY: Record<PendingProposalItem["parameterType"], string> = {
   insulinToCarbRatio: "paramInsulinToCarbRatio",
 }
 
+/** parameterType → clé i18n de l'unité (lève l'ambiguïté clinique des valeurs). */
+const PARAM_UNIT_KEY: Record<PendingProposalItem["parameterType"], string> = {
+  basalRate: "unitBasalRate",
+  insulinSensitivityFactor: "unitInsulinSensitivityFactor",
+  insulinToCarbRatio: "unitInsulinToCarbRatio",
+}
+
 /** Variante du badge selon l'ampleur de la variation (déterministe, |%|). */
 function changeVariant(percent: number): "destructive" | "secondary" {
   return Math.abs(percent) >= 20 ? "destructive" : "secondary"
@@ -33,6 +41,11 @@ function changeVariant(percent: number): "destructive" | "secondary" {
 
 export function PendingProposalsCard() {
   const t = useTranslations("dashboardCards.medecinProposals")
+  const locale = useLocale()
+  // Décimales bornées (max 2) — suffisant cliniquement (incrément basal 0.05,
+  // ISF 0.01, ICR 0.1) et évite d'afficher le bruit Decimal(8,4).
+  const fmt = (n: number) =>
+    n.toLocaleString(bcp47(locale), { maximumFractionDigits: 2 })
   const { data, error, loading, isStale } = usePollingFetch<ApiResponse>(
     "/api/dashboard/medecin/pending-proposals",
     60_000,
@@ -47,7 +60,7 @@ export function PendingProposalsCard() {
         </h2>
         <span className="text-xs text-muted-foreground">{items.length}</span>
       </header>
-      {isStale && <StaleBanner message={STALE_MESSAGE_FR} />}
+      {isStale && <StaleBanner message={t("stale")} />}
       <div className="px-4 pb-4">
         {loading && items.length === 0 && (
           <p className="text-sm text-muted-foreground">{t("loading")}</p>
@@ -84,7 +97,9 @@ export function PendingProposalsCard() {
                     </span>
                   </span>
                   <span className="text-xs tabular-nums text-foreground">
-                    {t("valueTransition", { from: p.currentValue, to: p.proposedValue })}
+                    {t("valueTransition", { from: fmt(p.currentValue), to: fmt(p.proposedValue) })}
+                    {" "}
+                    {t(PARAM_UNIT_KEY[p.parameterType])}
                   </span>
                   <Badge
                     variant={changeVariant(p.changePercent)}

--- a/src/components/diabeo/dashboard/medecin/PendingProposalsCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/PendingProposalsCard.tsx
@@ -13,9 +13,11 @@ import { useLocale, useTranslations } from "next-intl"
 import { DiabeoCard } from "@/components/diabeo/DiabeoCard"
 import { DiabeoEmptyState } from "@/components/diabeo/DiabeoEmptyState"
 import { StaleBanner } from "@/components/diabeo/dashboard/medecin/StaleBanner"
+import { Acronym, type AcronymCode } from "@/components/diabeo/Acronym"
 import { Badge } from "@/components/ui/badge"
 import { usePollingFetch } from "@/hooks/usePollingFetch"
 import { bcp47 } from "@/i18n/config"
+import { convertGlucoseFromGl, type GlucoseUnit } from "@/lib/conversions"
 import type { PendingProposalItem } from "@/lib/services/doctor-dashboard.service"
 
 type ApiResponse = { items: PendingProposalItem[] }
@@ -27,14 +29,45 @@ const PARAM_LABEL_KEY: Record<PendingProposalItem["parameterType"], string> = {
   insulinToCarbRatio: "paramInsulinToCarbRatio",
 }
 
-/** parameterType → clé i18n de l'unité (lève l'ambiguïté clinique des valeurs). */
-const PARAM_UNIT_KEY: Record<PendingProposalItem["parameterType"], string> = {
-  basalRate: "unitBasalRate",
-  insulinSensitivityFactor: "unitInsulinSensitivityFactor",
-  insulinToCarbRatio: "unitInsulinToCarbRatio",
+/** Unité d'affichage de l'ISF selon l'unité de glycémie de l'appelant. */
+const ISF_UNIT_KEY: Record<GlucoseUnit, string> = {
+  "g/L": "unitIsfGl",
+  "mg/dL": "unitIsfMgdl",
+  "mmol/L": "unitIsfMmol",
 }
 
-/** Variante du badge selon l'ampleur de la variation (déterministe, |%|). */
+/** Pathologies connues du glossaire (`Acronym`) — garde-fou de typage. */
+const PATHOLOGY_CODES = new Set<AcronymCode>(["DT1", "DT2", "GD"])
+const asPathologyCode = (p: string | null): AcronymCode | null =>
+  p && PATHOLOGY_CODES.has(p as AcronymCode) ? (p as AcronymCode) : null
+
+/**
+ * Valeurs d'affichage + clé d'unité par proposition. L'ISF est stocké en g/L
+ * et converti vers l'unité de glycémie de l'appelant (g/L/U, mg/dL/U,
+ * mmol/L/U) ; basal (U/h) et ICR (g/U) sont indépendants de l'unité glycémie.
+ */
+function displayFor(p: PendingProposalItem): { from: number; to: number; unitKey: string } {
+  if (p.parameterType === "insulinSensitivityFactor") {
+    return {
+      from: convertGlucoseFromGl(p.currentValue, p.glucoseUnit),
+      to: convertGlucoseFromGl(p.proposedValue, p.glucoseUnit),
+      unitKey: ISF_UNIT_KEY[p.glucoseUnit],
+    }
+  }
+  return {
+    from: p.currentValue,
+    to: p.proposedValue,
+    unitKey: p.parameterType === "basalRate" ? "unitBasalRate" : "unitInsulinToCarbRatio",
+  }
+}
+
+/**
+ * Variante du badge selon l'ampleur de la variation. `changePercent` est
+ * borné à ±20 % en amont (clamp de l'algorithme de génération, cf.
+ * proposal-algorithm.ts) : `>= 20` signale donc l'ajustement maximal qu'un
+ * pas de titration propose — pas une valeur arbitraire. Indice visuel pur,
+ * aucune action clinique déclenchée ici.
+ */
 function changeVariant(percent: number): "destructive" | "secondary" {
   return Math.abs(percent) >= 20 ? "destructive" : "secondary"
 }
@@ -79,6 +112,8 @@ export function PendingProposalsCard() {
           <ul className="space-y-2">
             {items.map((p) => {
               const pct = Math.round(p.changePercent)
+              const pathologyCode = asPathologyCode(p.pathology)
+              const { from, to, unitKey } = displayFor(p)
               return (
                 <li
                   key={p.id}
@@ -87,19 +122,24 @@ export function PendingProposalsCard() {
                   <span className="flex h-8 w-8 items-center justify-center rounded-full bg-muted text-sm font-semibold">
                     {(p.patientFirstName || "?").charAt(0).toUpperCase()}
                   </span>
-                  <span className="flex flex-1 flex-col truncate">
+                  <span className="flex min-w-0 flex-1 flex-col">
                     <span className="truncate text-sm font-medium">
                       {p.patientFirstName || t("patientFallback")}
-                      {p.pathology ? ` · ${p.pathology}` : ""}
+                      {pathologyCode && (
+                        <>
+                          {" · "}
+                          <Acronym code={pathologyCode} />
+                        </>
+                      )}
                     </span>
                     <span className="truncate text-xs text-muted-foreground">
                       {t(PARAM_LABEL_KEY[p.parameterType])}
                     </span>
                   </span>
                   <span className="text-xs tabular-nums text-foreground">
-                    {t("valueTransition", { from: fmt(p.currentValue), to: fmt(p.proposedValue) })}
+                    {t("valueTransition", { from: fmt(from), to: fmt(to) })}
                     {" "}
-                    {t(PARAM_UNIT_KEY[p.parameterType])}
+                    {t(unitKey)}
                   </span>
                   <Badge
                     variant={changeVariant(p.changePercent)}

--- a/src/components/diabeo/dashboard/medecin/UnreadMessagesCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/UnreadMessagesCard.tsx
@@ -12,7 +12,7 @@
 import { useLocale, useTranslations } from "next-intl"
 import { DiabeoCard } from "@/components/diabeo/DiabeoCard"
 import { DiabeoEmptyState } from "@/components/diabeo/DiabeoEmptyState"
-import { StaleBanner, STALE_MESSAGE_FR } from "@/components/diabeo/dashboard/medecin/StaleBanner"
+import { StaleBanner } from "@/components/diabeo/dashboard/medecin/StaleBanner"
 import { Badge } from "@/components/ui/badge"
 import { Mail } from "lucide-react"
 import { usePollingFetch } from "@/hooks/usePollingFetch"
@@ -45,7 +45,7 @@ export function UnreadMessagesCard() {
         </h2>
         <span className="text-xs text-muted-foreground">{items.length}</span>
       </header>
-      {isStale && <StaleBanner message={STALE_MESSAGE_FR} />}
+      {isStale && <StaleBanner message={t("stale")} />}
       <div className="px-4 pb-4">
         {loading && items.length === 0 && (
           <p className="text-sm text-muted-foreground">{t("loading")}</p>

--- a/src/components/diabeo/dashboard/medecin/UnreadMessagesCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/UnreadMessagesCard.tsx
@@ -1,0 +1,98 @@
+/**
+ * US-2602 (Ma journée) — Messages non lus (médecin).
+ *
+ * Liste read-only des conversations comportant ≥ 1 message non lu (top 5),
+ * réutilise `messagingService.listThreads` (trigger `"poll"`) via la route
+ * dashboard. Polling 60s. Le preview est déjà déchiffré et tronqué côté
+ * service ; aucune logique métier ni déchiffrement côté frontend.
+ */
+
+"use client"
+
+import { useLocale, useTranslations } from "next-intl"
+import { DiabeoCard } from "@/components/diabeo/DiabeoCard"
+import { DiabeoEmptyState } from "@/components/diabeo/DiabeoEmptyState"
+import { StaleBanner, STALE_MESSAGE_FR } from "@/components/diabeo/dashboard/medecin/StaleBanner"
+import { Badge } from "@/components/ui/badge"
+import { Mail } from "lucide-react"
+import { usePollingFetch } from "@/hooks/usePollingFetch"
+import { bcp47 } from "@/i18n/config"
+import type { UnreadThreadItem } from "@/lib/services/doctor-dashboard.service"
+
+type ApiResponse = { items: UnreadThreadItem[] }
+
+function formatDate(d: Date | string, locale: string): string {
+  return new Date(d).toLocaleString(bcp47(locale), {
+    day: "2-digit", month: "2-digit", hour: "2-digit", minute: "2-digit",
+    timeZone: "Europe/Paris",
+  })
+}
+
+export function UnreadMessagesCard() {
+  const t = useTranslations("dashboardCards.medecinMessages")
+  const locale = useLocale()
+  const { data, error, loading, isStale } = usePollingFetch<ApiResponse>(
+    "/api/dashboard/medecin/unread-threads",
+    60_000,
+  )
+  const items = Array.isArray(data?.items) ? data!.items : []
+  const hasError = error !== null && data === null
+  return (
+    <DiabeoCard role="region" aria-labelledby="card-messages-title">
+      <header className="flex items-center justify-between px-4 pt-4">
+        <h2 id="card-messages-title" className="text-base font-semibold">
+          {t("title")}
+        </h2>
+        <span className="text-xs text-muted-foreground">{items.length}</span>
+      </header>
+      {isStale && <StaleBanner message={STALE_MESSAGE_FR} />}
+      <div className="px-4 pb-4">
+        {loading && items.length === 0 && (
+          <p className="text-sm text-muted-foreground">{t("loading")}</p>
+        )}
+        {hasError && (
+          <p className="text-sm text-glycemia-critical">{t("loadError")}</p>
+        )}
+        {!loading && !hasError && items.length === 0 && (
+          <DiabeoEmptyState
+            variant="noData"
+            title={t("emptyTitle")}
+            message={t("emptyMessage")}
+          />
+        )}
+        {items.length > 0 && (
+          <ul className="space-y-2">
+            {items.map((m) => {
+              const preview = m.preview
+                ? `${m.preview}${m.previewTruncated ? "…" : ""}`
+                : t("previewFallback")
+              return (
+                <li
+                  key={m.conversationKey}
+                  className="flex items-center gap-3 rounded-md border border-border bg-card px-3 py-2"
+                >
+                  <span
+                    className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted"
+                    aria-hidden="true"
+                  >
+                    <Mail size={14} />
+                  </span>
+                  <span className="flex-1 truncate text-sm">{preview}</span>
+                  <Badge variant="destructive" aria-label={t("unreadAria", { count: m.unreadCount })}>
+                    {m.unreadCount}
+                  </Badge>
+                  <time
+                    className="text-xs text-muted-foreground"
+                    dateTime={new Date(m.lastMessageAt).toISOString()}
+                  >
+                    {formatDate(m.lastMessageAt, locale)}
+                  </time>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+    </DiabeoCard>
+  )
+}

--- a/src/lib/services/doctor-dashboard.service.ts
+++ b/src/lib/services/doctor-dashboard.service.ts
@@ -31,6 +31,7 @@ import { getAccessiblePatientIds } from "@/lib/access-control"
 import { auditService, type AuditContext } from "./audit.service"
 import { messagingService, MESSAGING_BOUNDS } from "./messaging.service"
 import { safeDecryptField } from "@/lib/crypto/fields"
+import type { GlucoseUnit } from "@/lib/conversions"
 import type { Role } from "@prisma/client"
 
 // ─────────────────────────────────────────────────────────────
@@ -689,9 +690,23 @@ export type PendingProposalItem = {
   proposedValue: number
   changePercent: number
   createdAt: Date
+  /**
+   * Unité de glycémie préférée de l'APPELANT (médecin), pas du patient — sert
+   * à afficher l'ISF dans la bonne unité (g/L/U, mg/dL/U ou mmol/L/U). Les
+   * valeurs `currentValue`/`proposedValue` restent en g/L (stockage canonique) ;
+   * la conversion d'affichage est faite côté carte.
+   */
+  glucoseUnit: GlucoseUnit
 }
 
 const PENDING_PROPOSALS_LIMIT = 5
+
+/** Code `unitGlycemia` (UserUnitPreferences) → unité d'affichage glycémie.
+ *  3:g/L 4:mg/dL 5:mmol/L. Défaut (préf. absente) = mg/dL, cohérent avec les
+ *  autres cartes du dashboard médecin (EmergencyCard). */
+function glucoseUnitFromCode(code: number | undefined): GlucoseUnit {
+  return code === 3 ? "g/L" : code === 5 ? "mmol/L" : "mg/dL"
+}
 
 /**
  * Liste les propositions d'ajustement **en attente** du portefeuille du caller
@@ -725,6 +740,15 @@ export const pendingProposalsQuery = {
       take: PENDING_PROPOSALS_LIMIT,
     })
 
+    // Unité d'affichage ISF = préférence glycémie de l'appelant (lookup unique
+    // indexé). Évité quand il n'y a aucune ligne à afficher.
+    const prefRow = rows.length
+      ? await prisma.userUnitPreferences.findUnique({
+          where: { userId }, select: { unitGlycemia: true },
+        })
+      : null
+    const glucoseUnit = glucoseUnitFromCode(prefRow?.unitGlycemia)
+
     // Audit : résumé + pivot par patient (PHI : prénom déchiffré exposé).
     await auditService.log({
       userId: auditUserId, action: "READ", resource: "ADJUSTMENT_PROPOSAL",
@@ -751,6 +775,7 @@ export const pendingProposalsQuery = {
       proposedValue: Number(r.proposedValue),
       changePercent: Number(r.changePercent),
       createdAt: r.createdAt,
+      glucoseUnit,
     }))
   },
 }

--- a/src/lib/services/doctor-dashboard.service.ts
+++ b/src/lib/services/doctor-dashboard.service.ts
@@ -29,6 +29,7 @@ import {
 import { prisma } from "@/lib/db/client"
 import { getAccessiblePatientIds } from "@/lib/access-control"
 import { auditService, type AuditContext } from "./audit.service"
+import { messagingService, MESSAGING_BOUNDS } from "./messaging.service"
 import { safeDecryptField } from "@/lib/crypto/fields"
 import type { Role } from "@prisma/client"
 
@@ -751,5 +752,49 @@ export const pendingProposalsQuery = {
       changePercent: Number(r.changePercent),
       createdAt: r.createdAt,
     }))
+  },
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2602 (Ma journée) — Messages non lus (liste)
+// ─────────────────────────────────────────────────────────────
+
+export type UnreadThreadItem = {
+  conversationKey: string
+  otherUserId: number
+  /** Réf. patient opaque (8 chars) si le thread contextualise un patient. */
+  patientPublicRef: string | null
+  preview: string
+  previewTruncated: boolean
+  unreadCount: number
+  lastMessageAt: Date
+}
+
+const UNREAD_THREADS_LIMIT = 5
+
+/**
+ * Threads avec au moins un message non lu pour le caller, triés par
+ * récence (top {@link UNREAD_THREADS_LIMIT}). Réutilise
+ * `messagingService.listThreads` avec le trigger `"poll"` (audit coalescé —
+ * pas de pollution `audit_logs` sur le polling 60s de la carte dashboard).
+ * Déterministe : aucune génération de contenu côté frontend.
+ */
+export const unreadThreadsQuery = {
+  async forCaller(userId: number, ctx: AuditContext): Promise<UnreadThreadItem[]> {
+    const threads = await messagingService.listThreads(
+      userId, ctx, MESSAGING_BOUNDS.MAX_THREADS_PER_QUERY, "poll",
+    )
+    return threads
+      .filter((t) => t.unreadCount > 0)
+      .slice(0, UNREAD_THREADS_LIMIT)
+      .map((t) => ({
+        conversationKey: t.conversationKey,
+        otherUserId: t.otherUserId,
+        patientPublicRef: t.patientPublicRef,
+        preview: t.lastMessage.bodyPreview,
+        previewTruncated: t.lastMessage.bodyPreviewTruncated,
+        unreadCount: t.unreadCount,
+        lastMessageAt: t.lastMessage.createdAt,
+      }))
   },
 }

--- a/src/lib/services/doctor-dashboard.service.ts
+++ b/src/lib/services/doctor-dashboard.service.ts
@@ -22,6 +22,8 @@ import {
   EmergencyAlertType,
   EmergencyAlertSeverity,
   AppointmentStatus,
+  ProposalStatus,
+  type AdjustableParameter,
   type Prisma,
 } from "@prisma/client"
 import { prisma } from "@/lib/db/client"
@@ -669,5 +671,85 @@ export const kpisQuery = {
         delta: null, trend: null, unit: null,
       },
     ]
+  },
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2602 (Ma journée) — Propositions d'ajustement en attente (liste)
+// ─────────────────────────────────────────────────────────────
+
+export type PendingProposalItem = {
+  id: string
+  patientId: number
+  patientFirstName: string
+  pathology: string | null
+  parameterType: AdjustableParameter
+  currentValue: number
+  proposedValue: number
+  changePercent: number
+  createdAt: Date
+}
+
+const PENDING_PROPOSALS_LIMIT = 5
+
+/**
+ * Liste les propositions d'ajustement **en attente** du portefeuille du caller
+ * (déterministe ; `AdjustmentProposal` produites par le graphe d'orchestration
+ * backend, jamais par le frontend). Scopé via `getAccessiblePatientIds`.
+ */
+export const pendingProposalsQuery = {
+  async forCaller(
+    userId: number, role: Role,
+    auditUserId: number, ctx?: AuditContext,
+  ): Promise<PendingProposalItem[]> {
+    const ids = await getAccessiblePatientIds(userId, role)
+    const scope = patientScopeWhere(ids)
+    if (scope === null) return []
+    // `scope` porte déjà `patient: { deletedAt: null }` — ne pas le redéclarer.
+    const where: Prisma.AdjustmentProposalWhereInput = {
+      ...scope,
+      status: ProposalStatus.pending,
+    }
+    const rows = await prisma.adjustmentProposal.findMany({
+      where,
+      include: {
+        patient: {
+          select: {
+            id: true, pathology: true,
+            user: { select: { firstname: true } },
+          },
+        },
+      },
+      orderBy: [{ createdAt: "desc" }],
+      take: PENDING_PROPOSALS_LIMIT,
+    })
+
+    // Audit : résumé + pivot par patient (PHI : prénom déchiffré exposé).
+    await auditService.log({
+      userId: auditUserId, action: "READ", resource: "ADJUSTMENT_PROPOSAL",
+      resourceId: "0",
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { kind: "dashboard.medecin.pendingProposals", count: rows.length },
+    })
+    await Promise.allSettled(rows.map((r) =>
+      auditService.log({
+        userId: auditUserId, action: "READ", resource: "ADJUSTMENT_PROPOSAL",
+        resourceId: r.id,
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: { patientId: r.patientId, kind: "dashboard.medecin.pendingProposals" },
+      }),
+    ))
+
+    return rows.map((r) => ({
+      id: r.id,
+      patientId: r.patientId,
+      patientFirstName: safeDecryptField(r.patient.user.firstname ?? "") ?? "",
+      pathology: r.patient.pathology,
+      parameterType: r.parameterType,
+      currentValue: Number(r.currentValue),
+      proposedValue: Number(r.proposedValue),
+      changePercent: Number(r.changePercent),
+      createdAt: r.createdAt,
+    }))
   },
 }

--- a/tests/manual/bdd/features/dashboard-access.feature
+++ b/tests/manual/bdd/features/dashboard-access.feature
@@ -5,7 +5,7 @@ Fonctionnalité: Accès au tableau de bord médecin selon le rôle
   Scénario: un DOCTOR accède à son tableau de bord
     Étant donné que je suis connecté en tant que "DOCTOR"
     Quand je vais sur "/medecin"
-    Alors je vois le titre "Tableau de bord médecin"
+    Alors je vois le titre "Ma journée"
     # Effet base attendu : AUCUN (écran en lecture seule)
 
   Scénario: un VIEWER est redirigé hors du tableau de bord médecin

--- a/tests/unit/doctor-dashboard.service.test.ts
+++ b/tests/unit/doctor-dashboard.service.test.ts
@@ -20,7 +20,7 @@ vi.mock("@/lib/access-control", () => ({
 }))
 import {
   urgenciesQuery, appointmentsQuery,
-  patientsAtRiskQuery, kpisQuery,
+  patientsAtRiskQuery, kpisQuery, pendingProposalsQuery,
 } from "@/lib/services/doctor-dashboard.service"
 import { getAccessiblePatientIds } from "@/lib/access-control"
 
@@ -35,7 +35,7 @@ const pm = prismaMock as unknown as {
   cgmEntry: { findMany: any; count: any; groupBy: any }
   appointment: { findMany: any }
   patient: { findMany: any }
-  adjustmentProposal: { count: any }
+  adjustmentProposal: { count: any; findMany: any }
   auditLog: { create: any }
 }
 
@@ -342,6 +342,64 @@ describe("patientsAtRiskQuery summary audit (healthcare M2)", () => {
     const perPatient = calls.find((d) =>
       d.metadata?.patientId === 10
       && d.metadata?.kind === "dashboard.medecin.patientsAtRisk",
+    )
+    expect(perPatient).toBeDefined()
+  })
+})
+
+// ─── US-2602 pending proposals ───────────────────────────────────────────
+
+describe("pendingProposalsQuery (US-2602)", () => {
+  it("returns [] when caller has empty portfolio", async () => {
+    mockedAccessible.mockResolvedValue([])
+    const out = await pendingProposalsQuery.forCaller(1, "DOCTOR", 1)
+    expect(out).toEqual([])
+    expect(pm.adjustmentProposal.findMany).not.toHaveBeenCalled()
+  })
+
+  it("filters status=pending and maps Decimal → number", async () => {
+    mockedAccessible.mockResolvedValue([10, 20])
+    pm.adjustmentProposal.findMany.mockResolvedValue([
+      {
+        id: "p1", patientId: 10, parameterType: "basalRate",
+        currentValue: 1.2, proposedValue: 1.0, changePercent: -16.67,
+        createdAt: new Date("2026-06-10T08:00:00Z"),
+        patient: { id: 10, pathology: "DT1", user: { firstname: null } },
+      },
+    ] as any)
+    const out = await pendingProposalsQuery.forCaller(1, "DOCTOR", 1)
+    const where = pm.adjustmentProposal.findMany.mock.calls[0]![0].where
+    expect(where.status).toBe("pending")
+    expect(where.patientId).toEqual({ in: [10, 20] })
+    expect(out).toHaveLength(1)
+    expect(out[0]).toMatchObject({
+      id: "p1", patientId: 10, parameterType: "basalRate",
+      currentValue: 1.2, proposedValue: 1.0, patientFirstName: "",
+    })
+    expect(typeof out[0]!.changePercent).toBe("number")
+  })
+
+  it("audits a summary row (resourceId=0) and a per-patient pivot row", async () => {
+    mockedAccessible.mockResolvedValue([10])
+    pm.adjustmentProposal.findMany.mockResolvedValue([
+      {
+        id: "p1", patientId: 10, parameterType: "insulinToCarbRatio",
+        currentValue: 10, proposedValue: 12, changePercent: 20,
+        createdAt: new Date(), patient: { id: 10, pathology: "DT2", user: { firstname: null } },
+      },
+    ] as any)
+    await pendingProposalsQuery.forCaller(1, "DOCTOR", 1)
+    const calls = prismaMock.auditLog.create.mock.calls.map((c) => (c[0].data as any))
+    const summary = calls.find((d) =>
+      d.resourceId === "0"
+      && d.resource === "ADJUSTMENT_PROPOSAL"
+      && d.metadata?.kind === "dashboard.medecin.pendingProposals"
+      && d.metadata?.count === 1,
+    )
+    expect(summary).toBeDefined()
+    const perPatient = calls.find((d) =>
+      d.metadata?.patientId === 10
+      && d.metadata?.kind === "dashboard.medecin.pendingProposals",
     )
     expect(perPatient).toBeDefined()
   })

--- a/tests/unit/doctor-dashboard.service.test.ts
+++ b/tests/unit/doctor-dashboard.service.test.ts
@@ -45,6 +45,7 @@ const pm = prismaMock as unknown as {
   appointment: { findMany: any }
   patient: { findMany: any }
   adjustmentProposal: { count: any; findMany: any }
+  userUnitPreferences: { findUnique: any }
   auditLog: { create: any }
 }
 
@@ -379,6 +380,7 @@ describe("pendingProposalsQuery (US-2602)", () => {
         patient: { id: 10, pathology: "DT1", user: { firstname: null } },
       },
     ] as any)
+    pm.userUnitPreferences.findUnique.mockResolvedValue({ unitGlycemia: 4 }) // mg/dL
     const out = await pendingProposalsQuery.forCaller(1, "DOCTOR", 1)
     const where = pm.adjustmentProposal.findMany.mock.calls[0]![0].where
     expect(where.status).toBe("pending")
@@ -387,8 +389,28 @@ describe("pendingProposalsQuery (US-2602)", () => {
     expect(out[0]).toMatchObject({
       id: "p1", patientId: 10, parameterType: "basalRate",
       currentValue: 1.2, proposedValue: 1.0, patientFirstName: "",
+      glucoseUnit: "mg/dL",
     })
     expect(typeof out[0]!.changePercent).toBe("number")
+  })
+
+  it("resolves caller glucose unit from preferences (code → unit; default mg/dL)", async () => {
+    mockedAccessible.mockResolvedValue([10])
+    const row = [{
+      id: "p1", patientId: 10, parameterType: "insulinSensitivityFactor",
+      currentValue: 0.5, proposedValue: 0.55, changePercent: 10,
+      createdAt: new Date(), patient: { id: 10, pathology: "DT1", user: { firstname: null } },
+    }]
+    // code 3 → g/L
+    pm.adjustmentProposal.findMany.mockResolvedValue(row as any)
+    pm.userUnitPreferences.findUnique.mockResolvedValue({ unitGlycemia: 3 })
+    expect((await pendingProposalsQuery.forCaller(1, "DOCTOR", 1))[0]!.glucoseUnit).toBe("g/L")
+    // code 5 → mmol/L
+    pm.userUnitPreferences.findUnique.mockResolvedValue({ unitGlycemia: 5 })
+    expect((await pendingProposalsQuery.forCaller(1, "DOCTOR", 1))[0]!.glucoseUnit).toBe("mmol/L")
+    // no preference row → mg/dL default
+    pm.userUnitPreferences.findUnique.mockResolvedValue(null)
+    expect((await pendingProposalsQuery.forCaller(1, "DOCTOR", 1))[0]!.glucoseUnit).toBe("mg/dL")
   })
 
   it("audits a summary row (resourceId=0) and a per-patient pivot row", async () => {

--- a/tests/unit/doctor-dashboard.service.test.ts
+++ b/tests/unit/doctor-dashboard.service.test.ts
@@ -18,13 +18,22 @@ import { prismaMock } from "../helpers/prisma-mock"
 vi.mock("@/lib/access-control", () => ({
   getAccessiblePatientIds: vi.fn(),
 }))
+// Isolate `unreadThreadsQuery` from the heavy messaging service (pepper/env,
+// redis, encryption) — only `listThreads` + the bounds constant are consumed.
+vi.mock("@/lib/services/messaging.service", () => ({
+  messagingService: { listThreads: vi.fn() },
+  MESSAGING_BOUNDS: { MAX_THREADS_PER_QUERY: 100 },
+}))
 import {
   urgenciesQuery, appointmentsQuery,
   patientsAtRiskQuery, kpisQuery, pendingProposalsQuery,
+  unreadThreadsQuery,
 } from "@/lib/services/doctor-dashboard.service"
 import { getAccessiblePatientIds } from "@/lib/access-control"
+import { messagingService } from "@/lib/services/messaging.service"
 
 const mockedAccessible = vi.mocked(getAccessiblePatientIds)
+const mockedListThreads = vi.mocked(messagingService.listThreads)
 // Prisma's `groupBy` has a complex generic signature that defeats
 // vitest-mock-extended's deep auto-mock typing ; cast once here so test
 // `mockResolvedValue` calls type-check under CI's stricter tsc.
@@ -42,7 +51,10 @@ const pm = prismaMock as unknown as {
 beforeEach(() => {
   prismaMock.auditLog.create.mockResolvedValue({} as any)
   mockedAccessible.mockReset()
+  mockedListThreads.mockReset()
 })
+
+const CTX = { ipAddress: "127.0.0.1", userAgent: "test", requestId: "req-1" }
 
 // ─── US-2401 urgencies ───────────────────────────────────────────────────
 
@@ -402,5 +414,45 @@ describe("pendingProposalsQuery (US-2602)", () => {
       && d.metadata?.kind === "dashboard.medecin.pendingProposals",
     )
     expect(perPatient).toBeDefined()
+  })
+})
+
+// ─── US-2602 unread threads ──────────────────────────────────────────────
+
+describe("unreadThreadsQuery (US-2602)", () => {
+  const thread = (key: string, unread: number, at: string) => ({
+    conversationKey: key, otherUserId: 42, patientPublicRef: "ab12cd34",
+    lastMessage: {
+      id: `m-${key}`, fromUserId: 42, bodyPreview: "Bonjour",
+      bodyPreviewTruncated: false, createdAt: new Date(at), isRead: false,
+    },
+    unreadCount: unread,
+  })
+
+  it("calls listThreads with poll trigger (coalesced audit)", async () => {
+    mockedListThreads.mockResolvedValue([] as any)
+    await unreadThreadsQuery.forCaller(1, CTX as any)
+    expect(mockedListThreads).toHaveBeenCalledWith(1, CTX, 100, "poll")
+  })
+
+  it("keeps only threads with unreadCount > 0 and maps the shape", async () => {
+    mockedListThreads.mockResolvedValue([
+      thread("k1", 2, "2026-06-12T10:00:00Z"),
+      thread("k2", 0, "2026-06-12T09:00:00Z"), // read → dropped
+    ] as any)
+    const out = await unreadThreadsQuery.forCaller(1, CTX as any)
+    expect(out).toHaveLength(1)
+    expect(out[0]).toMatchObject({
+      conversationKey: "k1", otherUserId: 42, patientPublicRef: "ab12cd34",
+      preview: "Bonjour", previewTruncated: false, unreadCount: 2,
+    })
+  })
+
+  it("caps the list at 5 threads", async () => {
+    mockedListThreads.mockResolvedValue(
+      Array.from({ length: 8 }, (_, i) => thread(`k${i}`, 1, "2026-06-12T10:00:00Z")) as any,
+    )
+    const out = await unreadThreadsQuery.forCaller(1, CTX as any)
+    expect(out).toHaveLength(5)
   })
 })


### PR DESCRIPTION
## US-2602 — « Ma journée » (vue jour du médecin)

Premier bloc de dev de la série Navigation & Accès Backoffice. Approche **incrémentale additive** : le dashboard médecin existant (`/medecin`) est enrichi puis renommé « Ma journée », sans casser l'existant.

### Increments
1. **Relances en attente** — réutilise `nurseRecallQuery` + route infirmier (scopée portefeuille caller, minRole NURSE → DOCTOR éligible).
2. **Propositions d'ajustement en attente** — `pendingProposalsQuery` (scope RBAC, `status=pending`, Decimal→Number, déchiffrement prénom, audit résumé + pivot par patient ADR #18) + route + carte read-only.
3. **Messages non lus (liste)** — `unreadThreadsQuery` qui réutilise `messagingService.listThreads(..., "poll")` (audit coalescé, pas de pollution `audit_logs` sur le polling 60s) ; dégradation gracieuse en liste vide si pas de consentement RGPD.
4. **Renommage « Ma journée »** — titre de page + libellé nav home rôle-aware (DOCTOR → « Ma journée », NURSE/ADMIN gardent « Tableau de bord »).

### Déterminisme & sécurité
- **Aucune IA** sur ces features (décision produit) — toutes les données sont des requêtes déterministes.
- Toutes les nouvelles routes : auth + RBAC (minRole NURSE), audit HDS, scope portefeuille via `getAccessiblePatientIds`.
- Propositions jamais générées/auto-appliquées côté frontend ; la revue accepter/rejeter reste sur l'écran dédié.
- Aucun PHI en clair dans les logs ; previews messages déchiffrés/tronqués côté service.

### i18n
- Nouveaux namespaces `dashboardCards.medecinProposals` + `dashboardCards.medecinMessages`, clé `nav.dashboardMedecin`, renommage `dashboard.medecin.pageTitle`.
- Parité FR/EN/AR vérifiée (RTL inclus).
- Acronymes : libellés paramètres « Libellé (ACRONYME) » (ISF/ICR).

### Tests & checks
- `vitest` : 6 nouveaux cas (3 pending-proposals, 3 unread-threads) — suite dashboard + nav verte (38 tests).
- `tsc --noEmit` exit 0, `eslint` clean, design-system au baseline (285), parité i18n OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)