### PR TITLE
feat(nav): US-2601 — palette de commande Ctrl/Cmd-K (recherche rapide)

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -105,9 +105,11 @@
     "patientsGroup": "المرضى",
     "loading": "جارٍ البحث…",
     "noResults": "لا نتيجة",
-    "minCharsHint": "اكتب حرفين على الأقل للبحث عن مريض.",
     "hint": "↑↓ للتنقل · ↵ للفتح · Esc للإغلاق",
-    "openPatientAria": "فتح ملف {name}"
+    "openPatientAria": "فتح ملف {name}",
+    "navigateToAria": "الانتقال إلى {section}",
+    "resultsAria": "النتائج",
+    "unnamedPatient": "ملف بلا اسم"
   },
   "messages": {
     "pageTitle": "المراسلة",

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -98,6 +98,17 @@
     "devices": "الأجهزة",
     "messages": "المراسلة"
   },
+  "commandPalette": {
+    "ariaLabel": "لوحة الأوامر",
+    "placeholder": "ابحث عن مريض أو قسم…",
+    "goToGroup": "الانتقال إلى",
+    "patientsGroup": "المرضى",
+    "loading": "جارٍ البحث…",
+    "noResults": "لا نتيجة",
+    "minCharsHint": "اكتب حرفين على الأقل للبحث عن مريض.",
+    "hint": "↑↓ للتنقل · ↵ للفتح · Esc للإغلاق",
+    "openPatientAria": "فتح ملف {name}"
+  },
   "messages": {
     "pageTitle": "المراسلة",
     "pageSubtitle": "تواصل مع مرضاك وزملائك في العيادة.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -98,6 +98,17 @@
     "devices": "Devices",
     "messages": "Messages"
   },
+  "commandPalette": {
+    "ariaLabel": "Command palette",
+    "placeholder": "Search a patient or a section…",
+    "goToGroup": "Go to",
+    "patientsGroup": "Patients",
+    "loading": "Searching…",
+    "noResults": "No result",
+    "minCharsHint": "Type at least 2 characters to search a patient.",
+    "hint": "↑↓ to navigate · ↵ to open · Esc to close",
+    "openPatientAria": "Open {name}'s record"
+  },
   "messages": {
     "pageTitle": "Messages",
     "pageSubtitle": "Communicate with your patients and practice members.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -105,9 +105,11 @@
     "patientsGroup": "Patients",
     "loading": "Searching…",
     "noResults": "No result",
-    "minCharsHint": "Type at least 2 characters to search a patient.",
     "hint": "↑↓ to navigate · ↵ to open · Esc to close",
-    "openPatientAria": "Open {name}'s record"
+    "openPatientAria": "Open {name}'s record",
+    "navigateToAria": "Go to {section}",
+    "resultsAria": "Results",
+    "unnamedPatient": "Unnamed record"
   },
   "messages": {
     "pageTitle": "Messages",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -98,6 +98,17 @@
     "devices": "Appareils",
     "messages": "Messagerie"
   },
