### PR TITLE
docs: corrige la sélection créneaux ISF/ICR (fail-closed, pas de fallback)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,9 +389,11 @@ const CLINICAL_BOUNDS = {
 }
 
 // Formule : findSlotForHour(settings.sensitivityFactors, hour)
-// Les slots ISF/ICR sont triés par startHour ascendant
-// Sélection : premier slot où startHour <= heure actuelle
-// Fallback : dernier slot du tableau
+// Sélection : premier slot dont l'intervalle [startHour, endHour) contient `hour`
+// (intervalle demi-ouvert ; passage minuit géré si startHour > endHour)
+// Aucune correspondance → renvoie undefined → l'appelant LÈVE ("No ISF/ICR slot
+// found for current hour"). Fail-closed : pas de fallback, jamais de dose calculée
+// sur une heure non couverte par la config.
 
 // Calcul final :
 // Bolus repas     = carbsGrams / icr.gramsPerUnit
@@ -422,17 +424,19 @@ async calculateBolus(input: BolusInput, auditUserId: number): Promise<BolusResul
 // InsulinSensitivityFactor, CarbRatio, PumpBasalSlot utilisent Time (pas Timestamp)
 // Time = "HH:MM:SS" pour heure du jour — stockage léger, pas timezone
 
-const findSlotForHour = (
-  slots: { startHour: number; value: number }[],
-  hour: number
-): { value: number } | null => {
-  // Slots triés par startHour DESC (24h → 0h)
-  // On prend le premier slot où startHour <= hour
-  const slot = slots
-    .sort((a, b) => b.startHour - a.startHour)
-    .find(s => s.startHour <= hour)
-  return slot ?? slots[slots.length - 1]  // Fallback : 00:00
-}
+// ⚠️ Source de vérité = insulin.service.ts (findSlotForHour). Sélection par
+// intervalle demi-ouvert [startHour, endHour), avec gestion du passage minuit.
+// AUCUN fallback : une heure non couverte renvoie undefined et l'appelant lève
+// ("No ISF/ICR slot found for current hour") → calcul de bolus fail-closed.
+const findSlotForHour = <T extends { startHour: number; endHour: number }>(
+  slots: T[],
+  hour: number,
+): T | undefined =>
+  slots.find((s) =>
+    s.startHour <= s.endHour
+      ? hour >= s.startHour && hour < s.endHour       // intervalle normal
+      : hour >= s.startHour || hour < s.endHour,       // passage minuit (22h → 6h)
+  )
 ```
 
 ### Services avec transactions Prisma 7

--- a/README.md
+++ b/README.md
@@ -417,16 +417,19 @@ Cappage final     = min(recommendedDose, MAX_SINGLE_BOLUS)
 ISF, ICR, et profils basaux sont organisés par **slots horaires** (Time : "HH:MM:SS") :
 
 ```typescript
-const findSlotForHour = (
-  slots: { startHour: number; value: number }[],
-  hour: number
-): { value: number } => {
-  // Slots triés DESC (24h -> 0h)
-  // Sélectionner premier slot où startHour <= hour
-  return slots
-    .sort((a, b) => b.startHour - a.startHour)
-    .find(s => s.startHour <= hour) ?? slots[slots.length - 1]
-}
+// ⚠️ Source de vérité = src/lib/services/insulin.service.ts (findSlotForHour).
+// Sélection par intervalle demi-ouvert [startHour, endHour), passage minuit géré.
+// AUCUN fallback : une heure non couverte renvoie undefined et l'appelant lève
+// ("No ISF/ICR slot found for current hour") → calcul de bolus fail-closed.
+const findSlotForHour = <T extends { startHour: number; endHour: number }>(
+  slots: T[],
+  hour: number,
+): T | undefined =>
+  slots.find((s) =>
+    s.startHour <= s.endHour
+      ? hour >= s.startHour && hour < s.endHour       // intervalle normal
+      : hour >= s.startHour || hour < s.endHour,       // passage minuit (22h -> 6h)
+  )
 ```
 
 ### Transactions Prisma 7

--- a/docs/clinical-logic/bolus-calculation.md
+++ b/docs/clinical-logic/bolus-calculation.md
@@ -50,7 +50,7 @@
 
 ## Selections des creneaux horaires
 
-Les parametres ISF, ICR et basal sont definis par creneaux horaires (0-23h). La selection se fait par `findSlotForHour` :
+Les parametres ISF, ICR et basal sont definis par creneaux horaires (0-23h). La selection se fait par `findSlotForHour`, sur intervalle demi-ouvert `[startHour, endHour)` :
 
 ```typescript
 // Support du passage minuit (ex: 22h -> 6h)
