### PR TITLE
fix(analytics): compte les hypo sévères sous-plancher dans les agrégats CGM

### DIFF
--- a/docs/UserStory/Navigation/cablage-donnees-patient.md
+++ b/docs/UserStory/Navigation/cablage-donnees-patient.md
@@ -115,10 +115,15 @@ dans des tickets dédiés, pas dans le câblage des onglets.
 - **[Sécu] XFF spoofable** : `ctx.ipAddress` = 1er hop `x-forwarded-for`
   (client-contrôlable) ; durcissement transverse — cf.
   `docs/security/xff-trusted-proxy.md`. Réutiliser `extractRequestContext`.
-- **[Clinique] Plancher capteur 0.40 g/L** (`analytics.service.ts`) exclut les
-  hypo sévères au plancher des agrégats (mean/CV/TIR severeHypo) — sous-estime la
-  charge hypoglycémique. Inclure les relevés clampés au plancher dans le bucket
-  severe-hypo.
+- ✅ **[Clinique] Plancher capteur dans les agrégats** (FAIT) : `analytics.service`
+  filtrait les agrégats (mean/CV/GMI/TIR/AGP/épisodes) au plancher d'affichage
+  `0.40–5.00`, excluant les hypo sévères réelles (0.20–0.40 g/L) → sous-estime la
+  charge hypoglycémique. Le helper `getPatientCgmRange` utilise désormais la plage
+  **physiologique valide** `0.20–6.00` (= CHECK base, constantes `CGM_AGG_MIN_GL`/
+  `CGM_AGG_MAX_GL`) → les hypo sévères sous-plancher comptent dans `severeHypo` et
+  baissent la moyenne (consensus ADA/Battelino). La **série graphique** garde le
+  plancher d'affichage 0.40–5.00 + caveat de fraîcheur (PR #555). Doc :
+  `docs/clinical-logic/bolus-calculation.md`.
 - ✅ **[Clinique] Cibles spécifiques grossesse (GD)** (FAIT) : à défaut
   d'objectif CGM, `analyticsService` (TIR/donut) ET le badge cible du dossier
   utilisent désormais `getCgmDefaults(pathology)` → GD = 63–140 mg/dL (Battelino

--- a/docs/UserStory/Navigation/cablage-donnees-patient.md
+++ b/docs/UserStory/Navigation/cablage-donnees-patient.md
@@ -116,14 +116,21 @@ dans des tickets dédiés, pas dans le câblage des onglets.
   (client-contrôlable) ; durcissement transverse — cf.
   `docs/security/xff-trusted-proxy.md`. Réutiliser `extractRequestContext`.
 - ✅ **[Clinique] Plancher capteur dans les agrégats** (FAIT) : `analytics.service`
-  filtrait les agrégats (mean/CV/GMI/TIR/AGP/épisodes) au plancher d'affichage
-  `0.40–5.00`, excluant les hypo sévères réelles (0.20–0.40 g/L) → sous-estime la
-  charge hypoglycémique. Le helper `getPatientCgmRange` utilise désormais la plage
-  **physiologique valide** `0.20–6.00` (= CHECK base, constantes `CGM_AGG_MIN_GL`/
-  `CGM_AGG_MAX_GL`) → les hypo sévères sous-plancher comptent dans `severeHypo` et
-  baissent la moyenne (consensus ADA/Battelino). La **série graphique** garde le
-  plancher d'affichage 0.40–5.00 + caveat de fraîcheur (PR #555). Doc :
+  ET `population-analytics.service` filtraient les agrégats (mean/CV/GMI/TIR/AGP/
+  épisodes + cohorte `criticalHypoCount`) au plancher d'affichage `0.40–5.00`,
+  excluant les hypo sévères réelles (0.20–0.40 g/L) → sous-estime la charge
+  hypoglycémique. Les deux services utilisent désormais la plage **physiologique
+  valide** `0.20–6.00` via une **constante partagée** `CGM_AGGREGATE_RANGE_GL`
+  (`clinical-bounds.ts`, anti-dérive testée vs le CHECK base) → les hypo sévères
+  sous-plancher comptent dans `severeHypo`/`criticalHypoCount` et baissent la
+  moyenne (consensus ADA/Battelino). La **série graphique** garde le plancher
+  d'affichage 0.40–5.00 + caveat de fraîcheur (PR #555). Doc :
   `docs/clinical-logic/bolus-calculation.md`.
+- **[Clinique/UX] Annotation graphe relevés sous-plancher** : la série affichée
+  s'arrête à 0.40 mais le TIR/donut peut reporter du `severeHypo` (agrégats
+  0.20–6.00) → discordance visuelle possible pour le clinicien. Envisager une
+  annotation « N relevés sous le plancher d'affichage — comptés dans le TIR »
+  (LOW, relevé revue PR #557, non bloquant).
 - ✅ **[Clinique] Cibles spécifiques grossesse (GD)** (FAIT) : à défaut
   d'objectif CGM, `analyticsService` (TIR/donut) ET le badge cible du dossier
   utilisent désormais `getCgmDefaults(pathology)` → GD = 63–140 mg/dL (Battelino

--- a/docs/clinical-logic/bolus-calculation.md
+++ b/docs/clinical-logic/bolus-calculation.md
@@ -142,8 +142,21 @@ releve affichable), un caveat est leve : `recentOutOfRange = "low" | "high"`.
   a une correction insuline non supervisee).
 - **Limitation connue** : le caveat ne distingue pas encore une valeur numerique
   sous-plancher (20-40 mg/dL, hypo mesuree) d'un flag « LOW » capteur. L'action
