### PR TITLE
feat(patient): câblage données réelles — Phase 1 (vue d'ensemble)

### DIFF
--- a/docs/UserStory/Navigation/cablage-donnees-patient.md
+++ b/docs/UserStory/Navigation/cablage-donnees-patient.md
@@ -49,10 +49,14 @@
 
 ## Phases
 
-- [ ] **Phase 1 — Garde d'accès + audit + RSC + onglet « Vue d'ensemble »**
-  - Conversion RSC, `canAccessPatient` → `notFound()`, audit via services.
+- [x] **Phase 1 — Garde d'accès + audit + RSC + onglet « Vue d'ensemble »** (PR #543)
+  - Conversion RSC, `canAccessPatient` → audit `accessDenied` + `notFound()`, audit via services.
+  - **Garde consentement `shareWithProviders`** ajoutée (opt-out → état « partage désactivé », aucune PII déchiffrée) — cohérence avec routes cgm/analytics.
   - KPIs (moyenne, TIR, GMI, CV) + carte profil + objectifs + donut TIR — **réels**.
+  - Cible affichée = `cgm.low/ok` (mêmes bornes que le calcul TIR serveur).
+  - Caveat si capture CGM < 70 % (`warning`/`captureRate` du service).
   - Onglets Glycémie / Traitements / Documents → **état vide « bientôt disponible »**.
+  - Middleware : `/patients` ajouté à la liste `no-store` (PHI en SSR).
   - Suppression de `DEMO_PATIENT` / `DEMO_CGM`.
 - [ ] **Phase 2 — Onglet Glycémie** : graphe CGM réel (`/api/patients/[id]/cgm`),
   + KPI « glycémie actuelle » (dernier relevé).
@@ -60,12 +64,15 @@
   (`insulinTherapyService.getSettings`, route si nécessaire) + traitements associés.
 - [ ] **Phase 4 — Onglet Documents** : documents médicaux réels (MinIO).
 
-## Points de vigilance (revue)
+## Points de vigilance (revue) — tranchés en Phase 1
 
-- **Consentement `shareWithProviders`** : `getById` ne le filtre pas (accès PS =
-  base légale Art. 9.2.h). À arbitrer avec `healthcare-security-auditor` : faut-il
-  gater l'affichage si le patient a explicitement retiré le partage ? (cohérence
-  avec les routes `cgm`/`analytics` qui le vérifient.)
-- **404 vs 403** : accès refusé → `notFound()` (uniforme, anti-énumération).
-- **Capture CGM nulle** : si `readingCount === 0`, l'onglet affiche un état
-  « pas de données » plutôt que des stats à 0/NaN.
+- **Consentement `shareWithProviders`** : ✅ **gaté** au niveau page (opt-out →
+  état « partage désactivé », aucune PII déchiffrée). Décision : on honore
+  l'opposition Art. 21 comme les routes `cgm`/`analytics` (revue HSA).
+- **404 vs 403** : ✅ accès refusé → audit `accessDenied` + `notFound()` (uniforme,
+  anti-énumération + détection d'abus US-2265).
+- **Capture CGM** : ✅ `readingCount === 0` → état « pas de données » ; capture
+  < 70 % → caveat clinique (stats non représentatives).
+- **Reste (LOW, suivi)** : `getById` sur-déchiffre `email` + relations non
+  affichées (minimisation Art. 5.1.c) — méthode allégée à envisager ; plancher
+  capteur 0.40 g/L de l'analytics à documenter (pré-existant, hors PR).

--- a/docs/UserStory/Navigation/cablage-donnees-patient.md
+++ b/docs/UserStory/Navigation/cablage-donnees-patient.md
@@ -73,6 +73,33 @@
   anti-énumération + détection d'abus US-2265).
 - **Capture CGM** : ✅ `readingCount === 0` → état « pas de données » ; capture
   < 70 % → caveat clinique (stats non représentatives).
-- **Reste (LOW, suivi)** : `getById` sur-déchiffre `email` + relations non
-  affichées (minimisation Art. 5.1.c) — méthode allégée à envisager ; plancher
-  capteur 0.40 g/L de l'analytics à documenter (pré-existant, hors PR).
+- **Reste (LOW, suivi)** : voir backlog ci-dessous.
+
+## Backlog / suivi (relevé en revue PR #543, non bloquant — patterns partagés)
+
+Items pré-existants ou transverses, hors périmètre de la Phase 1 — à traiter
+dans des tickets dédiés, pas dans le câblage des onglets.
+
+- **[Sécu] Convergence des sémantiques de consentement** : 2 implémentations
+  coexistent — `patientShareConsent()` (`src/lib/consent.ts`, **fail-closed** +
+  gate `gdprConsent`) vs le check inline **fail-open** des routes
+  `/api/patients/[id]/cgm` et `/analytics` (que la page Phase 1 réplique pour
+  cohérence). Faire converger toutes les lectures PHI sur un seul helper, décision
+  documentée en DPIA.
+- **[Sécu] Audit de l'accès « partage désactivé »** : la branche opt-out ne
+  trace rien (parité avec cgm/analytics) — envisager une ligne `accessDenied`
+  `kind: "sharingDisabled"` pour la traçabilité HDS.
+- **[Sécu] XFF spoofable** : `ctx.ipAddress` = 1er hop `x-forwarded-for`
+  (client-contrôlable) ; durcissement transverse — cf.
+  `docs/security/xff-trusted-proxy.md`. Réutiliser `extractRequestContext`.
+- **[Clinique] Plancher capteur 0.40 g/L** (`analytics.service.ts`) exclut les
+  hypo sévères au plancher des agrégats (mean/CV/TIR severeHypo) — sous-estime la
+  charge hypoglycémique. Inclure les relevés clampés au plancher dans le bucket
+  severe-hypo.
+- **[Clinique] Cibles spécifiques grossesse (GD)** : les cibles consensus
+  (70/180, TIR 70 %, hypo 4 %, CV 36 %) sont DT1/DT2 ; seeder des cibles GD plus
+  strictes (TIR 63–140) côté `cgmObjective`.
+- **[RGPD] `getById` sur-déchiffre** `email` + relations non affichées
+  (minimisation Art. 5.1.c) — méthode de lecture allégée pour la page.
+- **[Perf] Double lookup patient** : la garde consentement fait un `findFirst`
+  léger puis `getById` en refait un complet — fusionnable.

--- a/docs/UserStory/Navigation/cablage-donnees-patient.md
+++ b/docs/UserStory/Navigation/cablage-donnees-patient.md
@@ -1,0 +1,71 @@
+# Câblage des vraies données patient — plan de suivi
+
+> **Contexte** : la page dossier patient `src/app/(dashboard)/patients/[id]/page.tsx`
+> (US-802) était un **composant client** affichant des données **démo synthétiques**
+> (`DEMO_PATIENT` / `DEMO_CGM`). Ce chantier remplace la démo par les **vraies
+> données** patient, **scopées serveur**, **PII déchiffrée serveur**, **accès audité**.
+> C'est le **prérequis** du dossier patient en onglets (US-2604) et de la barre de
+> contexte (US-2603).
+>
+> **Décisions** :
+> - **Phasé** : 1 onglet ≈ 1 PR (revue PHI maîtrisée).
+> - Les onglets **pas encore câblés** affichent un **état vide « bientôt disponible »**
+>   — jamais de fausses données patient.
+> - **Aucune statistique clinique calculée côté frontend** : TIR/GMI/CV/moyenne
+>   viennent des **projections serveur** (`analytics.service`). Zéro IA.
+
+---
+
+## Architecture cible
+
+- `page.tsx` devient un **Server Component** : lit `params.id` + rôle/headers,
+  **vérifie `canAccessPatient`** (sinon `notFound()` — anti-énumération), appelle
+  les **services** (audit `READ` + pivot `metadata.patientId`, ADR #18), mappe et
+  passe les données à un enfant **client** `PatientDetailClient` (onglets + graphe).
+- Le client ne fait **aucun calcul clinique** ; il rend les valeurs serveur.
+
+## Sources serveur (existantes)
+
+| Donnée | Service | Route | Notes |
+|---|---|---|---|
+| Profil (PII déchiffrée) + objectifs + devices | `patientService.getById` | `GET /api/patients/[id]` | inclut `glycemiaObjectives`, `cgmObjectives`, `referent`, `medicalData` |
+| Accès patient | `canAccessPatient` | — | ADMIN / DOCTOR-NURSE (via service) / VIEWER self |
+| Stats TIR/GMI/CV/moy. (calc. serveur) | `analyticsService.glycemicProfile` | `GET /api/patients/[id]/analytics` | max 90j |
+| CGM (série) | `glycemiaService.getCgmEntries` | `GET /api/patients/[id]/cgm` | max 30j |
+| Réglages insuline (ISF/ICR/basal/pompe) | `insulinTherapyService.getSettings` | (route à ajouter ou appel RSC) | — |
+| Documents | (pipeline MinIO/MedicalDocument) | (à brancher) | — |
+
+## Mappings clés
+
+- **TIR** : `analytics.tir {severeHypo, hypo, inRange, elevated, hyper}` →
+  `TirData {veryLow, low, inRange, high, veryHigh}`.
+- **Objectif cible** : `cgmObjectives.titrLow/titrHigh` (g/L) → mg/dL (×100).
+- **Cibles consensus** (TIR ≥ 70 %, hypo < 4 %) : constantes cliniques ADA/EASD
+  (mêmes pour tous), pas des champs patient.
+- **Âge** : dérivé de `user.birthday`. **Diag** : `medicalData.yearDiag`.
+- **Référent** : `referent.pro.name` (fallback `patientServices[0].service.name`).
+
+---
+
+## Phases
+
+- [ ] **Phase 1 — Garde d'accès + audit + RSC + onglet « Vue d'ensemble »**
+  - Conversion RSC, `canAccessPatient` → `notFound()`, audit via services.
+  - KPIs (moyenne, TIR, GMI, CV) + carte profil + objectifs + donut TIR — **réels**.
+  - Onglets Glycémie / Traitements / Documents → **état vide « bientôt disponible »**.
+  - Suppression de `DEMO_PATIENT` / `DEMO_CGM`.
+- [ ] **Phase 2 — Onglet Glycémie** : graphe CGM réel (`/api/patients/[id]/cgm`),
+  + KPI « glycémie actuelle » (dernier relevé).
+- [ ] **Phase 3 — Onglet Traitements** : réglages insuline réels
+  (`insulinTherapyService.getSettings`, route si nécessaire) + traitements associés.
+- [ ] **Phase 4 — Onglet Documents** : documents médicaux réels (MinIO).
+
+## Points de vigilance (revue)
+
+- **Consentement `shareWithProviders`** : `getById` ne le filtre pas (accès PS =
+  base légale Art. 9.2.h). À arbitrer avec `healthcare-security-auditor` : faut-il
+  gater l'affichage si le patient a explicitement retiré le partage ? (cohérence
+  avec les routes `cgm`/`analytics` qui le vérifient.)
+- **404 vs 403** : accès refusé → `notFound()` (uniforme, anti-énumération).
+- **Capture CGM nulle** : si `readingCount === 0`, l'onglet affiche un état
+  « pas de données » plutôt que des stats à 0/NaN.

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1537,7 +1537,6 @@
     "tabDocuments": "المستندات",
     "subtitle": "{pathology} — {age} سنة — متابعة من {referent}",
     "kpiCurrentGlucose": "سكر الدم الحالي",
-    "kpiTir7d": "الوقت ضمن النطاق (TIR) — 14 يومًا",
     "kpiGmi": "مؤشر إدارة الجلوكوز (GMI)",
     "kpiCv": "معامل التغاير (CV)",
     "profileTitle": "ملف المريض",
@@ -1569,7 +1568,11 @@
     "comingSoon": "قريبًا",
     "comingSoonDesc": "سيتم ربط هذا القسم بالبيانات الحقيقية قريبًا.",
     "noCgmData": "لا توجد بيانات الغلوكوز المستمر (CGM) للفترة.",
-    "patientFallback": "مريض"
+    "patientFallback": "مريض",
+    "kpiTir14d": "الوقت ضمن النطاق (TIR) — 14 يومًا",
+    "lowCaptureWarning": "التقاط الغلوكوز المستمر (CGM) غير كافٍ ({rate}%) — فسّر الإحصاءات بحذر.",
+    "sharingDisabledTitle": "المشاركة معطّلة",
+    "sharingDisabledDesc": "عطّل هذا المريض مشاركة بياناته مع مقدّمي الرعاية."
   },
   "patientDashboard": {
     "pageTitle": "لوحة التحكم الخاصة بي",

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1537,7 +1537,7 @@
     "tabDocuments": "المستندات",
     "subtitle": "{pathology} — {age} سنة — متابعة من {referent}",
     "kpiCurrentGlucose": "سكر الدم الحالي",
-    "kpiTir7d": "الوقت ضمن النطاق (TIR) — ٧ أيام",
+    "kpiTir7d": "الوقت ضمن النطاق (TIR) — 14 يومًا",
     "kpiGmi": "مؤشر إدارة الجلوكوز (GMI)",
     "kpiCv": "معامل التغاير (CV)",
     "profileTitle": "ملف المريض",
@@ -1554,7 +1554,7 @@
     "targetBadge": "الهدف: {low}–{high} mg/dL",
     "tirTargetBadge": "الهدف (TIR): {target}%",
     "hypoMaxBadge": "أقصى هبوط: {target}%",
-    "tirDonutPeriod": "(٧ أيام)",
+    "tirDonutPeriod": "(14 يومًا)",
     "glycemicProfile24h": "ملف سكر الدم (٢٤ ساعة)",
     "insulinConfigTitle": "إعداد العلاج بالأنسولين",
     "method": "الطريقة",
@@ -1565,7 +1565,11 @@
     "associatedTreatmentsTitle": "العلاجات المرتبطة",
     "noComplementaryTreatment": "لا يوجد علاج تكميلي مسجّل",
     "medicalDocumentsTitle": "المستندات الطبية",
-    "noDocument": "لا يوجد مستند مسجّل"
+    "noDocument": "لا يوجد مستند مسجّل",
+    "comingSoon": "قريبًا",
+    "comingSoonDesc": "سيتم ربط هذا القسم بالبيانات الحقيقية قريبًا.",
+    "noCgmData": "لا توجد بيانات الغلوكوز المستمر (CGM) للفترة.",
+    "patientFallback": "مريض"
   },
   "patientDashboard": {
     "pageTitle": "لوحة التحكم الخاصة بي",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1537,7 +1537,7 @@
     "tabDocuments": "Documents",
     "subtitle": "{pathology} — {age} y.o. — Followed by {referent}",
     "kpiCurrentGlucose": "Current glucose",
-    "kpiTir7d": "Time in range (TIR) — 7d",
+    "kpiTir7d": "Time in range (TIR) — 14d",
     "kpiGmi": "Glucose management indicator (GMI)",
     "kpiCv": "Coefficient of variation (CV)",
     "profileTitle": "Patient profile",
@@ -1554,7 +1554,7 @@
     "targetBadge": "Target: {low}–{high} mg/dL",
     "tirTargetBadge": "Target (TIR): {target}%",
     "hypoMaxBadge": "Max hypo: {target}%",
-    "tirDonutPeriod": "(7 days)",
+    "tirDonutPeriod": "(14 days)",
     "glycemicProfile24h": "Glycemic profile (24h)",
     "insulinConfigTitle": "Insulin therapy configuration",
     "method": "Method",
@@ -1565,7 +1565,11 @@
     "associatedTreatmentsTitle": "Associated treatments",
     "noComplementaryTreatment": "No complementary treatment recorded",
     "medicalDocumentsTitle": "Medical documents",
-    "noDocument": "No document recorded"
+    "noDocument": "No document recorded",
+    "comingSoon": "Coming soon",
+    "comingSoonDesc": "This section will be wired to real data soon.",
+    "noCgmData": "No continuous glucose (CGM) data for the period.",
+    "patientFallback": "Patient"
   },
   "patientDashboard": {
     "pageTitle": "My dashboard",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1537,7 +1537,6 @@
     "tabDocuments": "Documents",
     "subtitle": "{pathology} — {age} y.o. — Followed by {referent}",
     "kpiCurrentGlucose": "Current glucose",
-    "kpiTir7d": "Time in range (TIR) — 14d",
     "kpiGmi": "Glucose management indicator (GMI)",
     "kpiCv": "Coefficient of variation (CV)",
     "profileTitle": "Patient profile",
@@ -1569,7 +1568,11 @@
     "comingSoon": "Coming soon",
     "comingSoonDesc": "This section will be wired to real data soon.",
     "noCgmData": "No continuous glucose (CGM) data for the period.",
-    "patientFallback": "Patient"
+    "patientFallback": "Patient",
+    "kpiTir14d": "Time in range (TIR) — 14d",
+    "lowCaptureWarning": "Insufficient continuous glucose (CGM) capture ({rate}%) — interpret statistics with caution.",
+    "sharingDisabledTitle": "Sharing disabled",
+    "sharingDisabledDesc": "This patient has disabled sharing their data with care providers."
   },
   "patientDashboard": {
     "pageTitle": "My dashboard",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1537,7 +1537,6 @@
     "tabDocuments": "Documents",
     "subtitle": "{pathology} — {age} ans — Suivi par {referent}",
     "kpiCurrentGlucose": "Glycémie actuelle",
-    "kpiTir7d": "Temps dans la cible (TIR) — 14j",
     "kpiGmi": "Indicateur de gestion du glucose (GMI)",
     "kpiCv": "Coefficient de variation (CV)",
     "profileTitle": "Profil patient",
@@ -1569,7 +1568,11 @@
     "comingSoon": "Bientôt disponible",
     "comingSoonDesc": "Cette section sera câblée aux données réelles prochainement.",
     "noCgmData": "Pas de données de glycémie continue (CGM) sur la période.",
-    "patientFallback": "Patient"
+    "patientFallback": "Patient",
+    "kpiTir14d": "Temps dans la cible (TIR) — 14j",
+    "lowCaptureWarning": "Capture de glycémie continue (CGM) insuffisante ({rate} %) — statistiques à interpréter avec prudence.",
+    "sharingDisabledTitle": "Partage désactivé",
+    "sharingDisabledDesc": "Ce patient a désactivé le partage de ses données avec les soignants."
   },
   "patientDashboard": {
     "pageTitle": "Mon tableau de bord",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1537,7 +1537,7 @@
     "tabDocuments": "Documents",
     "subtitle": "{pathology} — {age} ans — Suivi par {referent}",
     "kpiCurrentGlucose": "Glycémie actuelle",
-    "kpiTir7d": "Temps dans la cible (TIR) — 7j",
+    "kpiTir7d": "Temps dans la cible (TIR) — 14j",
     "kpiGmi": "Indicateur de gestion du glucose (GMI)",
     "kpiCv": "Coefficient de variation (CV)",
     "profileTitle": "Profil patient",
@@ -1554,7 +1554,7 @@
     "targetBadge": "Cible : {low}–{high} mg/dL",
     "tirTargetBadge": "Cible (TIR) : {target}%",
     "hypoMaxBadge": "Hypo max : {target}%",
-    "tirDonutPeriod": "(7 jours)",
+    "tirDonutPeriod": "(14 jours)",
     "glycemicProfile24h": "Profil glycémique (24h)",
     "insulinConfigTitle": "Configuration insulinothérapie",
     "method": "Méthode",
@@ -1565,7 +1565,11 @@
     "associatedTreatmentsTitle": "Traitements associés",
     "noComplementaryTreatment": "Aucun traitement complémentaire enregistré",
     "medicalDocumentsTitle": "Documents médicaux",
-    "noDocument": "Aucun document enregistré"
+    "noDocument": "Aucun document enregistré",
+    "comingSoon": "Bientôt disponible",
+    "comingSoonDesc": "Cette section sera câblée aux données réelles prochainement.",
+    "noCgmData": "Pas de données de glycémie continue (CGM) sur la période.",
+    "patientFallback": "Patient"
   },
   "patientDashboard": {
     "pageTitle": "Mon tableau de bord",

--- a/src/app/(dashboard)/patients/[id]/PatientDetailClient.tsx
+++ b/src/app/(dashboard)/patients/[id]/PatientDetailClient.tsx
@@ -35,6 +35,7 @@ export type PatientDetailData = {
     targetHighMgdl: number
     tirTargetPct: number
     hypoMaxPct: number
+    cvMaxPct: number
   }
   /** Stats glycémiques calculées serveur ; `null` si aucune donnée CGM. */
   stats: {
@@ -43,12 +44,41 @@ export type PatientDetailData = {
     cv: number
     tir: TirData
     readingCount: number
+    captureRate: number
+    /** Capture CGM < 70 % → stats non représentatives (caveat clinique). */
+    insufficientCapture: boolean
   } | null
 }
 
-export function PatientDetailClient({ data }: { data: PatientDetailData }) {
+export function PatientDetailClient({
+  data,
+  sharingDisabled = false,
+}: {
+  data: PatientDetailData | null
+  sharingDisabled?: boolean
+}) {
   const t = useTranslations("patientDetail")
   const [activeTab, setActiveTab] = useState("overview")
+
+  // Consentement retiré : aucune donnée patient rendue (cf. page.tsx).
+  if (sharingDisabled || !data) {
+    return (
+      <>
+        <DashboardHeader title={t("patientFallback")} subtitle="" />
+        <div className="p-6">
+          <Card>
+            <CardContent className="py-10">
+              <DiabeoEmptyState
+                variant="noData"
+                title={t("sharingDisabledTitle")}
+                message={t("sharingDisabledDesc")}
+              />
+            </CardContent>
+          </Card>
+        </div>
+      </>
+    )
+  }
 
   const name = data.name || t("patientFallback")
   const sexLabel = data.sex === "F" ? t("female") : data.sex === "M" ? t("male") : "—"
@@ -76,6 +106,14 @@ export function PatientDetailClient({ data }: { data: PatientDetailData }) {
 
           {/* ── Vue d'ensemble (câblée) ─────────────────────── */}
           <TabsContent value="overview" className="space-y-6">
+            {stats?.insufficientCapture && (
+              <p
+                role="status"
+                className="rounded-md border border-feedback-warning bg-warning-bg px-4 py-2 text-sm text-warning-fg"
+              >
+                {t("lowCaptureWarning", { rate: Math.round(stats.captureRate) })}
+              </p>
+            )}
             {stats ? (
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
                 <StatCard
@@ -86,7 +124,7 @@ export function PatientDetailClient({ data }: { data: PatientDetailData }) {
                   variant="default"
                 />
                 <StatCard
-                  label={t("kpiTir7d")}
+                  label={t("kpiTir14d")}
                   value={`${Math.round(stats.tir.inRange)}%`}
                   icon={<TrendingUp className="h-5 w-5" />}
                   variant={stats.tir.inRange >= objectives.tirTargetPct ? "success" : "warning"}
@@ -101,7 +139,7 @@ export function PatientDetailClient({ data }: { data: PatientDetailData }) {
                   label={t("kpiCv")}
                   value={`${stats.cv}%`}
                   icon={<Clock className="h-5 w-5" />}
-                  variant={stats.cv <= 36 ? "success" : "warning"}
+                  variant={stats.cv <= objectives.cvMaxPct ? "success" : "warning"}
                 />
               </div>
             ) : (

--- a/src/app/(dashboard)/patients/[id]/PatientDetailClient.tsx
+++ b/src/app/(dashboard)/patients/[id]/PatientDetailClient.tsx
@@ -1,0 +1,228 @@
+/**
+ * Dossier patient — vue client (onglets + rendu).
+ *
+ * Reçoit les données déjà résolues/auditées par le Server Component parent
+ * (`page.tsx`). Ne fait AUCUN calcul clinique : rend les valeurs serveur.
+ * Phase 1 : onglet « Vue d'ensemble » câblé ; Glycémie / Traitements /
+ * Documents → état « bientôt disponible » (phases suivantes).
+ */
+
+"use client"
+
+import { useState } from "react"
+import { useTranslations } from "next-intl"
+import { DashboardHeader } from "@/components/diabeo/DashboardHeader"
+import { GlycemiaValue, TirDonut, ClinicalBadge, StatCard } from "@/components/diabeo"
+import type { TirData } from "@/components/diabeo/TirDonut"
+import { Acronym } from "@/components/diabeo/Acronym"
+import { DiabeoEmptyState } from "@/components/diabeo/DiabeoEmptyState"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Separator } from "@/components/ui/separator"
+import { Badge } from "@/components/ui/badge"
+import { Activity, Clock, Heart, TrendingUp, User } from "lucide-react"
+
+export type PatientDetailData = {
+  id: number
+  name: string
+  age: number | null
+  sex: "M" | "F" | "X" | null
+  pathology: string | null
+  diagYear: number | null
+  referent: string | null
+  objectives: {
+    targetLowMgdl: number
+    targetHighMgdl: number
+    tirTargetPct: number
+    hypoMaxPct: number
+  }
+  /** Stats glycémiques calculées serveur ; `null` si aucune donnée CGM. */
+  stats: {
+    avgGlucoseMgdl: number
+    gmi: number
+    cv: number
+    tir: TirData
+    readingCount: number
+  } | null
+}
+
+export function PatientDetailClient({ data }: { data: PatientDetailData }) {
+  const t = useTranslations("patientDetail")
+  const [activeTab, setActiveTab] = useState("overview")
+
+  const name = data.name || t("patientFallback")
+  const sexLabel = data.sex === "F" ? t("female") : data.sex === "M" ? t("male") : "—"
+  const { stats, objectives } = data
+
+  return (
+    <>
+      <DashboardHeader
+        title={name}
+        subtitle={t("subtitle", {
+          pathology: data.pathology ?? "—",
+          age: data.age ?? "—",
+          referent: data.referent ?? "—",
+        })}
+      />
+
+      <div className="p-6">
+        <Tabs value={activeTab} onValueChange={setActiveTab}>
+          <TabsList className="mb-6" aria-label={t("tabsAriaLabel")}>
+            <TabsTrigger value="overview">{t("tabOverview")}</TabsTrigger>
+            <TabsTrigger value="glycemia">{t("tabGlycemia")}</TabsTrigger>
+            <TabsTrigger value="treatment">{t("tabTreatment")}</TabsTrigger>
+            <TabsTrigger value="documents">{t("tabDocuments")}</TabsTrigger>
+          </TabsList>
+
+          {/* ── Vue d'ensemble (câblée) ─────────────────────── */}
+          <TabsContent value="overview" className="space-y-6">
+            {stats ? (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                <StatCard
+                  label={t("avgGlucose14d")}
+                  value={String(stats.avgGlucoseMgdl)}
+                  unit="mg/dL"
+                  icon={<Activity className="h-5 w-5" />}
+                  variant="default"
+                />
+                <StatCard
+                  label={t("kpiTir7d")}
+                  value={`${Math.round(stats.tir.inRange)}%`}
+                  icon={<TrendingUp className="h-5 w-5" />}
+                  variant={stats.tir.inRange >= objectives.tirTargetPct ? "success" : "warning"}
+                />
+                <StatCard
+                  label={t("kpiGmi")}
+                  value={`${stats.gmi}%`}
+                  icon={<Heart className="h-5 w-5" />}
+                  variant="default"
+                />
+                <StatCard
+                  label={t("kpiCv")}
+                  value={`${stats.cv}%`}
+                  icon={<Clock className="h-5 w-5" />}
+                  variant={stats.cv <= 36 ? "success" : "warning"}
+                />
+              </div>
+            ) : (
+              <Card>
+                <CardContent className="py-6">
+                  <p className="text-sm text-muted-foreground">{t("noCgmData")}</p>
+                </CardContent>
+              </Card>
+            )}
+
+            <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+              <Card className="lg:col-span-2">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-base">
+                    <User className="h-4 w-4" aria-hidden="true" />
+                    {t("profileTitle")}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid grid-cols-2 gap-4 text-sm">
+                    <div>
+                      <span className="text-muted-foreground">{t("pathology")}</span>
+                      <div className="mt-1">
+                        {data.pathology ? (
+                          <ClinicalBadge type="pathology" value={data.pathology} />
+                        ) : (
+                          <span className="font-medium">—</span>
+                        )}
+                      </div>
+                    </div>
+                    <div>
+                      <span className="text-muted-foreground">{t("diagnostic")}</span>
+                      <p className="mt-1 font-medium">{data.diagYear ?? "—"}</p>
+                    </div>
+                    <div>
+                      <span className="text-muted-foreground">{t("sex")}</span>
+                      <p className="mt-1 font-medium">{sexLabel}</p>
+                    </div>
+                    <div>
+                      <span className="text-muted-foreground">{t("age")}</span>
+                      <p className="mt-1 font-medium">
+                        {data.age !== null ? t("ageValue", { age: data.age }) : "—"}
+                      </p>
+                    </div>
+                    <div>
+                      <span className="text-muted-foreground">{t("referentDoctor")}</span>
+                      <p className="mt-1 font-medium">{data.referent ?? "—"}</p>
+                    </div>
+                    <div>
+                      <span className="text-muted-foreground">{t("avgGlucose14d")}</span>
+                      <div className="mt-1">
+                        {stats ? (
+                          <GlycemiaValue value={stats.avgGlucoseMgdl} unit="mg/dL" size="sm" />
+                        ) : (
+                          <span className="font-medium">—</span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+
+                  <Separator className="my-4" />
+
+                  <div className="text-sm">
+                    <span className="text-muted-foreground">{t("glycemicObjectives")}</span>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      <Badge variant="outline">
+                        {t("targetBadge", {
+                          low: objectives.targetLowMgdl,
+                          high: objectives.targetHighMgdl,
+                        })}
+                      </Badge>
+                      <Badge variant="outline">
+                        {t("tirTargetBadge", { target: objectives.tirTargetPct })}
+                      </Badge>
+                      <Badge variant="outline">
+                        {t("hypoMaxBadge", { target: objectives.hypoMaxPct })}
+                      </Badge>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">
+                    <Acronym code="TIR" /> {t("tirDonutPeriod")}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="flex justify-center">
+                  {stats ? (
+                    <TirDonut data={stats.tir} size={180} showLegend />
+                  ) : (
+                    <p className="py-8 text-sm text-muted-foreground">{t("noCgmData")}</p>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+          </TabsContent>
+
+          {/* ── Glycémie / Traitements / Documents (phases suivantes) ── */}
+          <TabsContent value="glycemia">
+            <ComingSoon t={t} />
+          </TabsContent>
+          <TabsContent value="treatment">
+            <ComingSoon t={t} />
+          </TabsContent>
+          <TabsContent value="documents">
+            <ComingSoon t={t} />
+          </TabsContent>
+        </Tabs>
+      </div>
+    </>
+  )
+}
+
+function ComingSoon({ t }: { t: ReturnType<typeof useTranslations> }) {
+  return (
+    <Card>
+      <CardContent className="py-10">
+        <DiabeoEmptyState variant="noData" title={t("comingSoon")} message={t("comingSoonDesc")} />
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/src/app/(dashboard)/patients/[id]/page.tsx
@@ -1,311 +1,116 @@
-"use client"
-
 /**
- * Patient detail page — US-802.
+ * Dossier patient (`/patients/[id]`) — Server Component.
  *
- * Full patient view with tabs:
- * - Vue d'ensemble (profile, objectives, TIR donut)
- * - Glycemie (CGM chart — US-803)
- * - Traitements (insulin settings, devices)
- * - Documents
+ * Câblage données réelles, Phase 1 (cf. docs/UserStory/Navigation/cablage-donnees-patient.md) :
+ * profil + objectifs + stats glycémiques (TIR/GMI/CV/moyenne) RÉELS, scopés
+ * serveur, PII déchiffrée serveur, accès audité (ADR #18). Les onglets Glycémie /
+ * Traitements / Documents arrivent dans les phases suivantes (état « bientôt
+ * disponible » en attendant — jamais de données démo).
  *
- * Uses design system: GlycemiaValue, TirDonut, ClinicalBadge, StatCard, AlertBanner.
+ * Sécurité :
+ *  - `canAccessPatient` (RBAC : ADMIN / DOCTOR-NURSE via service / VIEWER self) ;
+ *    accès refusé → `notFound()` (404 uniforme, anti-énumération).
+ *  - Aucune statistique clinique calculée côté frontend : tout vient des
+ *    projections serveur (`analyticsService.glycemicProfile`).
  */
 
-import { useState } from "react"
-import { useTranslations } from "next-intl"
-import { DashboardHeader } from "@/components/diabeo/DashboardHeader"
-import {
-  GlycemiaValue,
-  TirDonut,
-  ClinicalBadge,
-  StatCard,
-} from "@/components/diabeo"
-import { Acronym } from "@/components/diabeo/Acronym"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Separator } from "@/components/ui/separator"
-import { Badge } from "@/components/ui/badge"
-import {
-  Activity,
-  Calendar,
-  Clock,
-  Heart,
-  Pill,
-  Syringe,
-  TrendingUp,
-  User,
-} from "lucide-react"
-import { CgmChart } from "@/components/diabeo/CgmChart"
+import { headers } from "next/headers"
+import { notFound, redirect } from "next/navigation"
+import type { Role } from "@prisma/client"
+import { patientService } from "@/lib/services/patient.service"
+import { analyticsService } from "@/lib/services/analytics.service"
+import { canAccessPatient } from "@/lib/access-control"
+import { GLYCEMIA_THRESHOLDS_MGDL } from "@/lib/glycemia-thresholds"
+import { PatientDetailClient, type PatientDetailData } from "./PatientDetailClient"
 
-// DEMO DATA — synthetic, no real PII
-const DEMO_PATIENT = {
-  id: 1,
-  name: "Patient DT1-001",
-  age: 34,
-  sex: "F",
-  pathology: "DT1" as const,
-  diagYear: 2015,
-  referent: "Service diabétologie — CH Demo",
-  lastGlucoseMgdl: 127,
-  gmi: 7.1,
-  cv: 34.2,
-  avgGlucoseMgdl: 158,
-  tir: { veryLow: 1, low: 3, inRange: 75, high: 17, veryHigh: 4 },
-  insulinSettings: {
-    delivery: "Pompe",
-    pump: "INSULET OMNIPOD Dash",
-    bolusInsulin: "FIASP 100 U/mL",
-    basalRate: "0.8 U/h (moy.)",
-    icr: "10 g/U (moy.)",
-    isf: "0.30 g/L/U (moy.)",
-  },
-  objectives: {
-    targetLow: 70,
-    targetHigh: 180,
-    tirTarget: 70,
-    hypoTarget: 4,
-  },
+// Période d'agrégation de la vue d'ensemble (jours). Bornée < 90j (analytics).
+const OVERVIEW_PERIOD = "14d"
+// Cibles consensus ADA/EASD (identiques pour tous les patients, pas des champs
+// patient) — TIR ≥ 70 %, temps < 70 mg/dL ≤ 4 %.
+const CONSENSUS_TIR_TARGET_PCT = 70
+const CONSENSUS_HYPO_MAX_PCT = 4
+
+function computeAge(birthday: Date | null | undefined, now: Date): number | null {
+  if (!birthday) return null
+  let age = now.getFullYear() - birthday.getFullYear()
+  const m = now.getMonth() - birthday.getMonth()
+  if (m < 0 || (m === 0 && now.getDate() < birthday.getDate())) age--
+  return age >= 0 && age < 150 ? age : null
 }
 
-// Demo CGM data (24h)
-const DEMO_CGM = Array.from({ length: 288 }, (_, i) => {
-  const hour = (i * 5) / 60
-  const base = 130 + 40 * Math.sin((hour - 8) * Math.PI / 6)
-  const noise = (Math.sin(i * 0.7) + Math.cos(i * 1.3)) * 15
-  return {
-    time: `${String(Math.floor(hour) % 24).padStart(2, "0")}:${String((i * 5) % 60).padStart(2, "0")}`,
-    glucose: Math.round(Math.max(40, Math.min(350, base + noise))),
+export default async function PatientDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const patientId = Number(id)
+  if (!Number.isInteger(patientId) || patientId <= 0) notFound()
+
+  const h = await headers()
+  const userId = Number(h.get("x-user-id"))
+  const role = h.get("x-user-role") as Role | null
+  if (!userId || !Number.isInteger(userId) || !role) redirect("/login")
+
+  // Garde d'accès — refus = 404 uniforme (ne révèle pas l'existence du patient).
+  const allowed = await canAccessPatient(userId, role, patientId)
+  if (!allowed) notFound()
+
+  const ctx = {
+    ipAddress: (h.get("x-forwarded-for")?.split(",")[0] ?? "").trim() || "unknown",
+    userAgent: h.get("user-agent") || "unknown",
+    requestId: h.get("x-request-id") || "rsc-patient-detail",
   }
-})
 
-export default function PatientDetailPage() {
-  const t = useTranslations("patientDetail")
-  const [activeTab, setActiveTab] = useState("overview")
-  const patient = DEMO_PATIENT
+  // Profil (PII déchiffrée serveur) + objectifs + référent — audité (READ PATIENT).
+  const patient = await patientService.getById(patientId, userId, ctx)
+  if (!patient) notFound()
 
-  return (
-    <>
-      <DashboardHeader
-        title={patient.name}
-        subtitle={t("subtitle", {
-          pathology: patient.pathology,
-          age: patient.age,
-          referent: patient.referent,
-        })}
-      />
+  // Stats glycémiques — projection serveur (audité READ ANALYTICS).
+  const profile = await analyticsService.glycemicProfile(patientId, OVERVIEW_PERIOD, userId, ctx)
 
-      <div className="p-6">
-        <Tabs value={activeTab} onValueChange={setActiveTab}>
-          <TabsList className="mb-6" aria-label={t("tabsAriaLabel")}>
-            <TabsTrigger value="overview">{t("tabOverview")}</TabsTrigger>
-            <TabsTrigger value="glycemia">{t("tabGlycemia")}</TabsTrigger>
-            <TabsTrigger value="treatment">{t("tabTreatment")}</TabsTrigger>
-            <TabsTrigger value="documents">{t("tabDocuments")}</TabsTrigger>
-          </TabsList>
+  const now = new Date()
+  const cgmObj = patient.cgmObjectives
+  const targetLowMgdl = cgmObj ? Math.round(Number(cgmObj.titrLow) * 100) : GLYCEMIA_THRESHOLDS_MGDL.TARGET_LOW
+  const targetHighMgdl = cgmObj ? Math.round(Number(cgmObj.titrHigh) * 100) : GLYCEMIA_THRESHOLDS_MGDL.TARGET_HIGH
 
-          {/* ── Overview Tab ──────────────────────────────── */}
-          <TabsContent value="overview" className="space-y-6">
-            {/* KPI row */}
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-              <StatCard
-                label={t("kpiCurrentGlucose")}
-                value={String(patient.lastGlucoseMgdl)}
-                unit="mg/dL"
-                icon={<Activity className="h-5 w-5" />}
-                variant="success"
-              />
-              <StatCard
-                label={t("kpiTir7d")}
-                value={`${patient.tir.inRange}%`}
-                icon={<TrendingUp className="h-5 w-5" />}
-                variant={patient.tir.inRange >= 70 ? "success" : "warning"}
-              />
-              <StatCard
-                label={t("kpiGmi")}
-                value={`${patient.gmi}%`}
-                icon={<Heart className="h-5 w-5" />}
-                variant="default"
-              />
-              <StatCard
-                label={t("kpiCv")}
-                value={`${patient.cv}%`}
-                icon={<Clock className="h-5 w-5" />}
-                variant={patient.cv <= 36 ? "success" : "warning"}
-              />
-            </div>
+  const referentName =
+    patient.referent?.pro?.name ?? patient.patientServices?.[0]?.service?.name ?? null
 
-            {/* Profile + TIR */}
-            <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-              {/* Profile card */}
-              <Card className="lg:col-span-2">
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2 text-base">
-                    <User className="h-4 w-4" aria-hidden="true" />
-                    {t("profileTitle")}
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="grid grid-cols-2 gap-4 text-sm">
-                    <div>
-                      <span className="text-muted-foreground">{t("pathology")}</span>
-                      <div className="mt-1">
-                        <ClinicalBadge type="pathology" value={patient.pathology} />
-                      </div>
-                    </div>
-                    <div>
-                      <span className="text-muted-foreground">{t("diagnostic")}</span>
-                      <p className="mt-1 font-medium">{patient.diagYear}</p>
-                    </div>
-                    <div>
-                      <span className="text-muted-foreground">{t("sex")}</span>
-                      <p className="mt-1 font-medium">{patient.sex === "F" ? t("female") : t("male")}</p>
-                    </div>
-                    <div>
-                      <span className="text-muted-foreground">{t("age")}</span>
-                      <p className="mt-1 font-medium">{t("ageValue", { age: patient.age })}</p>
-                    </div>
-                    <div>
-                      <span className="text-muted-foreground">{t("referentDoctor")}</span>
-                      <p className="mt-1 font-medium">{patient.referent}</p>
-                    </div>
-                    <div>
-                      <span className="text-muted-foreground">{t("avgGlucose14d")}</span>
-                      <div className="mt-1">
-                        <GlycemiaValue value={patient.avgGlucoseMgdl} unit="mg/dL" size="sm" />
-                      </div>
-                    </div>
-                  </div>
+  const fullName = `${patient.user.firstname ?? ""} ${patient.user.lastname ?? ""}`.trim()
 
-                  <Separator className="my-4" />
+  const data: PatientDetailData = {
+    id: patient.id,
+    name: fullName,
+    age: computeAge(patient.user.birthday ?? null, now),
+    sex: patient.user.sex ?? null,
+    pathology: patient.pathology ?? null,
+    diagYear: patient.medicalData?.yearDiag ?? null,
+    referent: referentName,
+    objectives: {
+      targetLowMgdl,
+      targetHighMgdl,
+      tirTargetPct: CONSENSUS_TIR_TARGET_PCT,
+      hypoMaxPct: CONSENSUS_HYPO_MAX_PCT,
+    },
+    stats:
+      profile.readingCount > 0
+        ? {
+            avgGlucoseMgdl: profile.metrics.averageGlucoseMgdl,
+            gmi: profile.metrics.gmi,
+            cv: profile.metrics.coefficientOfVariation,
+            // analytics.tir (severeHypo/hypo/inRange/elevated/hyper) → TirData.
+            tir: {
+              veryLow: profile.tir.severeHypo,
+              low: profile.tir.hypo,
+              inRange: profile.tir.inRange,
+              high: profile.tir.elevated,
+              veryHigh: profile.tir.hyper,
+            },
+            readingCount: profile.readingCount,
+          }
+        : null,
+  }
 
-                  <div className="text-sm">
-                    <span className="text-muted-foreground">{t("glycemicObjectives")}</span>
-                    <div className="mt-2 flex flex-wrap gap-2">
-                      <Badge variant="outline">
-                        {t("targetBadge", {
-                          low: patient.objectives.targetLow,
-                          high: patient.objectives.targetHigh,
-                        })}
-                      </Badge>
-                      <Badge variant="outline">
-                        {t("tirTargetBadge", { target: patient.objectives.tirTarget })}
-                      </Badge>
-                      <Badge variant="outline">
-                        {t("hypoMaxBadge", { target: patient.objectives.hypoTarget })}
-                      </Badge>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-
-              {/* TIR Donut */}
-              <Card>
-                <CardHeader>
-                  <CardTitle className="text-base"><Acronym code="TIR" /> {t("tirDonutPeriod")}</CardTitle>
-                </CardHeader>
-                <CardContent className="flex justify-center">
-                  <TirDonut
-                    data={patient.tir}
-                    size={180}
-                    showLegend
-                  />
-                </CardContent>
-              </Card>
-            </div>
-          </TabsContent>
-
-          {/* ── Glycemia Tab (US-803) ────────────────────── */}
-          <TabsContent value="glycemia" className="space-y-6">
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-base">
-                  <Activity className="h-4 w-4" aria-hidden="true" />
-                  {t("glycemicProfile24h")}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <CgmChart
-                  data={DEMO_CGM}
-                  targetLow={patient.objectives.targetLow}
-                  targetHigh={patient.objectives.targetHigh}
-                />
-              </CardContent>
-            </Card>
-          </TabsContent>
-
-          {/* ── Treatment Tab ────────────────────────────── */}
-          <TabsContent value="treatment" className="space-y-6">
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-base">
-                  <Syringe className="h-4 w-4" aria-hidden="true" />
-                  {t("insulinConfigTitle")}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="grid grid-cols-2 gap-4 text-sm">
-                  <div>
-                    <span className="text-muted-foreground">{t("method")}</span>
-                    <p className="mt-1 font-medium">{patient.insulinSettings.delivery}</p>
-                  </div>
-                  <div>
-                    <span className="text-muted-foreground">{t("pump")}</span>
-                    <p className="mt-1 font-medium">{patient.insulinSettings.pump}</p>
-                  </div>
-                  <div>
-                    <span className="text-muted-foreground">{t("bolusInsulin")}</span>
-                    <p className="mt-1 font-medium">{patient.insulinSettings.bolusInsulin}</p>
-                  </div>
-                  <div>
-                    <span className="text-muted-foreground">{t("avgBasalRate")}</span>
-                    <p className="mt-1 font-medium">{patient.insulinSettings.basalRate}</p>
-                  </div>
-                  <div>
-                    <span className="text-muted-foreground"><Acronym code="ICR" /> {t("average")}</span>
-                    <p className="mt-1 font-medium">{patient.insulinSettings.icr}</p>
-                  </div>
-                  <div>
-                    <span className="text-muted-foreground"><Acronym code="ISF" /> {t("average")}</span>
-                    <p className="mt-1 font-medium">{patient.insulinSettings.isf}</p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-base">
-                  <Pill className="h-4 w-4" aria-hidden="true" />
-                  {t("associatedTreatmentsTitle")}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground">
-                  {t("noComplementaryTreatment")}
-                </p>
-              </CardContent>
-            </Card>
-          </TabsContent>
-
-          {/* ── Documents Tab ────────────────────────────── */}
-          <TabsContent value="documents" className="space-y-6">
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-base">
-                  <Calendar className="h-4 w-4" aria-hidden="true" />
-                  {t("medicalDocumentsTitle")}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground">
-                  {t("noDocument")}
-                </p>
-              </CardContent>
-            </Card>
-          </TabsContent>
-        </Tabs>
-      </div>
-    </>
-  )
+  return <PatientDetailClient data={data} />
 }

--- a/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/src/app/(dashboard)/patients/[id]/page.tsx
@@ -5,30 +5,33 @@
  * profil + objectifs + stats glycémiques (TIR/GMI/CV/moyenne) RÉELS, scopés
  * serveur, PII déchiffrée serveur, accès audité (ADR #18). Les onglets Glycémie /
  * Traitements / Documents arrivent dans les phases suivantes (état « bientôt
- * disponible » en attendant — jamais de données démo).
+ * disponible » — jamais de données démo).
  *
  * Sécurité :
- *  - `canAccessPatient` (RBAC : ADMIN / DOCTOR-NURSE via service / VIEWER self) ;
- *    accès refusé → `notFound()` (404 uniforme, anti-énumération).
- *  - Aucune statistique clinique calculée côté frontend : tout vient des
- *    projections serveur (`analyticsService.glycemicProfile`).
+ *  - `canAccessPatient` (RBAC) ; refus → audit `accessDenied` + `notFound()`
+ *    (404 uniforme, anti-énumération + détection d'abus US-2265).
+ *  - Garde consentement `shareWithProviders` (cohérence avec routes cgm/analytics) :
+ *    opt-out explicite du patient → aucune donnée rendue (PHI non déchiffrée).
+ *  - Aucune statistique clinique calculée côté frontend (projections serveur).
  */
 
 import { headers } from "next/headers"
 import { notFound, redirect } from "next/navigation"
 import type { Role } from "@prisma/client"
+import { prisma } from "@/lib/db/client"
 import { patientService } from "@/lib/services/patient.service"
 import { analyticsService } from "@/lib/services/analytics.service"
+import { auditService } from "@/lib/services/audit.service"
 import { canAccessPatient } from "@/lib/access-control"
-import { GLYCEMIA_THRESHOLDS_MGDL } from "@/lib/glycemia-thresholds"
 import { PatientDetailClient, type PatientDetailData } from "./PatientDetailClient"
 
-// Période d'agrégation de la vue d'ensemble (jours). Bornée < 90j (analytics).
+// Période d'agrégation de la vue d'ensemble. Bornée < 90j (analytics).
 const OVERVIEW_PERIOD = "14d"
 // Cibles consensus ADA/EASD (identiques pour tous les patients, pas des champs
-// patient) — TIR ≥ 70 %, temps < 70 mg/dL ≤ 4 %.
+// patient) — TIR ≥ 70 %, temps < 70 mg/dL ≤ 4 %, CV ≤ 36 % (stabilité glycémique).
 const CONSENSUS_TIR_TARGET_PCT = 70
 const CONSENSUS_HYPO_MAX_PCT = 4
+const CONSENSUS_CV_MAX_PCT = 36
 
 function computeAge(birthday: Date | null | undefined, now: Date): number | null {
   if (!birthday) return null
@@ -52,14 +55,41 @@ export default async function PatientDetailPage({
   const role = h.get("x-user-role") as Role | null
   if (!userId || !Number.isInteger(userId) || !role) redirect("/login")
 
-  // Garde d'accès — refus = 404 uniforme (ne révèle pas l'existence du patient).
-  const allowed = await canAccessPatient(userId, role, patientId)
-  if (!allowed) notFound()
-
   const ctx = {
     ipAddress: (h.get("x-forwarded-for")?.split(",")[0] ?? "").trim() || "unknown",
     userAgent: h.get("user-agent") || "unknown",
     requestId: h.get("x-request-id") || "rsc-patient-detail",
+  }
+
+  // Garde d'accès (RBAC). NB : un VIEWER n'atteint jamais cette route — le
+  // layout (dashboard) le redirige vers /patient/dashboard ; la branche VIEWER
+  // de canAccessPatient est donc inerte ici (défense en profondeur).
+  const allowed = await canAccessPatient(userId, role, patientId)
+  if (!allowed) {
+    // Tentative hors périmètre → trace SOC (détection d'énumération US-2265)
+    // AVANT le 404 uniforme.
+    await auditService.accessDenied({
+      userId, resource: "PATIENT", resourceId: String(patientId),
+      ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+      metadata: { patientId, surface: "patient-detail-page" },
+    })
+    notFound()
+  }
+
+  // Garde consentement `shareWithProviders` AVANT tout déchiffrement PII
+  // (cohérence avec /api/patients/[id]/cgm et /analytics). Fail-open si pas de
+  // row (patient récent). Opt-out → aucune donnée rendue.
+  const base = await prisma.patient.findFirst({
+    where: { id: patientId, deletedAt: null },
+    select: { userId: true },
+  })
+  if (!base) notFound()
+  const privacy = await prisma.userPrivacySettings.findUnique({
+    where: { userId: base.userId },
+    select: { shareWithProviders: true },
+  })
+  if (privacy && !privacy.shareWithProviders) {
+    return <PatientDetailClient data={null} sharingDisabled />
   }
 
   // Profil (PII déchiffrée serveur) + objectifs + référent — audité (READ PATIENT).
@@ -71,11 +101,10 @@ export default async function PatientDetailPage({
 
   const now = new Date()
   const cgmObj = patient.cgmObjectives
-  const targetLowMgdl = cgmObj ? Math.round(Number(cgmObj.titrLow) * 100) : GLYCEMIA_THRESHOLDS_MGDL.TARGET_LOW
-  const targetHighMgdl = cgmObj ? Math.round(Number(cgmObj.titrHigh) * 100) : GLYCEMIA_THRESHOLDS_MGDL.TARGET_HIGH
-
-  const referentName =
-    patient.referent?.pro?.name ?? patient.patientServices?.[0]?.service?.name ?? null
+  // Cible affichée = MÊMES bornes que le calcul TIR serveur (cgm.low / cgm.ok),
+  // pas titrLow/titrHigh (qui peuvent diverger). Défaut 70/180 si pas d'objectif.
+  const targetLowMgdl = cgmObj ? Math.round(Number(cgmObj.low) * 100) : 70
+  const targetHighMgdl = cgmObj ? Math.round(Number(cgmObj.ok) * 100) : 180
 
   const fullName = `${patient.user.firstname ?? ""} ${patient.user.lastname ?? ""}`.trim()
 
@@ -86,12 +115,14 @@ export default async function PatientDetailPage({
     sex: patient.user.sex ?? null,
     pathology: patient.pathology ?? null,
     diagYear: patient.medicalData?.yearDiag ?? null,
-    referent: referentName,
+    // Référent = médecin référent uniquement (le libellé est « Médecin référent »).
+    referent: patient.referent?.pro?.name ?? null,
     objectives: {
       targetLowMgdl,
       targetHighMgdl,
       tirTargetPct: CONSENSUS_TIR_TARGET_PCT,
       hypoMaxPct: CONSENSUS_HYPO_MAX_PCT,
+      cvMaxPct: CONSENSUS_CV_MAX_PCT,
     },
     stats:
       profile.readingCount > 0
@@ -99,7 +130,6 @@ export default async function PatientDetailPage({
             avgGlucoseMgdl: profile.metrics.averageGlucoseMgdl,
             gmi: profile.metrics.gmi,
             cv: profile.metrics.coefficientOfVariation,
-            // analytics.tir (severeHypo/hypo/inRange/elevated/hyper) → TirData.
             tir: {
               veryLow: profile.tir.severeHypo,
               low: profile.tir.hypo,
@@ -108,6 +138,10 @@ export default async function PatientDetailPage({
               veryHigh: profile.tir.hyper,
             },
             readingCount: profile.readingCount,
+            captureRate: profile.captureRate,
+            // Sécurité clinique : sous 70 % de capture CGM, GMI/TIR/moyenne ne
+            // sont pas représentatifs (consensus ADA/EASD) → caveat UI.
+            insufficientCapture: profile.warning === "insufficientCgmCapture",
           }
         : null,
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -231,7 +231,9 @@ export async function middleware(request: NextRequest) {
     // arrivent (PR #438 patient module + PR #440 messaging).
     // #475 — `/settings` affiche des PII (nom/naissance) et, pour un patient,
     // NIRPP/INS/données médicales : même posture no-store que les autres pages.
-    const PHI_PATH_PREFIXES = ["/patient/", "/messages/", "/messages", "/settings/", "/settings"]
+    // `/patients` (pluriel, dossier patient pro) rend du PHI déchiffré en SSR
+    // depuis le câblage données réelles (Phase 1) → même posture no-store.
+    const PHI_PATH_PREFIXES = ["/patient/", "/patients/", "/patients", "/messages/", "/messages", "/settings/", "/settings"]
     if (PHI_PATH_PREFIXES.some((p) => pathname === p || pathname.startsWith(p))) {
       res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, private")
       res.headers.set("Pragma", "no-cache")

--- a/tests/components/patient-detail-client.test.tsx
+++ b/tests/components/patient-detail-client.test.tsx
@@ -56,13 +56,15 @@ const baseData: PatientDetailData = {
   pathology: "DT1",
   diagYear: 2015,
   referent: "Dr House",
-  objectives: { targetLowMgdl: 70, targetHighMgdl: 180, tirTargetPct: 70, hypoMaxPct: 4 },
+  objectives: { targetLowMgdl: 70, targetHighMgdl: 180, tirTargetPct: 70, hypoMaxPct: 4, cvMaxPct: 36 },
   stats: {
     avgGlucoseMgdl: 158,
     gmi: 7.1,
     cv: 34.2,
     tir: { veryLow: 1, low: 3, inRange: 75, high: 17, veryHigh: 4 },
     readingCount: 1200,
+    captureRate: 92,
+    insufficientCapture: false,
   },
 }
 
@@ -98,6 +100,22 @@ describe("PatientDetailClient (Phase 1)", () => {
     // Glycémie + Traitements + Documents → 3 états vides
     expect(screen.getAllByTestId("empty")).toHaveLength(3)
     expect(screen.getAllByText(/Bientôt disponible/).length).toBe(3)
+  })
+
+  it("renders the sharing-disabled state (no PHI) when consent is withdrawn", () => {
+    render(<PatientDetailClient data={null} sharingDisabled />)
+    expect(screen.getByText(/Partage désactivé/)).toBeTruthy()
+    expect(screen.queryByTestId("stat")).toBeNull()
+    expect(screen.queryByText("Jean Dupont")).toBeNull()
+  })
+
+  it("shows the low-CGM-capture caveat when capture is insufficient", () => {
+    render(
+      <PatientDetailClient
+        data={{ ...baseData, stats: { ...baseData.stats!, captureRate: 35, insufficientCapture: true } }}
+      />,
+    )
+    expect(screen.getByText(/\(CGM\) insuffisante \(35 %\)/)).toBeTruthy()
   })
 
   it("degrades gracefully on missing profile fields (fallbacks)", () => {

--- a/tests/components/patient-detail-client.test.tsx
+++ b/tests/components/patient-detail-client.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Tests — PatientDetailClient (câblage données patient, Phase 1).
+ *
+ * Vérifie le rendu/branchement client (valeurs serveur affichées telles
+ * quelles, état « pas de CGM », onglets non câblés en « bientôt disponible ») ;
+ * la garde d'accès + l'audit sont côté Server Component / services (testés
+ * ailleurs).
+ */
+
+import { describe, it, expect, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+
+vi.mock("next-intl", async () => (await import("../helpers/nextIntlMock")).makeNextIntlMock())
+
+// Tabs base-ui → rend TOUT le contenu (pas d'interaction d'onglet à piloter).
+vi.mock("@/components/ui/tabs", () => ({
+  Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+  TabsContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+// Composants présentation → stubs légers exposant label/valeur.
+vi.mock("@/components/diabeo", () => ({
+  StatCard: ({ label, value, unit }: { label: string; value: string; unit?: string }) => (
+    <div data-testid="stat">{label}: {value}{unit ? ` ${unit}` : ""}</div>
+  ),
+  TirDonut: () => <div data-testid="tir-donut" />,
+  ClinicalBadge: ({ value }: { value: string }) => <span data-testid="pathology">{value}</span>,
+  GlycemiaValue: ({ value }: { value: number }) => <span data-testid="glyc">{value}</span>,
+}))
+vi.mock("@/components/diabeo/DashboardHeader", () => ({
+  DashboardHeader: ({ title, subtitle }: { title: string; subtitle: string }) => (
+    <header><h1>{title}</h1><p>{subtitle}</p></header>
+  ),
+}))
+vi.mock("@/components/diabeo/Acronym", () => ({
+  Acronym: ({ code }: { code: string }) => <abbr>{code}</abbr>,
+}))
+vi.mock("@/components/diabeo/DiabeoEmptyState", () => ({
+  DiabeoEmptyState: ({ title, message }: { title: string; message: string }) => (
+    <div data-testid="empty">{title} — {message}</div>
+  ),
+}))
+
+import { PatientDetailClient, type PatientDetailData } from "@/app/(dashboard)/patients/[id]/PatientDetailClient"
+
+const baseData: PatientDetailData = {
+  id: 42,
+  name: "Jean Dupont",
+  age: 34,
+  sex: "F",
+  pathology: "DT1",
+  diagYear: 2015,
+  referent: "Dr House",
+  objectives: { targetLowMgdl: 70, targetHighMgdl: 180, tirTargetPct: 70, hypoMaxPct: 4 },
+  stats: {
+    avgGlucoseMgdl: 158,
+    gmi: 7.1,
+    cv: 34.2,
+    tir: { veryLow: 1, low: 3, inRange: 75, high: 17, veryHigh: 4 },
+    readingCount: 1200,
+  },
+}
+
+describe("PatientDetailClient (Phase 1)", () => {
+  it("renders the patient name + server-computed KPIs", () => {
+    render(<PatientDetailClient data={baseData} />)
+    expect(screen.getByText("Jean Dupont")).toBeTruthy()
+    const stats = screen.getAllByTestId("stat").map((n) => n.textContent)
+    expect(stats.some((s) => s?.includes("158"))).toBe(true) // moyenne mg/dL
+    expect(stats.some((s) => s?.includes("75%"))).toBe(true) // TIR inRange
+    expect(stats.some((s) => s?.includes("7.1%"))).toBe(true) // GMI
+    expect(stats.some((s) => s?.includes("34.2%"))).toBe(true) // CV
+    expect(screen.getByTestId("tir-donut")).toBeTruthy()
+    expect(screen.getByTestId("pathology").textContent).toBe("DT1")
+  })
+
+  it("renders objective badges from server data (range + consensus targets)", () => {
+    render(<PatientDetailClient data={baseData} />)
+    expect(screen.getByText("Cible : 70–180 mg/dL")).toBeTruthy()
+    expect(screen.getByText("Cible (TIR) : 70%")).toBeTruthy()
+    expect(screen.getByText("Hypo max : 4%")).toBeTruthy()
+  })
+
+  it("shows the no-CGM state (no KPIs, no donut) when stats are null", () => {
+    render(<PatientDetailClient data={{ ...baseData, stats: null }} />)
+    expect(screen.queryByTestId("stat")).toBeNull()
+    expect(screen.queryByTestId("tir-donut")).toBeNull()
+    expect(screen.getAllByText("Pas de données de glycémie continue (CGM) sur la période.").length).toBeGreaterThan(0)
+  })
+
+  it("renders « coming soon » for the not-yet-wired tabs", () => {
+    render(<PatientDetailClient data={baseData} />)
+    // Glycémie + Traitements + Documents → 3 états vides
+    expect(screen.getAllByTestId("empty")).toHaveLength(3)
+    expect(screen.getAllByText(/Bientôt disponible/).length).toBe(3)
+  })
+
+  it("degrades gracefully on missing profile fields (fallbacks)", () => {
+    render(
+      <PatientDetailClient
+        data={{ ...baseData, name: "", pathology: null, diagYear: null, age: null, referent: null, sex: null }}
+      />,
+    )
+    expect(screen.getByText("Patient")).toBeTruthy() // patientFallback
+    expect(screen.queryByTestId("pathology")).toBeNull() // pas de badge si pathologie absente
+  })
+})


### PR DESCRIPTION
## Câblage des vraies données patient — Phase 1

Premier incrément du chantier « câbler les vraies données patient » (prérequis du dossier en onglets US-2604 et de la barre de contexte US-2603). **Plan complet tracé** dans `docs/UserStory/Navigation/cablage-donnees-patient.md`.

Remplace la page dossier patient **démo** (`DEMO_PATIENT` / `DEMO_CGM`) par les **vraies données**, en Server Component scopé + audité.

### Ce que fait la Phase 1
- **`page.tsx` → Server Component** :
  - garde d'accès `canAccessPatient` (ADMIN / DOCTOR-NURSE via service / VIEWER self) ; refus → `notFound()` (**404 uniforme, anti-énumération**).
  - profil **PII déchiffrée serveur** (`patientService.getById`, audit `READ PATIENT` + pivot `metadata.patientId` ADR #18).
  - stats **calculées serveur** (`analyticsService.glycemicProfile`, audit `READ ANALYTICS`) — **aucune statistique clinique côté frontend**.
- **`PatientDetailClient.tsx`** : onglet **Vue d'ensemble** réel — KPIs (moyenne/TIR/GMI/CV), carte profil (pathologie/diag/sexe/âge/référent), objectifs, donut TIR. Mapping TIR `analytics`→`TirData` ; cible depuis `cgmObjectives.titrLow/High` ; cibles consensus ADA/EASD (TIR ≥ 70 %, hypo < 4 %). État **« pas de CGM »** si aucune donnée.
- Onglets **Glycémie / Traitements / Documents** → **« bientôt disponible »** (Phases 2-4) — **plus aucune donnée démo**.

### Sécurité / conformité
- PII déchiffrée **serveur uniquement**, jamais en clair dans les logs ; pas de PHI en URL (id numérique).
- Accès **audité** (profil + analytics) avec pivot patient (forensics ADR #18).
- ⚠️ **Point ouvert pour la revue** (documenté) : `getById` ne filtre pas le consentement `shareWithProviders` (accès PS = base légale Art. 9.2.h) — à arbitrer avec `healthcare-security-auditor` (cohérence avec routes `cgm`/`analytics` qui le vérifient).

### Tests & checks
- `patient-detail-client.test.tsx` (5 cas : KPIs réels, objectifs, état no-CGM, onglets « bientôt disponible », fallbacks profil manquant).
- Suite complète : **217 fichiers / 3070 tests** verts. `tsc` exit 0, design-system baseline (285), parité i18n FR/EN/AR OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)