### PR TITLE
test(appointments): corrige la time-bomb du test 'Déplacer' (CI rouge)

### DIFF
--- a/tests/unit/AppointmentDetailModal.test.tsx
+++ b/tests/unit/AppointmentDetailModal.test.tsx
@@ -775,7 +775,13 @@ describe("<AppointmentDetailModal>", () => {
 
       const dateInput = screen.getByLabelText("dateLabel") as HTMLInputElement
       const timeInput = screen.getByLabelText("hourLabel") as HTMLInputElement
-      fireEvent.change(dateInput, { target: { value: "2026-06-15" } })
+      // Le champ date du form 'Déplacer' a `min={today}` et jsdom applique
+      // rangeUnderflow au submit — une date codée en dur dans le passé (relatif
+      // à l'horloge) bloque le submit et le PUT n'est jamais émis. Date calculée
+      // dans le futur pour ne pas être une time-bomb (était "2026-06-15", cassé
+      // une fois l'horloge passée ce jour). Cf. même correctif sur proposeAlt.
+      const futureDate = new Date(Date.now() + 14 * 86_400_000).toISOString().split("T")[0]
+      fireEvent.change(dateInput, { target: { value: futureDate } })
       fireEvent.change(timeInput, { target: { value: "11:00" } })
       fireEvent.click(screen.getByText("actionConfirmMove"))
 
@@ -785,7 +791,7 @@ describe("<AppointmentDetailModal>", () => {
           expect.objectContaining({
             method: "PUT",
             // Backend PUT accepte {date, hour} séparé (vs ISO Z proposeAlt).
-            body: JSON.stringify({ date: "2026-06-15", hour: "11:00" }),
+            body: JSON.stringify({ date: futureDate, hour: "11:00" }),
           }),
         )
       })


### PR DESCRIPTION
## Problème

Le test `tests/unit/AppointmentDetailModal.test.tsx > FE-2 — submit form 'Déplacer' → PUT /api/appointments/[id]` fait **échouer la CI Unit & Integration** depuis le 2026-06-16, **sans aucun rapport avec une modification de code**.

Cause : le test codait la date du formulaire en dur (`"2026-06-15"`). Le champ date du sous-mode « Déplacer » porte `min={today}`, et **jsdom applique `rangeUnderflow` au submit**. Une fois l'horloge passée le 2026-06-15, la valeur devient antérieure à `today` → le submit est bloqué → le `PUT` n'est jamais émis → `expect(fetch).toHaveBeenCalledWith(...)` échoue (0 appel).

C'est **exactement la même time-bomb** déjà corrigée pour le test `proposeAlt` (commentaire en place lignes ~400-406), mais le test « Déplacer » avait été oublié.

## Correctif

- Date du formulaire calculée à `Date.now() + 14 j` (jamais dans le passé) au lieu d'être codée en dur.
- Body de l'assertion aligné sur la date calculée.
- Commentaire expliquant le piège (parité avec le correctif `proposeAlt`).

Aucun changement de code applicatif — fix de test uniquement.

## Vérif

- `tests/unit/AppointmentDetailModal.test.tsx` : **39/39 passent**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)