### PR TITLE
fix(security): converge les gardes consentement patient sur patientShareConsent

### DIFF
--- a/docs/UserStory/Navigation/cablage-donnees-patient.md
+++ b/docs/UserStory/Navigation/cablage-donnees-patient.md
@@ -95,12 +95,13 @@
 Items pré-existants ou transverses, hors périmètre de la Phase 1 — à traiter
 dans des tickets dédiés, pas dans le câblage des onglets.
 
-- **[Sécu] Convergence des sémantiques de consentement** : 2 implémentations
-  coexistent — `patientShareConsent()` (`src/lib/consent.ts`, **fail-closed** +
-  gate `gdprConsent`) vs le check inline **fail-open** des routes
-  `/api/patients/[id]/cgm` et `/analytics` (que la page Phase 1 réplique pour
-  cohérence). Faire converger toutes les lectures PHI sur un seul helper, décision
-  documentée en DPIA.
+- ✅ **[Sécu] Convergence des sémantiques de consentement** (FAIT) : les 4
+  outliers (page dossier, routes `cgm`/`analytics`, route `download`) convergés
+  sur `patientShareConsent` (**fail-closed** + `gdprConsent` + `shareWithProviders`),
+  alignés sur les ~18 autres routes per-patient. **Delta de comportement** : un
+  patient sans consentement RGPD / sans partage / sans row privacy est désormais
+  bloqué sur ces surfaces (404 si inexistant, 403/état « partage désactivé »
+  sinon) — durcissement cohérent avec le reste de l'app. À refléter au DPIA.
 - **[Sécu] Audit de l'accès « partage désactivé »** : la branche opt-out ne
   trace rien (parité avec cgm/analytics) — envisager une ligne `accessDenied`
   `kind: "sharingDisabled"` pour la traçabilité HDS.

--- a/docs/UserStory/Navigation/cablage-donnees-patient.md
+++ b/docs/UserStory/Navigation/cablage-donnees-patient.md
@@ -102,6 +102,12 @@ dans des tickets dédiés, pas dans le câblage des onglets.
   patient sans consentement RGPD / sans partage / sans row privacy est désormais
   bloqué sur ces surfaces (404 si inexistant, 403/état « partage désactivé »
   sinon) — durcissement cohérent avec le reste de l'app. À refléter au DPIA.
