### PR TITLE
feat(patients): signal hypo sévère récente exclue par le plancher CGM

### DIFF
--- a/docs/UserStory/Navigation/cablage-donnees-patient.md
+++ b/docs/UserStory/Navigation/cablage-donnees-patient.md
@@ -127,9 +127,15 @@ dans des tickets dédiés, pas dans le câblage des onglets.
   (minimisation Art. 5.1.c) — méthode de lecture allégée pour la page.
 - **[Perf] Double lookup patient** : la garde consentement fait un `findFirst`
   léger puis `getById` en refait un complet — fusionnable.
-- **[Clinique] Plancher 0.40 ↔ fraîcheur (Phase 2)** : une hypo sévère < 40 mg/dL
-  exclue par le plancher peut laisser un relevé bénin plus ancien passer pour le
-  « dernier relevé » sans déclencher `stale`. À traiter avec l'item plancher.
+- ✅ **[Clinique] Plancher 0.40 ↔ fraîcheur (Phase 2)** (FAIT) : nouvelle méthode
+  `glycemiaService.getLatestCgmFreshness` (relevé brut le plus récent dans la
+  fenêtre, SANS filtre de valeur, classé `belowFloor`/`aboveCeiling`, audité).
+  `buildGlycemiaView` croise ce signal : si un relevé hors plage (< 40 mg/dL hypo
+  sévère / capteur LOW, ou > 500 capteur HIGH) est **plus récent** que l'affiché
+  (ou s'il n'y a aucun relevé affichable), `recentOutOfRange` = `"low"`/`"high"`.
+  Bannière d'alerte prioritaire sur l'onglet Glycémie (même sans série).
+  i18n FR/EN/AR. Ne modifie pas les analytics/TIR (item plancher agrégats
+  ci-dessus reste ouvert).
 - ✅ **[Audit] Pivot `metadata.patientId` harmonisé** (FAIT) : ajouté sur
   `READ CGM_ENTRY` / `GLYCEMIA_ENTRY` (`glycemia.service`) et `READ BOLUS_LOG`
   (`getBolusLogs`/`getBolusLogById`, `insulin-therapy.service`), + `requestId`.

--- a/docs/UserStory/Navigation/cablage-donnees-patient.md
+++ b/docs/UserStory/Navigation/cablage-donnees-patient.md
@@ -133,9 +133,19 @@ dans des tickets dédiés, pas dans le câblage des onglets.
   `buildGlycemiaView` croise ce signal : si un relevé hors plage (< 40 mg/dL hypo
   sévère / capteur LOW, ou > 500 capteur HIGH) est **plus récent** que l'affiché
   (ou s'il n'y a aucun relevé affichable), `recentOutOfRange` = `"low"`/`"high"`.
-  Bannière d'alerte prioritaire sur l'onglet Glycémie (même sans série).
-  i18n FR/EN/AR. Ne modifie pas les analytics/TIR (item plancher agrégats
-  ci-dessus reste ouvert).
+  Bannière d'alerte prioritaire (`role="alert"`) sur l'onglet Glycémie (même
+  sans série). Helper de croisement partagé `src/lib/cgm-freshness.ts`
+  (`recentOutOfRangeFrom`, dépendance-free). i18n FR/EN/AR. Ne modifie pas les
+  analytics/TIR (item plancher agrégats ci-dessus reste ouvert). Service
+  fail-closed (valueGl null → suspect) ; appel fail-soft côté page (n'altère
+  jamais le rendu du dossier).
+  **Étendu (revue PR #555, choix « tout étendre »)** : signal exposé en HEADER
+  additif `X-CGM-Recent-Out-Of-Range` (`low`/`high`/`none`) sur `/api/cgm` et
+  `/api/patients/[id]/cgm` — body inchangé (tableau plat) → **zéro casse** iOS ni
+  consommateurs in-repo. **Dashboard patient** (`(patient)/patient/dashboard`)
+  lit ce header et affiche la même bannière (surface la plus à risque : pas de
+  clinicien dans la boucle). Export RGPD `/api/userdata` hors périmètre (dump
+  historique, pas un « état courant »).
 - ✅ **[Audit] Pivot `metadata.patientId` harmonisé** (FAIT) : ajouté sur
   `READ CGM_ENTRY` / `GLYCEMIA_ENTRY` (`glycemia.service`) et `READ BOLUS_LOG`
   (`getBolusLogs`/`getBolusLogById`, `insulin-therapy.service`), + `requestId`.

--- a/docs/clinical-logic/bolus-calculation.md
+++ b/docs/clinical-logic/bolus-calculation.md
@@ -117,6 +117,34 @@ Remplace l'ancienne formule eA1c par consensus international 2019.
 
 70% de capture sur la periode analysee est requis (consensus ADA 2019). En dessous, un warning `insufficientCgmCapture` est emis.
 
+### Plancher d'affichage CGM & signal de fraichesse (securite clinique)
+
+`getCgmEntries` exclut les valeurs hors plage capteur affichable : `< 0.40 g/L`
+(40 mg/dL) et `> 5.00 g/L` (500 mg/dL). **Attention** : la BDD stocke une plage
+plus large (`CHECK 0.20-6.00 g/L`, `cgm_partitioning.sql`). Une valeur numerique
+mesuree entre **0.20 et 0.40 g/L est donc une hypoglycemie severe reelle**, pas
+seulement un artefact « LOW » capteur.
+
+Risque : un releve hors plage **recent** (hypo severe / capteur LOW) exclu de la
+serie peut laisser un releve benin plus ancien passer pour le « dernier releve »
+sans declencher `stale` -> fausse reassurance.
+
+Garde-fou (`src/lib/cgm-freshness.ts`, `glycemiaService.getLatestCgmFreshness`) :
+le releve brut le plus recent (sans filtre de valeur) est croise avec le dernier
+releve affiche. S'il est hors plage **et plus recent** (ou s'il n'y a aucun
+releve affichable), un caveat est leve : `recentOutOfRange = "low" | "high"`.
+
+- Affichage : dossier medecin (onglet Glycemie), dashboard patient, et header
+  HTTP additif `X-CGM-Recent-Out-Of-Range` sur `/api/cgm` et
+  `/api/patients/[id]/cgm`.
+- Consigne patient (LOW) : confirmer au doigt (BGM) avant d'agir + auto-traiter
+  si confirme. Variante HIGH : confirmer au doigt uniquement (jamais d'incitation
+  a une correction insuline non supervisee).
+- **Limitation connue** : le caveat ne distingue pas encore une valeur numerique
+  sous-plancher (20-40 mg/dL, hypo mesuree) d'un flag « LOW » capteur. L'action
+  (confirmer au doigt) est correcte dans les deux cas. Les analytics/TIR ne sont
+  pas modifies (les valeurs hors plage restent exclues des agregats).
+
 ## Propositions d'ajustement
 
 ### Algorithme

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1583,6 +1583,8 @@
     "agoMinutes": "قبل {n, plural, zero {# دقيقة} one {دقيقة واحدة} two {دقيقتان} few {# دقائق} many {# دقيقة} other {# دقيقة}}",
     "agoHours": "قبل {n, plural, zero {# ساعة} one {ساعة واحدة} two {ساعتان} few {# ساعات} many {# ساعة} other {# ساعة}}",
     "staleReadingNote": "قياس قديم — قد لا يعكس الحالة الحالية.",
