### PR TITLE
refactor(i18n): namespace insulinUnits — source unique des libellés d'unités

### DIFF
--- a/docs/UserStory/Navigation/cablage-donnees-patient.md
+++ b/docs/UserStory/Navigation/cablage-donnees-patient.md
@@ -145,8 +145,12 @@ dans des tickets dédiés, pas dans le câblage des onglets.
   un calcul clinique.
 - **[Produit] Insuline bolus (nom) + modèle pompe** : nécessitent join
   catalogue/device — à ajouter à l'onglet Traitements.
-- **[i18n] Clé unité ISF dupliquée** : `dashboardCards.medecinProposals.unitIsfGl`
-  ≈ `patientDetail.unitIsf` (« g/L/U ») — consolider une source unique.
+- ✅ **[i18n] Clés d'unités insuline dédupliquées** (FAIT) : nouveau namespace
+  top-level `insulinUnits` (`isfGl`/`isfMgdl`/`isfMmol`/`icr`/`basal`) = source
+  unique. `PatientDetailClient` et `PendingProposalsCard` y réfèrent ; les clés
+  dupliquées `patientDetail.unitIsf|unitIcr|unitBasal` et
+  `medecinProposals.unitIsfGl|unitIsfMgdl|unitIsfMmol|unitBasalRate|unitInsulinToCarbRatio`
+  sont supprimées (FR/EN/AR). Symboles universels → identiques dans les 3 langues.
 - **[Sécu] Route download — `documentNotFound` vs `patientNotFound`** : 2 chaînes
   d'erreur 404 distinctes (oracle d'énumération mineur) — uniformiser en `notFound`
   neutre (Phase 4 a déjà ajouté la garde consentement `shareWithProviders` PRO).

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1483,12 +1483,7 @@
       "paramInsulinToCarbRatio": "نسبة الأنسولين إلى الكربوهيدرات (ICR)",
       "valueTransition": "{from} ← {to}",
       "changeAria": "تغيّر بنسبة {percent}٪",
