### PR TITLE
feat(patients): US-2603 backend — switcher de contexte (récents + épinglés)

### DIFF
--- a/prisma/migrations/20260616120000_us2603_patient_switcher/migration.sql
+++ b/prisma/migrations/20260616120000_us2603_patient_switcher/migration.sql
@@ -1,0 +1,54 @@
+-- US-2603 — Switcher de contexte patient (récemment vus + épinglés).
+--
+-- Deux tables per-user, additives et non destructives. La portée (périmètre du
+-- PS) est appliquée à la LECTURE côté service (intersection avec
+-- getAccessiblePatientIds) — la table ne contraint pas le périmètre, elle
+-- mémorise l'historique de navigation / les épingles.
+--
+-- onDelete: Cascade depuis users ET patients : si l'un disparaît (anonymisation
+-- RGPD côté user reste non-DELETE, mais suppression patient cascade), l'entrée
+-- de navigation disparaît (pas de référence orpheline).
+
+-- CreateTable
+CREATE TABLE "recently_viewed_patients" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "patient_id" INTEGER NOT NULL,
+    "viewed_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "recently_viewed_patients_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "pinned_patients" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "patient_id" INTEGER NOT NULL,
+    "pinned_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "pinned_patients_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "recently_viewed_patients_user_id_patient_id_key" ON "recently_viewed_patients"("user_id", "patient_id");
+
+-- CreateIndex
+CREATE INDEX "recently_viewed_patients_user_id_viewed_at_idx" ON "recently_viewed_patients"("user_id", "viewed_at" DESC);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "pinned_patients_user_id_patient_id_key" ON "pinned_patients"("user_id", "patient_id");
+
+-- CreateIndex
+CREATE INDEX "pinned_patients_user_id_pinned_at_idx" ON "pinned_patients"("user_id", "pinned_at" DESC);
+
+-- AddForeignKey
+ALTER TABLE "recently_viewed_patients" ADD CONSTRAINT "recently_viewed_patients_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "recently_viewed_patients" ADD CONSTRAINT "recently_viewed_patients_patient_id_fkey" FOREIGN KEY ("patient_id") REFERENCES "patients"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "pinned_patients" ADD CONSTRAINT "pinned_patients_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "pinned_patients" ADD CONSTRAINT "pinned_patients_patient_id_fkey" FOREIGN KEY ("patient_id") REFERENCES "patients"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -443,6 +443,9 @@ model User {
   // US-2026 H5 review — Forensique : qui a saisi cet INS / pour qui.
   insSetByUser                      User?                             @relation("InsSetter", fields: [insSetByUserId], references: [id], onDelete: SetNull)
   insSetForUsers                    User[]                            @relation("InsSetter")
+  /// US-2603 — switcher patient : dossiers récemment vus / épinglés par ce PS.
+  recentlyViewedPatients            RecentlyViewedPatient[]
+  pinnedPatients                    PinnedPatient[]
 
   /// US-2026 — INS unique anti-doublon RNIPP. PG default NULLS DISTINCT
   /// autorise plusieurs NULL (PS / ADMIN sans INS renseigne).
@@ -675,12 +678,48 @@ model Patient {
   invoices               Invoice[]
   /// US-2076 scope A — Messages liés au patient (pivot audit US-2268).
   messages               Message[]
+  /// US-2603 — switcher patient : entrées « récemment vu » / « épinglé » par les PS.
+  recentlyViewedBy       RecentlyViewedPatient[]
+  pinnedBy               PinnedPatient[]
 
   /// US-2076bis-V2 (Issue #442) — lookup `publicRef → patientId` interne
   /// (résolve quand UI envoie ref opaque). UNIQUE empêche collision UUID v4.
   @@unique([publicRef], map: "patients_public_ref_key")
   @@index([deletedAt])
   @@map("patients")
+}
+
+/// US-2603 — Dossiers patients récemment consultés par un PS (switcher de
+/// contexte). Un upsert par (user, patient) met à jour `viewedAt`. Scopé au
+/// périmètre du PS à la lecture (intersection `getAccessiblePatientIds`).
+model RecentlyViewedPatient {
+  id        Int      @id @default(autoincrement())
+  userId    Int      @map("user_id")
+  patientId Int      @map("patient_id")
+  viewedAt  DateTime @default(now()) @map("viewed_at") @db.Timestamptz()
+
+  user    User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, patientId])
+  @@index([userId, viewedAt(sort: Desc)])
+  @@map("recently_viewed_patients")
+}
+
+/// US-2603 — Dossiers patients épinglés par un PS (switcher de contexte).
+/// Toggle on/off ; scopé au périmètre du PS à la lecture.
+model PinnedPatient {
+  id        Int      @id @default(autoincrement())
+  userId    Int      @map("user_id")
+  patientId Int      @map("patient_id")
+  pinnedAt  DateTime @default(now()) @map("pinned_at") @db.Timestamptz()
+
+  user    User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, patientId])
+  @@index([userId, pinnedAt(sort: Desc)])
+  @@map("pinned_patients")
 }
 
 model PatientMedicalData {

--- a/src/app/api/patients/[id]/pin/route.ts
+++ b/src/app/api/patients/[id]/pin/route.ts
@@ -1,0 +1,90 @@
+/**
+ * US-2603 — Épinglage d'un patient au switcher de contexte (par PS).
+ *
+ * `POST /api/patients/:id/pin`   → épingle (409 si plafond atteint).
+ * `DELETE /api/patients/:id/pin` → désépingle (idempotent).
+ *
+ * Sécurité (modèle des routes per-patient) : RBAC NURSE+, pré-check existence
+ * (404), `canAccessPatient` sinon `accessDenied` + 403 uniforme (anti-énumération),
+ * garde consentement `patientShareConsent`, audit `CREATE`/`DELETE` `PINNED_PATIENT`.
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { requireRole, AuthError } from "@/lib/auth"
+import { canAccessPatient } from "@/lib/access-control"
+import { patientShareConsent } from "@/lib/consent"
+import { recentPatientsService } from "@/lib/services/recent-patients.service"
+import { prisma } from "@/lib/db/client"
+import { auditService, extractRequestContext } from "@/lib/services/audit.service"
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+async function ensurePatientAlive(patientId: number): Promise<boolean> {
+  const p = await prisma.patient.findFirst({
+    where: { id: patientId, deletedAt: null }, select: { id: true },
+  })
+  return !!p
+}
+
+/** Gardes communes POST/DELETE : RBAC + existence + accès + consentement. */
+async function guard(req: NextRequest, params: RouteParams["params"], endpoint: string) {
+  const user = requireRole(req, "NURSE")
+  const { id } = await params
+  if (!/^\d+$/.test(id)) {
+    return { error: NextResponse.json({ error: "invalidPatientId" }, { status: 400 }) }
+  }
+  const patientId = parseInt(id, 10)
+  const ctx = extractRequestContext(req)
+
+  if (!(await ensurePatientAlive(patientId))) {
+    return { error: NextResponse.json({ error: "patientNotFound" }, { status: 404 }) }
+  }
+  if (!(await canAccessPatient(user.id, user.role, patientId))) {
+    await auditService.accessDenied({
+      userId: user.id, resource: "PINNED_PATIENT", resourceId: String(patientId),
+      ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+      metadata: { patientId, endpoint },
+    })
+    return { error: NextResponse.json({ error: "forbidden" }, { status: 403 }) }
+  }
+  const consent = await patientShareConsent(patientId)
+  if (!consent.ok) {
+    return { error: NextResponse.json({ error: consent.error }, { status: consent.status }) }
+  }
+  return { user, patientId, ctx }
+}
+
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  try {
+    const g = await guard(req, params, "pin")
+    if ("error" in g) return g.error
+    const result = await recentPatientsService.pin(g.user.id, g.patientId, g.user.id, g.ctx)
+    if (!result.ok) {
+      return NextResponse.json({ error: result.reason }, { status: 409 })
+    }
+    return NextResponse.json({ pinned: true })
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    console.error("[patients/:id/pin POST]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: RouteParams) {
+  try {
+    const g = await guard(req, params, "unpin")
+    if ("error" in g) return g.error
+    await recentPatientsService.unpin(g.user.id, g.patientId, g.user.id, g.ctx)
+    return NextResponse.json({ pinned: false })
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    console.error("[patients/:id/pin DELETE]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/app/api/patients/recent/route.ts
+++ b/src/app/api/patients/recent/route.ts
@@ -1,0 +1,53 @@
+/**
+ * US-2603 — Switcher de contexte patient : récemment vus + épinglés du PS.
+ *
+ * `GET /api/patients/recent` → `{ recent: PatientRef[], pinned: PatientRef[] }`.
+ *
+ * Sécurité : RBAC NURSE+, scope dur appliqué côté service (intersection
+ * `getAccessiblePatientIds`), rate-limit `patientDataRead` (la réponse contient
+ * des noms PII déchiffrés), headers `no-store` (RGPD Art. 32), accès audité.
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { requireRole, AuthError } from "@/lib/auth"
+import { checkApiRateLimit, RATE_LIMITS } from "@/lib/auth/api-rate-limit"
+import { recentPatientsService } from "@/lib/services/recent-patients.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+
+/** Headers anti-cache sur une réponse contenant des PII (cf. /patients/search). */
+function setNoStore(res: NextResponse): NextResponse {
+  res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, private")
+  res.headers.set("Pragma", "no-cache")
+  res.headers.set("Referrer-Policy", "no-referrer")
+  res.headers.set("X-Content-Type-Options", "nosniff")
+  return res
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const user = requireRole(req, "NURSE")
+    const ctx = extractRequestContext(req)
+
+    const rl = await checkApiRateLimit(String(user.id), RATE_LIMITS.patientDataRead)
+    if (!rl.allowed) {
+      return setNoStore(
+        NextResponse.json(
+          { error: "rateLimitExceeded" },
+          { status: 429, headers: { "Retry-After": String(rl.retryAfterSec) } },
+        ),
+      )
+    }
+
+    const result = await recentPatientsService.listRecentAndPinned(
+      user.id, user.role, user.id, ctx,
+    )
+    return setNoStore(NextResponse.json(result))
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return setNoStore(NextResponse.json({ error: error.message }, { status: error.status }))
+    }
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    console.error("[patients/recent GET]", msg)
+    return setNoStore(NextResponse.json({ error: "serverError" }, { status: 500 }))
+  }
+}

--- a/src/app/api/patients/recent/route.ts
+++ b/src/app/api/patients/recent/route.ts
@@ -28,14 +28,30 @@ export async function GET(req: NextRequest) {
     const user = requireRole(req, "NURSE")
     const ctx = extractRequestContext(req)
 
-    const rl = await checkApiRateLimit(String(user.id), RATE_LIMITS.patientDataRead)
-    if (!rl.allowed) {
+    // Double bucket per-user + per-IP (réponse = noms PII déchiffrés), aligné sur
+    // /patients/search. Fail-open — la confidentialité repose sur le scope RBAC.
+    const rlUser = await checkApiRateLimit(String(user.id), RATE_LIMITS.patientDataRead)
+    if (!rlUser.allowed) {
       return setNoStore(
         NextResponse.json(
           { error: "rateLimitExceeded" },
-          { status: 429, headers: { "Retry-After": String(rl.retryAfterSec) } },
+          { status: 429, headers: { "Retry-After": String(rlUser.retryAfterSec) } },
         ),
       )
+    }
+    // Per-IP : SKIP quand l'IP n'est pas résolue ("unknown") pour éviter un
+    // bucket partagé `ip:unknown` (DoS auto-infligé). XFF spoofable — durcissement
+    // transverse suivi dans docs/security/xff-trusted-proxy.md.
+    if (ctx.ipAddress && ctx.ipAddress !== "unknown") {
+      const rlIp = await checkApiRateLimit(`ip:${ctx.ipAddress}`, RATE_LIMITS.patientDataReadIp)
+      if (!rlIp.allowed) {
+        return setNoStore(
+          NextResponse.json(
+            { error: "rateLimitExceeded" },
+            { status: 429, headers: { "Retry-After": String(rlIp.retryAfterSec) } },
+          ),
+        )
+      }
     }
 
     const result = await recentPatientsService.listRecentAndPinned(

--- a/src/lib/services/audit.service.ts
+++ b/src/lib/services/audit.service.ts
@@ -95,6 +95,7 @@ export type AuditResource =
   | "BOLUS_LOG"
   | "ADJUSTMENT_PROPOSAL"
   | "MEDICAL_DOCUMENT"
+  | "PINNED_PATIENT"
   | "SESSION"
   | "MYDIABBY_CREDENTIAL"
   | "MEDICATION"

--- a/src/lib/services/doctor-dashboard.service.ts
+++ b/src/lib/services/doctor-dashboard.service.ts
@@ -566,6 +566,9 @@ export async function getPatientFlags(patientId: number): Promise<PatientFlags> 
   const sevenDaysAgo = new Date(now.getTime() - 7 * 86_400_000)
   const silentCutoff = new Date(now.getTime() - SILENT_DAYS * 86_400_000)
   const [openUrgencyCount, hypoCount, latestCgm] = await Promise.all([
+    // NB : compte TOUTES les sévérités d'alerte en cours (≠ `urgenciesQuery` qui
+    // surface les critiques en tête) — pour la barre, toute urgence ouverte est un
+    // drapeau. Choix produit assumé, pas une dérive vs la worklist.
     prisma.emergencyAlert.count({
       where: {
         patientId,

--- a/src/lib/services/doctor-dashboard.service.ts
+++ b/src/lib/services/doctor-dashboard.service.ts
@@ -533,6 +533,65 @@ export const patientsAtRiskQuery = {
 }
 
 // ─────────────────────────────────────────────────────────────
+// US-2603 — Drapeaux d'alerte mono-patient (barre de contexte)
+// ─────────────────────────────────────────────────────────────
+
+/** Drapeaux d'alerte d'UN patient pour la barre de contexte (US-2603). */
+export type PatientFlags = {
+  /** ≥ {@link HYPO_THRESHOLD_7D} hypos sur 7 j. */
+  recentHypos: boolean
+  hypoCount: number
+  /** Aucune saisie CGM depuis ≥ {@link SILENT_DAYS} jours (ou jamais). */
+  silentMonitoring: boolean
+  /** Jours depuis le dernier relevé CGM ; null si aucun relevé. */
+  silentDays: number | null
+  /** Urgence en cours (open/acknowledged). */
+  openUrgency: boolean
+}
+
+/**
+ * Drapeaux d'alerte d'un patient pour la barre de contexte (US-2603).
+ *
+ * SOURCE UNIQUE des seuils/prédicats partagée avec « Ma journée »
+ * (`patientsAtRiskQuery`/`urgenciesQuery`) — mêmes constantes
+ * {@link HYPO_THRESHOLD_7D}/{@link SILENT_DAYS}, mêmes types d'alerte → pas de
+ * dérive entre la worklist cohorte et la barre mono-patient.
+ *
+ * L'appelant a déjà vérifié l'accès (`canAccessPatient`) et l'audit READ PATIENT
+ * (via `patientService.getById`) couvre la consultation — pas d'audit dédié ici
+ * (signal dérivé : comptes/horodatage, aucune PHI).
+ */
+export async function getPatientFlags(patientId: number): Promise<PatientFlags> {
+  const now = new Date()
+  const sevenDaysAgo = new Date(now.getTime() - 7 * 86_400_000)
+  const silentCutoff = new Date(now.getTime() - SILENT_DAYS * 86_400_000)
+  const [openUrgencyCount, hypoCount, latestCgm] = await Promise.all([
+    prisma.emergencyAlert.count({
+      where: {
+        patientId,
+        status: { in: [EmergencyAlertStatus.open, EmergencyAlertStatus.acknowledged] },
+      },
+    }),
+    prisma.emergencyAlert.count({
+      where: {
+        patientId,
+        alertType: { in: [EmergencyAlertType.hypo, EmergencyAlertType.severe_hypo] },
+        triggeredAt: { gte: sevenDaysAgo },
+      },
+    }),
+    prisma.cgmEntry.aggregate({ where: { patientId }, _max: { timestamp: true } }),
+  ])
+  const last = latestCgm._max.timestamp
+  return {
+    recentHypos: hypoCount >= HYPO_THRESHOLD_7D,
+    hypoCount,
+    silentMonitoring: last == null || last < silentCutoff,
+    silentDays: last ? Math.floor((now.getTime() - last.getTime()) / 86_400_000) : null,
+    openUrgency: openUrgencyCount > 0,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
 // US-2404 — KPI cabinet 14j
 // ─────────────────────────────────────────────────────────────
 

--- a/src/lib/services/recent-patients.service.ts
+++ b/src/lib/services/recent-patients.service.ts
@@ -143,6 +143,9 @@ export const recentPatientsService = {
       select: { id: true },
     })
     if (!already) {
+      // Check-then-write non atomique : 2 épinglages concourants du MÊME PS
+      // pourraient dépasser le plafond de +1. Course bénigne (mono-acteur,
+      // plafond purement défensif) — pas de transaction pour cette borne souple.
       const count = await prisma.pinnedPatient.count({ where: { userId } })
       if (count >= PINNED_CAP) return { ok: false, reason: "pinnedLimitReached" }
     }

--- a/src/lib/services/recent-patients.service.ts
+++ b/src/lib/services/recent-patients.service.ts
@@ -1,0 +1,174 @@
+/**
+ * @module recent-patients.service
+ * @description US-2603 — switcher de contexte patient : dossiers récemment vus
+ * et épinglés, par PS.
+ *
+ * Sécurité (HDS/RGPD) :
+ *  - **Scope dur à la lecture** : `listRecentAndPinned` intersecte TOUJOURS les
+ *    entrées avec `getAccessiblePatientIds` (+ `deletedAt: null`). Un patient
+ *    sorti du périmètre du PS (ou soft-deleted) disparaît silencieusement, même
+ *    s'il avait été épinglé → aucune fuite hors périmètre.
+ *  - Les noms renvoyés sont de la PII : déchiffrement **serveur**
+ *    (`safeDecryptField`), endpoint `no-store`, accès **audité** (résumé + pivots
+ *    `metadata.patientId`, ADR #18).
+ *  - `recordView` n'écrit que des métadonnées de navigation (userId/patientId/
+ *    timestamp, aucune PHI) ; la consultation elle-même est auditée par
+ *    `patientService.getById` (READ PATIENT) → pas d'audit dédié ici (anti-bruit).
+ *  - L'accès patient pour `pin`/`unpin` est vérifié par la route appelante
+ *    (`canAccessPatient` → `accessDenied` + 403 uniforme).
+ */
+
+import type { Role } from "@prisma/client"
+import { prisma } from "@/lib/db/client"
+import { getAccessiblePatientIds } from "@/lib/access-control"
+import { auditService, type AuditContext } from "./audit.service"
+import { safeDecryptField } from "@/lib/crypto/fields"
+
+/** Référence patient minimale pour le switcher (PII déchiffrée serveur). */
+export type PatientRef = {
+  id: number
+  publicRef: string
+  name: string
+  pathology: string | null
+}
+
+/** Nombre max de « récemment vus » renvoyés. */
+const RECENT_LIMIT = 10
+/** Plafond défensif d'épingles par PS. */
+const PINNED_CAP = 20
+
+type PatientSelectRow = {
+  patient: {
+    id: number
+    publicRef: string
+    pathology: string | null
+    user: { firstname: string | null; lastname: string | null }
+  }
+}
+
+const PATIENT_SELECT = {
+  patient: {
+    select: {
+      id: true,
+      publicRef: true,
+      pathology: true,
+      user: { select: { firstname: true, lastname: true } },
+    },
+  },
+} as const
+
+function toRef(row: PatientSelectRow): PatientRef {
+  const p = row.patient
+  const name = `${safeDecryptField(p.user.firstname ?? "") ?? ""} ${safeDecryptField(p.user.lastname ?? "") ?? ""}`.trim()
+  return { id: p.id, publicRef: p.publicRef, name, pathology: p.pathology }
+}
+
+export const recentPatientsService = {
+  /**
+   * Enregistre/rafraîchit la consultation d'un dossier par un PS (upsert →
+   * `viewedAt = now()`). Idempotent par (user, patient). Aucune PHI ; pas d'audit
+   * dédié (la consultation est auditée par getById). Doit être appelé fail-soft.
+   */
+  async recordView(userId: number, patientId: number): Promise<void> {
+    await prisma.recentlyViewedPatient.upsert({
+      where: { userId_patientId: { userId, patientId } },
+      create: { userId, patientId },
+      update: { viewedAt: new Date() },
+    })
+  },
+
+  /**
+   * Liste les récemment vus + épinglés du PS, **scopés au périmètre** (anti-fuite)
+   * et hors patients soft-deleted. Déchiffre les noms serveur + audite.
+   */
+  async listRecentAndPinned(
+    userId: number, role: Role,
+    auditUserId: number, ctx?: AuditContext,
+  ): Promise<{ recent: PatientRef[]; pinned: PatientRef[] }> {
+    const accessible = await getAccessiblePatientIds(userId, role)
+    // Portefeuille vide (DOCTOR/NURSE sans patient) → rien.
+    if (accessible !== null && accessible.length === 0) return { recent: [], pinned: [] }
+    // ADMIN (null) = pas de restriction d'IDs ; sinon intersection dure.
+    const scope = accessible === null ? {} : { patientId: { in: accessible } }
+
+    const [recentRows, pinnedRows] = await Promise.all([
+      prisma.recentlyViewedPatient.findMany({
+        where: { userId, ...scope, patient: { deletedAt: null } },
+        orderBy: { viewedAt: "desc" },
+        take: RECENT_LIMIT,
+        select: PATIENT_SELECT,
+      }),
+      prisma.pinnedPatient.findMany({
+        where: { userId, ...scope, patient: { deletedAt: null } },
+        orderBy: { pinnedAt: "desc" },
+        take: PINNED_CAP,
+        select: PATIENT_SELECT,
+      }),
+    ])
+
+    const recent = recentRows.map(toRef)
+    const pinned = pinnedRows.map(toRef)
+
+    // Audit : résumé + pivots per-patient (noms = PII). allSettled : un échec
+    // d'audit ne casse pas le switcher après calcul.
+    await auditService.log({
+      userId: auditUserId, action: "READ", resource: "PATIENT", resourceId: "list",
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { kind: "patient.switcher", recent: recent.length, pinned: pinned.length },
+    })
+    const pivotIds = new Set([...recent, ...pinned].map((p) => p.id))
+    await Promise.allSettled(
+      [...pivotIds].map((id) =>
+        auditService.log({
+          userId: auditUserId, action: "READ", resource: "PATIENT", resourceId: String(id),
+          ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+          metadata: { patientId: id, kind: "patient.switcher" },
+        }),
+      ),
+    )
+
+    return { recent, pinned }
+  },
+
+  /**
+   * Épingle un patient pour le PS. Plafonné à {@link PINNED_CAP}. L'accès patient
+   * est vérifié par la route appelante. Retourne `{ ok: false }` si plafond atteint.
+   */
+  async pin(
+    userId: number, patientId: number,
+    auditUserId: number, ctx?: AuditContext,
+  ): Promise<{ ok: true } | { ok: false; reason: "pinnedLimitReached" }> {
+    const already = await prisma.pinnedPatient.findUnique({
+      where: { userId_patientId: { userId, patientId } },
+      select: { id: true },
+    })
+    if (!already) {
+      const count = await prisma.pinnedPatient.count({ where: { userId } })
+      if (count >= PINNED_CAP) return { ok: false, reason: "pinnedLimitReached" }
+    }
+    await prisma.pinnedPatient.upsert({
+      where: { userId_patientId: { userId, patientId } },
+      create: { userId, patientId },
+      update: {},
+    })
+    await auditService.log({
+      userId: auditUserId, action: "CREATE", resource: "PINNED_PATIENT", resourceId: String(patientId),
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { patientId },
+    })
+    return { ok: true }
+  },
+
+  /** Désépingle un patient pour le PS (idempotent). Accès vérifié par la route. */
+  async unpin(
+    userId: number, patientId: number,
+    auditUserId: number, ctx?: AuditContext,
+  ): Promise<void> {
+    await prisma.pinnedPatient.deleteMany({ where: { userId, patientId } })
+    await auditService.log({
+      userId: auditUserId, action: "DELETE", resource: "PINNED_PATIENT", resourceId: String(patientId),
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { patientId },
+    })
+  },
+}

--- a/tests/integration/api-patients-pin.test.ts
+++ b/tests/integration/api-patients-pin.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @description US-2603 — routes du switcher de contexte patient.
+ * `POST/DELETE /api/patients/[id]/pin` (RBAC, 404, accès, consentement, cap) et
+ * `GET /api/patients/recent` (RBAC). Le scope dur de la liste est testé au
+ * niveau service (recent-patients.service.test.ts).
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { NextRequest } from "next/server"
+
+const canAccessMock = vi.fn()
+vi.mock("@/lib/access-control", () => ({ canAccessPatient: canAccessMock }))
+
+const consentMock = vi.fn()
+vi.mock("@/lib/consent", () => ({ patientShareConsent: consentMock }))
+
+const pinMock = vi.fn()
+const unpinMock = vi.fn()
+const listMock = vi.fn()
+vi.mock("@/lib/services/recent-patients.service", () => ({
+  recentPatientsService: { pin: pinMock, unpin: unpinMock, listRecentAndPinned: listMock },
+}))
+
+vi.mock("@/lib/auth/api-rate-limit", () => ({
+  checkApiRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+  RATE_LIMITS: { patientDataRead: {} },
+}))
+
+const findFirstMock = vi.fn()
+vi.mock("@/lib/db/client", () => ({ prisma: { patient: { findFirst: findFirstMock } } }))
+
+const accessDeniedMock = vi.fn()
+vi.mock("@/lib/services/audit.service", () => ({
+  auditService: { accessDenied: accessDeniedMock },
+  extractRequestContext: () => ({ ipAddress: "127.0.0.1", userAgent: "test", requestId: "r1" }),
+}))
+
+const { POST, DELETE } = await import("@/app/api/patients/[id]/pin/route")
+const { GET: GET_RECENT } = await import("@/app/api/patients/recent/route")
+
+function req(role: string, method = "POST", id = "42"): NextRequest {
+  const headers = new Headers()
+  headers.set("x-user-id", "1")
+  headers.set("x-user-role", role)
+  return new NextRequest(new URL(`/api/patients/${id}/pin`, "http://test.local"), { method, headers })
+}
+const params = (id: string) => ({ params: Promise.resolve({ id }) })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  findFirstMock.mockResolvedValue({ id: 42 }) // patient alive by default
+  canAccessMock.mockResolvedValue(true)
+  consentMock.mockResolvedValue({ ok: true })
+})
+
+describe("POST /api/patients/[id]/pin", () => {
+  it("VIEWER → 403 (RBAC NURSE+)", async () => {
+    const res = await POST(req("VIEWER"), params("42"))
+    expect(res?.status).toBe(403)
+    expect(pinMock).not.toHaveBeenCalled()
+  })
+
+  it("404 when the patient does not exist / is soft-deleted", async () => {
+    findFirstMock.mockResolvedValue(null)
+    const res = await POST(req("NURSE"), params("42"))
+    expect(res?.status).toBe(404)
+  })
+
+  it("out-of-perimeter → accessDenied + 403, no pin", async () => {
+    canAccessMock.mockResolvedValue(false)
+    const res = await POST(req("DOCTOR"), params("42"))
+    expect(res?.status).toBe(403)
+    expect(accessDeniedMock).toHaveBeenCalled()
+    expect(pinMock).not.toHaveBeenCalled()
+  })
+
+  it("sharing disabled → blocked with consent status, no pin", async () => {
+    consentMock.mockResolvedValue({ ok: false, status: 403, error: "sharingDisabled" })
+    const res = await POST(req("NURSE"), params("42"))
+    expect(res?.status).toBe(403)
+    expect(pinMock).not.toHaveBeenCalled()
+  })
+
+  it("happy path → pins (200)", async () => {
+    pinMock.mockResolvedValue({ ok: true })
+    const res = await POST(req("NURSE"), params("42"))
+    expect(res?.status).toBe(200)
+    expect(pinMock).toHaveBeenCalledWith(1, 42, 1, expect.anything())
+  })
+
+  it("cap reached → 409", async () => {
+    pinMock.mockResolvedValue({ ok: false, reason: "pinnedLimitReached" })
+    const res = await POST(req("NURSE"), params("42"))
+    expect(res?.status).toBe(409)
+  })
+
+  it("invalid id → 400", async () => {
+    const res = await POST(req("NURSE", "POST", "abc"), params("abc"))
+    expect(res?.status).toBe(400)
+  })
+})
+
+describe("DELETE /api/patients/[id]/pin", () => {
+  it("happy path → unpins (200)", async () => {
+    unpinMock.mockResolvedValue(undefined)
+    const res = await DELETE(req("NURSE", "DELETE"), params("42"))
+    expect(res?.status).toBe(200)
+    expect(unpinMock).toHaveBeenCalledWith(1, 42, 1, expect.anything())
+  })
+})
+
+describe("GET /api/patients/recent", () => {
+  it("VIEWER → 403 (RBAC NURSE+)", async () => {
+    const headers = new Headers()
+    headers.set("x-user-id", "1")
+    headers.set("x-user-role", "VIEWER")
+    const res = await GET_RECENT(
+      new NextRequest(new URL("/api/patients/recent", "http://test.local"), { headers }),
+    )
+    expect(res?.status).toBe(403)
+    expect(listMock).not.toHaveBeenCalled()
+  })
+
+  it("NURSE → 200 with recent+pinned, no-store header", async () => {
+    listMock.mockResolvedValue({ recent: [], pinned: [] })
+    const headers = new Headers()
+    headers.set("x-user-id", "1")
+    headers.set("x-user-role", "NURSE")
+    const res = await GET_RECENT(
+      new NextRequest(new URL("/api/patients/recent", "http://test.local"), { headers }),
+    )
+    expect(res?.status).toBe(200)
+    expect(res?.headers.get("Cache-Control")).toContain("no-store")
+    expect(listMock).toHaveBeenCalledWith(1, "NURSE", 1, expect.anything())
+  })
+})

--- a/tests/integration/api-patients-pin.test.ts
+++ b/tests/integration/api-patients-pin.test.ts
@@ -20,9 +20,10 @@ vi.mock("@/lib/services/recent-patients.service", () => ({
   recentPatientsService: { pin: pinMock, unpin: unpinMock, listRecentAndPinned: listMock },
 }))
 
+const rateLimitMock = vi.fn()
 vi.mock("@/lib/auth/api-rate-limit", () => ({
-  checkApiRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
-  RATE_LIMITS: { patientDataRead: {} },
+  checkApiRateLimit: rateLimitMock,
+  RATE_LIMITS: { patientDataRead: {}, patientDataReadIp: {} },
 }))
 
 const findFirstMock = vi.fn()
@@ -50,6 +51,7 @@ beforeEach(() => {
   findFirstMock.mockResolvedValue({ id: 42 }) // patient alive by default
   canAccessMock.mockResolvedValue(true)
   consentMock.mockResolvedValue({ ok: true })
+  rateLimitMock.mockResolvedValue({ allowed: true })
 })
 
 describe("POST /api/patients/[id]/pin", () => {
@@ -73,11 +75,14 @@ describe("POST /api/patients/[id]/pin", () => {
     expect(pinMock).not.toHaveBeenCalled()
   })
 
-  it("sharing disabled → blocked with consent status, no pin", async () => {
+  it("sharing disabled → blocked with consent status, no pin, NO accessDenied", async () => {
     consentMock.mockResolvedValue({ ok: false, status: 403, error: "sharingDisabled" })
     const res = await POST(req("NURSE"), params("42"))
     expect(res?.status).toBe(403)
     expect(pinMock).not.toHaveBeenCalled()
+    // Un refus de consentement n'est PAS un accès refusé (accessDenied réservé
+    // au hors-périmètre, pour ne pas polluer la détection d'abus US-2265).
+    expect(accessDeniedMock).not.toHaveBeenCalled()
   })
 
   it("happy path → pins (200)", async () => {
@@ -117,6 +122,19 @@ describe("GET /api/patients/recent", () => {
       new NextRequest(new URL("/api/patients/recent", "http://test.local"), { headers }),
     )
     expect(res?.status).toBe(403)
+    expect(listMock).not.toHaveBeenCalled()
+  })
+
+  it("rate-limited → 429 with no-store, no service call", async () => {
+    rateLimitMock.mockResolvedValue({ allowed: false, retryAfterSec: 30 })
+    const headers = new Headers()
+    headers.set("x-user-id", "1")
+    headers.set("x-user-role", "NURSE")
+    const res = await GET_RECENT(
+      new NextRequest(new URL("/api/patients/recent", "http://test.local"), { headers }),
+    )
+    expect(res?.status).toBe(429)
+    expect(res?.headers.get("Cache-Control")).toContain("no-store")
     expect(listMock).not.toHaveBeenCalled()
   })
 

--- a/tests/unit/doctor-dashboard.service.test.ts
+++ b/tests/unit/doctor-dashboard.service.test.ts
@@ -27,7 +27,7 @@ vi.mock("@/lib/services/messaging.service", () => ({
 import {
   urgenciesQuery, appointmentsQuery,
   patientsAtRiskQuery, kpisQuery, pendingProposalsQuery,
-  unreadThreadsQuery,
+  unreadThreadsQuery, getPatientFlags,
 } from "@/lib/services/doctor-dashboard.service"
 import { getAccessiblePatientIds } from "@/lib/access-control"
 import { messagingService } from "@/lib/services/messaging.service"
@@ -476,5 +476,56 @@ describe("unreadThreadsQuery (US-2602)", () => {
     )
     const out = await unreadThreadsQuery.forCaller(1, CTX as any)
     expect(out).toHaveLength(5)
+  })
+})
+
+// ─── US-2603 getPatientFlags (drapeaux mono-patient, source unique) ──────────
+
+describe("getPatientFlags (US-2603)", () => {
+  const pmf = prismaMock as unknown as {
+    emergencyAlert: { count: any }
+    cgmEntry: { aggregate: any }
+  }
+
+  it("flags recentHypos at the shared threshold (≥3 hypos/7j)", async () => {
+    // Ordre Promise.all : count(open-urgency), count(hypos), aggregate(cgm).
+    pmf.emergencyAlert.count.mockResolvedValueOnce(0).mockResolvedValueOnce(3)
+    pmf.cgmEntry.aggregate.mockResolvedValue({ _max: { timestamp: new Date() } })
+
+    const f = await getPatientFlags(42)
+    expect(f.recentHypos).toBe(true)
+    expect(f.hypoCount).toBe(3)
+    expect(f.openUrgency).toBe(false)
+    expect(f.silentMonitoring).toBe(false)
+  })
+
+  it("does NOT flag recentHypos below threshold (2 hypos)", async () => {
+    pmf.emergencyAlert.count.mockResolvedValueOnce(0).mockResolvedValueOnce(2)
+    pmf.cgmEntry.aggregate.mockResolvedValue({ _max: { timestamp: new Date() } })
+    const f = await getPatientFlags(42)
+    expect(f.recentHypos).toBe(false)
+  })
+
+  it("flags silentMonitoring when last CGM older than the silent cutoff (and never)", async () => {
+    pmf.emergencyAlert.count.mockResolvedValueOnce(0).mockResolvedValueOnce(0)
+    const old = new Date(Date.now() - 10 * 86_400_000) // 10 j > 5 j
+    pmf.cgmEntry.aggregate.mockResolvedValue({ _max: { timestamp: old } })
+    const f = await getPatientFlags(42)
+    expect(f.silentMonitoring).toBe(true)
+    expect(f.silentDays).toBe(10)
+
+    // Aucun relevé → silent, silentDays null.
+    pmf.emergencyAlert.count.mockResolvedValueOnce(0).mockResolvedValueOnce(0)
+    pmf.cgmEntry.aggregate.mockResolvedValue({ _max: { timestamp: null } })
+    const f2 = await getPatientFlags(42)
+    expect(f2.silentMonitoring).toBe(true)
+    expect(f2.silentDays).toBeNull()
+  })
+
+  it("flags openUrgency when an open/acknowledged alert exists", async () => {
+    pmf.emergencyAlert.count.mockResolvedValueOnce(1).mockResolvedValueOnce(0)
+    pmf.cgmEntry.aggregate.mockResolvedValue({ _max: { timestamp: new Date() } })
+    const f = await getPatientFlags(42)
+    expect(f.openUrgency).toBe(true)
   })
 })

--- a/tests/unit/recent-patients.service.test.ts
+++ b/tests/unit/recent-patients.service.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Test suite : recent-patients.service (US-2603 — switcher de contexte patient).
+ *
+ * Comportements de sécurité couverts :
+ *  - **Scope dur** : la liste récents/épinglés est TOUJOURS intersectée avec
+ *    `getAccessiblePatientIds` (anti-fuite hors périmètre) + `deletedAt: null`.
+ *  - Portefeuille vide → aucune requête, retour vide.
+ *  - ADMIN (null) → pas de filtre d'IDs.
+ *  - `recordView` upsert idempotent (re-vue = update viewedAt).
+ *  - `pin` plafonné, `unpin` idempotent ; audit CREATE/DELETE PINNED_PATIENT.
+ *  - Noms déchiffrés serveur (PII).
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { prismaMock } from "../helpers/prisma-mock"
+
+vi.mock("@/lib/access-control", () => ({
+  getAccessiblePatientIds: vi.fn(),
+}))
+vi.mock("@/lib/crypto/fields", () => ({
+  safeDecryptField: (v: string | null) => (v ? `dec:${v}` : v),
+}))
+
+import { recentPatientsService } from "@/lib/services/recent-patients.service"
+import { getAccessiblePatientIds } from "@/lib/access-control"
+
+const mockedAccessible = vi.mocked(getAccessiblePatientIds)
+const pm = prismaMock as unknown as {
+  recentlyViewedPatient: { findMany: any; upsert: any }
+  pinnedPatient: { findMany: any; upsert: any; deleteMany: any; count: any; findUnique: any }
+  auditLog: { create: any }
+}
+
+beforeEach(() => {
+  prismaMock.auditLog.create.mockResolvedValue({} as any)
+  mockedAccessible.mockReset()
+})
+
+const row = (id: number, fn: string, ln: string, pathology = "DT1") => ({
+  patient: { id, publicRef: `ref-${id}`, pathology, user: { firstname: fn, lastname: ln } },
+})
+
+describe("recentPatientsService.listRecentAndPinned", () => {
+  it("returns empty without querying when the portfolio is empty", async () => {
+    mockedAccessible.mockResolvedValue([])
+    const out = await recentPatientsService.listRecentAndPinned(1, "DOCTOR", 1)
+    expect(out).toEqual({ recent: [], pinned: [] })
+    expect(pm.recentlyViewedPatient.findMany).not.toHaveBeenCalled()
+  })
+
+  it("intersects recent/pinned with the accessible scope (anti-leak) + deletedAt null", async () => {
+    mockedAccessible.mockResolvedValue([10, 20])
+    pm.recentlyViewedPatient.findMany.mockResolvedValue([row(10, "Jean", "Dupont")])
+    pm.pinnedPatient.findMany.mockResolvedValue([row(20, "Marie", "Curie")])
+
+    const out = await recentPatientsService.listRecentAndPinned(1, "DOCTOR", 1)
+
+    // Le filtre de scope est appliqué dans les DEUX requêtes.
+    const recentWhere = pm.recentlyViewedPatient.findMany.mock.calls[0][0].where
+    const pinnedWhere = pm.pinnedPatient.findMany.mock.calls[0][0].where
+    expect(recentWhere).toMatchObject({ userId: 1, patientId: { in: [10, 20] }, patient: { deletedAt: null } })
+    expect(pinnedWhere).toMatchObject({ userId: 1, patientId: { in: [10, 20] }, patient: { deletedAt: null } })
+
+    // Noms déchiffrés serveur.
+    expect(out.recent[0]).toEqual({ id: 10, publicRef: "ref-10", name: "dec:Jean dec:Dupont", pathology: "DT1" })
+    expect(out.pinned[0].name).toBe("dec:Marie dec:Curie")
+  })
+
+  it("applies NO id filter for ADMIN (accessible = null)", async () => {
+    mockedAccessible.mockResolvedValue(null)
+    pm.recentlyViewedPatient.findMany.mockResolvedValue([])
+    pm.pinnedPatient.findMany.mockResolvedValue([])
+    await recentPatientsService.listRecentAndPinned(9, "ADMIN", 9)
+    const where = pm.recentlyViewedPatient.findMany.mock.calls[0][0].where
+    expect(where.patientId).toBeUndefined()
+    expect(where).toMatchObject({ userId: 9, patient: { deletedAt: null } })
+  })
+
+  it("audits a summary row (resource PATIENT, kind patient.switcher)", async () => {
+    mockedAccessible.mockResolvedValue([10])
+    pm.recentlyViewedPatient.findMany.mockResolvedValue([row(10, "A", "B")])
+    pm.pinnedPatient.findMany.mockResolvedValue([])
+    await recentPatientsService.listRecentAndPinned(1, "DOCTOR", 1)
+    const summary = prismaMock.auditLog.create.mock.calls[0][0].data as any
+    expect(summary.resource).toBe("PATIENT")
+    expect(summary.metadata.kind).toBe("patient.switcher")
+  })
+})
+
+describe("recentPatientsService.recordView", () => {
+  it("upserts on (userId, patientId), refreshing viewedAt", async () => {
+    pm.recentlyViewedPatient.upsert.mockResolvedValue({} as any)
+    await recentPatientsService.recordView(1, 10)
+    const arg = pm.recentlyViewedPatient.upsert.mock.calls[0][0]
+    expect(arg.where).toEqual({ userId_patientId: { userId: 1, patientId: 10 } })
+    expect(arg.create).toEqual({ userId: 1, patientId: 10 })
+    expect(arg.update).toHaveProperty("viewedAt")
+  })
+})
+
+describe("recentPatientsService.pin / unpin", () => {
+  it("pins and audits CREATE PINNED_PATIENT", async () => {
+    pm.pinnedPatient.findUnique.mockResolvedValue(null)
+    pm.pinnedPatient.count.mockResolvedValue(0)
+    pm.pinnedPatient.upsert.mockResolvedValue({} as any)
+    const r = await recentPatientsService.pin(1, 10, 1)
+    expect(r).toEqual({ ok: true })
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.action).toBe("CREATE")
+    expect(audit.resource).toBe("PINNED_PATIENT")
+    expect(audit.metadata.patientId).toBe(10)
+  })
+
+  it("refuses to pin beyond the cap (returns pinnedLimitReached)", async () => {
+    pm.pinnedPatient.findUnique.mockResolvedValue(null)
+    pm.pinnedPatient.count.mockResolvedValue(20)
+    const r = await recentPatientsService.pin(1, 10, 1)
+    expect(r).toEqual({ ok: false, reason: "pinnedLimitReached" })
+    expect(pm.pinnedPatient.upsert).not.toHaveBeenCalled()
+  })
+
+  it("re-pinning an already-pinned patient bypasses the cap", async () => {
+    pm.pinnedPatient.findUnique.mockResolvedValue({ id: 1 })
+    pm.pinnedPatient.upsert.mockResolvedValue({} as any)
+    const r = await recentPatientsService.pin(1, 10, 1)
+    expect(r).toEqual({ ok: true })
+    expect(pm.pinnedPatient.count).not.toHaveBeenCalled()
+  })
+
+  it("unpins (deleteMany) and audits DELETE", async () => {
+    pm.pinnedPatient.deleteMany.mockResolvedValue({ count: 1 } as any)
+    await recentPatientsService.unpin(1, 10, 1)
+    expect(pm.pinnedPatient.deleteMany.mock.calls[0][0]).toEqual({ where: { userId: 1, patientId: 10 } })
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.action).toBe("DELETE")
+    expect(audit.resource).toBe("PINNED_PATIENT")
+  })
+})


### PR DESCRIPTION
## Contexte

**PR 1/2 de US-2603** (barre de contexte patient + switcher), dernière sous-série « navigation médecin V1 ». Cette PR livre le **backend** ; l'UI (barre persistante + switcher dropdown) suivra en **PR 2**. US-2605 (mode revue) réutilisera la barre, planifiée ensuite.

Décisions actées : switcher **complet** (récents + épinglés persistés) ; livraison **backend puis UI**.

## Changements

### Schéma + migration
- Modèles `RecentlyViewedPatient` + `PinnedPatient` (per-user, `@@unique([userId, patientId])`, index `viewedAt`/`pinnedAt` desc, `onDelete: Cascade` depuis `User` et `Patient`).
- Migration versionnée **non destructive** `20260616120000_us2603_patient_switcher` (US-2267). Appliquée ; **zéro drift** schéma↔base (`migrate diff` = « No difference detected »).

### Drapeaux d'alerte — source unique (anti-dérive)
- `doctor-dashboard.service.getPatientFlags(patientId)` : version mono-patient réutilisant les **mêmes constantes/prédicats** que « Ma journée » (`HYPO_THRESHOLD_7D` ≥3/7j, `SILENT_DAYS` ≥5j, urgence open/acknowledged) → la barre et la worklist ne peuvent pas diverger.

### Service `recent-patients.service`
- `recordView` : upsert idempotent (`viewedAt = now()`), fail-soft, sans audit dédié (la consultation est auditée par `getById`).
- `listRecentAndPinned` : **scope DUR** — intersection systématique avec `getAccessiblePatientIds` (ADMIN = illimité) + `deletedAt: null` → un patient hors périmètre/supprimé n'apparaît **jamais**, même épinglé. Noms **déchiffrés serveur** (PII), audit résumé + pivots (ADR #18).
- `pin`/`unpin` : plafond 20 épingles, audit `CREATE`/`DELETE` `PINNED_PATIENT`.

### Endpoints
- `GET /api/patients/recent` — RBAC NURSE+, rate-limit `patientDataRead`, headers `no-store` (PII).
- `POST`/`DELETE /api/patients/[id]/pin` — RBAC + 404 + `canAccessPatient`/`accessDenied` + `patientShareConsent` + audit (squelette `tags/route.ts`).

## Tests / vérifs
- Service : **test de fuite central** (scope dur), `recordView`, `pin` cap, `unpin`, audit.
- `getPatientFlags` : seuils partagés (recentHypos/silent/urgency).
- Routes : RBAC (VIEWER 403), 404, accès (accessDenied 403), consentement, cap 409, no-store.
- `tsc` ✅ · ESLint ✅ · **suite complète 3173 tests verts** · drift Prisma = 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)