+- **[Sécu, à investiguer] Route `glycemia` GET — sur-blocage self-service** :
+  cette route admet un VIEWER (`requireAuth`, pas `requireRole`) MAIS appelle
+  `patientShareConsent` (qui vérifie `shareWithProviders`) — un patient lisant
+  SA propre glycémie avec `shareWithProviders=false` serait bloqué à tort.
+  Confirmer si la route est réellement atteinte par un VIEWER ; si oui, exempter
+  le VIEWER (comme la route download). Pré-existant (relevé revue PR #547).
 - **[Sécu] Audit de l'accès « partage désactivé »** : la branche opt-out ne
   trace rien (parité avec cgm/analytics) — envisager une ligne `accessDenied`
   `kind: "sharingDisabled"` pour la traçabilité HDS.

--- a/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/src/app/(dashboard)/patients/[id]/page.tsx
@@ -17,7 +17,7 @@
 import { headers } from "next/headers"
 import { notFound, redirect } from "next/navigation"
 import type { Role } from "@prisma/client"
-import { prisma } from "@/lib/db/client"
+import { patientShareConsent } from "@/lib/consent"
 import { patientService } from "@/lib/services/patient.service"
 import { analyticsService } from "@/lib/services/analytics.service"
 import { glycemiaService } from "@/lib/services/glycemia.service"
@@ -82,19 +82,14 @@ export default async function PatientDetailPage({
     notFound()
   }
 
-  // Garde consentement `shareWithProviders` AVANT tout déchiffrement PII
-  // (cohérence avec /api/patients/[id]/cgm et /analytics). Fail-open si pas de
-  // row (patient récent). Opt-out → aucune donnée rendue.
-  const base = await prisma.patient.findFirst({
-    where: { id: patientId, deletedAt: null },
-    select: { userId: true },
-  })
-  if (!base) notFound()
-  const privacy = await prisma.userPrivacySettings.findUnique({
-    where: { userId: base.userId },
-    select: { shareWithProviders: true },
-  })
-  if (privacy && !privacy.shareWithProviders) {
+  // Garde consentement patient AVANT tout déchiffrement PII — source unique
+  // `patientShareConsent` (gdprConsent + shareWithProviders, fail-closed),
+  // cohérent avec toutes les routes per-patient. Patient inexistant → 404
+  // uniforme ; consentement/partage absent → état « partage désactivé »
+  // (aucune PII déchiffrée).
+  const consent = await patientShareConsent(patientId)
+  if (!consent.ok) {
+    if (consent.status === 404) notFound()
     return <PatientDetailClient data={null} sharingDisabled />
   }
 

--- a/src/app/api/documents/[id]/download/route.ts
+++ b/src/app/api/documents/[id]/download/route.ts
@@ -2,7 +2,7 @@ import { NextResponse, type NextRequest } from "next/server"
 import { requireAuth, AuthError } from "@/lib/auth"
 import { resolvePatientId } from "@/lib/access-control"
 import { requireGdprConsent } from "@/lib/gdpr"
-import { prisma } from "@/lib/db/client"
+import { patientShareConsent } from "@/lib/consent"
 import { documentService } from "@/lib/services/document.service"
 import { extractRequestContext } from "@/lib/services/audit.service"
 import { logger } from "@/lib/logger"
@@ -31,24 +31,16 @@ export async function GET(req: NextRequest, { params }: Params) {
     if (!patientId)
       return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
 
-    // Garde consentement `shareWithProviders` pour les rôles PRO (cohérence avec
-    // la liste/le dossier patient : un patient ayant retiré le partage ne doit
-    // pas voir ses documents servis à un soignant). Le patient lui-même (VIEWER)
-    // accède à ses propres documents — gouverné par `patientShare` côté service.
-    // Refus → 404 uniforme (anti-énumération, indistinct de "pas d'accès").
+    // Garde consentement patient pour les rôles PRO — source unique
+    // `patientShareConsent` (gdprConsent + shareWithProviders, fail-closed),
+    // cohérent avec la liste/le dossier patient et les routes analytics. Le
+    // patient lui-même (VIEWER) accède à ses propres documents (gouverné par
+    // `patientShare` côté service), donc non gaté ici.
     if (user.role !== "VIEWER") {
-      const subject = await prisma.patient.findFirst({
-        where: { id: patientId, deletedAt: null },
-        select: { userId: true },
-      })
-      if (!subject)
-        return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
-      const privacy = await prisma.userPrivacySettings.findUnique({
-        where: { userId: subject.userId },
-        select: { shareWithProviders: true },
-      })
-      if (privacy && !privacy.shareWithProviders)
-        return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+      const consent = await patientShareConsent(patientId)
+      if (!consent.ok) {
+        return NextResponse.json({ error: consent.error }, { status: consent.status })
+      }
     }
 
     const ctx = extractRequestContext(req)

--- a/src/app/api/patients/[id]/analytics/route.ts
+++ b/src/app/api/patients/[id]/analytics/route.ts
@@ -3,7 +3,7 @@ import { z } from "zod"
 import { requireRole, AuthError } from "@/lib/auth"
 import { checkApiRateLimit, RATE_LIMITS } from "@/lib/auth/api-rate-limit"
 import { canAccessPatient } from "@/lib/access-control"
-import { prisma } from "@/lib/db/client"
+import { patientShareConsent } from "@/lib/consent"
 import { analyticsService } from "@/lib/services/analytics.service"
 import { auditService, extractRequestContext } from "@/lib/services/audit.service"
 
@@ -45,13 +45,12 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: "forbidden" }, { status: 403 })
     }
 
-    // Check shareWithProviders
-    const patient = await prisma.patient.findFirst({ where: { id: patientId, deletedAt: null }, select: { userId: true } })
-    if (!patient) return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
-
-    const privacy = await prisma.userPrivacySettings.findUnique({ where: { userId: patient.userId } })
-    if (privacy && !privacy.shareWithProviders) {
-      return NextResponse.json({ error: "sharingDisabled" }, { status: 403 })
+    // Consentement patient (gdprConsent + shareWithProviders) — source unique
+    // `patientShareConsent` (fail-closed), cohérent avec les autres routes
+    // per-patient (glycemia, heatmap, agp…).
+    const consent = await patientShareConsent(patientId)
+    if (!consent.ok) {
+      return NextResponse.json({ error: consent.error }, { status: consent.status })
     }
 
     const result = await analyticsService.glycemicProfile(patientId, parsed.data.period, user.id, ctx)

--- a/src/app/api/patients/[id]/cgm/route.ts
+++ b/src/app/api/patients/[id]/cgm/route.ts
@@ -2,9 +2,9 @@ import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
 import { requireRole, AuthError } from "@/lib/auth"
 import { canAccessPatient } from "@/lib/access-control"
+import { patientShareConsent } from "@/lib/consent"
 import { glycemiaService } from "@/lib/services/glycemia.service"
 import { auditService, extractRequestContext } from "@/lib/services/audit.service"
-import { prisma } from "@/lib/db/client"
 
 type RouteParams = { params: Promise<{ id: string }> }
 
@@ -37,13 +37,12 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: "forbidden" }, { status: 403 })
     }
 