-      "stale": "البيانات قديمة — في انتظار التحديث.",
-      "unitBasalRate": "U/h",
-      "unitInsulinToCarbRatio": "g/U",
-      "unitIsfGl": "g/L/U",
-      "unitIsfMgdl": "mg/dL/U",
-      "unitIsfMmol": "mmol/L/U"
+      "stale": "البيانات قديمة — في انتظار التحديث."
     },
     "medecinMessages": {
       "title": "رسائل غير مقروءة",
@@ -1528,6 +1523,13 @@
     "nursePage": {
       "title": "لوحة تحكم الممرّض"
     }
+  },
+  "insulinUnits": {
+    "isfGl": "g/L/U",
+    "isfMgdl": "mg/dL/U",
+    "isfMmol": "mmol/L/U",
+    "icr": "g/U",
+    "basal": "U/h"
   },
   "patientDetail": {
     "tabsAriaLabel": "أقسام ملف المريض",
@@ -1583,9 +1585,6 @@
     "slotGapNoteBasal": "تغطية قاعدية غير كاملة على مدار 24 ساعة — يُرجى مراجعة الإعدادات.",
     "slotOverlapNote": "فترات متداخلة — يُرجى مراجعة الإعدادات.",
     "basalLabel": "المعدل القاعدي",
-    "unitIsf": "g/L/U",
-    "unitIcr": "g/U",
-    "unitBasal": "U/h",
     "download": "تنزيل",
     "uncategorized": "بدون فئة",
     "sizeBytes": "بايت",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1483,12 +1483,7 @@
       "paramInsulinToCarbRatio": "Insulin-to-carb ratio (ICR)",
       "valueTransition": "{from} → {to}",
       "changeAria": "{percent}% change",
-      "stale": "Data is stale — refresh pending.",
-      "unitBasalRate": "U/h",
-      "unitInsulinToCarbRatio": "g/U",
-      "unitIsfGl": "g/L/U",
-      "unitIsfMgdl": "mg/dL/U",
-      "unitIsfMmol": "mmol/L/U"
+      "stale": "Data is stale — refresh pending."
     },
     "medecinMessages": {
       "title": "Unread messages",
@@ -1528,6 +1523,13 @@
     "nursePage": {
       "title": "Nurse dashboard"
     }
+  },
+  "insulinUnits": {
+    "isfGl": "g/L/U",
+    "isfMgdl": "mg/dL/U",
+    "isfMmol": "mmol/L/U",
+    "icr": "g/U",
+    "basal": "U/h"
   },
   "patientDetail": {
     "tabsAriaLabel": "Patient record sections",
@@ -1583,9 +1585,6 @@
     "slotGapNoteBasal": "Incomplete basal coverage over 24 h — configuration to review.",
     "slotOverlapNote": "Overlapping slots — configuration to review.",
     "basalLabel": "Basal rate",
-    "unitIsf": "g/L/U",
-    "unitIcr": "g/U",
-    "unitBasal": "U/h",
     "download": "Download",
     "uncategorized": "Uncategorized",
     "sizeBytes": "B",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1483,12 +1483,7 @@
       "paramInsulinToCarbRatio": "Ratio insuline/glucides (ICR)",
       "valueTransition": "{from} → {to}",
       "changeAria": "Variation de {percent} %",
-      "stale": "Données obsolètes — rafraîchissement en attente.",
-      "unitBasalRate": "U/h",
-      "unitInsulinToCarbRatio": "g/U",
-      "unitIsfGl": "g/L/U",
-      "unitIsfMgdl": "mg/dL/U",
-      "unitIsfMmol": "mmol/L/U"
+      "stale": "Données obsolètes — rafraîchissement en attente."
     },
     "medecinMessages": {
       "title": "Messages non lus",
@@ -1528,6 +1523,13 @@
     "nursePage": {
       "title": "Tableau de bord infirmier"
     }
+  },
+  "insulinUnits": {
+    "isfGl": "g/L/U",
+    "isfMgdl": "mg/dL/U",
+    "isfMmol": "mmol/L/U",
+    "icr": "g/U",
+    "basal": "U/h"
   },
   "patientDetail": {
     "tabsAriaLabel": "Sections du dossier patient",
@@ -1583,9 +1585,6 @@
     "slotGapNoteBasal": "Couverture basale incomplète sur 24 h — configuration à vérifier.",
     "slotOverlapNote": "Créneaux qui se chevauchent — configuration à vérifier.",
     "basalLabel": "Débit basal",
-    "unitIsf": "g/L/U",
-    "unitIcr": "g/U",
-    "unitBasal": "U/h",
     "download": "Télécharger",
     "uncategorized": "Sans catégorie",
     "sizeBytes": "o",

--- a/src/app/(dashboard)/patients/[id]/PatientDetailClient.tsx
+++ b/src/app/(dashboard)/patients/[id]/PatientDetailClient.tsx
@@ -78,6 +78,9 @@ export function PatientDetailClient({
   sharingDisabled?: boolean
 }) {
   const t = useTranslations("patientDetail")
+  // Libellés d'unités de paramètres insuline : source unique partagée avec la
+  // carte « propositions » (namespace `insulinUnits`).
+  const tUnits = useTranslations("insulinUnits")
   const locale = useLocale()
   const [activeTab, setActiveTab] = useState("overview")
 
@@ -342,7 +345,7 @@ export function PatientDetailClient({
                     {data.treatment.isfSlots.length > 0 && (
                       <SlotList
                         label={<Acronym code="ISF" />}
-                        unit={t("unitIsf")}
+                        unit={tUnits("isfGl")}
                         slots={data.treatment.isfSlots}
                         coverage={data.treatment.isfCoverage}
                         family="ratio"
@@ -351,7 +354,7 @@ export function PatientDetailClient({
                     {data.treatment.icrSlots.length > 0 && (
                       <SlotList
                         label={<Acronym code="ICR" />}
-                        unit={t("unitIcr")}
+                        unit={tUnits("icr")}
                         slots={data.treatment.icrSlots}
                         coverage={data.treatment.icrCoverage}
                         family="ratio"
@@ -360,7 +363,7 @@ export function PatientDetailClient({
                     {data.treatment.basalSlots.length > 0 && (
                       <SlotList
                         label={t("basalLabel")}
-                        unit={t("unitBasal")}
+                        unit={tUnits("basal")}
                         slots={data.treatment.basalSlots.map((b) => ({ range: b.range, value: b.rate }))}
                         coverage={data.treatment.basalCoverage}
                         family="basal"

--- a/src/components/diabeo/dashboard/medecin/PendingProposalsCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/PendingProposalsCard.tsx
@@ -29,11 +29,14 @@ const PARAM_LABEL_KEY: Record<PendingProposalItem["parameterType"], string> = {
   insulinToCarbRatio: "paramInsulinToCarbRatio",
 }
 
+/** Clés du namespace i18n `insulinUnits` (source unique des libellés d'unités). */
+type InsulinUnitKey = "isfGl" | "isfMgdl" | "isfMmol" | "icr" | "basal"
+
 /**
  * Unité d'affichage de l'ISF selon l'unité de glycémie de l'appelant.
  * Clés du namespace `insulinUnits` (source unique partagée avec le dossier).
  */
-const ISF_UNIT_KEY: Record<GlucoseUnit, string> = {
+const ISF_UNIT_KEY: Record<GlucoseUnit, InsulinUnitKey> = {
   "g/L": "isfGl",
   "mg/dL": "isfMgdl",
   "mmol/L": "isfMmol",
@@ -49,7 +52,7 @@ const asPathologyCode = (p: string | null): AcronymCode | null =>
  * et converti vers l'unité de glycémie de l'appelant (g/L/U, mg/dL/U,
  * mmol/L/U) ; basal (U/h) et ICR (g/U) sont indépendants de l'unité glycémie.
  */
-function displayFor(p: PendingProposalItem): { from: number; to: number; unitKey: string } {
+function displayFor(p: PendingProposalItem): { from: number; to: number; unitKey: InsulinUnitKey } {
   if (p.parameterType === "insulinSensitivityFactor") {
     return {
       from: convertGlucoseFromGl(p.currentValue, p.glucoseUnit),

--- a/src/components/diabeo/dashboard/medecin/PendingProposalsCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/PendingProposalsCard.tsx
@@ -29,11 +29,14 @@ const PARAM_LABEL_KEY: Record<PendingProposalItem["parameterType"], string> = {
   insulinToCarbRatio: "paramInsulinToCarbRatio",
 }
 
-/** Unité d'affichage de l'ISF selon l'unité de glycémie de l'appelant. */
+/**
+ * Unité d'affichage de l'ISF selon l'unité de glycémie de l'appelant.
+ * Clés du namespace `insulinUnits` (source unique partagée avec le dossier).
+ */
 const ISF_UNIT_KEY: Record<GlucoseUnit, string> = {
-  "g/L": "unitIsfGl",
-  "mg/dL": "unitIsfMgdl",
-  "mmol/L": "unitIsfMmol",
+  "g/L": "isfGl",
+  "mg/dL": "isfMgdl",
+  "mmol/L": "isfMmol",
 }
 
 /** Pathologies connues du glossaire (`Acronym`) — garde-fou de typage. */
@@ -57,7 +60,7 @@ function displayFor(p: PendingProposalItem): { from: number; to: number; unitKey
   return {
     from: p.currentValue,
     to: p.proposedValue,
-    unitKey: p.parameterType === "basalRate" ? "unitBasalRate" : "unitInsulinToCarbRatio",
+    unitKey: p.parameterType === "basalRate" ? "basal" : "icr",
   }
 }
 
@@ -74,6 +77,8 @@ function changeVariant(percent: number): "destructive" | "secondary" {
 
 export function PendingProposalsCard() {
   const t = useTranslations("dashboardCards.medecinProposals")
+  // Libellés d'unités : source unique partagée avec le dossier patient.
+  const tUnits = useTranslations("insulinUnits")
   const locale = useLocale()
   // Décimales bornées (max 2) — suffisant cliniquement (incrément basal 0.05,
   // ISF 0.01, ICR 0.1) et évite d'afficher le bruit Decimal(8,4).
@@ -139,7 +144,7 @@ export function PendingProposalsCard() {
                   <span className="text-xs tabular-nums text-foreground">
                     {t("valueTransition", { from: fmt(from), to: fmt(to) })}
                     {" "}
-                    {t(unitKey)}
+                    {tUnits(unitKey)}
                   </span>
                   <Badge
                     variant={changeVariant(p.changePercent)}


### PR DESCRIPTION
## Contexte

Dernier item du backlog « Clé unité ISF dupliquée » (cf. `docs/UserStory/Navigation/cablage-donnees-patient.md`). Le libellé « g/L/U » — et plus largement les unités de paramètres insuline — étaient **dupliqués** entre deux namespaces i18n :

- `patientDetail.unitIsf` / `unitIcr` / `unitBasal`
- `dashboardCards.medecinProposals.unitIsfGl` / `unitIsfMgdl` / `unitIsfMmol` / `unitBasalRate` / `unitInsulinToCarbRatio`

Risque de divergence à terme (deux sources pour la même chaîne).

## Changements

- **Nouveau namespace top-level `insulinUnits`** (FR/EN/AR), source unique :
  `isfGl` (g/L/U) · `isfMgdl` (mg/dL/U) · `isfMmol` (mmol/L/U) · `icr` (g/U) · `basal` (U/h).
  Symboles d'unités universels → valeurs identiques dans les 3 langues.
- **`PatientDetailClient`** : `useTranslations("insulinUnits")` → `isfGl` / `icr` / `basal`.
- **`PendingProposalsCard`** : `ISF_UNIT_KEY` et la map basal/icr pointent désormais les clés `insulinUnits` ; rendu via un translator dédié `tUnits`.
- **Suppression** des clés dupliquées dans `patientDetail` et `medecinProposals` (FR/EN/AR).

> ⚠️ Distinct du namespace `units` existant (réglages : préférence d'unité de mesure utilisateur) — `insulinUnits` concerne uniquement les libellés d'unités de paramètres insuline.

## Tests / vérifs

- `tsc` ✅ · ESLint fichiers touchés ✅ · design-system = baseline 285 ✅
- `tests/unit/i18n-parity.test.ts` ✅ (parité des 3 langues maintenue)
- `tests/components/patient-detail-client.test.tsx` ✅ (les libellés `g/L/U` / `g/U` / `U/h` se résolvent via le nouveau namespace)
- Aucune clé orpheline (`grep` des anciennes clés = 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)