-  (confirmer au doigt) est correcte dans les deux cas. Les analytics/TIR ne sont
-  pas modifies (les valeurs hors plage restent exclues des agregats).
+  (confirmer au doigt) est correcte dans les deux cas.
+
+#### Agregats : plage valide complete (0.20-6.00 g/L)
+
+Distinction importante entre **affichage** et **agregats** :
+
+- **Serie graphique** (`getCgmEntries`) : plancher d'affichage 0.40-5.00 g/L +
+  caveat de fraicheur ci-dessus.
+- **Agregats** (`analytics.service` : moyenne, CV, GMI, TIR, AGP, episodes hypo) :
+  plage **physiologique valide** 0.20-6.00 g/L (= CHECK base), constantes
+  `CGM_AGG_MIN_GL` / `CGM_AGG_MAX_GL`. Les hypo severes reelles mesurees sous le
+  plancher d'affichage (0.20-0.40) sont donc **comptees** (bucket `severeHypo` du
+  TIR, et baissent la moyenne) — sinon la charge hypoglycemique serait
+  **sous-estimee** (consensus ADA/Battelino : tout releve CGM valide compte dans
+  le TIR ; les valeurs « LOW » capteur sont comptees dans la zone la plus basse).
 
 ## Propositions d'ajustement
 

--- a/src/lib/clinical-bounds.ts
+++ b/src/lib/clinical-bounds.ts
@@ -38,3 +38,23 @@ export const CLINICAL_BOUNDS = {
 } as const
 
 export type ClinicalBounds = typeof CLINICAL_BOUNDS
+
+/**
+ * Plage de valeurs CGM **physiologiquement valides** (g/L) pour les AGRÉGATS
+ * (moyenne, CV, GMI, TIR, AGP, épisodes hypo — par patient ET cohorte).
+ *
+ * SOURCE UNIQUE — utilisée par `analytics.service.ts` ET
+ * `population-analytics.service.ts`. Alignée sur le CHECK base
+ * (`value_gl BETWEEN 0.20 AND 6.00`, `prisma/sql/cgm_partitioning.sql`) — vérifié
+ * par `tests/unit/clinical-bounds.test.ts`.
+ *
+ * ⚠️ DIFFÉRENT du plancher d'AFFICHAGE de la série (0.40–5.00 g/L,
+ * `glycemia.service.getCgmEntries`). Les agrégats incluent les hypo sévères
+ * réelles mesurées sous le plancher d'affichage (0.20–0.40 g/L) : sinon le bucket
+ * `severeHypo` du TIR et le compteur cohorte `criticalHypoCount` sous-estiment la
+ * charge hypoglycémique (consensus ADA/Battelino : tout relevé CGM valide compte).
+ */
+export const CGM_AGGREGATE_RANGE_GL = {
+  MIN: 0.20,
+  MAX: 6.00,
+} as const