-    // Privacy check (shareWithProviders)
-    const patient = await prisma.patient.findFirst({ where: { id: patientId, deletedAt: null }, select: { userId: true } })
-    if (!patient) return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
-
-    const privacy = await prisma.userPrivacySettings.findUnique({ where: { userId: patient.userId } })
-    if (privacy && !privacy.shareWithProviders) {
-      return NextResponse.json({ error: "sharingDisabled" }, { status: 403 })
+    // Consentement patient (gdprConsent + shareWithProviders) — source unique
+    // `patientShareConsent` (fail-closed), cohérent avec les autres routes
+    // per-patient (glycemia, heatmap, agp…).
+    const consent = await patientShareConsent(patientId)
+    if (!consent.ok) {
+      return NextResponse.json({ error: consent.error }, { status: consent.status })
     }
 
     const entries = await glycemiaService.getCgmEntries(patientId, parsed.data.from, parsed.data.to, user.id, ctx)

--- a/tests/integration/api-documents-download-consent.test.ts
+++ b/tests/integration/api-documents-download-consent.test.ts
@@ -1,23 +1,17 @@
 /**
- * @description Phase 4 — garde consentement `shareWithProviders` sur
- * `/api/documents/[id]/download` (frontière de sécu ajoutée en réponse à la
- * revue PR #546). Vérifie : PRO + opt-out → 404 (et pas de stream) ; PRO sans
- * row privacy → fail-open ; VIEWER → non gaté (accès à ses propres documents).
+ * @description Garde consentement sur `/api/documents/[id]/download` (frontière
+ * de sécu, revue PR #546 ; convergée sur `patientShareConsent`). Vérifie :
+ * PRO + consentement refusé → bloqué sans stream ; PRO + ok → sert ;
+ * VIEWER → non gaté (accès à ses propres documents).
  */
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { NextRequest } from "next/server"
 
-const prismaMock = {
-  patient: { findFirst: vi.fn() },
-  userPrivacySettings: { findUnique: vi.fn() },
-}
-vi.mock("@/lib/db/client", () => ({ prisma: prismaMock }))
-
 vi.mock("@/lib/gdpr", () => ({ requireGdprConsent: vi.fn().mockResolvedValue(true) }))
+vi.mock("@/lib/access-control", () => ({ resolvePatientId: vi.fn().mockResolvedValue(42) }))
 
-vi.mock("@/lib/access-control", () => ({
-  resolvePatientId: vi.fn().mockResolvedValue(42),
-}))
+const consentMock = vi.fn()
+vi.mock("@/lib/consent", () => ({ patientShareConsent: consentMock }))
 
 const downloadMock = vi.fn()
 vi.mock("@/lib/services/document.service", () => ({
@@ -40,36 +34,34 @@ function makeReq(role: string, docId = "7", patientId = "42"): NextRequest {
   })
 }
 const params = (id: string) => ({ params: Promise.resolve({ id }) })
-
 const okDownload = () =>
   downloadMock.mockResolvedValue({ body: "PDF", contentType: "application/pdf", contentLength: 3, fileName: "doc.pdf" })
 
 beforeEach(() => {
   vi.clearAllMocks()
-  prismaMock.patient.findFirst.mockResolvedValue({ userId: 99 })
 })
 
 describe("GET /api/documents/[id]/download — garde consentement", () => {
-  it("PRO + patient opt-out (shareWithProviders=false) → 404, pas de stream", async () => {
-    prismaMock.userPrivacySettings.findUnique.mockResolvedValue({ shareWithProviders: false })
+  it("PRO + consentement refusé → bloqué (403), pas de stream", async () => {
+    consentMock.mockResolvedValue({ ok: false, status: 403, error: "sharingDisabled" })
     const res = await GET(makeReq("DOCTOR"), params("7"))
-    expect(res.status).toBe(404)
+    expect(res.status).toBe(403)
     expect(downloadMock).not.toHaveBeenCalled()
   })
 
-  it("PRO + pas de préférence (fail-open) → sert le document", async () => {
-    prismaMock.userPrivacySettings.findUnique.mockResolvedValue(null)
+  it("PRO + consentement OK → sert le document", async () => {
+    consentMock.mockResolvedValue({ ok: true })
     okDownload()
     const res = await GET(makeReq("NURSE"), params("7"))
     expect(res.status).toBe(200)
     expect(downloadMock).toHaveBeenCalled()
   })
 
-  it("VIEWER → non gaté par shareWithProviders (accès à ses propres documents)", async () => {
+  it("VIEWER → non gaté par le consentement provider (accès à ses propres documents)", async () => {
     okDownload()
     const res = await GET(makeReq("VIEWER"), params("7"))
     expect(res.status).toBe(200)
-    expect(prismaMock.userPrivacySettings.findUnique).not.toHaveBeenCalled()
+    expect(consentMock).not.toHaveBeenCalled()
     expect(downloadMock).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Convergence des gardes de consentement patient (backlog sécu)

Élimine une divergence de politique relevée lors des reviews du chantier câblage données patient.

### Problème
Deux politiques de consentement coexistaient pour les lectures PHI per-patient :
- **`patientShareConsent`** (`src/lib/consent.ts`) — **fail-closed**, vérifie `gdprConsent` **et** `shareWithProviders` — utilisée par ~18 routes (glycemia, heatmap, agp, compare, tags, referent, meals…).
- **Check inline fail-open** (`shareWithProviders` seul) sur **4 outliers** : routes `cgm` et `analytics`, page dossier patient, route `download`.

### Changement
Les 4 outliers convergent sur `patientShareConsent` :
- `GET /api/patients/[id]/cgm`
- `GET /api/patients/[id]/analytics`
- `GET /api/documents/[id]/download` (PRO uniquement ; le patient `VIEWER` accède à ses propres documents via `patientShare`, non gaté)
- page `(dashboard)/patients/[id]` (patient inexistant → `notFound()` ; sinon → état « partage désactivé », **aucune PII déchiffrée**)

### ⚠️ Delta de comportement (à valider / refléter au DPIA)
Sur ces 4 surfaces, un patient **sans `gdprConsent`**, **sans `shareWithProviders`**, ou **sans row `UserPrivacySettings`** est désormais **bloqué** (auparavant fail-open laissait passer). C'est un **durcissement** qui aligne ces surfaces sur le comportement des ~18 autres routes (RGPD Art. 7.3 — révocation immédiate). Cas concret : un patient fraîchement créé qui n'a pas encore complété son consentement n'est plus visible côté pro sur ces 4 surfaces (déjà le cas sur glycemia/heatmap/etc.).

Résout aussi la divergence de code retour (`download` passait 404, désormais 403 `sharingDisabled` comme cgm/analytics). Imports `prisma` désormais inutiles retirés des 4 fichiers.

### Tests & checks
- `api-documents-download-consent` réécrit sur le mock `patientShareConsent` (PRO refusé → 403 sans stream ; PRO ok → sert ; VIEWER → non gaté). `patientShareConsent` reste couvert par `consent-and-decimal.test`.
- Suite complète : **221 fichiers / 3093 tests** verts. `tsc` exit 0, eslint clean, design-system baseline (285), parité i18n OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)