+  "commandPalette": {
+    "ariaLabel": "Palette de commande",
+    "placeholder": "Rechercher un patient ou une section…",
+    "goToGroup": "Aller à",
+    "patientsGroup": "Patients",
+    "loading": "Recherche…",
+    "noResults": "Aucun résultat",
+    "minCharsHint": "Tapez au moins 2 caractères pour rechercher un patient.",
+    "hint": "↑↓ pour naviguer · ↵ pour ouvrir · Échap pour fermer",
+    "openPatientAria": "Ouvrir le dossier de {name}"
+  },
   "messages": {
     "pageTitle": "Messagerie",
     "pageSubtitle": "Échangez avec vos patients et collègues du cabinet.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -105,9 +105,11 @@
     "patientsGroup": "Patients",
     "loading": "Recherche…",
     "noResults": "Aucun résultat",
-    "minCharsHint": "Tapez au moins 2 caractères pour rechercher un patient.",
     "hint": "↑↓ pour naviguer · ↵ pour ouvrir · Échap pour fermer",
-    "openPatientAria": "Ouvrir le dossier de {name}"
+    "openPatientAria": "Ouvrir le dossier de {name}",
+    "navigateToAria": "Aller à {section}",
+    "resultsAria": "Résultats",
+    "unnamedPatient": "Dossier sans nom"
   },
   "messages": {
     "pageTitle": "Messagerie",

--- a/src/components/diabeo/CommandPalette.tsx
+++ b/src/components/diabeo/CommandPalette.tsx
@@ -1,0 +1,334 @@
+/**
+ * US-2601 (Navigation) — Palette de commande & recherche rapide (Ctrl/Cmd-K).
+ *
+ * Ouverture globale au clavier (Ctrl/Cmd-K) ; deux familles de résultats :
+ *   - « Aller à » : sections autorisées par le rôle (filtrage client cosmétique,
+ *     les pages restent protégées serveur par leur propre guard RBAC).
+ *   - « Patients » : recherche **scopée serveur** via `/api/patients/search`
+ *     (RBAC `accessibleIds`, rate-limit, audit `READ PATIENT`). La liste n'expose
+ *     que l'identité (nom) + pathologie — aucune donnée de santé détaillée.
+ *
+ * Sélectionner un patient ouvre son dossier (`/patients/[id]`) — l'accès est
+ * journalisé par la page dossier elle-même + par la recherche. Déterministe :
+ * aucune inférence, aucun calcul clinique côté frontend.
+ *
+ * A11y : `Dialog` (base-ui) fournit le focus-trap, `Esc`, le retour de focus et
+ * `role=dialog`. La saisie est un `combobox` lié à un `listbox`
+ * (`aria-activedescendant`) ; navigation `↑/↓/↵`. RTL hérité du `dir` document.
+ */
+
+"use client"
+
+import { useCallback, useDeferredValue, useEffect, useId, useMemo, useRef, useState } from "react"
+import { useRouter } from "next/navigation"
+import { useTranslations } from "next-intl"
+import { Search, ArrowRight, User } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Acronym, type AcronymCode } from "@/components/diabeo/Acronym"
+import { resolveHomeForRole, type KnownRole } from "@/lib/auth/role-home"
+
+type UserRole = "ADMIN" | "DOCTOR" | "NURSE" | "VIEWER"
+
+const ROLE_HIERARCHY: Record<UserRole, number> = { ADMIN: 4, DOCTOR: 3, NURSE: 2, VIEWER: 1 }
+
+/** Sentinelle : résolue vers le home rôle-spécifique au render. */
+const HOME_MARKER = "__home__"
+
+type Destination = { href: string; navKey: string; minRole?: UserRole }
+
+/** Sidebar maigre (US-2600) — destinations seulement, filtrées par rôle. */
+const DESTINATIONS: Destination[] = [
+  { href: HOME_MARKER, navKey: "dashboard" },
+  { href: "/patients", navKey: "patients" },
+  { href: "/appointments", navKey: "appointments", minRole: "NURSE" },
+  { href: "/messages", navKey: "messages", minRole: "NURSE" },
+  { href: "/documents", navKey: "documents" },
+  { href: "/analytics", navKey: "analytics" },
+  { href: "/settings", navKey: "settings" },
+]
+
+const PATHOLOGY_CODES = new Set<AcronymCode>(["DT1", "DT2", "GD"])
+const asPathologyCode = (p: string | null): AcronymCode | null =>
+  p && PATHOLOGY_CODES.has(p as AcronymCode) ? (p as AcronymCode) : null
+
+const MIN_PATIENT_QUERY = 2
+const PATIENT_SEARCH_LIMIT = 8
+
+type PatientHit = { id: number; name: string; pathology: string | null }
+
+type Entry =
+  | { kind: "dest"; id: string; href: string; label: string }
+  | { kind: "patient"; id: string; patientId: number; name: string; pathology: string | null }
+
+export function CommandPalette({ userRole }: { userRole: UserRole }) {
+  const t = useTranslations("commandPalette")
+  const tNav = useTranslations("nav")
+  const router = useRouter()
+  const baseId = useId()
+
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState("")
+  const [activeIndex, setActiveIndex] = useState(0)
+  const [patients, setPatients] = useState<PatientHit[]>([])
+  const [loading, setLoading] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  const deferredQuery = useDeferredValue(query)
+
+  // Ref miroir de `open` pour le listener clavier (évite une closure périmée
+  // et tout setState synchrone dans un effet).
+  const openRef = useRef(open)
+  useEffect(() => {
+    openRef.current = open
+  }, [open])
+
+  // Ouverture/reset/fermeture — handler d'évènement (pas d'effet) : setState
+  // ici est légitime (réagit à une action), contrairement au corps d'un effet.
+  const handleOpenChange = useCallback((next: boolean) => {
+    setOpen(next)
+    if (next) {
+      setQuery("")
+      setActiveIndex(0)
+      setPatients([])
+    } else {
+      abortRef.current?.abort()
+    }
+  }, [])
+
+  // Ouverture/fermeture globale Ctrl/Cmd-K.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
+        e.preventDefault()
+        handleOpenChange(!openRef.current)
+      }
+    }
+    document.addEventListener("keydown", onKeyDown)
+    return () => document.removeEventListener("keydown", onKeyDown)
+  }, [handleOpenChange])
+
+  // Recherche patient scopée serveur (≥ 2 caractères), annulable. Quand la
+  // saisie est trop courte ou la palette fermée, on annule sans setState
+  // synchrone — le rendu des patients est gardé par `showPatients`.
+  useEffect(() => {
+    const q = deferredQuery.trim()
+    if (!open || q.length < MIN_PATIENT_QUERY) {
+      abortRef.current?.abort()
+      return
+    }
+    abortRef.current?.abort()
+    const ctrl = new AbortController()
+    abortRef.current = ctrl
+    // Tout le setState (y compris `loading=true`) vit dans cette fonction async,
+    // pas dans le corps synchrone de l'effet (règle react-hooks/set-state-in-effect).
+    const run = async () => {
+      setLoading(true)
+      try {
+        const params = new URLSearchParams({ search: q, limit: String(PATIENT_SEARCH_LIMIT) })
+        const res = await fetch(`/api/patients/search?${params.toString()}`, {
+          credentials: "include",
+          signal: ctrl.signal,
+        })
+        if (!res.ok) throw new Error(String(res.status))
+        const data: {
+          items?: Array<{ id: number; pathology: string | null; user: { firstname: string | null; lastname: string | null } }>
+        } = await res.json()
+        const items = Array.isArray(data.items) ? data.items : []
+        setPatients(
+          items.map((p) => ({
+            id: p.id,
+            name: `${p.user.firstname ?? ""} ${p.user.lastname ?? ""}`.trim(),
+            pathology: p.pathology,
+          })),
+        )
+        setLoading(false)
+      } catch (err) {
+        if ((err as { name?: string })?.name === "AbortError") return
+        setPatients([])
+        setLoading(false)
+      }
+    }
+    void run()
+    return () => ctrl.abort()
+  }, [deferredQuery, open])
+
+  // Destinations filtrées par rôle + par la saisie (match libellé).
+  const destinations = useMemo<Entry[]>(() => {
+    const q = query.trim().toLowerCase()
+    return DESTINATIONS.filter((d) => !d.minRole || ROLE_HIERARCHY[userRole] >= ROLE_HIERARCHY[d.minRole])
+      .map((d) => {
+        const label =
+          d.navKey === "dashboard" && userRole === "DOCTOR" ? tNav("dashboardMedecin") : tNav(d.navKey)
+        const href = d.href === HOME_MARKER ? resolveHomeForRole(userRole as KnownRole) : d.href
+        return { kind: "dest" as const, id: `${baseId}-dest-${d.navKey}`, href, label }
+      })
+      .filter((e) => !q || e.label.toLowerCase().includes(q))
+  }, [query, userRole, tNav, baseId])
+
+  // Gate d'affichage des patients : saisie ≥ seuil (le state `patients`/`loading`
+  // peut être périmé après un retour sous le seuil — on s'appuie sur ce drapeau
+  // plutôt que sur un reset synchrone dans l'effet de recherche).
+  const showPatients = open && deferredQuery.trim().length >= MIN_PATIENT_QUERY
+
+  const patientEntries = useMemo<Entry[]>(
+    () =>
+      showPatients
+        ? patients.map((p) => ({
+            kind: "patient" as const,
+            id: `${baseId}-pat-${p.id}`,
+            patientId: p.id,
+            name: p.name || t("patientsGroup"),
+            pathology: p.pathology,
+          }))
+        : [],
+    [showPatients, patients, baseId, t],
+  )
+
+  const entries = useMemo(() => [...destinations, ...patientEntries], [destinations, patientEntries])
+
+  // Index actif borné par dérivation (pas d'effet) — la liste rétrécit quand la
+  // saisie affine les résultats ; on clamp à la lecture plutôt qu'en state.
+  const clampedActive = entries.length === 0 ? -1 : Math.min(activeIndex, entries.length - 1)
+
+  const activate = useCallback(
+    (entry: Entry | undefined) => {
+      if (!entry) return
+      setOpen(false)
+      router.push(entry.kind === "dest" ? entry.href : `/patients/${entry.patientId}`)
+    },
+    [router],
+  )
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (entries.length === 0) return
+      if (e.key === "ArrowDown") {
+        e.preventDefault()
+        setActiveIndex((i) => (i + 1) % entries.length)
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault()
+        setActiveIndex((i) => (i - 1 + entries.length) % entries.length)
+      } else if (e.key === "Enter") {
+        e.preventDefault()
+        activate(entries[clampedActive])
+      }
+    },
+    [entries, clampedActive, activate],
+  )
+
+  const q = query.trim()
+  const showMinCharsHint = q.length > 0 && q.length < MIN_PATIENT_QUERY
+  const listboxId = `${baseId}-listbox`
+  const activeId = entries[clampedActive]?.id
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        className="top-[12%] max-w-lg translate-y-0 gap-0 overflow-hidden p-0 sm:max-w-lg"
+        aria-label={t("ariaLabel")}
+      >
+        <DialogTitle className="sr-only">{t("ariaLabel")}</DialogTitle>
+
+        <div className="flex items-center gap-2 border-b border-border px-3">
+          <Search size={16} aria-hidden="true" className="text-muted-foreground" />
+          <input
+            ref={inputRef}
+            type="text"
+            autoFocus
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value)
+              setActiveIndex(0)
+            }}
+            onKeyDown={onKeyDown}
+            placeholder={t("placeholder")}
+            aria-label={t("placeholder")}
+            role="combobox"
+            aria-expanded={entries.length > 0}
+            aria-controls={listboxId}
+            aria-activedescendant={activeId}
+            className="h-12 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          />
+        </div>
+
+        <ul id={listboxId} role="listbox" aria-label={t("ariaLabel")} className="max-h-80 overflow-y-auto p-2">
+          {destinations.length > 0 && (
+            <li role="presentation" className="px-2 py-1 text-xs font-medium text-muted-foreground">
+              {t("goToGroup")}
+            </li>
+          )}
+          {destinations.map((e) => {
+            const idx = entries.indexOf(e)
+            const active = idx === clampedActive
+            return (
+              <li
+                key={e.id}
+                id={e.id}
+                role="option"
+                aria-selected={active}
+                onMouseEnter={() => setActiveIndex(idx)}
+                onClick={() => activate(e)}
+                className={`flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 text-sm ${active ? "bg-accent text-accent-foreground" : ""}`}
+              >
+                <ArrowRight size={14} aria-hidden="true" className="text-muted-foreground" />
+                <span className="flex-1 truncate">{e.kind === "dest" ? e.label : ""}</span>
+              </li>
+            )
+          })}
+
+          {patientEntries.length > 0 && (
+            <li role="presentation" className="mt-1 px-2 py-1 text-xs font-medium text-muted-foreground">
+              {t("patientsGroup")}
+            </li>
+          )}
+          {patientEntries.map((e) => {
+            if (e.kind !== "patient") return null
+            const idx = entries.indexOf(e)
+            const active = idx === clampedActive
+            const code = asPathologyCode(e.pathology)
+            return (
+              <li
+                key={e.id}
+                id={e.id}
+                role="option"
+                aria-selected={active}
+                aria-label={t("openPatientAria", { name: e.name })}
+                onMouseEnter={() => setActiveIndex(idx)}
+                onClick={() => activate(e)}
+                className={`flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 text-sm ${active ? "bg-accent text-accent-foreground" : ""}`}
+              >
+                <User size={14} aria-hidden="true" className="text-muted-foreground" />
+                <span className="flex-1 truncate">{e.name}</span>
+                {code && <Acronym code={code} />}
+              </li>
+            )
+          })}
+
+          {loading && showPatients && (
+            <li role="presentation" className="px-2 py-3 text-sm text-muted-foreground">
+              {t("loading")}
+            </li>
+          )}
+          {showMinCharsHint && (
+            <li role="presentation" className="px-2 py-3 text-sm text-muted-foreground">
+              {t("minCharsHint")}
+            </li>
+          )}
+          {!(loading && showPatients) && !showMinCharsHint && entries.length === 0 && (
+            <li role="presentation" className="px-2 py-3 text-sm text-muted-foreground">
+              {t("noResults")}
+            </li>
+          )}
+        </ul>
+
+        <p className="border-t border-border px-3 py-2 text-xs text-muted-foreground">{t("hint")}</p>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/diabeo/CommandPalette.tsx
+++ b/src/components/diabeo/CommandPalette.tsx
@@ -2,19 +2,23 @@
  * US-2601 (Navigation) — Palette de commande & recherche rapide (Ctrl/Cmd-K).
  *
  * Ouverture globale au clavier (Ctrl/Cmd-K) ; deux familles de résultats :