@@ -60,6 +60,14 @@ if (startHour <= endHour) {
   return hour >= startHour || hour < endHour
 }
 ```
+
+**Securite clinique (fail-closed)** : si aucun creneau ne couvre l'heure
+courante, `findSlotForHour` renvoie `undefined` et l'appelant **leve** une
+erreur (`"No ISF/ICR slot found for current hour"`) **avant** tout calcul de
+dose. Aucun fallback, aucune dose calculee sur une heure non couverte par la
+configuration. Les chevauchements de creneaux sont par ailleurs rejetes a
+l'ecriture (HR-2, `hasTimeSlotOverlap`), garantissant l'unicite du creneau
+selectionne.
 
 ## Analytics glycemiques
 

--- a/docs/database/schema.md
+++ b/docs/database/schema.md
@@ -1110,11 +1110,14 @@ Facteur de sensibilité insuline (ISF) par tranche horaire.
 - `INDEX(settingsId, startHour)` — lookup rapide pour heure courante
 
 **Règles métier**:
-- Slots ordonnés par `startHour` ascendant (00:00 → 23:00)
-- Sélection: premier slot où `startHour <= heure_courante`
-- Fallback: dernier slot (minuit)
+- Sélection (`findSlotForHour`, `insulin.service.ts`): premier slot dont
+  l'intervalle demi-ouvert `[startHour, endHour)` contient l'heure courante
+  (passage minuit géré si `startHour > endHour`)
+- **Pas de fallback**: heure non couverte → `undefined` → l'appelant lève
+  ("No ISF slot found for current hour"). Calcul de bolus fail-closed.
 - **Validation clinique**: ISF ∈ [0.10, 1.00] g/L/U (voir `CLINICAL_BOUNDS` dans `src/lib/clinical-bounds.ts`)
-- ❌ **TODO**: Empêcher chevauchements horaires
+- **Anti-chevauchement** (HR-2): rejeté au write-path via `hasTimeSlotOverlap`
+  (`insulin-therapy.service.ts`) — un nouveau slot recouvrant un slot existant lève.
 
 ---
 

--- a/src/app/(dashboard)/patients/[id]/PatientDetailClient.tsx
+++ b/src/app/(dashboard)/patients/[id]/PatientDetailClient.tsx
@@ -463,7 +463,7 @@ function SlotList({
   unit: string
   slots: { range: string; value: number }[]
   coverage?: SlotCoverage
-  /** "ratio" = ISF/ICR (trou rattrapé par fallback) ; "basal" = pompe (24 h requis). */
+  /** "ratio" = ISF/ICR (trou = config à vérifier) ; "basal" = pompe (24 h requis). */
   family?: "ratio" | "basal"
 }) {
   const t = useTranslations("patientDetail")
@@ -481,7 +481,8 @@ function SlotList({
         ))}
       </ul>
       {/* Garde-fou structurel non bloquant (lignes indépendantes). Trou : pour
-          ISF/ICR la sélection retombe sur le dernier créneau (fallback) → simple
+          ISF/ICR une heure non couverte est gérée fail-closed au calcul de bolus
+          (findSlotForHour → undefined → l'appelant lève), donc ici simple
           « config à vérifier » ; pour le basal pompe une heure non couverte est
           plus significative. Chevauchement : déjà rejeté au write-path ISF/ICR,
           donc canari d'intégrité (donnée legacy/import). */}


### PR DESCRIPTION
## Contexte

Item backlog **[Doc]** relevé par le `medical-domain-validator` lors de la revue de la PR #551. La documentation décrivait un `findSlotForHour` **inexact** : tri `startHour` DESC + *fallback* sur le dernier slot. L'implémentation réelle (`src/lib/services/insulin.service.ts:307-318`) :

- sélectionne par **intervalle demi-ouvert** `[startHour, endHour)` (avec gestion du **passage minuit** si `startHour > endHour`) ;
- renvoie `undefined` si aucune correspondance → l'appelant **lève** (`"No ISF/ICR slot found for current hour"`, l.135-139).

C'est un comportement **fail-closed** : jamais de dose calculée sur une heure non couverte par la config. Important pour l'exactitude de la doc clinique (traçabilité `/docs/clinical-logic`).

## Changements (doc + commentaires uniquement, zéro logique)

- **`CLAUDE.md`** — les 2 passages (commentaire formule bolus + section « Sélection du ratio horaire ») réécrits pour refléter le code réel (intervalle demi-ouvert, passage minuit, fail-closed, pas de fallback).
- **`docs/database/schema.md`** — règles métier ISF corrigées ; le `❌ TODO: Empêcher chevauchements horaires` (en fait **déjà implémenté**) remplacé par la description de l'anti-chevauchement réel (HR-2, `hasTimeSlotOverlap` au write-path ISF l.158 / ICR l.212 / basal l.306).
- **`PatientDetailClient.tsx`** — les commentaires du garde-fou de créneaux (introduits en PR #551) corrigés : « trou rattrapé par fallback » → « géré fail-closed au calcul de bolus ». Aucun changement de rendu/logique.

## Vérifs

- `tsc` ✅ (changements limités à doc + commentaires)
- Comportement réel vérifié dans le code avant correction (`findSlotForHour`, callers, `hasTimeSlotOverlap`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)