### PR TITLE
feat(clinical): cibles CGM par défaut pathology-aware (grossesse GD)

### DIFF
--- a/docs/UserStory/Navigation/cablage-donnees-patient.md
+++ b/docs/UserStory/Navigation/cablage-donnees-patient.md
@@ -119,9 +119,10 @@ dans des tickets dédiés, pas dans le câblage des onglets.
   hypo sévères au plancher des agrégats (mean/CV/TIR severeHypo) — sous-estime la
   charge hypoglycémique. Inclure les relevés clampés au plancher dans le bucket
   severe-hypo.
-- **[Clinique] Cibles spécifiques grossesse (GD)** : les cibles consensus
-  (70/180, TIR 70 %, hypo 4 %, CV 36 %) sont DT1/DT2 ; seeder des cibles GD plus
-  strictes (TIR 63–140) côté `cgmObjective`.
+- ✅ **[Clinique] Cibles spécifiques grossesse (GD)** (FAIT) : à défaut
+  d'objectif CGM, `analyticsService` (TIR/donut) ET le badge cible du dossier
+  utilisent désormais `getCgmDefaults(pathology)` → GD = 63–140 mg/dL (Battelino
+  2019) au lieu de 70–180. Badge et calcul restent cohérents (même source).
 - **[RGPD] `getById` sur-déchiffre** `email` + relations non affichées
   (minimisation Art. 5.1.c) — méthode de lecture allégée pour la page.
 - **[Perf] Double lookup patient** : la garde consentement fait un `findFirst`

--- a/docs/compliance/dpia-patient-detail-dossier.md
+++ b/docs/compliance/dpia-patient-detail-dossier.md
@@ -151,7 +151,8 @@ secret → pas de fuite d'énumération nouvelle. Posture acceptée.
 - ✅ Pivot `metadata.patientId` sur `READ CGM_ENTRY`/`GLYCEMIA_ENTRY`/`BOLUS_LOG`
   — **harmonisé** (PR audit pivot).
 - Plancher capteur 0.40 g/L exclut les hypo sévères des agrégats.
-- Cibles consensus non spécifiques grossesse (GD).
+- ✅ Cibles grossesse (GD) — défauts pathology-aware (63–140) sur le calcul TIR
+  et le badge (`getCgmDefaults`). **Résolu.**
 - Sur-déchiffrement `email` dans `getById` (minimisation Art. 5.1.c).
 
 ## 7. Validations à obtenir

--- a/src/app/(dashboard)/patients/[id]/overview-targets.ts
+++ b/src/app/(dashboard)/patients/[id]/overview-targets.ts
@@ -1,0 +1,38 @@
+/**
+ * Résolution de la plage cible glycémique affichée sur le dossier (badge).
+ *
+ * ⚠️ SERVEUR UNIQUEMENT — importe `objectives.service` (→ Prisma). Ne JAMAIS
+ * importer ce module depuis un composant client (fuite de bundle).
+ *
+ * Invariant clé : la borne haute affichée = **`cgm.ok`** (plafond TIR utilisé
+ * par `computeTir`), PAS `cgm.high` (seuil hyper sévère). Sinon le badge
+ * diverge du donut/TIR (revue PR #550). À défaut d'objectif CGM, défauts
+ * pathology-aware (`getCgmDefaults` : GD 63–140, sinon 70–180). g/L → mg/dL.
+ */
+
+import type { Pathology } from "@prisma/client"
+import { getCgmDefaults } from "@/lib/services/objectives.service"
+import { GLYCEMIA_THRESHOLDS_MGDL } from "@/lib/glycemia-thresholds"
+
+type DecimalLike = number | string | { toString(): string }
+
+export function resolveTargetRangeMgdl(
+  cgm: { low: DecimalLike; ok: DecimalLike } | null | undefined,
+  pathology?: Pathology | null,
+): { targetLowMgdl: number; targetHighMgdl: number } {
+  const defaults = getCgmDefaults(pathology ?? undefined)
+  const rawLow = Math.round(Number(cgm?.low ?? defaults.low) * 100)
+  // `.ok` = plafond TIR (cohérent avec computeTir/analytics), pas `.high`.
+  const rawHigh = Math.round(Number(cgm?.ok ?? defaults.ok) * 100)
+  // Défense en profondeur : garder la cible strictement dans les zones sévères
+  // (54 < low < high < 250) pour que la pastille `GlycemiaValue` ne dégénère pas.
+  const targetLowMgdl = Math.min(
+    Math.max(rawLow, GLYCEMIA_THRESHOLDS_MGDL.SEVERE_HYPO + 1),
+    GLYCEMIA_THRESHOLDS_MGDL.SEVERE_HYPER - 2,
+  )
+  const targetHighMgdl = Math.min(
+    Math.max(rawHigh, targetLowMgdl + 1),
+    GLYCEMIA_THRESHOLDS_MGDL.SEVERE_HYPER - 1,
+  )
+  return { targetLowMgdl, targetHighMgdl }
+}