- *   - « Aller à » : sections autorisées par le rôle (filtrage client cosmétique,
- *     les pages restent protégées serveur par leur propre guard RBAC).
- *   - « Patients » : recherche **scopée serveur** via `/api/patients/search`
- *     (RBAC `accessibleIds`, rate-limit, audit `READ PATIENT`). La liste n'expose
- *     que l'identité (nom) + pathologie — aucune donnée de santé détaillée.
+ *   - « Aller à » : destinations dérivées de la source unique `navItems`
+ *     (`navigation-items`), filtrées par rôle (mêmes gates que la sidebar) +
+ *     par la saisie. Navigation client-side.
+ *   - « Patients » : à l'ouverture, on charge une fois le portefeuille
+ *     accessible (limit 50, `/api/patients/search` — RBAC, rate-limit, audit)
+ *     et on **filtre en sous-chaîne côté client** (vrai type-ahead). Pour les
+ *     cabinets > 50 patients, une recherche serveur **exacte** (HMAC token,
+ *     ≥ 2 car.) complète la liste de base. La liste n'expose que l'identité
+ *     (nom) + pathologie (libellé complet) — aucune donnée de santé détaillée.
  *
  * Sélectionner un patient ouvre son dossier (`/patients/[id]`) — l'accès est
- * journalisé par la page dossier elle-même + par la recherche. Déterministe :
- * aucune inférence, aucun calcul clinique côté frontend.
+ * journalisé par la page dossier + par la recherche. Déterministe : aucune IA.
  *
- * A11y : `Dialog` (base-ui) fournit le focus-trap, `Esc`, le retour de focus et
- * `role=dialog`. La saisie est un `combobox` lié à un `listbox`
- * (`aria-activedescendant`) ; navigation `↑/↓/↵`. RTL hérité du `dir` document.
+ * A11y : `Dialog` base-ui (focus-trap, `Esc`, retour focus, `initialFocus` sur
+ * l'input). Saisie `combobox` (`aria-autocomplete="list"`) liée à un `listbox`
+ * (`aria-activedescendant`) ; nav `↑/↓/↵`. État actif signalé hors-couleur
+ * (graisse). RTL hérité du `dir` document (icônes de section non directionnelles).
  */
 
 "use client"
@@ -22,88 +26,92 @@
 import { useCallback, useDeferredValue, useEffect, useId, useMemo, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
-import { Search, ArrowRight, User } from "lucide-react"
-import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-} from "@/components/ui/dialog"
-import { Acronym, type AcronymCode } from "@/components/diabeo/Acronym"
+import { Search, User } from "lucide-react"
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
 import { resolveHomeForRole, type KnownRole } from "@/lib/auth/role-home"
+import {
+  navItems,
+  hasRoleAccess,
+  HOME_HREF_MARKER,
+  type UserRole,
+  type NavItem,
+} from "@/components/diabeo/navigation-items"
 
-type UserRole = "ADMIN" | "DOCTOR" | "NURSE" | "VIEWER"
+/** Pathologies connues du glossaire (libellé complet affiché, pas l'acronyme nu). */
+const PATHOLOGY_CODES = new Set(["DT1", "DT2", "GD"])
 
-const ROLE_HIERARCHY: Record<UserRole, number> = { ADMIN: 4, DOCTOR: 3, NURSE: 2, VIEWER: 1 }
+const MIN_EXACT_QUERY = 2
+const PATIENT_RESULTS_CAP = 8
+const BASE_LIST_LIMIT = 50
 
-/** Sentinelle : résolue vers le home rôle-spécifique au render. */
-const HOME_MARKER = "__home__"
+type PatientHit = { id: number; name: string; pathologyLabel: string | null }
 
-type Destination = { href: string; navKey: string; minRole?: UserRole }
+type RawPatient = {
+  id: number
+  pathology: string | null
+  user: { firstname: string | null; lastname: string | null }
+}
 
-/** Sidebar maigre (US-2600) — destinations seulement, filtrées par rôle. */
-const DESTINATIONS: Destination[] = [
-  { href: HOME_MARKER, navKey: "dashboard" },
-  { href: "/patients", navKey: "patients" },
-  { href: "/appointments", navKey: "appointments", minRole: "NURSE" },
-  { href: "/messages", navKey: "messages", minRole: "NURSE" },
-  { href: "/documents", navKey: "documents" },
-  { href: "/analytics", navKey: "analytics" },
-  { href: "/settings", navKey: "settings" },
-]
-
-const PATHOLOGY_CODES = new Set<AcronymCode>(["DT1", "DT2", "GD"])
-const asPathologyCode = (p: string | null): AcronymCode | null =>
-  p && PATHOLOGY_CODES.has(p as AcronymCode) ? (p as AcronymCode) : null
-
-const MIN_PATIENT_QUERY = 2
-const PATIENT_SEARCH_LIMIT = 8
-
-type PatientHit = { id: number; name: string; pathology: string | null }
-
-type Entry =
-  | { kind: "dest"; id: string; href: string; label: string }
-  | { kind: "patient"; id: string; patientId: number; name: string; pathology: string | null }
+type DestEntry = { kind: "dest"; id: string; href: string; label: string; icon: NavItem["icon"] }
+type PatientEntry = { kind: "patient"; id: string; patientId: number; name: string; pathologyLabel: string | null }
+type Entry = DestEntry | PatientEntry
 
 export function CommandPalette({ userRole }: { userRole: UserRole }) {
   const t = useTranslations("commandPalette")
   const tNav = useTranslations("nav")
+  const tGlossary = useTranslations("glossary")
   const router = useRouter()
   const baseId = useId()
 
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState("")
   const [activeIndex, setActiveIndex] = useState(0)
-  const [patients, setPatients] = useState<PatientHit[]>([])
-  const [loading, setLoading] = useState(false)
+  const [basePatients, setBasePatients] = useState<PatientHit[]>([])
+  const [exactHits, setExactHits] = useState<PatientHit[]>([])
+  const [searching, setSearching] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
-  const abortRef = useRef<AbortController | null>(null)
+  const baseAbortRef = useRef<AbortController | null>(null)
+  const exactAbortRef = useRef<AbortController | null>(null)
 
   const deferredQuery = useDeferredValue(query)
 
-  // Ref miroir de `open` pour le listener clavier (évite une closure périmée
-  // et tout setState synchrone dans un effet).
+  const pathologyLabel = useCallback(
+    (code: string | null): string | null =>
+      code && PATHOLOGY_CODES.has(code) ? tGlossary(code as Parameters<typeof tGlossary>[0]) : null,
+    [tGlossary],
+  )
+  const toHit = useCallback(
+    (p: RawPatient): PatientHit => ({
+      id: p.id,
+      name: `${p.user.firstname ?? ""} ${p.user.lastname ?? ""}`.trim(),
+      pathologyLabel: pathologyLabel(p.pathology),
+    }),
+    [pathologyLabel],
+  )
+
+  // Ref miroir de `open` pour le listener clavier (closure non périmée).
   const openRef = useRef(open)
   useEffect(() => {
     openRef.current = open
   }, [open])
 
-  // Ouverture/reset/fermeture — handler d'évènement (pas d'effet) : setState
-  // ici est légitime (réagit à une action), contrairement au corps d'un effet.
+  // Ouverture/reset/fermeture — handler d'évènement (setState légitime).
   const handleOpenChange = useCallback((next: boolean) => {
     setOpen(next)
     if (next) {
       setQuery("")
       setActiveIndex(0)
-      setPatients([])
+      setExactHits([])
     } else {
-      abortRef.current?.abort()
+      baseAbortRef.current?.abort()
+      exactAbortRef.current?.abort()
     }
   }, [])
 
-  // Ouverture/fermeture globale Ctrl/Cmd-K.
+  // Ctrl/Cmd-K global.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
         e.preventDefault()
         handleOpenChange(!openRef.current)
       }
@@ -112,87 +120,107 @@ export function CommandPalette({ userRole }: { userRole: UserRole }) {
     return () => document.removeEventListener("keydown", onKeyDown)
   }, [handleOpenChange])
 