+    "recentOutOfRangeLow": "يوجد قياس أحدث خارج النطاق القابل للعرض (احتمال هبوط سكر حاد < 40 mg/dL أو مستشعر «LOW») — يُرجى فحص المريض.",
+    "recentOutOfRangeHigh": "يوجد قياس أحدث خارج النطاق القابل للعرض (> 500 mg/dL أو مستشعر «HIGH») — يُرجى فحص المريض.",
     "deliveryPump": "مضخة الأنسولين",
     "deliveryManual": "قلم / يدوي",
     "noInsulinSettings": "لا توجد إعدادات علاج بالأنسولين مسجّلة.",

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1609,6 +1609,8 @@
     "periodSubtitle": "نظرة عامة على آخر {days} أيام.",
     "comingSoon": "متوفر قريبًا",
     "glycemiaSectionTitle": "سكر الدم خلال 24 ساعة",
+    "cgmRecentOutOfRangeLow": "توجد قراءة أحدث خارج النطاق القابل للعرض (احتمال هبوط سكر حاد < 40 mg/dL أو مستشعر «LOW»). تحقّق من سكر الدم بوخز الإصبع وعالج عند الحاجة.",
+    "cgmRecentOutOfRangeHigh": "توجد قراءة أحدث خارج النطاق القابل للعرض (> 500 mg/dL أو مستشعر «HIGH»). تحقّق من سكر الدم بوخز الإصبع.",
     "agpSectionTitle": "الملف المتنقل لسكر الدم (AGP)",
     "quickActionsTitle": "إجراءات سريعة",
     "metricTir": "الوقت ضمن النطاق المستهدف (TIR)",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1583,6 +1583,8 @@
     "agoMinutes": "{n} min ago",
     "agoHours": "{n} h ago",
     "staleReadingNote": "Old reading — may not reflect the current state.",
+    "recentOutOfRangeLow": "A more recent reading is out of displayable range (possible severe hypoglycemia < 40 mg/dL or sensor \"LOW\") — check the patient.",
+    "recentOutOfRangeHigh": "A more recent reading is out of displayable range (> 500 mg/dL or sensor \"HIGH\") — check the patient.",
     "deliveryPump": "Insulin pump",
     "deliveryManual": "Pen / manual",
     "noInsulinSettings": "No insulin therapy settings recorded.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1609,6 +1609,8 @@
     "periodSubtitle": "Overview of the last {days} days.",
     "comingSoon": "Coming soon",
     "glycemiaSectionTitle": "Glucose over 24 h",
+    "cgmRecentOutOfRangeLow": "A more recent reading is out of displayable range (possible severe hypoglycemia < 40 mg/dL or sensor \"LOW\"). Check your finger-stick glucose and treat if needed.",
+    "cgmRecentOutOfRangeHigh": "A more recent reading is out of displayable range (> 500 mg/dL or sensor \"HIGH\"). Check your finger-stick glucose.",
     "agpSectionTitle": "Ambulatory glucose profile (AGP)",
     "quickActionsTitle": "Quick actions",
     "metricTir": "Time in range (TIR)",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1583,6 +1583,8 @@
     "agoMinutes": "il y a {n} min",
     "agoHours": "il y a {n} h",
     "staleReadingNote": "Relevé ancien — peut ne pas refléter l'état actuel.",
+    "recentOutOfRangeLow": "Un relevé plus récent est hors plage affichable (hypoglycémie sévère < 40 mg/dL possible ou capteur « LOW ») — vérifier le patient.",
+    "recentOutOfRangeHigh": "Un relevé plus récent est hors plage affichable (> 500 mg/dL ou capteur « HIGH ») — vérifier le patient.",
     "deliveryPump": "Pompe à insuline",
     "deliveryManual": "Stylo / manuel",
     "noInsulinSettings": "Aucun réglage d'insulinothérapie enregistré.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1609,6 +1609,8 @@
     "periodSubtitle": "Aperçu des {days} derniers jours.",
     "comingSoon": "Bientôt disponible",
     "glycemiaSectionTitle": "Glycémie sur 24 h",
+    "cgmRecentOutOfRangeLow": "Une mesure plus récente est hors plage affichable (hypoglycémie sévère < 40 mg/dL possible ou capteur « LOW »). Vérifiez votre glycémie au doigt et traitez si besoin.",
+    "cgmRecentOutOfRangeHigh": "Une mesure plus récente est hors plage affichable (> 500 mg/dL ou capteur « HIGH »). Vérifiez votre glycémie au doigt.",
     "agpSectionTitle": "Profil ambulatoire (AGP)",
     "quickActionsTitle": "Actions rapides",
     "metricTir": "Temps dans la cible (TIR)",