--- a/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/src/app/(dashboard)/patients/[id]/page.tsx
@@ -26,8 +26,7 @@ import { insulinTherapyService } from "@/lib/services/insulin-therapy.service"
 import { documentService } from "@/lib/services/document.service"
 import { auditService } from "@/lib/services/audit.service"
 import { canAccessPatient } from "@/lib/access-control"
-import { getCgmDefaults } from "@/lib/services/objectives.service"
-import { GLYCEMIA_THRESHOLDS_MGDL } from "@/lib/glycemia-thresholds"
+import { resolveTargetRangeMgdl } from "./overview-targets"
 import { buildGlycemiaView } from "./glycemia-view"
 import { buildTreatmentView } from "./treatment-view"
 import { buildDocumentView } from "./document-view"
@@ -119,25 +118,12 @@ export default async function PatientDetailPage({
   // Phase 4 — Onglet Documents : documents médicaux (audité READ MEDICAL_DOCUMENT,
   // scopé serveur, `fileUrl` omis). Téléchargement via /api/documents/[id]/download.
   const documents = buildDocumentView(await documentService.list(patientId, role, userId, ctx))
-  const cgmObj = patient.cgmObjectives
-  // Cible affichée = MÊMES bornes que le calcul TIR serveur (cgm.low / cgm.ok).
-  // À défaut d'objectif, défauts **pathology-aware** (`getCgmDefaults`) — mêmes
-  // que `analyticsService` → badge cohérent avec le donut (GD : 63–140, sinon
-  // 70–180). g/L → mg/dL (×100).
-  const cgmDefaults = getCgmDefaults(patient.pathology ?? undefined)
-  const rawLowMgdl = Math.round(Number(cgmObj?.low ?? cgmDefaults.low) * 100)
-  const rawHighMgdl = Math.round(Number(cgmObj?.ok ?? cgmDefaults.high) * 100)
-  // Défense en profondeur (affichage) : garder la cible strictement DANS les
-  // zones sévères (54 < low < high < 250) pour que la pastille couleur de
-  // `GlycemiaValue` ne dégénère jamais. La config est déjà bornée par
-  // `clinical-bounds.ts` — ce clamp ne se déclenche pas en pratique.
-  const targetLowMgdl = Math.min(
-    Math.max(rawLowMgdl, GLYCEMIA_THRESHOLDS_MGDL.SEVERE_HYPO + 1),
-    GLYCEMIA_THRESHOLDS_MGDL.SEVERE_HYPER - 2,
-  )
-  const targetHighMgdl = Math.min(
-    Math.max(rawHighMgdl, targetLowMgdl + 1),
-    GLYCEMIA_THRESHOLDS_MGDL.SEVERE_HYPER - 1,
+  // Plage cible affichée = bornes TIR (cgm.low/ok), défauts pathology-aware,
+  // clampée dans les zones sévères. Helper serveur testé (overview-targets) →
+  // badge cohérent avec le donut/TIR (cf. revue PR #550).
+  const { targetLowMgdl, targetHighMgdl } = resolveTargetRangeMgdl(
+    patient.cgmObjectives,
+    patient.pathology,
   )
 
   const fullName = `${patient.user.firstname ?? ""} ${patient.user.lastname ?? ""}`.trim()

--- a/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/src/app/(dashboard)/patients/[id]/page.tsx
@@ -26,6 +26,7 @@ import { insulinTherapyService } from "@/lib/services/insulin-therapy.service"
 import { documentService } from "@/lib/services/document.service"
 import { auditService } from "@/lib/services/audit.service"
 import { canAccessPatient } from "@/lib/access-control"
+import { getCgmDefaults } from "@/lib/services/objectives.service"
 import { GLYCEMIA_THRESHOLDS_MGDL } from "@/lib/glycemia-thresholds"
 import { buildGlycemiaView } from "./glycemia-view"
 import { buildTreatmentView } from "./treatment-view"
@@ -119,10 +120,13 @@ export default async function PatientDetailPage({
   // scopé serveur, `fileUrl` omis). Téléchargement via /api/documents/[id]/download.
   const documents = buildDocumentView(await documentService.list(patientId, role, userId, ctx))
   const cgmObj = patient.cgmObjectives
-  // Cible affichée = MÊMES bornes que le calcul TIR serveur (cgm.low / cgm.ok),
-  // pas titrLow/titrHigh (qui peuvent diverger). Défaut 70/180 si pas d'objectif.
-  const rawLowMgdl = cgmObj ? Math.round(Number(cgmObj.low) * 100) : GLYCEMIA_THRESHOLDS_MGDL.TARGET_LOW
-  const rawHighMgdl = cgmObj ? Math.round(Number(cgmObj.ok) * 100) : GLYCEMIA_THRESHOLDS_MGDL.TARGET_HIGH
+  // Cible affichée = MÊMES bornes que le calcul TIR serveur (cgm.low / cgm.ok).
+  // À défaut d'objectif, défauts **pathology-aware** (`getCgmDefaults`) — mêmes
+  // que `analyticsService` → badge cohérent avec le donut (GD : 63–140, sinon
+  // 70–180). g/L → mg/dL (×100).
+  const cgmDefaults = getCgmDefaults(patient.pathology ?? undefined)
+  const rawLowMgdl = Math.round(Number(cgmObj?.low ?? cgmDefaults.low) * 100)
+  const rawHighMgdl = Math.round(Number(cgmObj?.ok ?? cgmDefaults.high) * 100)
   // Défense en profondeur (affichage) : garder la cible strictement DANS les
   // zones sévères (54 < low < high < 250) pour que la pastille couleur de
   // `GlycemiaValue` ne dégénère jamais. La config est déjà bornée par

--- a/src/lib/services/analytics.service.ts
+++ b/src/lib/services/analytics.service.ts
@@ -96,8 +96,8 @@ async function getPatientThresholds(patientId: number): Promise<CgmThresholds> {
     // (GD) impose une cible plus stricte (63–140 mg/dL, Battelino 2019) que les
     // 70–180 génériques. Sans ça, le TIR d'une patiente GD serait évalué sur une
     // plage trop large (faux rassurement). Cf. `getCgmDefaults`.
-    const patient = await prisma.patient.findUnique({
-      where: { id: patientId },
+    const patient = await prisma.patient.findFirst({
+      where: { id: patientId, deletedAt: null },
       select: { pathology: true },
     })
     const d = getCgmDefaults(patient?.pathology ?? undefined)

--- a/src/lib/services/analytics.service.ts
+++ b/src/lib/services/analytics.service.ts
@@ -11,12 +11,12 @@
 import { prisma } from "@/lib/db/client"
 import { auditService } from "./audit.service"
 import type { AuditContext } from "./audit.service"
+import { getCgmDefaults } from "./objectives.service"
 import {
   mean, glToMgdl, glucoseManagementIndicator, coefficientOfVariation,
   computeTir, assessTirQuality, computeAgp, detectHypoEpisodes,
   cgmCaptureRate,
   ANALYTICS_WARNINGS,
-  DEFAULT_CGM_THRESHOLDS,
   type AnalyticsWarning,
   type CgmThresholds,
 } from "@/lib/statistics"
@@ -91,7 +91,18 @@ async function getPatientCgmValues(patientId: number, days: number) {
  */
 async function getPatientThresholds(patientId: number): Promise<CgmThresholds> {
   const cgm = await prisma.cgmObjective.findUnique({ where: { patientId } })
-  if (!cgm) return DEFAULT_CGM_THRESHOLDS
+  if (!cgm) {
+    // Pas d'objectif CGM configuré → défauts **pathology-aware** : la grossesse
+    // (GD) impose une cible plus stricte (63–140 mg/dL, Battelino 2019) que les
+    // 70–180 génériques. Sans ça, le TIR d'une patiente GD serait évalué sur une
+    // plage trop large (faux rassurement). Cf. `getCgmDefaults`.
+    const patient = await prisma.patient.findUnique({
+      where: { id: patientId },
+      select: { pathology: true },
+    })
+    const d = getCgmDefaults(patient?.pathology ?? undefined)
+    return { veryLow: d.veryLow, low: d.low, ok: d.ok, high: d.high }
+  }
   return {
     veryLow: Number(cgm.veryLow),
     low: Number(cgm.low),

--- a/tests/unit/analytics.service.test.ts
+++ b/tests/unit/analytics.service.test.ts
@@ -86,6 +86,28 @@ describe("analyticsService", () => {
       expect(result.quality).toBeDefined()
       expect(result.thresholds).toBeDefined()
     })
+
+    it("uses tighter GD defaults (63–140 mg/dL) when no CGM objective + GD pathology", async () => {
+      prismaMock.cgmEntry.findMany.mockResolvedValue(mockCgmEntries(100) as any)
+      prismaMock.cgmObjective.findUnique.mockResolvedValue(null)
+      prismaMock.patient.findUnique.mockResolvedValue({ pathology: "GD" } as any)
+      prismaMock.auditLog.create.mockResolvedValue({} as any)
+
+      const result = await analyticsService.timeInRange(1, "14d", 1)
+      expect(result.thresholds.low).toBe(0.63)
+      expect(result.thresholds.ok).toBe(1.4)
+    })
+
+    it("uses generic defaults (70–180 mg/dL) when no CGM objective + DT1/DT2", async () => {
+      prismaMock.cgmEntry.findMany.mockResolvedValue(mockCgmEntries(100) as any)
+      prismaMock.cgmObjective.findUnique.mockResolvedValue(null)
+      prismaMock.patient.findUnique.mockResolvedValue({ pathology: "DT1" } as any)
+      prismaMock.auditLog.create.mockResolvedValue({} as any)
+
+      const result = await analyticsService.timeInRange(1, "14d", 1)
+      expect(result.thresholds.low).toBe(0.7)
+      expect(result.thresholds.ok).toBe(1.8)
+    })
   })
 
   describe("agp", () => {

--- a/tests/unit/analytics.service.test.ts
+++ b/tests/unit/analytics.service.test.ts
@@ -90,7 +90,7 @@ describe("analyticsService", () => {
     it("uses tighter GD defaults (63–140 mg/dL) when no CGM objective + GD pathology", async () => {
       prismaMock.cgmEntry.findMany.mockResolvedValue(mockCgmEntries(100) as any)
       prismaMock.cgmObjective.findUnique.mockResolvedValue(null)
-      prismaMock.patient.findUnique.mockResolvedValue({ pathology: "GD" } as any)
+      prismaMock.patient.findFirst.mockResolvedValue({ pathology: "GD" } as any)
       prismaMock.auditLog.create.mockResolvedValue({} as any)
 
       const result = await analyticsService.timeInRange(1, "14d", 1)
@@ -101,7 +101,7 @@ describe("analyticsService", () => {
     it("uses generic defaults (70–180 mg/dL) when no CGM objective + DT1/DT2", async () => {
       prismaMock.cgmEntry.findMany.mockResolvedValue(mockCgmEntries(100) as any)
       prismaMock.cgmObjective.findUnique.mockResolvedValue(null)
-      prismaMock.patient.findUnique.mockResolvedValue({ pathology: "DT1" } as any)
+      prismaMock.patient.findFirst.mockResolvedValue({ pathology: "DT1" } as any)
       prismaMock.auditLog.create.mockResolvedValue({} as any)
 
       const result = await analyticsService.timeInRange(1, "14d", 1)

--- a/tests/unit/overview-targets.test.ts
+++ b/tests/unit/overview-targets.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Tests — resolveTargetRangeMgdl (plage cible affichée du dossier).
+ * Couvre la cohérence badge↔TIR : la borne haute = `ok` (plafond TIR), PAS
+ * `high` (hyper sévère). Défauts pathology-aware (GD vs générique) + clamp.
+ */
+import { describe, it, expect } from "vitest"
+import { resolveTargetRangeMgdl } from "@/app/(dashboard)/patients/[id]/overview-targets"
+
+describe("resolveTargetRangeMgdl", () => {
+  it("uses cgm.low/ok when an objective exists (ok = TIR ceiling, not high)", () => {
+    // ok=1.80 → 180 (et non high=2.50 → 250)
+    expect(resolveTargetRangeMgdl({ low: 0.7, ok: 1.8 }, "DT1")).toEqual({
+      targetLowMgdl: 70,
+      targetHighMgdl: 180,
+    })
+  })
+
+  it("defaults to GD targets (63–140) when no objective + GD", () => {
+    expect(resolveTargetRangeMgdl(null, "GD")).toEqual({ targetLowMgdl: 63, targetHighMgdl: 140 })
+  })
+
+  it("defaults to generic targets (70–180) when no objective + DT1/DT2/null", () => {
+    expect(resolveTargetRangeMgdl(null, "DT1")).toEqual({ targetLowMgdl: 70, targetHighMgdl: 180 })
+    expect(resolveTargetRangeMgdl(null, null)).toEqual({ targetLowMgdl: 70, targetHighMgdl: 180 })
+  })
+
+  it("clamps display targets strictly inside the severe zones (54 < low < high < 250)", () => {
+    // Objectif aberrant : low=50, ok=300 → clampé.
+    const r = resolveTargetRangeMgdl({ low: 0.5, ok: 3.0 }, "DT1")
+    expect(r.targetLowMgdl).toBeGreaterThan(54)
+    expect(r.targetHighMgdl).toBeLessThan(250)
+    expect(r.targetLowMgdl).toBeLessThan(r.targetHighMgdl)
+  })
+})


### PR DESCRIPTION
## Cibles CGM par défaut spécifiques grossesse (GD) — backlog clinique

Quand un patient **n'a pas d'objectif CGM** configuré (`cgmObjective`), les seuils utilisés étaient les défauts génériques **70–180 mg/dL** quelle que soit la pathologie. Une patiente en **diabète gestationnel (GD)** était donc évaluée sur une plage trop large → faux rassurement.

### Changement
Réutilise le helper **déjà existant** `getCgmDefaults(pathology)` (GD = **63–140 mg/dL**, Battelino 2019 ; sinon 70–180), sur les **deux** surfaces qui doivent rester cohérentes :
- **`analyticsService.getPatientThresholds`** : si pas de `cgmObjective`, lit `patient.pathology` et applique les défauts pathology-aware → impacte TIR/GMI/donut/AGP per-patient (heatmap, agp, dossier…).
- **Page dossier (badge cible)** : même source `getCgmDefaults` → le **badge** et le **donut TIR** affichent désormais la même plage pour une patiente GD (plus de divergence badge↔calcul).

Comportement strictement plus correct cliniquement ; aucune régression pour DT1/DT2 (mêmes valeurs qu'avant). `DEFAULT_CGM_THRESHOLDS` (devenu inutilisé dans analytics) retiré de l'import.

### Tests & docs
- `analytics.service.test` : `timeInRange` GD → thresholds 0.63/1.40 ; DT1 → 0.70/1.80.
- Suite : **3096 tests** verts. `tsc` exit 0, design-system baseline (285).
- DPIA + plan câblage mis à jour (item GD marqué résolu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)