-  // Recherche patient scopée serveur (≥ 2 caractères), annulable. Quand la
-  // saisie est trop courte ou la palette fermée, on annule sans setState
-  // synchrone — le rendu des patients est gardé par `showPatients`.
+  // Liste de base (portefeuille accessible, scopée serveur) chargée une fois à
+  // l'ouverture — sert au filtrage sous-chaîne côté client.
   useEffect(() => {
-    const q = deferredQuery.trim()
-    if (!open || q.length < MIN_PATIENT_QUERY) {
-      abortRef.current?.abort()
+    if (!open) {
+      baseAbortRef.current?.abort()
       return
     }
-    abortRef.current?.abort()
     const ctrl = new AbortController()
-    abortRef.current = ctrl
-    // Tout le setState (y compris `loading=true`) vit dans cette fonction async,
-    // pas dans le corps synchrone de l'effet (règle react-hooks/set-state-in-effect).
+    baseAbortRef.current = ctrl
     const run = async () => {
-      setLoading(true)
       try {
-        const params = new URLSearchParams({ search: q, limit: String(PATIENT_SEARCH_LIMIT) })
+        const res = await fetch(`/api/patients/search?limit=${BASE_LIST_LIMIT}`, {
+          credentials: "include",
+          signal: ctrl.signal,
+        })
+        if (!res.ok) throw new Error(String(res.status))
+        const data: { items?: RawPatient[] } = await res.json()
+        setBasePatients((Array.isArray(data.items) ? data.items : []).map(toHit))
+      } catch (err) {
+        if ((err as { name?: string })?.name === "AbortError") return
+        setBasePatients([])
+      }
+    }
+    void run()
+    return () => ctrl.abort()
+  }, [open, toHit])
+
+  // Recherche serveur EXACTE (HMAC token) en complément — couvre les cabinets
+  // > 50 patients où la cible n'est pas dans la liste de base.
+  useEffect(() => {
+    const q = deferredQuery.trim()
+    if (!open || q.length < MIN_EXACT_QUERY) {
+      exactAbortRef.current?.abort()
+      return
+    }
+    const ctrl = new AbortController()
+    exactAbortRef.current = ctrl
+    const run = async () => {
+      setSearching(true)
+      try {
+        const params = new URLSearchParams({ search: q, limit: String(PATIENT_RESULTS_CAP) })
         const res = await fetch(`/api/patients/search?${params.toString()}`, {
           credentials: "include",
           signal: ctrl.signal,
         })
         if (!res.ok) throw new Error(String(res.status))
-        const data: {
-          items?: Array<{ id: number; pathology: string | null; user: { firstname: string | null; lastname: string | null } }>
-        } = await res.json()
-        const items = Array.isArray(data.items) ? data.items : []
-        setPatients(
-          items.map((p) => ({
-            id: p.id,
-            name: `${p.user.firstname ?? ""} ${p.user.lastname ?? ""}`.trim(),
-            pathology: p.pathology,
-          })),
-        )
-        setLoading(false)
+        const data: { items?: RawPatient[] } = await res.json()
+        setExactHits((Array.isArray(data.items) ? data.items : []).map(toHit))
+        setSearching(false)
       } catch (err) {
         if ((err as { name?: string })?.name === "AbortError") return
-        setPatients([])
-        setLoading(false)
+        setExactHits([])
+        setSearching(false)
       }
     }
     void run()
     return () => ctrl.abort()
-  }, [deferredQuery, open])
+  }, [deferredQuery, open, toHit])
 
