### PR TITLE
feat(patient): câblage données réelles — Phase 4 (onglet Documents)

### DIFF
--- a/docs/UserStory/Navigation/cablage-donnees-patient.md
+++ b/docs/UserStory/Navigation/cablage-donnees-patient.md
@@ -136,3 +136,9 @@ dans des tickets dédiés, pas dans le câblage des onglets.
   catalogue/device — à ajouter à l'onglet Traitements.
 - **[i18n] Clé unité ISF dupliquée** : `dashboardCards.medecinProposals.unitIsfGl`
   ≈ `patientDetail.unitIsf` (« g/L/U ») — consolider une source unique.
+- **[Sécu] Route download — `documentNotFound` vs `patientNotFound`** : 2 chaînes
+  d'erreur 404 distinctes (oracle d'énumération mineur) — uniformiser en `notFound`
+  neutre (Phase 4 a déjà ajouté la garde consentement `shareWithProviders` PRO).
+- **[Sécu] Convergence consentement download/list** : la garde `shareWithProviders`
+  PRO est désormais sur la route download ET la liste, mais via des checks inline ;
+  à converger sur le helper unique (cf. item « convergence des sémantiques »).

--- a/docs/UserStory/Navigation/cablage-donnees-patient.md
+++ b/docs/UserStory/Navigation/cablage-donnees-patient.md
@@ -71,7 +71,13 @@
   associés (`getById.treatments`, soft-deleted filtrés). Mapping pur
   `treatment-view.ts` (unit-testé). Insuline bolus/modèle pompe (catalogue/
   device) → backlog. État vide si pas de réglages.