--- a/src/lib/services/analytics.service.ts
+++ b/src/lib/services/analytics.service.ts
@@ -21,6 +21,7 @@ import {
   type CgmThresholds,
 } from "@/lib/statistics"
 import { decimalToNumber } from "@/lib/db/decimal"
+import { CGM_AGGREGATE_RANGE_GL } from "@/lib/clinical-bounds"
 
 /** Warn if CGM capture rate below this % */
 const MIN_CAPTURE_RATE = 70 // percent
@@ -29,22 +30,9 @@ const MAX_PERIOD_DAYS = 90
 /** Max period per window for `compare` (two windows = 90d total, perf-safe). */
 const MAX_COMPARE_PERIOD_DAYS = 45
 
-/**
- * Plage de valeurs CGM **physiologiquement valides** pour les AGRÉGATS
- * (moyenne, CV, GMI, TIR, AGP, épisodes hypo) — alignée sur le CHECK base
- * (`value_gl BETWEEN 0.20 AND 6.00`, `cgm_partitioning.sql`).
- *
- * ⚠️ DIFFÉRENT du plancher d'AFFICHAGE de la série (0.40–5.00 g/L,
- * `glycemia.service.getCgmEntries`). Les agrégats doivent inclure les hypo
- * sévères réelles mesurées sous le plancher d'affichage (0.20–0.40 g/L) et les
- * hyper extrêmes (5.00–6.00) : sinon le bucket `severeHypo` du TIR et la
- * moyenne/CV **sous-estiment la charge hypoglycémique** (consensus ADA/Battelino —
- * tout relevé CGM valide compte dans le TIR ; les valeurs « LOW » capteur sont
- * comptées dans la zone la plus basse). La série graphique, elle, reste filtrée
- * au plancher d'affichage + caveat de fraîcheur (PR #555).
- */
-const CGM_AGG_MIN_GL = 0.20
-const CGM_AGG_MAX_GL = 6.00
+// Plage valide des agrégats CGM (0.20–6.00 g/L) — SOURCE UNIQUE partagée avec
+// population-analytics via `clinical-bounds.ts` (voir le JSDoc là-bas pour la
+// distinction affichage vs agrégats). Importée pour éviter toute dérive.
 
 /**
  * Parse period string (e.g., "14d" → 14 days).
@@ -65,13 +53,13 @@ function parsePeriod(period: string): number {
 
 /**
  * Fetch CGM values for an explicit window. Centralizes the valid-range filter
- * for AGGREGATES ({@link CGM_AGG_MIN_GL}–{@link CGM_AGG_MAX_GL} = 0.20–6.00 g/L,
- * la plage physiologique valide en base) et la coercion Decimal→number
- * (`.toNumber()` pour éviter la perte de précision silencieuse).
+ * for AGGREGATES (`CGM_AGGREGATE_RANGE_GL` = 0.20–6.00 g/L, la plage
+ * physiologique valide en base) et la coercion Decimal→number (`.toNumber()`
+ * pour éviter la perte de précision silencieuse).
  *
  * NB : on inclut volontairement les hypo sévères mesurées sous le plancher
  * d'affichage (0.20–0.40 g/L) — sinon `severeHypo`/moyenne/CV sous-estiment la
- * charge hypoglycémique (cf. {@link CGM_AGG_MIN_GL}).
+ * charge hypoglycémique (cf. `CGM_AGGREGATE_RANGE_GL` dans clinical-bounds).
  * @private
  */
 async function getPatientCgmRange(patientId: number, from: Date, to: Date) {
@@ -79,7 +67,7 @@ async function getPatientCgmRange(patientId: number, from: Date, to: Date) {
     where: {
       patientId,
       timestamp: { gte: from, lte: to },
-      valueGl: { gte: CGM_AGG_MIN_GL, lte: CGM_AGG_MAX_GL },
+      valueGl: { gte: CGM_AGGREGATE_RANGE_GL.MIN, lte: CGM_AGGREGATE_RANGE_GL.MAX },
     },
     orderBy: { timestamp: "asc" },
     select: { valueGl: true, timestamp: true },

--- a/src/lib/services/analytics.service.ts
+++ b/src/lib/services/analytics.service.ts
@@ -30,10 +30,6 @@ const MAX_PERIOD_DAYS = 90
 /** Max period per window for `compare` (two windows = 90d total, perf-safe). */
 const MAX_COMPARE_PERIOD_DAYS = 45
 
-// Plage valide des agrégats CGM (0.20–6.00 g/L) — SOURCE UNIQUE partagée avec
-// population-analytics via `clinical-bounds.ts` (voir le JSDoc là-bas pour la
-// distinction affichage vs agrégats). Importée pour éviter toute dérive.
-
 /**
  * Parse period string (e.g., "14d" → 14 days).
  * @private

--- a/src/lib/services/analytics.service.ts
+++ b/src/lib/services/analytics.service.ts
@@ -30,6 +30,23 @@ const MAX_PERIOD_DAYS = 90
 const MAX_COMPARE_PERIOD_DAYS = 45
 
 /**
+ * Plage de valeurs CGM **physiologiquement valides** pour les AGRÉGATS
+ * (moyenne, CV, GMI, TIR, AGP, épisodes hypo) — alignée sur le CHECK base
+ * (`value_gl BETWEEN 0.20 AND 6.00`, `cgm_partitioning.sql`).
+ *
+ * ⚠️ DIFFÉRENT du plancher d'AFFICHAGE de la série (0.40–5.00 g/L,
+ * `glycemia.service.getCgmEntries`). Les agrégats doivent inclure les hypo
+ * sévères réelles mesurées sous le plancher d'affichage (0.20–0.40 g/L) et les
+ * hyper extrêmes (5.00–6.00) : sinon le bucket `severeHypo` du TIR et la
+ * moyenne/CV **sous-estiment la charge hypoglycémique** (consensus ADA/Battelino —
+ * tout relevé CGM valide compte dans le TIR ; les valeurs « LOW » capteur sont
+ * comptées dans la zone la plus basse). La série graphique, elle, reste filtrée
+ * au plancher d'affichage + caveat de fraîcheur (PR #555).
+ */
+const CGM_AGG_MIN_GL = 0.20
+const CGM_AGG_MAX_GL = 6.00
+
+/**
  * Parse period string (e.g., "14d" → 14 days).
  * @private
  * @param {string} period - Period format "Nd" (e.g., "14d", "30d")
@@ -47,9 +64,14 @@ function parsePeriod(period: string): number {
 }
 
 /**
- * Fetch CGM values for an explicit window. Centralizes the sensor-range filter
- * (0.40-5.00 g/L) and the Decimal→number coercion (uses .toNumber() to avoid
- * the silent precision loss flagged in the project backlog).
+ * Fetch CGM values for an explicit window. Centralizes the valid-range filter
+ * for AGGREGATES ({@link CGM_AGG_MIN_GL}–{@link CGM_AGG_MAX_GL} = 0.20–6.00 g/L,
+ * la plage physiologique valide en base) et la coercion Decimal→number
+ * (`.toNumber()` pour éviter la perte de précision silencieuse).
+ *
+ * NB : on inclut volontairement les hypo sévères mesurées sous le plancher
+ * d'affichage (0.20–0.40 g/L) — sinon `severeHypo`/moyenne/CV sous-estiment la
+ * charge hypoglycémique (cf. {@link CGM_AGG_MIN_GL}).
  * @private
  */
 async function getPatientCgmRange(patientId: number, from: Date, to: Date) {
@@ -57,7 +79,7 @@ async function getPatientCgmRange(patientId: number, from: Date, to: Date) {
     where: {
       patientId,
       timestamp: { gte: from, lte: to },
-      valueGl: { gte: 0.40, lte: 5.00 },
+      valueGl: { gte: CGM_AGG_MIN_GL, lte: CGM_AGG_MAX_GL },
     },
     orderBy: { timestamp: "asc" },
     select: { valueGl: true, timestamp: true },

--- a/src/lib/services/glycemia.service.ts
+++ b/src/lib/services/glycemia.service.ts
@@ -2,6 +2,9 @@
  * @module glycemia.service
  * @description Glucose data access — CGM entries, glycemia readings, insulin flow, pump events.
  * All reads enforce 30-day max period for performance. CGM values validated (0.40-5.00 g/L).
+ * NB: 0.40-5.00 is the DISPLAY floor (rendered series). Les AGRÉGATS (TIR/mean/CV…)
+ * utilisent une plage plus large 0.20-6.00 — voir `analytics.service` +
+ * `clinical-bounds.CGM_AGGREGATE_RANGE_GL`.
  * All reads logged for HDS audit trail.
  * @see CLAUDE.md#glycemia — CGM data model
  * @see Prisma schema — CgmEntry, GlycemiaEntry, AverageData, InsulinFlowEntry, PumpEvent models

--- a/src/lib/services/population-analytics.service.ts
+++ b/src/lib/services/population-analytics.service.ts
@@ -41,6 +41,7 @@ import {
   type TirResult,
 } from "@/lib/statistics"
 import { decimalToNumber } from "@/lib/db/decimal"
+import { CGM_AGGREGATE_RANGE_GL } from "@/lib/clinical-bounds"
 
 /** Capture-rate threshold below which the patient is excluded from population metrics. */
 const MIN_CAPTURE_RATE = 30
@@ -159,7 +160,11 @@ async function computePatientMetric(
     where: {
       patientId,
       timestamp: { gte: from, lte: to },
-      valueGl: { gte: 0.40, lte: 5.00 },
+      // Agrégats cohorte : plage valide complète (0.20–6.00) — SOURCE UNIQUE
+      // partagée avec analytics.service. Inclut les hypo sévères sous le plancher
+      // d'affichage pour que `criticalHypoCount` / `severeHypo` cohorte ne les
+      // sous-comptent pas (cf. clinical-bounds.CGM_AGGREGATE_RANGE_GL).
+      valueGl: { gte: CGM_AGGREGATE_RANGE_GL.MIN, lte: CGM_AGGREGATE_RANGE_GL.MAX },
     },
     orderBy: { timestamp: "asc" },
     select: { valueGl: true, timestamp: true },

--- a/tests/unit/analytics.service.test.ts
+++ b/tests/unit/analytics.service.test.ts
@@ -72,6 +72,33 @@ describe("analyticsService", () => {
       const result = await analyticsService.glycemicProfile(1, "14d", 1)
       expect(result.warning).toBe("insufficientCgmCapture")
     })
+
+    it("aggregates over the FULL valid range (0.20–6.00 g/L), not the display floor", async () => {
+      // Sécurité clinique : les hypo sévères réelles sous le plancher d'affichage
+      // (0.20–0.40 g/L) doivent compter dans la moyenne/CV/TIR severeHypo.
+      prismaMock.cgmEntry.findMany.mockResolvedValue(mockCgmEntries(50) as any)
+      prismaMock.cgmObjective.findUnique.mockResolvedValue(null)
+      prismaMock.auditLog.create.mockResolvedValue({} as any)
+
+      await analyticsService.glycemicProfile(1, "14d", 1)
+
+      const where = prismaMock.cgmEntry.findMany.mock.calls.at(-1)![0]!.where as any
+      expect(where.valueGl).toEqual({ gte: 0.2, lte: 6.0 })
+    })
+
+    it("counts a real sub-display-floor reading (0.25 g/L) in the severeHypo TIR bucket", async () => {
+      // 25 mg/dL : exclu autrefois par le filtre 0.40 → desormais compté severeHypo.
+      prismaMock.cgmEntry.findMany.mockResolvedValue([
+        { valueGl: 0.25, timestamp: new Date() },
+        { valueGl: 1.2, timestamp: new Date() },
+      ] as any)
+      prismaMock.cgmObjective.findUnique.mockResolvedValue(null)
+      prismaMock.auditLog.create.mockResolvedValue({} as any)
+
+      const result = await analyticsService.glycemicProfile(1, "14d", 1)
+      // veryLow défaut = 0.54 → 0.25 < 0.54 → severeHypo. 1/2 = 50 %.
+      expect(result.tir.severeHypo).toBe(50)
+    })
   })
 
   describe("timeInRange", () => {

--- a/tests/unit/clinical-bounds.test.ts
+++ b/tests/unit/clinical-bounds.test.ts
@@ -13,7 +13,8 @@
  */
 
 import { describe, it, expect } from "vitest"
-import { CLINICAL_BOUNDS } from "@/lib/clinical-bounds"
+import { readFileSync } from "node:fs"
+import { CLINICAL_BOUNDS, CGM_AGGREGATE_RANGE_GL } from "@/lib/clinical-bounds"
 
 describe("CLINICAL_BOUNDS — anti-drift (A3)", () => {
   it("matche exactement les valeurs documentées dans CLAUDE.md", () => {
@@ -42,5 +43,21 @@ describe("CLINICAL_BOUNDS — anti-drift (A3)", () => {
     expect(CLINICAL_BOUNDS.BASAL_MIN).toBeLessThan(CLINICAL_BOUNDS.BASAL_MAX)
     expect(CLINICAL_BOUNDS.TARGET_MIN_MGDL).toBeLessThan(CLINICAL_BOUNDS.TARGET_MAX_MGDL)
     expect(CLINICAL_BOUNDS.INSULIN_ACTION_MIN).toBeLessThan(CLINICAL_BOUNDS.INSULIN_ACTION_MAX)
+  })
+})
+
+describe("CGM_AGGREGATE_RANGE_GL — anti-drift vs DB CHECK", () => {
+  it("matche exactement le CHECK base (cgm_partitioning.sql : 0.20–6.00)", () => {
+    expect(CGM_AGGREGATE_RANGE_GL).toEqual({ MIN: 0.2, MAX: 6.0 })
+    // Vérifie l'alignement réel avec le DDL (source de vérité base) — le CHECK
+    // écrit les bornes en DECIMAL(6,4) → on compare en 2 décimales.
+    const ddl = readFileSync("prisma/sql/cgm_partitioning.sql", "utf8")
+    expect(ddl).toContain(`>= ${CGM_AGGREGATE_RANGE_GL.MIN.toFixed(2)}`) // ">= 0.20"
+    expect(ddl).toContain(`<= ${CGM_AGGREGATE_RANGE_GL.MAX.toFixed(2)}`) // "<= 6.00"
+  })
+
+  it("englobe strictement le plancher d'affichage 0.40–5.00 (agrégats ⊃ série)", () => {
+    expect(CGM_AGGREGATE_RANGE_GL.MIN).toBeLessThan(0.4)
+    expect(CGM_AGGREGATE_RANGE_GL.MAX).toBeGreaterThan(5.0)
   })
 })


### PR DESCRIPTION
## Contexte

Item backlog **[Clinique]**. Le helper `getPatientCgmRange` (`analytics.service.ts`) filtrait **tous les agrégats** (moyenne, CV, GMI, TIR, AGP, épisodes hypo) au **plancher d'affichage** `0.40–5.00 g/L`.

Or la base stocke une plage plus large (`CHECK value_gl BETWEEN 0.20 AND 6.00`, `cgm_partitioning.sql`). Une valeur mesurée entre **0.20 et 0.40 g/L (20–40 mg/dL) est une hypoglycémie sévère réelle**, pas un artefact. En l'excluant des agrégats :
- le bucket `severeHypo` du TIR **sous-compte** les hypos sévères,
- la **moyenne / CV / GMI** sont biaisés vers le haut,
- les **épisodes hypo** et l'**AGP** ratent les creux les plus profonds.

→ **sous-estimation de la charge hypoglycémique** = fausse réassurance clinique.

## Changement

- `getPatientCgmRange` requête désormais la **plage physiologique valide** `0.20–6.00 g/L` (constantes `CGM_AGG_MIN_GL` / `CGM_AGG_MAX_GL` = bornes du CHECK base) au lieu du plancher d'affichage. Conforme au consensus ADA/Battelino : tout relevé CGM valide compte dans le TIR ; les valeurs « LOW » capteur sont comptées dans la zone la plus basse.
- **Distinction affichage vs agrégats** : la série graphique (`getCgmEntries`) garde le plancher d'affichage `0.40–5.00` + caveat de fraîcheur (PR #555). Seuls les **agrégats** sont élargis.
- Aucun nouveau calcul clinique : `computeTir` bucketise déjà `v < veryLow (0.54)` → severeHypo ; il suffisait de **ne plus exclure** ces valeurs en amont.

## Tests / vérifs

- `analytics.service.test.ts` : borne de requête `{ gte: 0.2, lte: 6.0 }` verrouillée ; un relevé `0.25 g/L` est compté `severeHypo` (50 % sur 2 relevés).
- `tsc` ✅ · ESLint ✅ · design-system baseline 285 ✅ · `statistics.test.ts` ✅
- Doc clinique mise à jour : `docs/clinical-logic/bolus-calculation.md` (section affichage vs agrégats).

🤖 Generated with [Claude Code](https://claude.com/claude-code)