-  // Destinations filtrées par rôle + par la saisie (match libellé).
-  const destinations = useMemo<Entry[]>(() => {
+  // Destinations : source unique `navItems`, filtrées par rôle puis par saisie.
+  const destinations = useMemo<DestEntry[]>(() => {
     const q = query.trim().toLowerCase()
-    return DESTINATIONS.filter((d) => !d.minRole || ROLE_HIERARCHY[userRole] >= ROLE_HIERARCHY[d.minRole])
-      .map((d) => {
+    return navItems
+      .filter((item) => hasRoleAccess(userRole, item.minRole))
+      .map((item) => {
         const label =
-          d.navKey === "dashboard" && userRole === "DOCTOR" ? tNav("dashboardMedecin") : tNav(d.navKey)
-        const href = d.href === HOME_MARKER ? resolveHomeForRole(userRole as KnownRole) : d.href
-        return { kind: "dest" as const, id: `${baseId}-dest-${d.navKey}`, href, label }
+          item.labelKey === "dashboard" && userRole === "DOCTOR"
+            ? tNav("dashboardMedecin")
+            : tNav(item.labelKey)
+        const href = item.href === HOME_HREF_MARKER ? resolveHomeForRole(userRole as KnownRole) : item.href
+        return { kind: "dest" as const, id: `${baseId}-dest-${item.labelKey}`, href, label, icon: item.icon }
       })
       .filter((e) => !q || e.label.toLowerCase().includes(q))
   }, [query, userRole, tNav, baseId])
 
-  // Gate d'affichage des patients : saisie ≥ seuil (le state `patients`/`loading`
-  // peut être périmé après un retour sous le seuil — on s'appuie sur ce drapeau
-  // plutôt que sur un reset synchrone dans l'effet de recherche).
-  const showPatients = open && deferredQuery.trim().length >= MIN_PATIENT_QUERY
+  // Patients : filtrage sous-chaîne de la liste de base ∪ résultats exacts,
+  // dédupliqués (id), cappés. Dérivé à chaque rendu → jamais de reliquat périmé.
+  const patientEntries = useMemo<PatientEntry[]>(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return []
+    const fromBase = basePatients.filter((p) => p.name.toLowerCase().includes(q))
+    const seen = new Set<number>()
+    const merged: PatientHit[] = []
+    for (const p of [...fromBase, ...exactHits]) {
+      if (seen.has(p.id)) continue
+      seen.add(p.id)
+      merged.push(p)
+      if (merged.length >= PATIENT_RESULTS_CAP) break
+    }
+    return merged.map((p) => ({
+      kind: "patient" as const,
+      id: `${baseId}-pat-${p.id}`,
+      patientId: p.id,
+      name: p.name || t("unnamedPatient"),
+      pathologyLabel: p.pathologyLabel,
+    }))
+  }, [query, basePatients, exactHits, baseId, t])
 
-  const patientEntries = useMemo<Entry[]>(
-    () =>
-      showPatients
-        ? patients.map((p) => ({
-            kind: "patient" as const,
-            id: `${baseId}-pat-${p.id}`,
-            patientId: p.id,
-            name: p.name || t("patientsGroup"),
-            pathology: p.pathology,
-          }))
-        : [],
-    [showPatients, patients, baseId, t],
-  )
+  const entries = useMemo<Entry[]>(() => [...destinations, ...patientEntries], [destinations, patientEntries])
 
-  const entries = useMemo(() => [...destinations, ...patientEntries], [destinations, patientEntries])
-
-  // Index actif borné par dérivation (pas d'effet) — la liste rétrécit quand la
-  // saisie affine les résultats ; on clamp à la lecture plutôt qu'en state.
+  // Index actif borné par dérivation (la liste rétrécit pendant la frappe).
   const clampedActive = entries.length === 0 ? -1 : Math.min(activeIndex, entries.length - 1)
 
   const activate = useCallback(
@@ -209,10 +237,10 @@ export function CommandPalette({ userRole }: { userRole: UserRole }) {
       if (entries.length === 0) return
       if (e.key === "ArrowDown") {
         e.preventDefault()
-        setActiveIndex((i) => (i + 1) % entries.length)
+        setActiveIndex((i) => ((i < 0 ? 0 : i) + 1) % entries.length)
       } else if (e.key === "ArrowUp") {
         e.preventDefault()
-        setActiveIndex((i) => (i - 1 + entries.length) % entries.length)
+        setActiveIndex((i) => ((i < 0 ? 0 : i) - 1 + entries.length) % entries.length)
       } else if (e.key === "Enter") {
         e.preventDefault()
         activate(entries[clampedActive])
@@ -222,16 +250,20 @@ export function CommandPalette({ userRole }: { userRole: UserRole }) {
   )
 
   const q = query.trim()
-  const showMinCharsHint = q.length > 0 && q.length < MIN_PATIENT_QUERY
+  const showPatients = q.length > 0
   const listboxId = `${baseId}-listbox`
   const activeId = entries[clampedActive]?.id
+  const rowClass = (active: boolean) =>
+    `flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 text-sm ${
+      active ? "bg-accent font-medium text-accent-foreground" : "hover:bg-muted"
+    }`
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
         showCloseButton={false}
+        initialFocus={inputRef}
         className="top-[12%] max-w-lg translate-y-0 gap-0 overflow-hidden p-0 sm:max-w-lg"
-        aria-label={t("ariaLabel")}
       >
         <DialogTitle className="sr-only">{t("ariaLabel")}</DialogTitle>
 
@@ -240,16 +272,17 @@ export function CommandPalette({ userRole }: { userRole: UserRole }) {
           <input
             ref={inputRef}
             type="text"
-            autoFocus
             value={query}
             onChange={(e) => {
               setQuery(e.target.value)
               setActiveIndex(0)
+              setExactHits([])
             }}
             onKeyDown={onKeyDown}
             placeholder={t("placeholder")}
             aria-label={t("placeholder")}
             role="combobox"
+            aria-autocomplete="list"
             aria-expanded={entries.length > 0}
             aria-controls={listboxId}
             aria-activedescendant={activeId}
@@ -257,7 +290,7 @@ export function CommandPalette({ userRole }: { userRole: UserRole }) {
           />
         </div>
 
-        <ul id={listboxId} role="listbox" aria-label={t("ariaLabel")} className="max-h-80 overflow-y-auto p-2">
+        <ul id={listboxId} role="listbox" aria-label={t("resultsAria")} className="max-h-80 overflow-y-auto p-2">
           {destinations.length > 0 && (
             <li role="presentation" className="px-2 py-1 text-xs font-medium text-muted-foreground">
               {t("goToGroup")}
@@ -266,18 +299,19 @@ export function CommandPalette({ userRole }: { userRole: UserRole }) {
           {destinations.map((e) => {
             const idx = entries.indexOf(e)
             const active = idx === clampedActive
+            const Icon = e.icon
             return (
               <li
                 key={e.id}
                 id={e.id}
                 role="option"
                 aria-selected={active}
-                onMouseEnter={() => setActiveIndex(idx)}
+                aria-label={t("navigateToAria", { section: e.label })}
                 onClick={() => activate(e)}
-                className={`flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 text-sm ${active ? "bg-accent text-accent-foreground" : ""}`}
+                className={rowClass(active)}
               >
-                <ArrowRight size={14} aria-hidden="true" className="text-muted-foreground" />
-                <span className="flex-1 truncate">{e.kind === "dest" ? e.label : ""}</span>
+                <Icon size={14} aria-hidden="true" className="text-muted-foreground" />
+                <span className="flex-1 truncate">{e.label}</span>
               </li>
             )
           })}
@@ -288,39 +322,38 @@ export function CommandPalette({ userRole }: { userRole: UserRole }) {
             </li>
           )}
           {patientEntries.map((e) => {
-            if (e.kind !== "patient") return null
             const idx = entries.indexOf(e)
             const active = idx === clampedActive
-            const code = asPathologyCode(e.pathology)
+            const aria = e.pathologyLabel
+              ? `${t("openPatientAria", { name: e.name })} · ${e.pathologyLabel}`
+              : t("openPatientAria", { name: e.name })
             return (
               <li
                 key={e.id}
                 id={e.id}
                 role="option"
                 aria-selected={active}
-                aria-label={t("openPatientAria", { name: e.name })}
-                onMouseEnter={() => setActiveIndex(idx)}
+                aria-label={aria}
                 onClick={() => activate(e)}
-                className={`flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 text-sm ${active ? "bg-accent text-accent-foreground" : ""}`}
+                className={rowClass(active)}
               >
                 <User size={14} aria-hidden="true" className="text-muted-foreground" />
                 <span className="flex-1 truncate">{e.name}</span>
-                {code && <Acronym code={code} />}
+                {e.pathologyLabel && (
+                  <span aria-hidden="true" className="shrink-0 text-xs text-muted-foreground">
+                    {e.pathologyLabel}
+                  </span>
+                )}
               </li>
             )
           })}
 
-          {loading && showPatients && (
+          {searching && showPatients && (
             <li role="presentation" className="px-2 py-3 text-sm text-muted-foreground">
               {t("loading")}
             </li>
           )}
-          {showMinCharsHint && (
-            <li role="presentation" className="px-2 py-3 text-sm text-muted-foreground">
-              {t("minCharsHint")}
-            </li>
-          )}
-          {!(loading && showPatients) && !showMinCharsHint && entries.length === 0 && (
+          {!searching && entries.length === 0 && (
             <li role="presentation" className="px-2 py-3 text-sm text-muted-foreground">
               {t("noResults")}
             </li>

--- a/src/components/diabeo/NavigationShell.tsx
+++ b/src/components/diabeo/NavigationShell.tsx
@@ -19,27 +19,14 @@ import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { useTranslations } from "next-intl"
 import {
-  LayoutDashboard,
-  Users,
   Settings,
-  FileText,
   LogOut,
-  Activity,
-  Pill,
   Menu,
   ChevronLeft,
   ChevronRight,
   Bell,
   RefreshCw,
   User,
-  Download,
-  CalendarDays,
-  Syringe,
-  Smartphone,
-  Home,
-  CalendarClock,
-  MessageSquare,
-  type LucideIcon,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useAuth } from "@/hooks/use-auth"
@@ -49,6 +36,14 @@ import {
   useUnreadCountFromContext,
 } from "@/components/diabeo/messaging/UnreadCountContext"
 import { resolveHomeForRole } from "@/lib/auth/role-home"
+import {
+  navItems,
+  patientNavItems,
+  hasRoleAccess,
+  HOME_HREF_MARKER,
+  type NavItem,
+  type UserRole,
+} from "@/components/diabeo/navigation-items"
 import { CommandPalette } from "@/components/diabeo/CommandPalette"
 import { LocaleReconciliationBanner } from "@/components/diabeo/LocaleReconciliationBanner"
 import {
@@ -72,27 +67,6 @@ import {
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 
 // --- Types ---
-
-type UserRole = "ADMIN" | "DOCTOR" | "NURSE" | "VIEWER"
-
-interface NavItem {
-  href: string
-  labelKey: string
-  icon: LucideIcon
-  minRole?: UserRole
-  /**
-   * US-2076-UI iter 1 — affiche un badge dynamique unread count via
-   * `useUnreadCount()`. Activé uniquement sur `/messages` pour le moment.
-   * Polling 60s + pause sur tab hidden + refetch sur visibilitychange.
-   *
-   * **Single global count (Fix M7 round 1 review PR #440)** : tous les
-   * items avec `showUnreadBadge=true` partagent LA MÊME source
-   * `/api/messages/unread-count`. Si V2 nécessite des badges différents
-   * (ex: notifications cabinet ≠ messages patients), créer un
-   * `useNotificationCount` séparé avec un nouveau Context.
-   */
-  showUnreadBadge?: boolean
-}
 
 interface BreadcrumbItem {
   label: string
@@ -121,90 +95,9 @@ interface NavigationShellProps {
 }
 
 // --- Constants ---
-
-const ROLE_HIERARCHY: Record<UserRole, number> = {
-  VIEWER: 0,
-  NURSE: 1,
-  DOCTOR: 2,
-  ADMIN: 3,
-}
-
-/**
- * Marker sentinel pour `NavItem.href` : résolu dynamiquement vers le home
- * rôle-spécifique au render (DOCTOR → /medecin, NURSE → /infirmier, etc.).
- *
- * Fix CRIT-1 round 2 review PR #426 — Le pattern précédent `href: "/"`
- * dépendait du role-router serveur qui était cassé par `src/app/page.tsx`
- * (supprimé). Le marker permet de garder une nav statique tout en
- * dispatchant côté client selon le `userRole` prop.
- *
- * Mapping centralisé : `@/lib/auth/role-home` (SoT partagée).
- */
-const HOME_HREF_MARKER = "__home__"
-
-/**
- * Pro nav (DOCTOR / NURSE / ADMIN).
- *
- * Fix #11.b/#11.c (session 2026-05-22) :
- *   - 1er item `href: HOME_HREF_MARKER` — résolu vers `/medecin` / `/infirmier`
- *     / `/admin` selon le role courant.
- *   - `/admin/users` et `/audit` ADMIN-only. `/admin/users` = UI réelle
- *     (US-2148) ; `/users` n'est plus qu'une redirection legacy (anomalie A5).
- */
-const navItems: NavItem[] = [
-  { href: HOME_HREF_MARKER, labelKey: "dashboard", icon: LayoutDashboard },
-  { href: "/patients", labelKey: "patients", icon: Users },
-  // US-2500-UI — Calendrier RDV pro (issue #428, spec docs/UserStory/.../23-rdv/).
-  // Fix L-2 round 2 review — `CalendarClock` (vs `CalendarDays` partagé avec /weekly)
-  // pour distinguer visuellement dans la sidebar collapsed (icône seule).
-  { href: "/appointments", labelKey: "appointments", icon: CalendarClock, minRole: "NURSE" },
-  // US-2076-UI iter 1 — Messagerie pro (issue #429). Badge unread count
-  // dynamique via useUnreadCount() polling 60s. Gated NURSE+ (backend
-  // /api/messages route accepte tout user authentifié + GDPR consent
-  // mais la page pro est destinée aux praticiens uniquement).
-  { href: "/messages", labelKey: "messages", icon: MessageSquare, minRole: "NURSE", showUnreadBadge: true },
-  { href: "/medications", labelKey: "medications", icon: Pill },
-  { href: "/analytics", labelKey: "analytics", icon: Activity },
-  { href: "/weekly", labelKey: "weekly", icon: CalendarDays },
-  { href: "/insulin-therapy", labelKey: "insulinTherapy", icon: Syringe, minRole: "NURSE" },
-  { href: "/devices", labelKey: "devices", icon: Smartphone },
-  { href: "/documents", labelKey: "documents", icon: FileText },
-  { href: "/import", labelKey: "import", icon: Download, minRole: "DOCTOR" },
-  { href: "/admin/users", labelKey: "users", icon: Users, minRole: "ADMIN" },
-  { href: "/audit", labelKey: "audit", icon: FileText, minRole: "ADMIN" },
-  { href: "/settings", labelKey: "settings", icon: Settings },
-]
-
-/**
- * Patient self-service nav (VIEWER, layout `(patient)`).
- *
- * #10 (session 2026-05-22) — Batch 1 US-3356 ne livre que la page
- * `/patient/dashboard` ; les items nav sont limités aux routes
- * réellement implémentées pour qu'un clic ne tombe jamais sur 404.
- * Futures sections (glycémie/événements/RDV/profil/préférences) à
- * ajouter ici quand les pages correspondantes atterriront en Batch 2+.
- *
- * #3 (session 2026-05-22) — Déclaré dans ce client component pour
- * éviter de passer une référence `LucideIcon` à travers la boundary
- * RSC depuis `(patient)/layout.tsx`.
- */
-const patientNavItems: NavItem[] = [
-  { href: "/patient/dashboard", labelKey: "patientHome", icon: Home },
-  // US-2500-UI iter 12 — UI patient "Mes RDV" : vue read-only des RDV
-  // du patient connecté + bouton "Accepter alternative" si propAlt set.
-  // Fix L1 round 1 review PR #438 — `CalendarClock` cohérent avec sidebar pro
-  // (vs `CalendarDays` réservé /weekly côté pro).
-  { href: "/patient/appointments", labelKey: "appointments", icon: CalendarClock },
-  // US-3356 extension — /settings is the single page shared across all roles.
-  // VIEWER sees it in the patient sidebar (patient-only sections: medicalData,
-  // administrative, dayMoments, privacy) ; PS roles access it via the pro sidebar.
-  { href: "/settings", labelKey: "settings", icon: Settings },
-]
-
-function hasRoleAccess(userRole: UserRole, minRole?: UserRole): boolean {
-  if (!minRole) return true
-  return ROLE_HIERARCHY[userRole] >= ROLE_HIERARCHY[minRole]
-}
+// Définitions de nav (UserRole, NavItem, navItems, patientNavItems,
+// ROLE_HIERARCHY, hasRoleAccess, HOME_HREF_MARKER) extraites dans
+// `./navigation-items` — source unique partagée avec `CommandPalette` (US-2601).
 
 // --- Sidebar Content ---
 
@@ -660,4 +553,5 @@ export function NavigationShell({
   )
 }
 
-export type { NavigationShellProps, BreadcrumbItem, UserRole, NavItem }
+export type { NavigationShellProps, BreadcrumbItem }
+export type { UserRole, NavItem }

--- a/src/components/diabeo/NavigationShell.tsx
+++ b/src/components/diabeo/NavigationShell.tsx
@@ -49,6 +49,7 @@ import {
   useUnreadCountFromContext,
 } from "@/components/diabeo/messaging/UnreadCountContext"
 import { resolveHomeForRole } from "@/lib/auth/role-home"
+import { CommandPalette } from "@/components/diabeo/CommandPalette"
 import { LocaleReconciliationBanner } from "@/components/diabeo/LocaleReconciliationBanner"
 import {
   Sheet,
@@ -468,6 +469,8 @@ export function NavigationShell({
   return (
     <UnreadCountProvider skip={!hasBadgeItem}>
     <TooltipProvider delay={300}>
+      {/* US-2601 — Palette de commande Ctrl/Cmd-K (staff uniquement). */}
+      {variant === "pro" && <CommandPalette userRole={userRole} />}
       <div className="flex h-screen overflow-hidden bg-[var(--background)]">
         {/* Desktop sidebar */}
         <aside

--- a/src/components/diabeo/navigation-items.tsx
+++ b/src/components/diabeo/navigation-items.tsx
@@ -1,0 +1,86 @@
+/**
+ * Source unique des destinations de navigation (sidebar + palette Ctrl/Cmd-K).
+ *
+ * Extrait de `NavigationShell` (US-2601) pour être consommé AUSSI par
+ * `CommandPalette` sans dupliquer la liste ni les gates de rôle — les deux
+ * devaient rester synchronisés (review PR #541, M3 « drift »). Module feuille
+ * (aucun import de `NavigationShell`/`CommandPalette`) → pas de cycle.
+ */
+
+import {
+  LayoutDashboard,
+  Users,
+  Settings,
+  FileText,
+  Activity,
+  Pill,
+  Download,
+  CalendarDays,
+  Syringe,
+  Smartphone,
+  Home,
+  CalendarClock,
+  MessageSquare,
+  type LucideIcon,
+} from "lucide-react"
+
+export type UserRole = "ADMIN" | "DOCTOR" | "NURSE" | "VIEWER"
+
+export interface NavItem {
+  href: string
+  labelKey: string
+  icon: LucideIcon
+  minRole?: UserRole
+  /**
+   * US-2076-UI iter 1 — badge dynamique unread count via `useUnreadCount()`.
+   * Activé uniquement sur `/messages`. Cf. NavigationShell pour le détail.
+   */
+  showUnreadBadge?: boolean
+}
+
+export const ROLE_HIERARCHY: Record<UserRole, number> = {
+  VIEWER: 0,
+  NURSE: 1,
+  DOCTOR: 2,
+  ADMIN: 3,
+}
+
+export function hasRoleAccess(userRole: UserRole, minRole?: UserRole): boolean {
+  if (!minRole) return true
+  return ROLE_HIERARCHY[userRole] >= ROLE_HIERARCHY[minRole]
+}
+
+/**
+ * Marker sentinel pour `NavItem.href` : résolu dynamiquement vers le home
+ * rôle-spécifique au render (DOCTOR → /medecin, NURSE → /infirmier, etc.).
+ * Mapping centralisé : `@/lib/auth/role-home`.
+ */
+export const HOME_HREF_MARKER = "__home__"
+
+/**
+ * Pro nav (DOCTOR / NURSE / ADMIN). `/admin/users` et `/audit` ADMIN-only.
+ * `1er item HOME_HREF_MARKER` résolu selon le rôle courant.
+ */
+export const navItems: NavItem[] = [
+  { href: HOME_HREF_MARKER, labelKey: "dashboard", icon: LayoutDashboard },
+  { href: "/patients", labelKey: "patients", icon: Users },
+  { href: "/appointments", labelKey: "appointments", icon: CalendarClock, minRole: "NURSE" },
+  { href: "/messages", labelKey: "messages", icon: MessageSquare, minRole: "NURSE", showUnreadBadge: true },
+  { href: "/medications", labelKey: "medications", icon: Pill },
+  { href: "/analytics", labelKey: "analytics", icon: Activity },
+  { href: "/weekly", labelKey: "weekly", icon: CalendarDays },
+  { href: "/insulin-therapy", labelKey: "insulinTherapy", icon: Syringe, minRole: "NURSE" },
+  { href: "/devices", labelKey: "devices", icon: Smartphone },
+  { href: "/documents", labelKey: "documents", icon: FileText },
+  { href: "/import", labelKey: "import", icon: Download, minRole: "DOCTOR" },
+  { href: "/admin/users", labelKey: "users", icon: Users, minRole: "ADMIN" },
+  { href: "/audit", labelKey: "audit", icon: FileText, minRole: "ADMIN" },
+  { href: "/settings", labelKey: "settings", icon: Settings },
+]
+
+/** Patient self-service nav (VIEWER, layout `(patient)`). */
+export const patientNavItems: NavItem[] = [
+  { href: "/patient/dashboard", labelKey: "patientHome", icon: Home },
+  { href: "/patient/appointments", labelKey: "appointments", icon: CalendarClock },
+  { href: "/settings", labelKey: "settings", icon: Settings },
+]

--- a/tests/components/command-palette.test.tsx
+++ b/tests/components/command-palette.test.tsx
@@ -7,12 +7,13 @@
  *
  * Sécurité / nav : la recherche patient est scopée serveur (route
  * `/api/patients/search`) — ces tests vérifient le câblage UI (ouverture
- * clavier, destinations filtrées par rôle, requête de recherche, navigation),
- * pas le scoping (couvert côté service/route).
+ * clavier, destinations filtrées par rôle, filtrage sous-chaîne de la liste de
+ * base, recherche exacte de complément, navigation), pas le scoping (couvert
+ * côté service/route).
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { render, screen, fireEvent } from "@testing-library/react"
 
 vi.mock("next-intl", async () => (await import("../helpers/nextIntlMock")).makeNextIntlMock())
 
@@ -29,23 +30,23 @@ vi.mock("@/components/ui/dialog", () => ({
   DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }))
 
-// Tooltip base-ui (utilisé par <Acronym>) → rendu enfants.
-vi.mock("@/components/ui/tooltip", () => ({
-  Tooltip: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  TooltipProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  TooltipTrigger: ({ children, ...p }: React.PropsWithChildren<Record<string, unknown>>) => <span {...p}>{children}</span>,
-}))
-
 import { CommandPalette } from "@/components/diabeo/CommandPalette"
 
 function openWithCtrlK() {
   fireEvent.keyDown(document, { key: "k", ctrlKey: true })
 }
 
+/** Stub fetch renvoyant `items` pour toute requête /api/patients/search. */
+function stubFetch(items: unknown[]) {
+  const mock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ items }) })
+  vi.stubGlobal("fetch", mock)
+  return mock
+}
+
 beforeEach(() => {
   push.mockReset()
   vi.restoreAllMocks()
+  stubFetch([]) // défaut : aucun patient (les tests qui en ont besoin re-stubent)
 })
 
 describe("CommandPalette (US-2601)", () => {
@@ -56,12 +57,19 @@ describe("CommandPalette (US-2601)", () => {
     expect(screen.getByTestId("dialog")).toBeTruthy()
   })
 
-  it("shows role-aware destinations (DOCTOR home = « Ma journée »)", () => {
+  it("lists role-aware destinations from the shared navItems (DOCTOR home = « Ma journée »)", () => {
     render(<CommandPalette userRole="DOCTOR" />)
     openWithCtrlK()
-    // nav.dashboardMedecin (FR) = « Ma journée » pour le DOCTOR
     expect(screen.getByText("Ma journée")).toBeTruthy()
     expect(screen.getByText("Patients")).toBeTruthy()
+    expect(screen.getByText("Médicaments")).toBeTruthy() // section absente de l'ancienne liste figée
+  })
+
+  it("hides ADMIN-only destinations for a DOCTOR (RBAC gate from navItems)", () => {
+    render(<CommandPalette userRole="DOCTOR" />)
+    openWithCtrlK()
+    // « Audit » est minRole ADMIN → absent pour un DOCTOR
+    expect(screen.queryByText("Audit")).toBeNull()
   })
 
   it("filters destinations by the typed query", () => {
@@ -73,28 +81,29 @@ describe("CommandPalette (US-2601)", () => {
     expect(screen.queryByText("Patients")).toBeNull()
   })
 
-  it("searches patients (server-scoped route) at ≥ 2 chars and navigates on click", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        items: [{ id: 42, pathology: "DT1", user: { firstname: "Jean", lastname: "Dupont" } }],
-      }),
-    })
-    vi.stubGlobal("fetch", fetchMock)
+  it("Option A — substring-filters the base list client-side (typing « Dup » finds « Dupont »)", async () => {
+    stubFetch([{ id: 42, pathology: "DT1", user: { firstname: "Jean", lastname: "Dupont" } }])
+    render(<CommandPalette userRole="DOCTOR" />)
+    openWithCtrlK()
+    // laisse le fetch de liste de base se résoudre
+    await screen.findByText("Ma journée")
+    const input = screen.getByPlaceholderText("Rechercher un patient ou une section…")
+    fireEvent.change(input, { target: { value: "Dup" } }) // partiel — pas le nom complet
+    const hit = await screen.findByText("Jean Dupont")
+    fireEvent.click(hit)
+    expect(push).toHaveBeenCalledWith("/patients/42")
+  })
 
+  it("fires the server-scoped exact search for ≥ 2 chars", async () => {
+    const fetchMock = stubFetch([{ id: 7, pathology: null, user: { firstname: "Marie", lastname: "Martin" } }])
     render(<CommandPalette userRole="DOCTOR" />)
     openWithCtrlK()
     const input = screen.getByPlaceholderText("Rechercher un patient ou une section…")
-    fireEvent.change(input, { target: { value: "Jean Dupont" } })
-
-    const hit = await screen.findByText("Jean Dupont")
-    // la route appelée est bien la recherche patient scopée serveur
-    expect(fetchMock).toHaveBeenCalled()
-    expect(String(fetchMock.mock.calls[0]![0])).toContain("/api/patients/search?")
-    expect(String(fetchMock.mock.calls[0]![0])).toContain("search=Jean+Dupont")
-
-    fireEvent.click(hit)
-    expect(push).toHaveBeenCalledWith("/patients/42")
+    fireEvent.change(input, { target: { value: "Martin" } })
+    await screen.findByText("Marie Martin")
+    const urls = fetchMock.mock.calls.map((c) => String(c[0]))
+    expect(urls.some((u) => u.includes("/api/patients/search?") && u.includes("limit=50"))).toBe(true) // liste de base
+    expect(urls.some((u) => u.includes("search=Martin"))).toBe(true) // recherche exacte
   })
 
   it("navigates to a destination on click (DOCTOR home → /medecin)", () => {
@@ -102,13 +111,5 @@ describe("CommandPalette (US-2601)", () => {
     openWithCtrlK()
     fireEvent.click(screen.getByText("Ma journée"))
     expect(push).toHaveBeenCalledWith("/medecin")
-  })
-
-  it("shows the min-chars hint for a 1-char query", () => {
-    render(<CommandPalette userRole="DOCTOR" />)
-    openWithCtrlK()
-    const input = screen.getByPlaceholderText("Rechercher un patient ou une section…")
-    fireEvent.change(input, { target: { value: "x" } })
-    expect(screen.getByText("Tapez au moins 2 caractères pour rechercher un patient.")).toBeTruthy()
   })
 })

--- a/tests/components/command-palette.test.tsx
+++ b/tests/components/command-palette.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Tests US-2601 — CommandPalette (Ctrl/Cmd-K).
+ *
+ * Sécurité / nav : la recherche patient est scopée serveur (route
+ * `/api/patients/search`) — ces tests vérifient le câblage UI (ouverture
+ * clavier, destinations filtrées par rôle, requête de recherche, navigation),
+ * pas le scoping (couvert côté service/route).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+
+vi.mock("next-intl", async () => (await import("../helpers/nextIntlMock")).makeNextIntlMock())
+
+const push = vi.fn()
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}))
+
+// Dialog base-ui → rendu inline quand `open` (évite portail/focus-trap en jsdom).
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div data-testid="dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+// Tooltip base-ui (utilisé par <Acronym>) → rendu enfants.
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children, ...p }: React.PropsWithChildren<Record<string, unknown>>) => <span {...p}>{children}</span>,
+}))
+
+import { CommandPalette } from "@/components/diabeo/CommandPalette"
+
+function openWithCtrlK() {
+  fireEvent.keyDown(document, { key: "k", ctrlKey: true })
+}
+
+beforeEach(() => {
+  push.mockReset()
+  vi.restoreAllMocks()
+})
+
+describe("CommandPalette (US-2601)", () => {
+  it("is closed initially and opens on Ctrl/Cmd-K", () => {
+    render(<CommandPalette userRole="DOCTOR" />)
+    expect(screen.queryByTestId("dialog")).toBeNull()
+    openWithCtrlK()
+    expect(screen.getByTestId("dialog")).toBeTruthy()
+  })
+
+  it("shows role-aware destinations (DOCTOR home = « Ma journée »)", () => {
+    render(<CommandPalette userRole="DOCTOR" />)
+    openWithCtrlK()
+    // nav.dashboardMedecin (FR) = « Ma journée » pour le DOCTOR
+    expect(screen.getByText("Ma journée")).toBeTruthy()
+    expect(screen.getByText("Patients")).toBeTruthy()
+  })
+
+  it("filters destinations by the typed query", () => {
+    render(<CommandPalette userRole="DOCTOR" />)
+    openWithCtrlK()
+    const input = screen.getByPlaceholderText("Rechercher un patient ou une section…")
+    fireEvent.change(input, { target: { value: "param" } }) // → « Paramètres »
+    expect(screen.getByText("Paramètres")).toBeTruthy()
+    expect(screen.queryByText("Patients")).toBeNull()
+  })
+
+  it("searches patients (server-scoped route) at ≥ 2 chars and navigates on click", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [{ id: 42, pathology: "DT1", user: { firstname: "Jean", lastname: "Dupont" } }],
+      }),
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    render(<CommandPalette userRole="DOCTOR" />)
+    openWithCtrlK()
+    const input = screen.getByPlaceholderText("Rechercher un patient ou une section…")
+    fireEvent.change(input, { target: { value: "Jean Dupont" } })
+
+    const hit = await screen.findByText("Jean Dupont")
+    // la route appelée est bien la recherche patient scopée serveur
+    expect(fetchMock).toHaveBeenCalled()
+    expect(String(fetchMock.mock.calls[0]![0])).toContain("/api/patients/search?")
+    expect(String(fetchMock.mock.calls[0]![0])).toContain("search=Jean+Dupont")
+
+    fireEvent.click(hit)
+    expect(push).toHaveBeenCalledWith("/patients/42")
+  })
+
+  it("navigates to a destination on click (DOCTOR home → /medecin)", () => {
+    render(<CommandPalette userRole="DOCTOR" />)
+    openWithCtrlK()
+    fireEvent.click(screen.getByText("Ma journée"))
+    expect(push).toHaveBeenCalledWith("/medecin")
+  })
+
+  it("shows the min-chars hint for a 1-char query", () => {
+    render(<CommandPalette userRole="DOCTOR" />)
+    openWithCtrlK()
+    const input = screen.getByPlaceholderText("Rechercher un patient ou une section…")
+    fireEvent.change(input, { target: { value: "x" } })
+    expect(screen.getByText("Tapez au moins 2 caractères pour rechercher un patient.")).toBeTruthy()
+  })
+})

--- a/tests/components/phase11/phase11-navigation.test.tsx
+++ b/tests/components/phase11/phase11-navigation.test.tsx
@@ -23,6 +23,14 @@ import { usePathname } from "next/navigation"
 
 vi.mock("next/navigation", () => ({
   usePathname: vi.fn(() => "/dashboard"),
+  useRouter: vi.fn(() => ({ push: vi.fn() })),
+}))
+
+// US-2601 — la palette (Ctrl-K) est montée dans NavigationShell mais hors
+// périmètre de ces tests (nav items / RBAC) ; on la neutralise pour éviter de
+// tirer Dialog base-ui + le fetch de recherche patient.
+vi.mock("@/components/diabeo/CommandPalette", () => ({
+  CommandPalette: () => null,
 }))
 
 vi.mock("@/hooks/use-auth", () => ({


### PR DESCRIPTION
## US-2601 — Palette de commande & recherche rapide (Ctrl/Cmd-K)

Deuxième US du bloc Navigation médecin (après US-2602 « Ma journée », PR #540). **Purement additif** — aucune feature retirée.

### Ce que ça fait
Palette globale (staff) ouvrable au clavier `Ctrl/Cmd-K`, avec deux familles de résultats :
- **« Aller à »** — destinations filtrées par rôle (home rôle-aware : DOCTOR → « Ma journée »), navigation client-side Next.js.
- **« Patients »** — recherche **scopée serveur** via la route existante `/api/patients/search` (RBAC `accessibleIds`, rate-limit per-user/IP, audit `READ PATIENT`). Saisie ≥ 2 caractères, annulable (`AbortController`). La liste n'expose que **identité + pathologie** (`<Acronym>`), aucune donnée de santé détaillée. Sélection → ouverture du dossier `/patients/[id]`.

### Sécurité & conformité
- **Aucune IA / aucun calcul clinique côté frontend** (décision série navigation).
- Réutilise une route déjà auditée + scopée serveur (pas de nouveau point d'accès PHI). L'accès patient est journalisé par la recherche + par la page dossier à l'ouverture.
- Pathologie affichée via `<Acronym>` (règle CLAUDE.md « pas d'acronyme nu »).

### A11y
- `Dialog` base-ui : focus-trap, `Esc`, retour de focus, `role=dialog`.
- Saisie `combobox` liée à un `listbox` (`aria-activedescendant`), navigation `↑/↓/↵`, `aria-selected` sur l'option active.
- RTL hérité du `dir` document (FR/EN/AR).

### Périmètre / différé
- Déclencheur « champ de recherche du top header » mentionné dans l'US : **différé** (pas de champ header aujourd'hui) — l'ouverture `Ctrl/Cmd-K` est livrée.
- Métadonnées patient « âge / drapeau d'alerte » : non incluses (la route renvoie nom + pathologie) — extension possible ultérieure.

### Tests & checks
- Test composant `command-palette.test.tsx` (6 cas : ouverture clavier, destinations rôle-aware, filtre par saisie, recherche patient + navigation, hint < 2 car.).
- Suite complète verte : **216 fichiers / 3064 tests**. `tsc` exit 0, `eslint` clean, design-system baseline (285), parité i18n FR/EN/AR OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)