-- [ ] **Phase 4 — Onglet Documents** : documents médicaux réels (MinIO).
+- [x] **Phase 4 — Onglet Documents** (PR #546) : liste documents médicaux réels
+  via `documentService.list` (scopé serveur — VIEWER ne voit que `patientShare`,
+  `fileUrl` omis, audité READ MEDICAL_DOCUMENT, derrière la garde accès+
+  consentement). Affiche titre / catégorie / date / taille + **téléchargement**
+  via `/api/documents/[id]/download` (auth + scope + ClamAV serveur). Mapping pur
+  `document-view.ts` (unit-testé). État vide « Aucun document ». **Chantier
+  câblage données patient terminé.**
 
 ## Points de vigilance (revue) — tranchés en Phase 1
 

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1565,8 +1565,6 @@
     "noComplementaryTreatment": "لا يوجد علاج تكميلي مسجّل",
     "medicalDocumentsTitle": "المستندات الطبية",
     "noDocument": "لا يوجد مستند مسجّل",
-    "comingSoon": "قريبًا",
-    "comingSoonDesc": "سيتم ربط هذا القسم بالبيانات الحقيقية قريبًا.",
     "noCgmData": "لا توجد بيانات الغلوكوز المستمر (CGM) للفترة.",
     "patientFallback": "مريض",
     "kpiTir14d": "الوقت ضمن النطاق (TIR) — 14 يومًا",
@@ -1584,7 +1582,18 @@
     "basalLabel": "المعدل القاعدي",
     "unitIsf": "g/L/U",
     "unitIcr": "g/U",
-    "unitBasal": "U/h"
+    "unitBasal": "U/h",
+    "download": "تنزيل",
+    "uncategorized": "بدون فئة",
+    "sizeBytes": "بايت",
+    "sizeKb": "ك.ب",
+    "sizeMb": "م.ب",
+    "docCatGeneral": "عام",
+    "docCatForDoctor": "للطبيب",
+    "docCatPersonal": "شخصي",
+    "docCatPrescription": "وصفة طبية",
+    "docCatLabResults": "نتائج المختبر",
+    "docCatOther": "أخرى"
   },
   "patientDashboard": {
     "pageTitle": "لوحة التحكم الخاصة بي",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1565,8 +1565,6 @@
     "noComplementaryTreatment": "No complementary treatment recorded",
     "medicalDocumentsTitle": "Medical documents",
     "noDocument": "No document recorded",
-    "comingSoon": "Coming soon",
-    "comingSoonDesc": "This section will be wired to real data soon.",
     "noCgmData": "No continuous glucose (CGM) data for the period.",
     "patientFallback": "Patient",
     "kpiTir14d": "Time in range (TIR) — 14d",
@@ -1584,7 +1582,18 @@
     "basalLabel": "Basal rate",
     "unitIsf": "g/L/U",
     "unitIcr": "g/U",
-    "unitBasal": "U/h"
+    "unitBasal": "U/h",
+    "download": "Download",
+    "uncategorized": "Uncategorized",
+    "sizeBytes": "B",
+    "sizeKb": "KB",
+    "sizeMb": "MB",
+    "docCatGeneral": "General",
+    "docCatForDoctor": "For the doctor",
+    "docCatPersonal": "Personal",
+    "docCatPrescription": "Prescription",
+    "docCatLabResults": "Lab results",
+    "docCatOther": "Other"
   },
   "patientDashboard": {
     "pageTitle": "My dashboard",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1565,8 +1565,6 @@
     "noComplementaryTreatment": "Aucun traitement complémentaire enregistré",
     "medicalDocumentsTitle": "Documents médicaux",
     "noDocument": "Aucun document enregistré",
-    "comingSoon": "Bientôt disponible",
-    "comingSoonDesc": "Cette section sera câblée aux données réelles prochainement.",
     "noCgmData": "Pas de données de glycémie continue (CGM) sur la période.",
     "patientFallback": "Patient",
     "kpiTir14d": "Temps dans la cible (TIR) — 14j",
@@ -1584,7 +1582,18 @@
     "basalLabel": "Débit basal",
     "unitIsf": "g/L/U",
     "unitIcr": "g/U",
-    "unitBasal": "U/h"
+    "unitBasal": "U/h",
+    "download": "Télécharger",
+    "uncategorized": "Sans catégorie",
+    "sizeBytes": "o",
+    "sizeKb": "Ko",
+    "sizeMb": "Mo",
+    "docCatGeneral": "Général",
+    "docCatForDoctor": "Pour le médecin",
+    "docCatPersonal": "Personnel",
+    "docCatPrescription": "Ordonnance",
+    "docCatLabResults": "Résultats de laboratoire",
+    "docCatOther": "Autre"
   },
   "patientDashboard": {
     "pageTitle": "Mon tableau de bord",

--- a/src/app/(dashboard)/patients/[id]/PatientDetailClient.tsx
+++ b/src/app/(dashboard)/patients/[id]/PatientDetailClient.tsx
@@ -3,8 +3,7 @@
  *
  * Reçoit les données déjà résolues/auditées par le Server Component parent
  * (`page.tsx`). Ne fait AUCUN calcul clinique : rend les valeurs serveur.
- * Phase 1 : onglet « Vue d'ensemble » câblé ; Glycémie / Traitements /
- * Documents → état « bientôt disponible » (phases suivantes).
+ * Les 4 onglets (Vue d'ensemble, Glycémie, Traitements, Documents) sont câblés.
  */
 
 "use client"
@@ -414,7 +413,7 @@ export function PatientDetailClient({
                           </span>
                         </span>
                         <a
-                          href={`/api/documents/${doc.id}/download`}
+                          href={`/api/documents/${doc.id}/download?patientId=${data.id}`}
                           className="inline-flex h-8 shrink-0 items-center gap-1 rounded-md border border-border px-2 text-xs hover:bg-muted"
                         >
                           <Download size={14} aria-hidden="true" />

--- a/src/app/(dashboard)/patients/[id]/PatientDetailClient.tsx
+++ b/src/app/(dashboard)/patients/[id]/PatientDetailClient.tsx
@@ -10,20 +10,22 @@
 "use client"
 
 import { useState, type ReactNode } from "react"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { DashboardHeader } from "@/components/diabeo/DashboardHeader"
 import { GlycemiaValue, TirDonut, ClinicalBadge, StatCard } from "@/components/diabeo"
 import type { TirData } from "@/components/diabeo/TirDonut"
 import { Acronym } from "@/components/diabeo/Acronym"
 import { DiabeoEmptyState } from "@/components/diabeo/DiabeoEmptyState"
 import { CgmChart } from "@/components/diabeo/CgmChart"
+import { bcp47 } from "@/i18n/config"
 import type { GlycemiaView } from "./glycemia-view"
 import type { TreatmentView } from "./treatment-view"
+import type { DocumentItem } from "./document-view"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Separator } from "@/components/ui/separator"
 import { Badge } from "@/components/ui/badge"
-import { Activity, Clock, Heart, Pill, Syringe, TrendingUp, User } from "lucide-react"
+import { Activity, Clock, Download, FileText, Heart, Pill, Syringe, TrendingUp, User } from "lucide-react"
 
 export type PatientDetailData = {
   id: number
@@ -55,6 +57,18 @@ export type PatientDetailData = {
   glycemia: GlycemiaView
   /** Réglages insuline (par créneau) + traitements associés. */
   treatment: TreatmentView
+  /** Documents médicaux (métadonnées ; téléchargement via route sécurisée). */
+  documents: DocumentItem[]
+}
+
+/** category enum → clé i18n du libellé. */
+const DOC_CATEGORY_KEY: Record<string, string> = {
+  general: "docCatGeneral",
+  forDoctor: "docCatForDoctor",
+  personal: "docCatPersonal",
+  prescription: "docCatPrescription",
+  labResults: "docCatLabResults",
+  other: "docCatOther",
 }
 
 export function PatientDetailClient({
@@ -65,6 +79,7 @@ export function PatientDetailClient({
   sharingDisabled?: boolean
 }) {
   const t = useTranslations("patientDetail")
+  const locale = useLocale()
   const [activeTab, setActiveTab] = useState("overview")
 
   // Consentement retiré : aucune donnée patient rendue (cf. page.tsx).
@@ -369,9 +384,50 @@ export function PatientDetailClient({
             </Card>
           </TabsContent>
 
-          {/* ── Documents (phase suivante) ── */}
-          <TabsContent value="documents">
-            <ComingSoon t={t} />
+          {/* ── Documents (câblé — Phase 4) ─────────────────── */}
+          <TabsContent value="documents" className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <FileText className="h-4 w-4" aria-hidden="true" />
+                  {t("medicalDocumentsTitle")}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {data.documents.length > 0 ? (
+                  <ul className="space-y-2 text-sm">
+                    {data.documents.map((doc) => (
+                      <li
+                        key={doc.id}
+                        className="flex items-center gap-3 rounded-md border border-border bg-card px-3 py-2"
+                      >
+                        <FileText size={16} aria-hidden="true" className="shrink-0 text-muted-foreground" />
+                        <span className="flex min-w-0 flex-1 flex-col">
+                          <span className="truncate font-medium">{doc.title}</span>
+                          <span className="text-xs text-muted-foreground">
+                            {doc.category ? t(DOC_CATEGORY_KEY[doc.category] ?? "uncategorized") : t("uncategorized")}
+                            {" · "}
+                            {new Date(doc.dateIso).toLocaleDateString(bcp47(locale), {
+                              day: "2-digit", month: "2-digit", year: "numeric", timeZone: "Europe/Paris",
+                            })}
+                            {doc.size && ` · ${doc.size.value} ${t(doc.size.unitKey)}`}
+                          </span>
+                        </span>
+                        <a
+                          href={`/api/documents/${doc.id}/download`}
+                          className="inline-flex h-8 shrink-0 items-center gap-1 rounded-md border border-border px-2 text-xs hover:bg-muted"
+                        >
+                          <Download size={14} aria-hidden="true" />
+                          {t("download")}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-sm text-muted-foreground">{t("noDocument")}</p>
+                )}
+              </CardContent>
+            </Card>
           </TabsContent>
         </Tabs>
       </div>
@@ -411,12 +467,3 @@ function ageLabel(t: ReturnType<typeof useTranslations>, ageMin: number): string
   return ageMin < 60 ? t("agoMinutes", { n: ageMin }) : t("agoHours", { n: Math.floor(ageMin / 60) })
 }
 
-function ComingSoon({ t }: { t: ReturnType<typeof useTranslations> }) {
-  return (
-    <Card>
-      <CardContent className="py-10">
-        <DiabeoEmptyState variant="noData" title={t("comingSoon")} message={t("comingSoonDesc")} />
-      </CardContent>
-    </Card>
-  )
-}

--- a/src/app/(dashboard)/patients/[id]/document-view.ts
+++ b/src/app/(dashboard)/patients/[id]/document-view.ts
@@ -1,0 +1,47 @@
+/**
+ * Mapping pur (testable) des documents médicaux vers la vue dossier (Phase 4).
+ *
+ * Aucune dépendance RSC/Prisma. La liste vient déjà scopée + auditée + sans
+ * `fileUrl` (omis par le service) — ici on ne fait que projeter les champs
+ * d'affichage + formater la taille de fichier. Le téléchargement passe par la
+ * route `/api/documents/[id]/download` (auth + scope + ClamAV côté serveur).
+ */
+
+export type DocSize = { value: number; unitKey: "sizeBytes" | "sizeKb" | "sizeMb" } | null
+
+const KB = 1024
+const MB = 1024 * 1024
+
+/** Octets → {valeur, clé d'unité i18n}. `null` si taille inconnue. */
+export function formatDocSize(bytes: number | null | undefined): DocSize {
+  if (bytes === null || bytes === undefined || bytes < 0) return null
+  if (bytes < KB) return { value: bytes, unitKey: "sizeBytes" }
+  if (bytes < MB) return { value: Math.round((bytes / KB) * 10) / 10, unitKey: "sizeKb" }
+  return { value: Math.round((bytes / MB) * 10) / 10, unitKey: "sizeMb" }
+}
+
+export type DocumentItem = {
+  id: number
+  title: string
+  category: string | null
+  dateIso: string
+  size: DocSize
+}
+
+type RawDoc = {
+  id: number
+  title: string
+  category: string | null
+  date: Date | string
+  fileSize: number | null
+}
+
+export function buildDocumentView(docs: RawDoc[]): DocumentItem[] {
+  return docs.map((d) => ({
+    id: d.id,
+    title: d.title,
+    category: d.category,
+    dateIso: typeof d.date === "string" ? d.date : d.date.toISOString(),
+    size: formatDocSize(d.fileSize),
+  }))
+}

--- a/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/src/app/(dashboard)/patients/[id]/page.tsx
@@ -23,11 +23,13 @@ import { patientService } from "@/lib/services/patient.service"
 import { analyticsService } from "@/lib/services/analytics.service"
 import { glycemiaService } from "@/lib/services/glycemia.service"
 import { insulinTherapyService } from "@/lib/services/insulin-therapy.service"
+import { documentService } from "@/lib/services/document.service"
 import { auditService } from "@/lib/services/audit.service"
 import { canAccessPatient } from "@/lib/access-control"
 import { GLYCEMIA_THRESHOLDS_MGDL } from "@/lib/glycemia-thresholds"
 import { buildGlycemiaView } from "./glycemia-view"
 import { buildTreatmentView } from "./treatment-view"
+import { buildDocumentView } from "./document-view"
 import { PatientDetailClient, type PatientDetailData } from "./PatientDetailClient"
 
 // Période d'agrégation de la vue d'ensemble. Bornée < 90j (analytics).
@@ -117,6 +119,10 @@ export default async function PatientDetailPage({
   // READ INSULIN_THERAPY) + traitements associés (déjà chargés via getById).
   const insulinSettings = await insulinTherapyService.getSettings(patientId, userId, ctx)
   const treatmentView = buildTreatmentView(insulinSettings, patient.treatments ?? [])
+
+  // Phase 4 — Onglet Documents : documents médicaux (audité READ MEDICAL_DOCUMENT,
+  // scopé serveur, `fileUrl` omis). Téléchargement via /api/documents/[id]/download.
+  const documents = buildDocumentView(await documentService.list(patientId, role, userId, ctx))
   const cgmObj = patient.cgmObjectives
   // Cible affichée = MÊMES bornes que le calcul TIR serveur (cgm.low / cgm.ok),
   // pas titrLow/titrHigh (qui peuvent diverger). Défaut 70/180 si pas d'objectif.
@@ -175,6 +181,7 @@ export default async function PatientDetailPage({
         : null,
     glycemia: glycemiaView,
     treatment: treatmentView,
+    documents,
   }
 
   return <PatientDetailClient data={data} />

--- a/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/src/app/(dashboard)/patients/[id]/page.tsx
@@ -1,11 +1,10 @@
 /**
  * Dossier patient (`/patients/[id]`) — Server Component.
  *
- * Câblage données réelles, Phase 1 (cf. docs/UserStory/Navigation/cablage-donnees-patient.md) :
- * profil + objectifs + stats glycémiques (TIR/GMI/CV/moyenne) RÉELS, scopés
- * serveur, PII déchiffrée serveur, accès audité (ADR #18). Les onglets Glycémie /
- * Traitements / Documents arrivent dans les phases suivantes (état « bientôt
- * disponible » — jamais de données démo).
+ * Câblage données réelles (cf. docs/UserStory/Navigation/cablage-donnees-patient.md) :
+ * les 4 onglets (Vue d'ensemble, Glycémie, Traitements, Documents) sont sur
+ * données RÉELLES, scopées serveur, PII déchiffrée serveur, accès audité
+ * (ADR #18). Plus aucune donnée démo.
  *
  * Sécurité :
  *  - `canAccessPatient` (RBAC) ; refus → audit `accessDenied` + `notFound()`

--- a/src/app/api/documents/[id]/download/route.ts
+++ b/src/app/api/documents/[id]/download/route.ts
@@ -19,12 +19,12 @@ export async function GET(req: NextRequest, { params }: Params) {
 
     const { id } = await params
     const docId = parseInt(id, 10)
-    if (isNaN(docId) || docId <= 0)
+    if (Number.isNaN(docId) || docId <= 0)
       return NextResponse.json({ error: "invalidId" }, { status: 400 })
 
     const patientIdParam = req.nextUrl.searchParams.get("patientId")
     const parsedPid = patientIdParam ? parseInt(patientIdParam, 10) : undefined
-    if (patientIdParam && (isNaN(parsedPid!) || parsedPid! <= 0))
+    if (patientIdParam && (Number.isNaN(parsedPid!) || parsedPid! <= 0))
       return NextResponse.json({ error: "invalidPatientId" }, { status: 400 })
 
     const patientId = await resolvePatientId(user.id, user.role, parsedPid)

--- a/src/app/api/documents/[id]/download/route.ts
+++ b/src/app/api/documents/[id]/download/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server"
 import { requireAuth, AuthError } from "@/lib/auth"
 import { resolvePatientId } from "@/lib/access-control"
 import { requireGdprConsent } from "@/lib/gdpr"
+import { prisma } from "@/lib/db/client"
 import { documentService } from "@/lib/services/document.service"
 import { extractRequestContext } from "@/lib/services/audit.service"
 import { logger } from "@/lib/logger"
@@ -29,6 +30,26 @@ export async function GET(req: NextRequest, { params }: Params) {
     const patientId = await resolvePatientId(user.id, user.role, parsedPid)
     if (!patientId)
       return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+
+    // Garde consentement `shareWithProviders` pour les rôles PRO (cohérence avec
+    // la liste/le dossier patient : un patient ayant retiré le partage ne doit
+    // pas voir ses documents servis à un soignant). Le patient lui-même (VIEWER)
+    // accède à ses propres documents — gouverné par `patientShare` côté service.
+    // Refus → 404 uniforme (anti-énumération, indistinct de "pas d'accès").
+    if (user.role !== "VIEWER") {
+      const subject = await prisma.patient.findFirst({
+        where: { id: patientId, deletedAt: null },
+        select: { userId: true },
+      })
+      if (!subject)
+        return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+      const privacy = await prisma.userPrivacySettings.findUnique({
+        where: { userId: subject.userId },
+        select: { shareWithProviders: true },
+      })
+      if (privacy && !privacy.shareWithProviders)
+        return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+    }
 
     const ctx = extractRequestContext(req)
     const { body, contentType, contentLength, fileName } = await documentService.download(

--- a/tests/components/patient-detail-client.test.tsx
+++ b/tests/components/patient-detail-client.test.tsx
@@ -133,7 +133,8 @@ describe("PatientDetailClient (Phase 1)", () => {
     render(<PatientDetailClient data={baseData} />)
     expect(screen.getByText("Compte rendu HDJ")).toBeTruthy()
     const dl = screen.getByText("Télécharger").closest("a")
-    expect(dl?.getAttribute("href")).toBe("/api/documents/7/download")
+    // doit porter le patientId pour la résolution de scope côté route (pro)
+    expect(dl?.getAttribute("href")).toBe("/api/documents/7/download?patientId=42")
   })
 
   it("shows the empty Documents state when there are none", () => {

--- a/tests/components/patient-detail-client.test.tsx
+++ b/tests/components/patient-detail-client.test.tsx
@@ -89,6 +89,9 @@ const baseData: PatientDetailData = {
     basalSlots: [{ range: "00:00–06:00", rate: 0.8 }],
     treatments: [{ id: 1, name: "Metformine", posology: "850 mg x2/j" }],
   },
+  documents: [
+    { id: 7, title: "Compte rendu HDJ", category: "labResults", dateIso: "2026-06-01T09:00:00.000Z", size: { value: 1.2, unitKey: "sizeMb" } },
+  ],
 }
 
 describe("PatientDetailClient (Phase 1)", () => {
@@ -118,13 +121,24 @@ describe("PatientDetailClient (Phase 1)", () => {
     expect(screen.getAllByText("Pas de données de glycémie continue (CGM) sur la période.").length).toBeGreaterThan(0)
   })
 
-  it("renders the CGM chart + last reading (Phase 2) and « coming soon » only for Documents", () => {
+  it("renders the CGM chart + last reading (Phase 2) — all tabs now wired (no « coming soon »)", () => {
     render(<PatientDetailClient data={baseData} />)
-    // Glycémie câblée : graphe (2 pts) + dernière glycémie
     expect(screen.getByTestId("cgm-chart").textContent).toBe("2 pts")
     expect(screen.getByText("Dernière glycémie")).toBeTruthy()
-    // Reste : seul Documents → 1 état « bientôt disponible »
-    expect(screen.getAllByText(/Bientôt disponible/).length).toBe(1)
+    // Tous les onglets sont câblés → plus aucun état « bientôt disponible »
+    expect(screen.queryByText(/Bientôt disponible/)).toBeNull()
+  })
+
+  it("renders the Documents tab (Phase 4) — title, category, size, download link", () => {
+    render(<PatientDetailClient data={baseData} />)
+    expect(screen.getByText("Compte rendu HDJ")).toBeTruthy()
+    const dl = screen.getByText("Télécharger").closest("a")
+    expect(dl?.getAttribute("href")).toBe("/api/documents/7/download")
+  })
+
+  it("shows the empty Documents state when there are none", () => {
+    render(<PatientDetailClient data={{ ...baseData, documents: [] }} />)
+    expect(screen.getByText(/Aucun document/)).toBeTruthy()
   })
 
   it("renders the Traitements tab (Phase 3) — delivery, ISF/ICR/basal slots, treatments", () => {

--- a/tests/components/patient-detail-client.test.tsx
+++ b/tests/components/patient-detail-client.test.tsx
@@ -3,7 +3,7 @@
  */
 
 /**
- * Tests — PatientDetailClient (câblage données patient, Phase 1).
+ * Tests — PatientDetailClient (câblage données patient, Phases 1-4).
  *
  * Vérifie le rendu/branchement client (valeurs serveur affichées telles
  * quelles, état « pas de CGM », onglets non câblés en « bientôt disponible ») ;

--- a/tests/integration/api-documents-download-consent.test.ts
+++ b/tests/integration/api-documents-download-consent.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @description Phase 4 — garde consentement `shareWithProviders` sur
+ * `/api/documents/[id]/download` (frontière de sécu ajoutée en réponse à la
+ * revue PR #546). Vérifie : PRO + opt-out → 404 (et pas de stream) ; PRO sans
+ * row privacy → fail-open ; VIEWER → non gaté (accès à ses propres documents).
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { NextRequest } from "next/server"
+
+const prismaMock = {
+  patient: { findFirst: vi.fn() },
+  userPrivacySettings: { findUnique: vi.fn() },
+}
+vi.mock("@/lib/db/client", () => ({ prisma: prismaMock }))
+
+vi.mock("@/lib/gdpr", () => ({ requireGdprConsent: vi.fn().mockResolvedValue(true) }))
+
+vi.mock("@/lib/access-control", () => ({
+  resolvePatientId: vi.fn().mockResolvedValue(42),
+}))
+
+const downloadMock = vi.fn()
+vi.mock("@/lib/services/document.service", () => ({
+  documentService: { download: downloadMock },
+}))
+
+vi.mock("@/lib/services/audit.service", () => ({
+  extractRequestContext: () => ({ ipAddress: "127.0.0.1", userAgent: "test", requestId: "r1" }),
+}))
+
+const { GET } = await import("@/app/api/documents/[id]/download/route")
+
+function makeReq(role: string, docId = "7", patientId = "42"): NextRequest {
+  const headers = new Headers()
+  headers.set("x-user-id", "1")
+  headers.set("x-user-role", role)
+  return new NextRequest(new URL(`/api/documents/${docId}/download?patientId=${patientId}`, "http://test.local"), {
+    method: "GET",
+    headers,
+  })
+}
+const params = (id: string) => ({ params: Promise.resolve({ id }) })
+
+const okDownload = () =>
+  downloadMock.mockResolvedValue({ body: "PDF", contentType: "application/pdf", contentLength: 3, fileName: "doc.pdf" })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  prismaMock.patient.findFirst.mockResolvedValue({ userId: 99 })
+})
+
+describe("GET /api/documents/[id]/download — garde consentement", () => {
+  it("PRO + patient opt-out (shareWithProviders=false) → 404, pas de stream", async () => {
+    prismaMock.userPrivacySettings.findUnique.mockResolvedValue({ shareWithProviders: false })
+    const res = await GET(makeReq("DOCTOR"), params("7"))
+    expect(res.status).toBe(404)
+    expect(downloadMock).not.toHaveBeenCalled()
+  })
+
+  it("PRO + pas de préférence (fail-open) → sert le document", async () => {
+    prismaMock.userPrivacySettings.findUnique.mockResolvedValue(null)
+    okDownload()
+    const res = await GET(makeReq("NURSE"), params("7"))
+    expect(res.status).toBe(200)
+    expect(downloadMock).toHaveBeenCalled()
+  })
+
+  it("VIEWER → non gaté par shareWithProviders (accès à ses propres documents)", async () => {
+    okDownload()
+    const res = await GET(makeReq("VIEWER"), params("7"))
+    expect(res.status).toBe(200)
+    expect(prismaMock.userPrivacySettings.findUnique).not.toHaveBeenCalled()
+    expect(downloadMock).toHaveBeenCalled()
+  })
+})

--- a/tests/unit/document-view.test.ts
+++ b/tests/unit/document-view.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Tests du mapping pur documents médicaux → vue dossier (Phase 4).
+ * Couvre : formatage de taille (o/Ko/Mo), projection des champs, date→ISO.
+ */
+
+import { describe, it, expect } from "vitest"
+import { formatDocSize, buildDocumentView } from "@/app/(dashboard)/patients/[id]/document-view"
+
+describe("formatDocSize", () => {
+  it("formats bytes / KB / MB with rounded values", () => {
+    expect(formatDocSize(512)).toEqual({ value: 512, unitKey: "sizeBytes" })
+    expect(formatDocSize(2048)).toEqual({ value: 2, unitKey: "sizeKb" })
+    expect(formatDocSize(1_572_864)).toEqual({ value: 1.5, unitKey: "sizeMb" })
+  })
+  it("returns null for unknown/invalid size", () => {
+    expect(formatDocSize(null)).toBeNull()
+    expect(formatDocSize(undefined)).toBeNull()
+    expect(formatDocSize(-1)).toBeNull()
+  })
+})
+
+describe("buildDocumentView", () => {
+  it("projects display fields + ISO date + formatted size", () => {
+    const out = buildDocumentView([
+      { id: 7, title: "CR HDJ", category: "labResults", date: new Date("2026-06-01T09:00:00.000Z"), fileSize: 1_048_576 },
+      { id: 8, title: "Note", category: null, date: "2026-05-01T00:00:00.000Z", fileSize: null },
+    ])
+    expect(out[0]).toEqual({
+      id: 7, title: "CR HDJ", category: "labResults",
+      dateIso: "2026-06-01T09:00:00.000Z", size: { value: 1, unitKey: "sizeMb" },
+    })
+    expect(out[1]!.size).toBeNull()
+    expect(out[1]!.dateIso).toBe("2026-05-01T00:00:00.000Z")
+  })
+})


### PR DESCRIPTION
## Câblage des vraies données patient — Phase 4 (Documents) — **fin du chantier**

Dernière phase (après #543, #544, #545). Câble l'onglet **Documents** : le dossier patient `/patients/[id]` n'affiche **plus aucune donnée démo**. Plan : `docs/UserStory/Navigation/cablage-donnees-patient.md`.

### Ce que fait la Phase 4
- **`page.tsx` (RSC)** : documents via `documentService.list` — **scopé serveur** (un VIEWER ne voit que les documents `patientShare`), **`fileUrl` omis** (pas de fuite d'URL S3), **audité** `READ MEDICAL_DOCUMENT`, **derrière la garde accès + consentement**. Mapping **pur** (`document-view.ts`, unit-testé) : projection des champs + taille (o/Ko/Mo) + date ISO.
- **`PatientDetailClient`** : onglet Documents = liste (titre / catégorie i18n / date locale-aware / taille) + bouton **Télécharger** → `/api/documents/[id]/download` (auth + scope + ClamAV côté serveur). **État vide** « Aucun document ».
- `ComingSoon` retiré (les 4 onglets sont câblés) ; clés i18n mortes supprimées.

### Sécurité / conformité
- Lecture documents **auditée** + **scopée** + **gatée consentement** ; `fileUrl` jamais exposé (téléchargement via route sécurisée). Pas de PHI en log/URL.

### Tests & checks
- `document-view.test.ts` (formatage taille + projection) + onglet Documents côté client (liste, lien de téléchargement, état vide).
- Suite complète : **220 fichiers / 3090 tests** verts. `tsc` exit 0, design-system baseline (285), parité i18n FR/EN/AR OK.

### 🎉 Chantier « câblage données patient » terminé
Vue d'ensemble (#543) · Glycémie (#544) · Traitements (#545) · Documents (cette PR) — toutes les vues du dossier patient sont sur données réelles, scopées serveur, PII déchiffrée serveur, accès audité.

🤖 Generated with [Claude Code](https://claude.com/claude-code)