--- a/src/app/(dashboard)/patients/[id]/PatientDetailClient.tsx
+++ b/src/app/(dashboard)/patients/[id]/PatientDetailClient.tsx
@@ -270,7 +270,7 @@ export function PatientDetailClient({
                 LOW-HIGH) → bannière prioritaire, même sans relevé affichable. */}
             {data.glycemia.recentOutOfRange && (
               <p
-                role="status"
+                role="alert"
                 className="rounded-md border border-feedback-warning bg-warning-bg px-4 py-2 text-sm text-warning-fg"
               >
                 {data.glycemia.recentOutOfRange === "low"

--- a/src/app/(dashboard)/patients/[id]/PatientDetailClient.tsx
+++ b/src/app/(dashboard)/patients/[id]/PatientDetailClient.tsx
@@ -270,7 +270,9 @@ export function PatientDetailClient({
                 LOW-HIGH) → bannière prioritaire, même sans relevé affichable. */}
             {data.glycemia.recentOutOfRange && (
               <p
-                role="alert"
+                // LOW = urgence actionnable (assertif) ; HIGH = important mais
+                // non seconde-critique (poli) — cf. revue clinique PR #555.
+                role={data.glycemia.recentOutOfRange === "low" ? "alert" : "status"}
                 className="rounded-md border border-feedback-warning bg-warning-bg px-4 py-2 text-sm text-warning-fg"
               >
                 {data.glycemia.recentOutOfRange === "low"

--- a/src/app/(dashboard)/patients/[id]/PatientDetailClient.tsx
+++ b/src/app/(dashboard)/patients/[id]/PatientDetailClient.tsx
@@ -265,6 +265,19 @@ export function PatientDetailClient({
 
           {/* ── Glycémie (câblée — Phase 2) ─────────────────── */}
           <TabsContent value="glycemia" className="space-y-6">
+            {/* Sécurité clinique : un relevé plus récent que l'affiché est hors
+                plage et a été exclu de la série (hypo sévère < 40 / capteur
+                LOW-HIGH) → bannière prioritaire, même sans relevé affichable. */}
+            {data.glycemia.recentOutOfRange && (
+              <p
+                role="status"
+                className="rounded-md border border-feedback-warning bg-warning-bg px-4 py-2 text-sm text-warning-fg"
+              >
+                {data.glycemia.recentOutOfRange === "low"
+                  ? t("recentOutOfRangeLow")
+                  : t("recentOutOfRangeHigh")}
+              </p>
+            )}
             {data.glycemia.points.length > 0 ? (
               <>
                 {data.glycemia.lastReadingMgdl !== null && (

--- a/src/app/(dashboard)/patients/[id]/glycemia-view.ts
+++ b/src/app/(dashboard)/patients/[id]/glycemia-view.ts
@@ -11,14 +11,11 @@
 /** Seuil de fraîcheur du « dernier relevé » (minutes). Au-delà → `stale`. */
 export const CGM_STALE_AFTER_MIN = 30
 
-export type CgmEntryLite = { valueGl: number | null; timestamp: string }
+import { recentOutOfRangeFrom, type LatestRawSignal } from "@/lib/cgm-freshness"
 
-/**
- * Signal de fraîcheur « brut » : relevé CGM le plus récent dans la fenêtre, AVANT
- * le filtre de plage capteur (cf. `glycemiaService.getLatestCgmFreshness`).
- * Permet de détecter qu'un relevé plus récent que l'affiché est hors plage.
- */
-export type LatestRawSignal = { timestamp: string; belowFloor: boolean; aboveCeiling: boolean }
+export type { LatestRawSignal }
+
+export type CgmEntryLite = { valueGl: number | null; timestamp: string }
 
 export type GlycemiaView = {
   points: { time: string; glucose: number }[]
@@ -67,23 +64,15 @@ export function buildGlycemiaView(
     ? Math.max(0, Math.round((now.getTime() - new Date(last.timestamp).getTime()) / 60_000))
     : null
 
-  // Croisement fraîcheur : si le relevé brut le plus récent est hors plage ET
-  // plus récent que le dernier relevé affiché (ou s'il n'y a aucun relevé
-  // affichable), on signale l'hypo sévère / capteur LOW-HIGH masqué.
-  let recentOutOfRange: "low" | "high" | null = null
-  if (latestRaw && (latestRaw.belowFloor || latestRaw.aboveCeiling)) {
-    const lastShownMs = last ? new Date(last.timestamp).getTime() : Number.NEGATIVE_INFINITY
-    if (new Date(latestRaw.timestamp).getTime() > lastShownMs) {
-      recentOutOfRange = latestRaw.belowFloor ? "low" : "high"
-    }
-  }
-
   return {
     points,
     lastReadingMgdl: last ? toMgdl(last.valueGl) : null,
     lastReadingAt: last ? timeFmt.format(new Date(last.timestamp)) : null,
     lastReadingAgeMin,
     stale: lastReadingAgeMin !== null && lastReadingAgeMin > CGM_STALE_AFTER_MIN,
-    recentOutOfRange,
+    // Croisement fraîcheur (source unique `recentOutOfRangeFrom`) : relevé hors
+    // plage plus récent que l'affiché (ou aucun relevé affichable) → hypo sévère
+    // / capteur masqué.
+    recentOutOfRange: recentOutOfRangeFrom(last?.timestamp ?? null, latestRaw),
   }
 }

--- a/src/app/(dashboard)/patients/[id]/glycemia-view.ts
+++ b/src/app/(dashboard)/patients/[id]/glycemia-view.ts
@@ -13,6 +13,13 @@ export const CGM_STALE_AFTER_MIN = 30
 
 export type CgmEntryLite = { valueGl: number | null; timestamp: string }
 
+/**
+ * Signal de fraîcheur « brut » : relevé CGM le plus récent dans la fenêtre, AVANT
+ * le filtre de plage capteur (cf. `glycemiaService.getLatestCgmFreshness`).
+ * Permet de détecter qu'un relevé plus récent que l'affiché est hors plage.
+ */
+export type LatestRawSignal = { timestamp: string; belowFloor: boolean; aboveCeiling: boolean }
+
 export type GlycemiaView = {
   points: { time: string; glucose: number }[]
   lastReadingMgdl: number | null
@@ -21,6 +28,14 @@ export type GlycemiaView = {
   lastReadingAgeMin: number | null
   /** Dernier relevé plus ancien que {@link CGM_STALE_AFTER_MIN}. */
   stale: boolean
+  /**
+   * Un relevé PLUS RÉCENT que celui affiché est hors plage affichable et a donc
+   * été exclu de la série : `"low"` (< 40 mg/dL — hypo sévère possible / capteur
+   * LOW) ou `"high"` (> 500 mg/dL — capteur HIGH). `null` sinon. Sécurité
+   * clinique : évite qu'un relevé bénin plus ancien masque une hypo sévère
+   * récente sans signal.
+   */
+  recentOutOfRange: "low" | "high" | null
 }
 
 // Invariant : TZ + locale FIXES (heure clinique FR). Instancié une fois au
@@ -36,7 +51,11 @@ const timeFmt = new Intl.DateTimeFormat("fr-FR", {
 
 const toMgdl = (gl: number): number => Math.round(gl * 100)
 
-export function buildGlycemiaView(entries: CgmEntryLite[], now: Date): GlycemiaView {
+export function buildGlycemiaView(
+  entries: CgmEntryLite[],
+  now: Date,
+  latestRaw?: LatestRawSignal | null,
+): GlycemiaView {
   // valueGl null déjà exclu par la requête (CHECK gte/lte) — on borne le type.
   const valid = entries.filter((e): e is CgmEntryLite & { valueGl: number } => e.valueGl !== null)
   const points = valid.map((e) => ({
@@ -47,11 +66,24 @@ export function buildGlycemiaView(entries: CgmEntryLite[], now: Date): GlycemiaV
   const lastReadingAgeMin = last
     ? Math.max(0, Math.round((now.getTime() - new Date(last.timestamp).getTime()) / 60_000))
     : null
+
+  // Croisement fraîcheur : si le relevé brut le plus récent est hors plage ET
+  // plus récent que le dernier relevé affiché (ou s'il n'y a aucun relevé
+  // affichable), on signale l'hypo sévère / capteur LOW-HIGH masqué.
+  let recentOutOfRange: "low" | "high" | null = null
+  if (latestRaw && (latestRaw.belowFloor || latestRaw.aboveCeiling)) {
+    const lastShownMs = last ? new Date(last.timestamp).getTime() : Number.NEGATIVE_INFINITY
+    if (new Date(latestRaw.timestamp).getTime() > lastShownMs) {
+      recentOutOfRange = latestRaw.belowFloor ? "low" : "high"
+    }
+  }
+
   return {
     points,
     lastReadingMgdl: last ? toMgdl(last.valueGl) : null,
     lastReadingAt: last ? timeFmt.format(new Date(last.timestamp)) : null,
     lastReadingAgeMin,
     stale: lastReadingAgeMin !== null && lastReadingAgeMin > CGM_STALE_AFTER_MIN,
+    recentOutOfRange,
   }
 }

--- a/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/src/app/(dashboard)/patients/[id]/page.tsx
@@ -108,7 +108,10 @@ export default async function PatientDetailPage({
   // `buildGlycemiaView` (pur, unit-testé).
   const from24h = new Date(now.getTime() - 24 * 60 * 60 * 1000)
   const cgmEntries = await glycemiaService.getCgmEntries(patientId, from24h, now, userId, ctx)
-  const glycemiaView = buildGlycemiaView(cgmEntries, now)
+  // Signal de fraîcheur « brut » : détecte un relevé plus récent hors plage
+  // (hypo sévère < 40 / capteur LOW-HIGH) exclu de la série affichée.
+  const latestRaw = await glycemiaService.getLatestCgmFreshness(patientId, from24h, now, userId, ctx)
+  const glycemiaView = buildGlycemiaView(cgmEntries, now, latestRaw)
 
   // Phase 3 — Onglet Traitements : réglages insuline réels (audité
   // READ INSULIN_THERAPY) + traitements associés (déjà chargés via getById).

--- a/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/src/app/(dashboard)/patients/[id]/page.tsx
@@ -107,10 +107,17 @@ export default async function PatientDetailPage({
   // Mapping déterministe (g/L→mg/dL, heure Europe/Paris, fraîcheur) extrait dans
   // `buildGlycemiaView` (pur, unit-testé).
   const from24h = new Date(now.getTime() - 24 * 60 * 60 * 1000)
-  const cgmEntries = await glycemiaService.getCgmEntries(patientId, from24h, now, userId, ctx)
   // Signal de fraîcheur « brut » : détecte un relevé plus récent hors plage
-  // (hypo sévère < 40 / capteur LOW-HIGH) exclu de la série affichée.
-  const latestRaw = await glycemiaService.getLatestCgmFreshness(patientId, from24h, now, userId, ctx)
+  // (hypo sévère < 40 / capteur LOW-HIGH) exclu de la série affichée. Fail-soft :
+  // ce signal secondaire ne doit JAMAIS faire planter le dossier (on dégrade en
+  // « pas de caveat » et on trace l'erreur pour le SOC).
+  const [cgmEntries, latestRaw] = await Promise.all([
+    glycemiaService.getCgmEntries(patientId, from24h, now, userId, ctx),
+    glycemiaService.getLatestCgmFreshness(patientId, from24h, now, userId, ctx).catch((e) => {
+      console.error("[patient-detail] getLatestCgmFreshness failed", e instanceof Error ? e.message : e)
+      return null
+    }),
+  ])
   const glycemiaView = buildGlycemiaView(cgmEntries, now, latestRaw)
 
   // Phase 3 — Onglet Traitements : réglages insuline réels (audité

--- a/src/app/(patient)/patient/dashboard/page.tsx
+++ b/src/app/(patient)/patient/dashboard/page.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/components/diabeo/PeriodSelector"
 import { QuickActionsPanel, type QuickAction } from "@/components/diabeo/QuickActionsPanel"
 import { DiabeoCard } from "@/components/diabeo/DiabeoCard"
+import { CGM_RECENT_OOR_HEADER } from "@/lib/cgm-freshness"
 
 /**
  * H5 — exhaustive lookup. Adding a new TimePeriod yields a compile error.
@@ -93,7 +94,7 @@ function describeErrorKey(status: number, code?: KnownApiErrorCode | string): st
  *  so it is testable without rendering the page (M3). */
 async function fetchSection<T>(
   url: string,
-): Promise<{ ok: true; data: T } | { ok: false; error: string }> {
+): Promise<{ ok: true; data: T; headers: Headers } | { ok: false; error: string }> {
   try {
     const res = await fetch(url, { credentials: "include" })
     if (!res.ok) {
@@ -105,7 +106,7 @@ async function fetchSection<T>(
       return { ok: false, error: describeErrorKey(res.status, code) }
     }
     const data = (await res.json()) as T
-    return { ok: true, data }
+    return { ok: true, data, headers: res.headers }
   } catch {
     return { ok: false, error: "errorNetworkCheck" }
   }
@@ -115,6 +116,10 @@ export default function PatientDashboardPage() {
   const t = useTranslations("patientDashboard")
   const [period, setPeriod] = useState<TimePeriod>(TimePeriod.OneWeek)
   const [cgmPoints, setCgmPoints] = useState<{ time: string; glucose: number }[]>([])
+  // Sécurité clinique : un relevé hors plage plus récent que l'affiché a été
+  // exclu de la série (hypo sévère < 40 / capteur LOW-HIGH) — signal lu dans le
+  // header `X-CGM-Recent-Out-Of-Range` de /api/cgm (cf. cgm-freshness).
+  const [cgmRecentOutOfRange, setCgmRecentOutOfRange] = useState<"low" | "high" | null>(null)
   const [profile, setProfile] = useState<GlycemicProfileResponse | null>(null)
   const [agpSlots, setAgpSlots] = useState<AgpSlotPoint[]>([])
   const [cgmState, setCgmState] = useState<SectionState>(INITIAL_STATE)
@@ -161,6 +166,8 @@ export default function PatientDashboardPage() {
           glucose: Math.round(e.valueGl * 100),
         })),
       )
+      const oor = cgmSettled.value.headers.get(CGM_RECENT_OOR_HEADER)
+      setCgmRecentOutOfRange(oor === "low" || oor === "high" ? oor : null)
       setCgmState({ loading: false, error: null })
     } else {
       const err = cgmSettled.status === "fulfilled" && !cgmSettled.value.ok
@@ -260,6 +267,13 @@ export default function PatientDashboardPage() {
         <h2 id="glycemia-section" className="text-lg font-medium text-gray-800">
           {t("glycemiaSectionTitle")}
         </h2>
+        {/* Sécurité clinique : un relevé hors plage plus récent que l'affiché a
+            été exclu (hypo sévère < 40 / capteur LOW-HIGH) → alerte prioritaire. */}
+        {cgmRecentOutOfRange && (
+          <div role="alert" className="rounded-md border border-feedback-warning bg-warning-bg p-3 text-sm text-warning-fg">
+            {cgmRecentOutOfRange === "low" ? t("cgmRecentOutOfRangeLow") : t("cgmRecentOutOfRangeHigh")}
+          </div>
+        )}
         {metricsState.error && (
           // C5 — actionable error → role="alert" (assertive) per WCAG 4.1.3.
           <div role="alert" className="rounded-md border border-amber-200 bg-amber-50 text-amber-900 p-3 text-sm">

--- a/src/app/(patient)/patient/dashboard/page.tsx
+++ b/src/app/(patient)/patient/dashboard/page.tsx
@@ -270,7 +270,11 @@ export default function PatientDashboardPage() {
         {/* Sécurité clinique : un relevé hors plage plus récent que l'affiché a
             été exclu (hypo sévère < 40 / capteur LOW-HIGH) → alerte prioritaire. */}
         {cgmRecentOutOfRange && (
-          <div role="alert" className="rounded-md border border-feedback-warning bg-warning-bg p-3 text-sm text-warning-fg">
+          // LOW = urgence actionnable (assertif) ; HIGH = poli (cf. revue PR #555).
+          <div
+            role={cgmRecentOutOfRange === "low" ? "alert" : "status"}
+            className="rounded-md border border-feedback-warning bg-warning-bg p-3 text-sm text-warning-fg"
+          >
             {cgmRecentOutOfRange === "low" ? t("cgmRecentOutOfRangeLow") : t("cgmRecentOutOfRangeHigh")}
           </div>
         )}

--- a/src/app/api/cgm/route.ts
+++ b/src/app/api/cgm/route.ts
@@ -5,6 +5,7 @@ import { resolvePatientIdFromQuery } from "@/lib/auth/query-helpers"
 import { requireGdprConsent } from "@/lib/gdpr"
 import { glycemiaService } from "@/lib/services/glycemia.service"
 import { extractRequestContext } from "@/lib/services/audit.service"
+import { CGM_RECENT_OOR_HEADER, recentOutOfRangeFrom } from "@/lib/cgm-freshness"
 
 const querySchema = z.object({
   from: z.coerce.date(),
@@ -42,7 +43,17 @@ export async function GET(req: NextRequest) {
       patientId, parsed.data.from, parsed.data.to, user.id, ctx,
     )
 
-    return NextResponse.json(entries)
+    // Signal de fraîcheur (sécurité clinique) en HEADER additif — body inchangé
+    // (tableau plat) pour ne pas casser iOS ni les consommateurs in-repo.
+    // Fail-soft sur le signal secondaire.
+    const latestRaw = await glycemiaService
+      .getLatestCgmFreshness(patientId, parsed.data.from, parsed.data.to, user.id, ctx)
+      .catch(() => null)
+    const recentOutOfRange = recentOutOfRangeFrom(entries.at(-1)?.timestamp ?? null, latestRaw)
+
+    return NextResponse.json(entries, {
+      headers: { [CGM_RECENT_OOR_HEADER]: recentOutOfRange ?? "none" },
+    })
   } catch (error) {
     if (error instanceof AuthError) {
       return NextResponse.json({ error: error.message }, { status: error.status })

--- a/src/app/api/patients/[id]/cgm/route.ts
+++ b/src/app/api/patients/[id]/cgm/route.ts
@@ -5,6 +5,7 @@ import { canAccessPatient } from "@/lib/access-control"
 import { patientShareConsent } from "@/lib/consent"
 import { glycemiaService } from "@/lib/services/glycemia.service"
 import { auditService, extractRequestContext } from "@/lib/services/audit.service"
+import { CGM_RECENT_OOR_HEADER, recentOutOfRangeFrom } from "@/lib/cgm-freshness"
 
 type RouteParams = { params: Promise<{ id: string }> }
 
@@ -47,9 +48,19 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
 
     const entries = await glycemiaService.getCgmEntries(patientId, parsed.data.from, parsed.data.to, user.id, ctx)
 
+    // Signal de fraîcheur (sécurité clinique) exposé en HEADER additif — le body
+    // reste un tableau plat (contrat iOS + consommateurs in-repo inchangé).
+    // Fail-soft : une erreur du signal secondaire ne casse pas la réponse.
+    const latestRaw = await glycemiaService
+      .getLatestCgmFreshness(patientId, parsed.data.from, parsed.data.to, user.id, ctx)
+      .catch(() => null)
+    const recentOutOfRange = recentOutOfRangeFrom(entries.at(-1)?.timestamp ?? null, latestRaw)
+
     // `getCgmEntries` retourne déjà un DTO sérialisé (id:string, valueGl:number,
     // timestamp:string). Pas besoin de re-mapper BigInt/Decimal ici.
-    return NextResponse.json(entries)
+    return NextResponse.json(entries, {
+      headers: { [CGM_RECENT_OOR_HEADER]: recentOutOfRange ?? "none" },
+    })
   } catch (error) {
     if (error instanceof AuthError) return NextResponse.json({ error: error.message }, { status: error.status })
     const msg = error instanceof Error ? error.message : "Unknown error"

--- a/src/lib/cgm-freshness.ts
+++ b/src/lib/cgm-freshness.ts
@@ -16,8 +16,7 @@
  */
 export type LatestRawSignal = { timestamp: string; belowFloor: boolean; aboveCeiling: boolean }
 
-/** Valeur du header HTTP exposant le signal (`"none"` = pas de relevé masqué). */
-export type RecentOutOfRangeHeader = "low" | "high" | "none"
+/** Header HTTP exposant le signal (valeurs `"low"`/`"high"`/`"none"`). */
 export const CGM_RECENT_OOR_HEADER = "X-CGM-Recent-Out-Of-Range"
 
 /**

--- a/src/lib/cgm-freshness.ts
+++ b/src/lib/cgm-freshness.ts
@@ -1,0 +1,41 @@
+/**
+ * Croisement de fraîcheur CGM (sécurité clinique) — module pur, sans dépendance.
+ *
+ * `getCgmEntries` exclut les valeurs hors plage capteur (< 0.40 g/L = hypo
+ * sévère possible / capteur LOW, > 5.00 g/L = capteur HIGH). Un relevé hors
+ * plage RÉCENT peut donc laisser un relevé bénin plus ancien passer pour le
+ * « dernier relevé » sans déclencher `stale` → fausse réassurance.
+ *
+ * Source unique du croisement (réutilisé par le dossier médecin, le dashboard
+ * patient et les routes API — header `X-CGM-Recent-Out-Of-Range`).
+ */
+
+/**
+ * Relevé CGM le plus récent dans la fenêtre, AVANT filtre de plage (cf.
+ * `glycemiaService.getLatestCgmFreshness`).
+ */
+export type LatestRawSignal = { timestamp: string; belowFloor: boolean; aboveCeiling: boolean }
+
+/** Valeur du header HTTP exposant le signal (`"none"` = pas de relevé masqué). */
+export type RecentOutOfRangeHeader = "low" | "high" | "none"
+export const CGM_RECENT_OOR_HEADER = "X-CGM-Recent-Out-Of-Range"
+
+/**
+ * Détermine si un relevé hors plage est PLUS RÉCENT que le dernier relevé
+ * affiché (ou s'il n'y a aucun relevé affichable) → signal d'hypo sévère /
+ * capteur masqué. `null` sinon.
+ *
+ * @param lastShownIso horodatage ISO du dernier relevé affichable (null si aucun)
+ * @param latestRaw relevé brut le plus récent (hors filtre de valeur)
+ */
+export function recentOutOfRangeFrom(
+  lastShownIso: string | null,
+  latestRaw: LatestRawSignal | null | undefined,
+): "low" | "high" | null {
+  if (!latestRaw || (!latestRaw.belowFloor && !latestRaw.aboveCeiling)) return null
+  const lastShownMs = lastShownIso ? new Date(lastShownIso).getTime() : Number.NEGATIVE_INFINITY
+  if (new Date(latestRaw.timestamp).getTime() > lastShownMs) {
+    return latestRaw.belowFloor ? "low" : "high"
+  }
+  return null
+}

--- a/src/lib/services/glycemia.service.ts
+++ b/src/lib/services/glycemia.service.ts
@@ -109,6 +109,51 @@ export const glycemiaService = {
   },
 
   /**
+   * Relevé CGM le plus récent dans la fenêtre, SANS filtre de valeur (inclut
+   * donc les valeurs hors plage affichable : < 0.40 g/L = hypo sévère possible /
+   * capteur LOW, ou > 5.00 g/L = capteur HIGH).
+   *
+   * Sécurité clinique (revue PR #544/#554) : `getCgmEntries` exclut ces valeurs,
+   * ce qui peut faire passer un relevé bénin plus ancien pour le « dernier
+   * relevé ». Ce signal permet de croiser la fraîcheur et d'alerter si un relevé
+   * plus récent que l'affiché est hors plage (cf. `buildGlycemiaView`).
+   *
+   * @returns `{ timestamp, belowFloor, aboveCeiling }` ou null si aucun relevé.
+   */
+  async getLatestCgmFreshness(
+    patientId: number, from: Date, to: Date,
+    auditUserId: number, ctx?: AuditContext,
+  ) {
+    enforceMaxPeriod(from, to)
+
+    const latest = await prisma.cgmEntry.findFirst({
+      where: { patientId, timestamp: { gte: from, lte: to } },
+      orderBy: { timestamp: "desc" },
+      select: { timestamp: true, valueGl: true },
+    })
+
+    await auditService.log({
+      userId: auditUserId,
+      action: "READ",
+      resource: "CGM_ENTRY",
+      resourceId: String(patientId),
+      ipAddress: ctx?.ipAddress,
+      userAgent: ctx?.userAgent,
+      requestId: ctx?.requestId,
+      // ADR #18 — pivot per-patient ; signal de fraîcheur (relevé brut le + récent).
+      metadata: { patientId, purpose: "cgm-freshness-signal" },
+    })
+
+    if (!latest) return null
+    const v = dec(latest.valueGl) ?? 0
+    return {
+      timestamp: latest.timestamp.toISOString(),
+      belowFloor: v < CGM_MIN_GL,
+      aboveCeiling: v > CGM_MAX_GL,
+    }
+  },
+
+  /**
    * Get manual glycemia (point-of-care) readings for a patient.
    * @async
    * @param {number} patientId - Patient ID

--- a/src/lib/services/glycemia.service.ts
+++ b/src/lib/services/glycemia.service.ts
@@ -11,6 +11,7 @@ import { prisma } from "@/lib/db/client"
 import { PeriodType, Prisma } from "@prisma/client"
 import { auditService } from "./audit.service"
 import type { AuditContext } from "./patient.service"
+import type { LatestRawSignal } from "@/lib/cgm-freshness"
 
 /**
  * Coerce un Prisma.Decimal | null en `number | null` JSON-safe.
@@ -118,12 +119,17 @@ export const glycemiaService = {
    * relevé ». Ce signal permet de croiser la fraîcheur et d'alerter si un relevé
    * plus récent que l'affiché est hors plage (cf. `buildGlycemiaView`).
    *
+   * NB bornes : la BDD stocke jusqu'à 0.20–6.00 g/L (CHECK `cgm_partitioning.sql`)
+   * alors que l'affichage filtre 0.40–5.00. Une valeur numérique 0.20–0.40 est
+   * donc un relevé réel sous le plancher (hypo sévère probable), pas qu'un
+   * artefact « LOW » capteur.
+   *
    * @returns `{ timestamp, belowFloor, aboveCeiling }` ou null si aucun relevé.
    */
   async getLatestCgmFreshness(
     patientId: number, from: Date, to: Date,
     auditUserId: number, ctx?: AuditContext,
-  ) {
+  ): Promise<LatestRawSignal | null> {
     enforceMaxPeriod(from, to)
 
     const latest = await prisma.cgmEntry.findFirst({
@@ -145,7 +151,13 @@ export const glycemiaService = {
     })
 
     if (!latest) return null
-    const v = dec(latest.valueGl) ?? 0
+    const v = dec(latest.valueGl)
+    // `valueGl` est NOT NULL en base → `v` est toujours un number ; le garde
+    // null est du fail-closed défensif (valeur inconnue = traitée comme suspecte
+    // sous le plancher, jamais « rassurante »).
+    if (v === null) {
+      return { timestamp: latest.timestamp.toISOString(), belowFloor: true, aboveCeiling: false }
+    }
     return {
       timestamp: latest.timestamp.toISOString(),
       belowFloor: v < CGM_MIN_GL,

--- a/tests/components/patient-detail-client.test.tsx
+++ b/tests/components/patient-detail-client.test.tsx
@@ -269,6 +269,19 @@ describe("PatientDetailClient (Phase 1)", () => {
     )
     expect(screen.getByText(/hors plage affichable/)).toBeTruthy()
     expect(screen.getByText(/hypoglycémie sévère/)).toBeTruthy()
+    // LOW = urgence actionnable → annonce assertive (role="alert"), pas "status".
+    expect(screen.getByRole("alert").textContent).toMatch(/hypoglycémie sévère/)
+  })
+
+  it("uses a polite role=status for the HIGH out-of-range caveat (non seconde-critique)", () => {
+    render(
+      <PatientDetailClient
+        data={{ ...baseData, glycemia: { ...baseData.glycemia, recentOutOfRange: "high" } }}
+      />,
+    )
+    // HIGH = important mais non urgent → role="status" (poli), jamais "alert".
+    expect(screen.getByRole("status").textContent).toMatch(/hors plage affichable/)
+    expect(screen.queryByRole("alert")).toBeNull()
   })
 
   it("shows the caveat even with no displayable CGM series (most dangerous case)", () => {

--- a/tests/components/patient-detail-client.test.tsx
+++ b/tests/components/patient-detail-client.test.tsx
@@ -80,6 +80,7 @@ const baseData: PatientDetailData = {
     lastReadingAt: "08:05",
     lastReadingAgeMin: 3,
     stale: false,
+    recentOutOfRange: null,
   },
   treatment: {
     hasSettings: true,
@@ -256,8 +257,30 @@ describe("PatientDetailClient (Phase 1)", () => {
   })
 
   it("shows an empty Glycémie state when there is no CGM series", () => {
-    render(<PatientDetailClient data={{ ...baseData, glycemia: { points: [], lastReadingMgdl: null, lastReadingAt: null, lastReadingAgeMin: null, stale: false } }} />)
+    render(<PatientDetailClient data={{ ...baseData, glycemia: { points: [], lastReadingMgdl: null, lastReadingAt: null, lastReadingAgeMin: null, stale: false, recentOutOfRange: null } }} />)
     expect(screen.queryByTestId("cgm-chart")).toBeNull()
+  })
+
+  it("surfaces the severe-hypo caveat when a more recent out-of-range reading was excluded", () => {
+    render(
+      <PatientDetailClient
+        data={{ ...baseData, glycemia: { ...baseData.glycemia, recentOutOfRange: "low" } }}
+      />,
+    )
+    expect(screen.getByText(/hors plage affichable/)).toBeTruthy()
+    expect(screen.getByText(/hypoglycémie sévère/)).toBeTruthy()
+  })
+
+  it("shows the caveat even with no displayable CGM series (most dangerous case)", () => {
+    render(
+      <PatientDetailClient
+        data={{
+          ...baseData,
+          glycemia: { points: [], lastReadingMgdl: null, lastReadingAt: null, lastReadingAgeMin: null, stale: false, recentOutOfRange: "low" },
+        }}
+      />,
+    )
+    expect(screen.getByText(/hors plage affichable/)).toBeTruthy()
   })
 
   it("color-codes the last reading with the patient's target thresholds (not defaults)", () => {

--- a/tests/pages/patient-dashboard.test.tsx
+++ b/tests/pages/patient-dashboard.test.tsx
@@ -40,6 +40,7 @@ afterEach(() => {
 function mockApi(opts?: {
   cgmStatus?: number
   cgmBody?: unknown
+  cgmRecentOutOfRange?: "low" | "high" | "none"
   profileStatus?: number
   profileBody?: unknown
   agpStatus?: number
@@ -66,8 +67,9 @@ function mockApi(opts?: {
   vi.spyOn(global, "fetch").mockImplementation(async (input) => {
     const url = String(input)
     if (url.startsWith("/api/cgm")) {
-      return new Response(JSON.stringify(cgmEntries),
-        { status: opts?.cgmStatus ?? 200, headers: { "content-type": "application/json" } })
+      const headers: Record<string, string> = { "content-type": "application/json" }
+      if (opts?.cgmRecentOutOfRange) headers["X-CGM-Recent-Out-Of-Range"] = opts.cgmRecentOutOfRange
+      return new Response(JSON.stringify(cgmEntries), { status: opts?.cgmStatus ?? 200, headers })
     }
     if (url.startsWith("/api/analytics/glycemic-profile")) {
       return new Response(JSON.stringify(profile),
@@ -122,6 +124,23 @@ describe("Patient Dashboard (US-3356)", () => {
     await waitFor(() => {
       expect(screen.getByText(/Acceptez la politique de confidentialité/i)).toBeTruthy()
     })
+  })
+
+  it("surfaces the severe-hypo caveat when /api/cgm flags a recent out-of-range reading", async () => {
+    mockApi({ cgmRecentOutOfRange: "low" })
+    render(<PatientDashboardPage />)
+    await waitFor(() => {
+      expect(screen.getByText(/hors plage affichable/i)).toBeTruthy()
+    })
+  })
+
+  it("does NOT show the caveat when the CGM freshness header is 'none'", async () => {
+    mockApi({ cgmRecentOutOfRange: "none" })
+    render(<PatientDashboardPage />)
+    await waitFor(() => {
+      expect(screen.getByText("135")).toBeTruthy() // page loaded
+    })
+    expect(screen.queryByText(/hors plage affichable/i)).toBeNull()
   })
 
   it("C1 — does NOT wrap content in <main> (NavigationShell provides it)", () => {

--- a/tests/pages/patient-dashboard.test.tsx
+++ b/tests/pages/patient-dashboard.test.tsx
@@ -126,11 +126,24 @@ describe("Patient Dashboard (US-3356)", () => {
     })
   })
 
-  it("surfaces the severe-hypo caveat when /api/cgm flags a recent out-of-range reading", async () => {
+  it("surfaces the severe-hypo caveat (assertive role=alert) when /api/cgm flags a recent LOW", async () => {
     mockApi({ cgmRecentOutOfRange: "low" })
     render(<PatientDashboardPage />)
     await waitFor(() => {
-      expect(screen.getByText(/hors plage affichable/i)).toBeTruthy()
+      const banner = screen.getByText(/hors plage affichable/i)
+      expect(banner).toBeTruthy()
+      // LOW = urgence actionnable → role="alert" (assertif).
+      expect(banner.getAttribute("role")).toBe("alert")
+    })
+  })
+
+  it("uses a polite role=status for a recent HIGH out-of-range reading", async () => {
+    mockApi({ cgmRecentOutOfRange: "high" })
+    render(<PatientDashboardPage />)
+    await waitFor(() => {
+      const banner = screen.getByText(/hors plage affichable/i)
+      // HIGH = non seconde-critique → role="status" (poli).
+      expect(banner.getAttribute("role")).toBe("status")
     })
   })
 

--- a/tests/unit/cgm-freshness.test.ts
+++ b/tests/unit/cgm-freshness.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests du croisement de fraîcheur CGM (sécurité clinique) — `recentOutOfRangeFrom`.
+ *
+ * Comportement clinique testé : un relevé hors plage (hypo sévère < 40 mg/dL /
+ * capteur LOW, ou > 500 mg/dL / capteur HIGH) PLUS RÉCENT que le dernier relevé
+ * affiché — ou présent alors qu'aucun relevé n'est affichable — doit être
+ * signalé pour éviter qu'un relevé bénin plus ancien masque une hypo sévère.
+ * Risque associé : fausse réassurance → hypoglycémie sévère non traitée.
+ */
+import { describe, it, expect } from "vitest"
+import { recentOutOfRangeFrom } from "@/lib/cgm-freshness"
+
+const T = (iso: string) => iso
+
+describe("recentOutOfRangeFrom", () => {
+  it("returns null when there is no raw signal", () => {
+    expect(recentOutOfRangeFrom(T("2026-06-15T12:00:00Z"), null)).toBeNull()
+    expect(recentOutOfRangeFrom(null, undefined)).toBeNull()
+  })
+
+  it("returns null when the raw reading is in range", () => {
+    expect(
+      recentOutOfRangeFrom(T("2026-06-15T11:00:00Z"), {
+        timestamp: "2026-06-15T11:55:00Z",
+        belowFloor: false,
+        aboveCeiling: false,
+      }),
+    ).toBeNull()
+  })
+
+  it("flags low when a below-floor reading is newer than the displayed one", () => {
+    expect(
+      recentOutOfRangeFrom(T("2026-06-15T11:00:00Z"), {
+        timestamp: "2026-06-15T11:58:00Z",
+        belowFloor: true,
+        aboveCeiling: false,
+      }),
+    ).toBe("low")
+  })
+
+  it("flags high for a newer above-ceiling reading", () => {
+    expect(
+      recentOutOfRangeFrom(T("2026-06-15T11:00:00Z"), {
+        timestamp: "2026-06-15T11:58:00Z",
+        belowFloor: false,
+        aboveCeiling: true,
+      }),
+    ).toBe("high")
+  })
+
+  it("flags when there is NO displayable reading (most dangerous case)", () => {
+    expect(
+      recentOutOfRangeFrom(null, {
+        timestamp: "2026-06-15T11:58:00Z",
+        belowFloor: true,
+        aboveCeiling: false,
+      }),
+    ).toBe("low")
+  })
+
+  it("does NOT flag when the out-of-range reading is older than the displayed one", () => {
+    expect(
+      recentOutOfRangeFrom(T("2026-06-15T11:59:00Z"), {
+        timestamp: "2026-06-15T11:00:00Z",
+        belowFloor: true,
+        aboveCeiling: false,
+      }),
+    ).toBeNull()
+  })
+
+  it("does NOT flag on an equal timestamp (strict newer)", () => {
+    const ts = "2026-06-15T11:30:00Z"
+    expect(recentOutOfRangeFrom(ts, { timestamp: ts, belowFloor: true, aboveCeiling: false })).toBeNull()
+  })
+})

--- a/tests/unit/glycemia-view.test.ts
+++ b/tests/unit/glycemia-view.test.ts
@@ -41,5 +41,50 @@ describe("buildGlycemiaView", () => {
     expect(v.lastReadingMgdl).toBeNull()
     expect(v.lastReadingAgeMin).toBeNull()
     expect(v.stale).toBe(false)
+    expect(v.recentOutOfRange).toBeNull()
+  })
+
+  it("flags recentOutOfRange=low when a more recent below-floor reading was excluded", () => {
+    // Dernier relevé affiché bénin à -10 min ; relevé brut hors plancher à -2 min.
+    const v = buildGlycemiaView(
+      [{ valueGl: 0.9, timestamp: iso(10) }],
+      NOW,
+      { timestamp: iso(2), belowFloor: true, aboveCeiling: false },
+    )
+    expect(v.lastReadingMgdl).toBe(90) // l'affiché reste le bénin
+    expect(v.recentOutOfRange).toBe("low")
+  })
+
+  it("flags recentOutOfRange even when there is NO displayable reading", () => {
+    const v = buildGlycemiaView([], NOW, { timestamp: iso(3), belowFloor: true, aboveCeiling: false })
+    expect(v.points).toEqual([])
+    expect(v.recentOutOfRange).toBe("low")
+  })
+
+  it("flags recentOutOfRange=high for an above-ceiling most-recent raw reading", () => {
+    const v = buildGlycemiaView(
+      [{ valueGl: 1.1, timestamp: iso(15) }],
+      NOW,
+      { timestamp: iso(1), belowFloor: false, aboveCeiling: true },
+    )
+    expect(v.recentOutOfRange).toBe("high")
+  })
+
+  it("does NOT flag when the out-of-range raw reading is OLDER than the displayed one", () => {
+    const v = buildGlycemiaView(
+      [{ valueGl: 1.1, timestamp: iso(2) }],
+      NOW,
+      { timestamp: iso(30), belowFloor: true, aboveCeiling: false },
+    )
+    expect(v.recentOutOfRange).toBeNull()
+  })
+
+  it("does NOT flag when the most-recent raw reading is in range", () => {
+    const v = buildGlycemiaView(
+      [{ valueGl: 1.1, timestamp: iso(5) }],
+      NOW,
+      { timestamp: iso(1), belowFloor: false, aboveCeiling: false },
+    )
+    expect(v.recentOutOfRange).toBeNull()
   })
 })

--- a/tests/unit/glycemia-view.test.ts
+++ b/tests/unit/glycemia-view.test.ts
@@ -1,7 +1,9 @@
 /**
  * Tests du mapping pur CGM → vue dossier patient (Phase 2).
  * Couvre : conversion g/L→mg/dL, sélection du dernier relevé (ordre asc),
- * exclusion valueGl null, calcul d'âge + drapeau `stale`.
+ * exclusion valueGl null, calcul d'âge + drapeau `stale`, et le croisement de
+ * fraîcheur `recentOutOfRange` (hypo sévère / capteur masqué plus récent que
+ * l'affiché — low/high, plus récent vs plus ancien vs égal, sans série).
  */
 
 import { describe, it, expect } from "vitest"
@@ -84,6 +86,15 @@ describe("buildGlycemiaView", () => {
       [{ valueGl: 1.1, timestamp: iso(5) }],
       NOW,
       { timestamp: iso(1), belowFloor: false, aboveCeiling: false },
+    )
+    expect(v.recentOutOfRange).toBeNull()
+  })
+
+  it("does NOT flag when the out-of-range raw reading shares the displayed timestamp (strict newer)", () => {
+    const v = buildGlycemiaView(
+      [{ valueGl: 1.1, timestamp: iso(5) }],
+      NOW,
+      { timestamp: iso(5), belowFloor: true, aboveCeiling: false },
     )
     expect(v.recentOutOfRange).toBeNull()
   })

--- a/tests/unit/glycemia.service.test.ts
+++ b/tests/unit/glycemia.service.test.ts
@@ -116,6 +116,16 @@ describe("glycemiaService", () => {
       expect(await glycemiaService.getLatestCgmFreshness(1, from, to, 1)).toBeNull()
     })
 
+    it("fail-closed: a null valueGl (impossible today, NOT NULL col) is treated as below floor", async () => {
+      prismaMock.cgmEntry.findFirst.mockResolvedValue({
+        timestamp: new Date("2026-03-10T07:00:00.000Z"),
+        valueGl: null,
+      } as any)
+      prismaMock.auditLog.create.mockResolvedValue({} as any)
+      const r = await glycemiaService.getLatestCgmFreshness(1, from, to, 1)
+      expect(r).toEqual({ timestamp: "2026-03-10T07:00:00.000Z", belowFloor: true, aboveCeiling: false })
+    })
+
     it("does not classify an in-range most-recent reading", async () => {
       prismaMock.cgmEntry.findFirst.mockResolvedValue({
         timestamp: new Date("2026-03-10T09:00:00.000Z"),

--- a/tests/unit/glycemia.service.test.ts
+++ b/tests/unit/glycemia.service.test.ts
@@ -91,6 +91,58 @@ describe("glycemiaService", () => {
     })
   })
 
+  describe("getLatestCgmFreshness", () => {
+    const from = new Date("2026-03-01")
+    const to = new Date("2026-03-10")
+
+    it("classifies a below-floor most-recent raw reading (severe hypo / sensor LOW)", async () => {
+      prismaMock.cgmEntry.findFirst.mockResolvedValue({
+        timestamp: new Date("2026-03-10T08:00:00.000Z"),
+        valueGl: new Prisma.Decimal("0.35"), // 35 mg/dL < plancher 0.40
+      } as any)
+      prismaMock.auditLog.create.mockResolvedValue({} as any)
+
+      const r = await glycemiaService.getLatestCgmFreshness(1, from, to, 1)
+      expect(r).toEqual({
+        timestamp: "2026-03-10T08:00:00.000Z",
+        belowFloor: true,
+        aboveCeiling: false,
+      })
+    })
+
+    it("returns null when there is no reading in the window", async () => {
+      prismaMock.cgmEntry.findFirst.mockResolvedValue(null)
+      prismaMock.auditLog.create.mockResolvedValue({} as any)
+      expect(await glycemiaService.getLatestCgmFreshness(1, from, to, 1)).toBeNull()
+    })
+
+    it("does not classify an in-range most-recent reading", async () => {
+      prismaMock.cgmEntry.findFirst.mockResolvedValue({
+        timestamp: new Date("2026-03-10T09:00:00.000Z"),
+        valueGl: new Prisma.Decimal("1.20"),
+      } as any)
+      prismaMock.auditLog.create.mockResolvedValue({} as any)
+      const r = await glycemiaService.getLatestCgmFreshness(1, from, to, 1)
+      expect(r).toEqual({ timestamp: "2026-03-10T09:00:00.000Z", belowFloor: false, aboveCeiling: false })
+    })
+
+    it("audits READ CGM_ENTRY with the patientId pivot + freshness purpose", async () => {
+      prismaMock.cgmEntry.findFirst.mockResolvedValue(null)
+      prismaMock.auditLog.create.mockResolvedValue({} as any)
+      await glycemiaService.getLatestCgmFreshness(42, from, to, 1)
+      const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+      expect(audit.resource).toBe("CGM_ENTRY")
+      expect(audit.metadata.patientId).toBe(42)
+      expect(audit.metadata.purpose).toBe("cgm-freshness-signal")
+    })
+
+    it("enforces the 30-day max period", async () => {
+      await expect(
+        glycemiaService.getLatestCgmFreshness(1, new Date("2026-01-01"), new Date("2026-03-01"), 1),
+      ).rejects.toThrow("Period cannot exceed 30 days")
+    })
+  })
+
   describe("getGlycemiaEntries", () => {
     it("returns glycemia entries", async () => {
       prismaMock.glycemiaEntry.findMany.mockResolvedValue([])


### PR DESCRIPTION
## Contexte

Item backlog **[Clinique]** (plancher 0.40 ↔ fraîcheur, Phase 2). `getCgmEntries` exclut les valeurs hors plage capteur (`< 0.40 g/L` / `> 5.00 g/L`). Conséquence dangereuse : une **hypoglycémie sévère < 40 mg/dL récente** est silencieusement retirée → un relevé bénin **plus ancien** devient le « dernier relevé », il a < 30 min donc **pas de `stale`** → fausse réassurance pour le clinicien alors que le patient est en hypo sévère.

## Approche (conservatrice — n'altère pas les analytics/TIR)

Détecter qu'un relevé **plus récent** que l'affiché a été exclu par le plancher et **lever un caveat**, sans modifier la série ni les statistiques.

- **`glycemia.service.ts`** — nouvelle méthode **`getLatestCgmFreshness`** : relevé brut le plus récent dans la fenêtre, **sans filtre de valeur**, classé `{ belowFloor, aboveCeiling }`, **auditée** (READ CGM_ENTRY, pivot `patientId`). Le contrat de `getCgmEntries` (4 appelants) **n'est pas touché**.
- **`glycemia-view.ts`** — `buildGlycemiaView` accepte le signal et expose `recentOutOfRange` = `"low"`/`"high"` si le relevé brut hors plage est **plus récent** que l'affiché (ou s'il n'y a **aucun** relevé affichable). Pur, unit-testé.
- **`page.tsx`** — appelle `getLatestCgmFreshness` et le passe au builder.
- **`PatientDetailClient.tsx`** — **bannière d'alerte prioritaire** (warning-bg/fg, `role="status"`) en tête de l'onglet Glycémie, rendue **même sans série** (cas le plus dangereux).
- **i18n FR/EN/AR** — `recentOutOfRangeLow` / `recentOutOfRangeHigh`.

> L'item distinct « plancher dans les agrégats (mean/CV/TIR severeHypo) » reste ouvert au backlog — non traité ici pour ne pas modifier les analytics.

## Tests / vérifs

- `glycemia.service.test.ts` : classification (below-floor / in-range / null), audit pivot + purpose, garde 30 j.
- `glycemia-view.test.ts` : `recentOutOfRange` low/high, plus récent vs plus ancien, in-range, sans série.
- `patient-detail-client.test.tsx` : bannière affichée (avec et sans série).
- `tsc` ✅ · ESLint ✅ · design-system baseline 285 ✅ · i18n-parity ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)