### PR TITLE
feat(patients): US-2603 UI — barre de contexte patient + switcher

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -639,7 +639,7 @@ tous corrigés. Migration `20260513230000_groupe5_review_fixes` (FK + unique + p
 | US-2600 | Navigation globale (sidebar maigre, RBAC serveur, RTL, drawer) — ✅ DONE (PR #542) |
 | US-2601 | Palette de commande `Ctrl/Cmd-K` (recherche patient scopée, audit ouverture) — ✅ DONE (PR #541) |
 | US-2602 | « Ma journée » — worklist de tri médecin (déterministe, seuils source unique) — ✅ DONE (PR #540) |
-| US-2603 | Barre de contexte patient + switcher |
+| US-2603 | Barre de contexte patient + switcher — ✅ DONE (backend PR #560 : modèles recently-viewed/pinned + service scopé + endpoints ; UI PR #561 : barre persistante + switcher récents/épinglés) |
 | US-2604 | Onglets-routes du dossier (deep-link, audit niveau donnée, prefetch non-PII) — ✅ DONE (chantier câblage données patient, PR #543→#546 — 4 onglets sur données réelles, scopées/auditées ; enrichi #554–#558) |
 | US-2605 | Mode revue de consultation (**sans IA**) |
 | US-2606 | Bloc « Gestion cabinet » dans la sidebar (Variante A) |

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1531,6 +1531,27 @@
     "icr": "g/U",
     "basal": "U/h"
   },
+  "patientContextBar": {
+    "backToWorklist": "العودة إلى يومي",
+    "ageValue": "{age} سنة",
+    "referentValue": "الطبيب المرجعي: {referent}",
+    "flagUrgency": "حالة طارئة جارية",
+    "flagHypos": "{count, plural, zero {لا نقص سكر / 7 أيام} one {نقص سكر واحد / 7 أيام} two {نقصا سكر / 7 أيام} few {# حالات نقص سكر / 7 أيام} many {# حالة نقص سكر / 7 أيام} other {# نقص سكر / 7 أيام}}",
+    "flagSilent": "لا توجد قياسات",
+    "message": "رسالة",
+    "switch": "تغيير المريض",
+    "switcherTitle": "تغيير المريض",
+    "searchPlaceholder": "ابحث عن مريض (الاسم الدقيق)…",
+    "resultsLabel": "النتائج",
+    "pinnedLabel": "المثبّتون",
+    "recentLabel": "المعروضون مؤخرًا",
+    "noRecent": "لا يوجد ملف تمت مراجعته مؤخرًا.",
+    "noResults": "لم يُعثر على مريض.",
+    "loading": "جارٍ البحث…",
+    "pin": "تثبيت",
+    "unpin": "إلغاء التثبيت",
+    "unnamed": "مريض"
+  },
   "patientDetail": {
     "tabsAriaLabel": "أقسام ملف المريض",
     "tabOverview": "نظرة عامة",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1531,6 +1531,27 @@
     "icr": "g/U",
     "basal": "U/h"
   },
+  "patientContextBar": {
+    "backToWorklist": "Back to My day",
+    "ageValue": "{age} y.o.",
+    "referentValue": "Ref.: {referent}",
+    "flagUrgency": "Active urgency",
+    "flagHypos": "{count, plural, one {# hypo / 7 d} other {# hypos / 7 d}}",
+    "flagSilent": "No data",
+    "message": "Message",
+    "switch": "Switch patient",
+    "switcherTitle": "Switch patient",
+    "searchPlaceholder": "Search a patient (exact name)…",
+    "resultsLabel": "Results",
+    "pinnedLabel": "Pinned",
+    "recentLabel": "Recently viewed",
+    "noRecent": "No recently viewed record.",
+    "noResults": "No patient found.",
+    "loading": "Searching…",
+    "pin": "Pin",
+    "unpin": "Unpin",
+    "unnamed": "Patient"
+  },
   "patientDetail": {
     "tabsAriaLabel": "Patient record sections",
     "tabOverview": "Overview",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1531,6 +1531,27 @@
     "icr": "g/U",
     "basal": "U/h"
   },
+  "patientContextBar": {
+    "backToWorklist": "Retour à Ma journée",
+    "ageValue": "{age} ans",
+    "referentValue": "Réf. : {referent}",
+    "flagUrgency": "Urgence en cours",
+    "flagHypos": "{count, plural, one {# hypo / 7 j} other {# hypos / 7 j}}",
+    "flagSilent": "Sans saisie",
+    "message": "Message",
+    "switch": "Changer de patient",
+    "switcherTitle": "Changer de patient",
+    "searchPlaceholder": "Rechercher un patient (nom exact)…",
+    "resultsLabel": "Résultats",
+    "pinnedLabel": "Épinglés",
+    "recentLabel": "Récemment vus",
+    "noRecent": "Aucun dossier récemment consulté.",
+    "noResults": "Aucun patient trouvé.",
+    "loading": "Recherche…",
+    "pin": "Épingler",
+    "unpin": "Désépingler",
+    "unnamed": "Patient"
+  },
   "patientDetail": {
     "tabsAriaLabel": "Sections du dossier patient",
     "tabOverview": "Vue d'ensemble",

--- a/src/app/(dashboard)/patients/[id]/PatientDetailClient.tsx
+++ b/src/app/(dashboard)/patients/[id]/PatientDetailClient.tsx
@@ -11,6 +11,7 @@
 import { useState, type ReactNode } from "react"
 import { useLocale, useTranslations } from "next-intl"
 import { DashboardHeader } from "@/components/diabeo/DashboardHeader"
+import { PatientContextBar, type ContextFlags } from "@/components/diabeo/patient/PatientContextBar"
 import { GlycemiaValue, TirDonut, ClinicalBadge, StatCard } from "@/components/diabeo"
 import type { TirData } from "@/components/diabeo/TirDonut"
 import { Acronym } from "@/components/diabeo/Acronym"
@@ -28,7 +29,11 @@ import { Activity, Clock, Download, FileText, Heart, Pill, Syringe, TrendingUp, 
 
 export type PatientDetailData = {
   id: number
+  /** UUID opaque (anti-énumération) pour le switcher. */
+  publicRef: string
   name: string
+  /** Drapeaux d'alerte de la barre de contexte (cohérents « Ma journée »). */
+  flags: ContextFlags
   age: number | null
   sex: "M" | "F" | "X" | null
   pathology: string | null
@@ -110,13 +115,13 @@ export function PatientDetailClient({
 
   return (
     <>
-      <DashboardHeader
-        title={name}
-        subtitle={t("subtitle", {
-          pathology: data.pathology ?? "—",
-          age: data.age ?? "—",
-          referent: data.referent ?? "—",
-        })}
+      <PatientContextBar
+        patientId={data.id}
+        name={name}
+        age={data.age}
+        pathology={data.pathology}
+        referent={data.referent}
+        flags={data.flags}
       />
 
       <div className="p-6">

--- a/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/src/app/(dashboard)/patients/[id]/page.tsx
@@ -25,6 +25,8 @@ import { glycemiaService } from "@/lib/services/glycemia.service"
 import { insulinTherapyService } from "@/lib/services/insulin-therapy.service"
 import { documentService } from "@/lib/services/document.service"
 import { auditService } from "@/lib/services/audit.service"
+import { getPatientFlags } from "@/lib/services/doctor-dashboard.service"
+import { recentPatientsService } from "@/lib/services/recent-patients.service"
 import { canAccessPatient } from "@/lib/access-control"
 import { resolveTargetRangeMgdl } from "./overview-targets"
 import { buildGlycemiaView } from "./glycemia-view"
@@ -106,8 +108,24 @@ export default async function PatientDetailPage({
   const patient = await patientService.getById(patientId, userId, ctx)
   if (!patient) notFound()
 
+  // US-2603 — enregistre la consultation du dossier (switcher « récemment vus »).
+  // Fail-soft : un échec ne doit JAMAIS casser le rendu du dossier ; réservé aux
+  // PS (un VIEWER n'atteint pas cette route — défense en profondeur).
+  if (role !== "VIEWER") {
+    void recentPatientsService.recordView(userId, patientId).catch((e) => {
+      console.error("[patient-detail] recordView failed", e instanceof Error ? e.message : e)
+    })
+  }
+
   // Stats glycémiques — projection serveur (audité READ ANALYTICS).
   const profile = await analyticsService.glycemicProfile(patientId, OVERVIEW_PERIOD, userId, ctx)
+
+  // US-2603 — drapeaux d'alerte de la barre de contexte (source unique « Ma
+  // journée »). Fail-soft : signal secondaire, ne casse pas le dossier.
+  const flags = await getPatientFlags(patientId).catch((e) => {
+    console.error("[patient-detail] getPatientFlags failed", e instanceof Error ? e.message : e)
+    return null
+  })
 
   const now = new Date()
 
@@ -149,7 +167,9 @@ export default async function PatientDetailPage({
 
   const data: PatientDetailData = {
     id: patient.id,
+    publicRef: patient.publicRef,
     name: fullName,
+    flags: flags ?? { recentHypos: false, hypoCount: 0, silentMonitoring: false, silentDays: null, openUrgency: false },
     age: computeAge(patient.user.birthday ?? null, now),
     sex: patient.user.sex ?? null,
     pathology: patient.pathology ?? null,

--- a/src/components/diabeo/patient/PatientContextBar.tsx
+++ b/src/components/diabeo/patient/PatientContextBar.tsx
@@ -49,7 +49,7 @@ export function PatientContextBar({
   ]
 
   return (
-    <header className="flex h-16 items-center justify-between gap-4 border-b border-border bg-white px-6">
+    <header className="flex h-16 items-center justify-between gap-4 border-b border-border bg-card px-6">
       <div className="flex min-w-0 items-center gap-3">
         <Link
           href="/medecin"

--- a/src/components/diabeo/patient/PatientContextBar.tsx
+++ b/src/components/diabeo/patient/PatientContextBar.tsx
@@ -1,0 +1,101 @@
+/**
+ * US-2603 — Barre de contexte patient persistante (dossier + futur mode revue).
+ *
+ * Affiche en permanence : retour (Ma journée), identité (nom, âge, pathologie),
+ * drapeaux d'alerte (cohérents « Ma journée » — même source serveur
+ * `getPatientFlags`), action rapide Message, et le switcher de patient.
+ *
+ * Composant client alimenté par des props sérialisables (calculées serveur dans
+ * `page.tsx`). Aucune PII déchiffrée ici ; aucune statistique calculée.
+ */
+
+"use client"
+
+import Link from "next/link"
+import { useTranslations } from "next-intl"
+import { ArrowLeft, MessageSquare, AlertTriangle, Activity, ZapOff } from "lucide-react"
+import { PatientSwitcher } from "./PatientSwitcher"
+
+/** Drapeaux d'alerte sérialisables (miroir de `PatientFlags` serveur). */
+export type ContextFlags = {
+  recentHypos: boolean
+  hypoCount: number
+  silentMonitoring: boolean
+  silentDays: number | null
+  openUrgency: boolean
+}
+
+export function PatientContextBar({
+  patientId,
+  name,
+  age,
+  pathology,
+  referent,
+  flags,
+}: {
+  patientId: number
+  name: string
+  age: number | null
+  pathology: string | null
+  referent: string | null
+  flags: ContextFlags
+}) {
+  const t = useTranslations("patientContextBar")
+
+  const subtitleParts = [
+    pathology ?? "—",
+    age !== null ? t("ageValue", { age }) : "—",
+    t("referentValue", { referent: referent ?? "—" }),
+  ]
+
+  return (
+    <header className="flex h-16 items-center justify-between gap-4 border-b border-border bg-white px-6">
+      <div className="flex min-w-0 items-center gap-3">
+        <Link
+          href="/medecin"
+          aria-label={t("backToWorklist")}
+          className="rounded-lg p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+        >
+          <ArrowLeft className="h-5 w-5 rtl:rotate-180" aria-hidden="true" />
+        </Link>
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h1 className="truncate text-lg font-semibold text-foreground">{name}</h1>
+            {/* Drapeaux d'alerte — cohérents avec « Ma journée ». */}
+            {flags.openUrgency && (
+              <span className="inline-flex items-center gap-1 rounded-full border border-feedback-error bg-error-bg px-2 py-0.5 text-xs font-medium text-error-fg">
+                <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+                {t("flagUrgency")}
+              </span>
+            )}
+            {flags.recentHypos && (
+              <span className="inline-flex items-center gap-1 rounded-full border border-feedback-warning bg-warning-bg px-2 py-0.5 text-xs font-medium text-warning-fg">
+                <Activity className="h-3 w-3" aria-hidden="true" />
+                {t("flagHypos", { count: flags.hypoCount })}
+              </span>
+            )}
+            {flags.silentMonitoring && (
+              <span className="inline-flex items-center gap-1 rounded-full border border-feedback-warning bg-warning-bg px-2 py-0.5 text-xs font-medium text-warning-fg">
+                <ZapOff className="h-3 w-3" aria-hidden="true" />
+                {t("flagSilent")}
+              </span>
+            )}
+          </div>
+          <p className="truncate text-sm text-muted-foreground">{subtitleParts.join(" · ")}</p>
+        </div>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-2">
+        <PatientSwitcher currentPatientId={patientId} />
+        <Link
+          href={`/messages?patientId=${patientId}`}
+          aria-label={t("message")}
+          className="inline-flex items-center gap-2 rounded-md border border-border px-3 py-1.5 text-sm hover:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+        >
+          <MessageSquare className="h-4 w-4" aria-hidden="true" />
+          <span className="hidden sm:inline">{t("message")}</span>
+        </Link>
+      </div>
+    </header>
+  )
+}

--- a/src/components/diabeo/patient/PatientSwitcher.tsx
+++ b/src/components/diabeo/patient/PatientSwitcher.tsx
@@ -1,0 +1,213 @@
+/**
+ * US-2603 — Switcher de contexte patient.
+ *
+ * Dialog déclenché depuis la barre de contexte : recherche patient scopée
+ * (`/api/patients/search`, même endpoint que la palette), sections « épinglés »
+ * et « récemment vus » (`/api/patients/recent`), et bascule épingle
+ * (`POST`/`DELETE /api/patients/[id]/pin`). Sélectionner un patient ouvre son
+ * dossier — la consultation est journalisée serveur par la page de destination.
+ *
+ * Le périmètre est garanti serveur (intersection `getAccessiblePatientIds`) ;
+ * ce composant n'affiche que ce que l'API renvoie.
+ */
+
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useRouter } from "next/navigation"
+import { useTranslations } from "next-intl"
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
+import { Star, ArrowLeftRight } from "lucide-react"
+
+type PatientRef = { id: number; publicRef: string; name: string; pathology: string | null }
+type RawSearch = { id: number; pathology: string | null; user: { firstname: string | null; lastname: string | null } }
+
+const MIN_QUERY = 2
+
+export function PatientSwitcher({ currentPatientId }: { currentPatientId: number }) {
+  const t = useTranslations("patientContextBar")
+  const router = useRouter()
+
+  const [open, setOpen] = useState(false)
+  const [recent, setRecent] = useState<PatientRef[]>([])
+  const [pinned, setPinned] = useState<PatientRef[]>([])
+  const [pinnedIds, setPinnedIds] = useState<Set<number>>(new Set())
+  const [query, setQuery] = useState("")
+  const [results, setResults] = useState<PatientRef[]>([])
+  const [searching, setSearching] = useState(false)
+  const searchAbort = useRef<AbortController | null>(null)
+
+  // Chargement récents + épinglés à l'ouverture.
+  useEffect(() => {
+    if (!open) return
+    const ctrl = new AbortController()
+    void (async () => {
+      try {
+        const res = await fetch("/api/patients/recent", { credentials: "include", signal: ctrl.signal })
+        if (!res.ok) throw new Error(String(res.status))
+        const data: { recent?: PatientRef[]; pinned?: PatientRef[] } = await res.json()
+        const r = Array.isArray(data.recent) ? data.recent : []
+        const p = Array.isArray(data.pinned) ? data.pinned : []
+        setRecent(r)
+        setPinned(p)
+        setPinnedIds(new Set(p.map((x) => x.id)))
+      } catch (err) {
+        if ((err as { name?: string })?.name === "AbortError") return
+        setRecent([])
+        setPinned([])
+      }
+    })()
+    return () => ctrl.abort()
+  }, [open])
+
+  // Recherche serveur scopée (exacte HMAC) dès 2 caractères.
+  useEffect(() => {
+    const q = query.trim()
+    if (!open || q.length < MIN_QUERY) {
+      searchAbort.current?.abort()
+      setResults([])
+      setSearching(false)
+      return
+    }
+    const ctrl = new AbortController()
+    searchAbort.current = ctrl
+    setSearching(true)
+    void (async () => {
+      try {
+        const res = await fetch(`/api/patients/search?search=${encodeURIComponent(q)}&limit=20`, {
+          credentials: "include", signal: ctrl.signal,
+        })
+        if (!res.ok) throw new Error(String(res.status))
+        const data: { items?: RawSearch[] } = await res.json()
+        setResults(
+          (Array.isArray(data.items) ? data.items : []).map((p) => ({
+            id: p.id,
+            publicRef: "",
+            name: `${p.user.firstname ?? ""} ${p.user.lastname ?? ""}`.trim(),
+            pathology: p.pathology,
+          })),
+        )
+      } catch (err) {
+        if ((err as { name?: string })?.name === "AbortError") return
+        setResults([])
+      } finally {
+        setSearching(false)
+      }
+    })()
+    return () => ctrl.abort()
+  }, [open, query])
+
+  const goTo = useCallback((id: number) => {
+    setOpen(false)
+    router.push(`/patients/${id}`)
+  }, [router])
+
+  const togglePin = useCallback(async (id: number) => {
+    const isPinned = pinnedIds.has(id)
+    // Optimiste : on bascule l'icône, on réconcilie via le rechargement futur.
+    setPinnedIds((prev) => {
+      const next = new Set(prev)
+      if (isPinned) next.delete(id)
+      else next.add(id)
+      return next
+    })
+    try {
+      const res = await fetch(`/api/patients/${id}/pin`, {
+        method: isPinned ? "DELETE" : "POST",
+        credentials: "include",
+      })
+      if (!res.ok) throw new Error(String(res.status))
+      if (isPinned) setPinned((prev) => prev.filter((p) => p.id !== id))
+    } catch {
+      // Rollback de l'optimisme en cas d'échec.
+      setPinnedIds((prev) => {
+        const next = new Set(prev)
+        if (isPinned) next.add(id)
+        else next.delete(id)
+        return next
+      })
+    }
+  }, [pinnedIds])
+
+  const showSearch = query.trim().length >= MIN_QUERY
+
+  const renderRow = (p: PatientRef) => (
+    <li key={p.id} className="flex items-center gap-1">
+      <button
+        type="button"
+        onClick={() => goTo(p.id)}
+        disabled={p.id === currentPatientId}
+        className="flex min-w-0 flex-1 items-center justify-between rounded-md px-3 py-2 text-start text-sm hover:bg-muted disabled:opacity-50 disabled:hover:bg-transparent"
+      >
+        <span className="truncate font-medium">{p.name || t("unnamed")}</span>
+        {p.pathology && <span className="ms-2 shrink-0 text-xs text-muted-foreground">{p.pathology}</span>}
+      </button>
+      <button
+        type="button"
+        onClick={() => togglePin(p.id)}
+        aria-pressed={pinnedIds.has(p.id)}
+        aria-label={pinnedIds.has(p.id) ? t("unpin") : t("pin")}
+        className="rounded-md p-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        <Star className={`h-4 w-4 ${pinnedIds.has(p.id) ? "fill-current text-secondary" : ""}`} aria-hidden="true" />
+      </button>
+    </li>
+  )
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-2 rounded-md border border-border px-3 py-1.5 text-sm hover:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+      >
+        <ArrowLeftRight className="h-4 w-4" aria-hidden="true" />
+        {t("switch")}
+      </button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogTitle>{t("switcherTitle")}</DialogTitle>
+          <input
+            type="search"
+            autoFocus
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={t("searchPlaceholder")}
+            aria-label={t("searchPlaceholder")}
+            className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          />
+
+          <div className="max-h-80 overflow-y-auto">
+            {showSearch ? (
+              <section aria-label={t("resultsLabel")}>
+                {searching && <p className="px-3 py-2 text-sm text-muted-foreground">{t("loading")}</p>}
+                {!searching && results.length === 0 && (
+                  <p className="px-3 py-2 text-sm text-muted-foreground">{t("noResults")}</p>
+                )}
+                <ul className="space-y-0.5">{results.map(renderRow)}</ul>
+              </section>
+            ) : (
+              <>
+                {pinned.length > 0 && (
+                  <section aria-label={t("pinnedLabel")} className="mb-2">
+                    <h3 className="px-3 py-1 text-xs font-semibold uppercase text-muted-foreground">{t("pinnedLabel")}</h3>
+                    <ul className="space-y-0.5">{pinned.map(renderRow)}</ul>
+                  </section>
+                )}
+                <section aria-label={t("recentLabel")}>
+                  <h3 className="px-3 py-1 text-xs font-semibold uppercase text-muted-foreground">{t("recentLabel")}</h3>
+                  {recent.length === 0 ? (
+                    <p className="px-3 py-2 text-sm text-muted-foreground">{t("noRecent")}</p>
+                  ) : (
+                    <ul className="space-y-0.5">{recent.map(renderRow)}</ul>
+                  )}
+                </section>
+              </>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/components/diabeo/patient/PatientSwitcher.tsx
+++ b/src/components/diabeo/patient/PatientSwitcher.tsx
@@ -19,7 +19,7 @@ import { useTranslations } from "next-intl"
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
 import { Star, ArrowLeftRight } from "lucide-react"
 
-type PatientRef = { id: number; publicRef: string; name: string; pathology: string | null }
+type PatientRef = { id: number; name: string; pathology: string | null }
 type RawSearch = { id: number; pathology: string | null; user: { firstname: string | null; lastname: string | null } }
 
 const MIN_QUERY = 2
@@ -82,7 +82,6 @@ export function PatientSwitcher({ currentPatientId }: { currentPatientId: number
         setResults(
           (Array.isArray(data.items) ? data.items : []).map((p) => ({
             id: p.id,
-            publicRef: "",
             name: `${p.user.firstname ?? ""} ${p.user.lastname ?? ""}`.trim(),
             pathology: p.pathology,
           })),
@@ -131,28 +130,37 @@ export function PatientSwitcher({ currentPatientId }: { currentPatientId: number
 
   const showSearch = query.trim().length >= MIN_QUERY
 
-  const renderRow = (p: PatientRef) => (
-    <li key={p.id} className="flex items-center gap-1">
-      <button
-        type="button"
-        onClick={() => goTo(p.id)}
-        disabled={p.id === currentPatientId}
-        className="flex min-w-0 flex-1 items-center justify-between rounded-md px-3 py-2 text-start text-sm hover:bg-muted disabled:opacity-50 disabled:hover:bg-transparent"
-      >
-        <span className="truncate font-medium">{p.name || t("unnamed")}</span>
-        {p.pathology && <span className="ms-2 shrink-0 text-xs text-muted-foreground">{p.pathology}</span>}
-      </button>
-      <button
-        type="button"
-        onClick={() => togglePin(p.id)}
-        aria-pressed={pinnedIds.has(p.id)}
-        aria-label={pinnedIds.has(p.id) ? t("unpin") : t("pin")}
-        className="rounded-md p-2 text-muted-foreground hover:bg-muted hover:text-foreground"
-      >
-        <Star className={`h-4 w-4 ${pinnedIds.has(p.id) ? "fill-current text-secondary" : ""}`} aria-hidden="true" />
-      </button>
-    </li>
-  )
+  const renderRow = (p: PatientRef) => {
+    const isCurrent = p.id === currentPatientId
+    const isPinned = pinnedIds.has(p.id)
+    return (
+      <li key={p.id} className="flex items-center gap-1">
+        <button
+          type="button"
+          onClick={() => goTo(p.id)}
+          disabled={isCurrent}
+          // a11y 1.4.3 : état désactivé via `text-muted-foreground` (≥ 4.5:1),
+          // PAS `opacity-50` (qui tomberait à ~3:1).
+          className="flex min-w-0 flex-1 items-center justify-between rounded-md px-3 py-2 text-start text-sm hover:bg-muted disabled:cursor-default disabled:text-muted-foreground disabled:hover:bg-transparent"
+        >
+          <span className="truncate font-medium">{p.name || t("unnamed")}</span>
+          {p.pathology && <span className="ms-2 shrink-0 text-xs text-muted-foreground">{p.pathology}</span>}
+        </button>
+        <button
+          type="button"
+          onClick={() => togglePin(p.id)}
+          disabled={isCurrent}
+          aria-pressed={isPinned}
+          aria-label={isPinned ? t("unpin") : t("pin")}
+          className="rounded-md p-2 text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-default disabled:opacity-40"
+        >
+          {/* a11y 1.4.1 : l'état épinglé est signalé par la FORME (étoile pleine
+              `fill-current` vs contour), pas seulement la couleur. */}
+          <Star className={`h-4 w-4 ${isPinned ? "fill-current text-secondary" : ""}`} aria-hidden="true" />
+        </button>
+      </li>
+    )
+  }
 
   return (
     <>
@@ -180,10 +188,12 @@ export function PatientSwitcher({ currentPatientId }: { currentPatientId: number
 
           <div className="max-h-80 overflow-y-auto">
             {showSearch ? (
-              <section aria-label={t("resultsLabel")}>
-                {searching && <p className="px-3 py-2 text-sm text-muted-foreground">{t("loading")}</p>}
+              // a11y 4.1.3 : états recherche/aucun résultat annoncés (live region
+              // polite + aria-busy).
+              <section aria-label={t("resultsLabel")} aria-live="polite" aria-busy={searching}>
+                {searching && <p role="status" className="px-3 py-2 text-sm text-muted-foreground">{t("loading")}</p>}
                 {!searching && results.length === 0 && (
-                  <p className="px-3 py-2 text-sm text-muted-foreground">{t("noResults")}</p>
+                  <p role="status" className="px-3 py-2 text-sm text-muted-foreground">{t("noResults")}</p>
                 )}
                 <ul className="space-y-0.5">{results.map(renderRow)}</ul>
               </section>

--- a/tests/components/patient-context-bar.test.tsx
+++ b/tests/components/patient-context-bar.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Tests US-2603 — PatientContextBar + PatientSwitcher.
+ * Vérifie le câblage UI : drapeaux d'alerte rendus, switcher (récents/épinglés
+ * chargés, navigation, bascule épingle). Le scope serveur est couvert ailleurs
+ * (recent-patients.service.test.ts + api-patients-pin.test.ts).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+
+vi.mock("next-intl", async () => (await import("../helpers/nextIntlMock")).makeNextIntlMock())
+
+const push = vi.fn()
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }))
+
+// next/link → <a> simple.
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>{children}</a>
+  ),
+}))
+
+// Dialog base-ui → rendu inline quand `open` (évite portail/focus-trap jsdom).
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div data-testid="dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}))
+
+import { PatientContextBar } from "@/components/diabeo/patient/PatientContextBar"
+import { PatientSwitcher } from "@/components/diabeo/patient/PatientSwitcher"
+
+const NO_FLAGS = { recentHypos: false, hypoCount: 0, silentMonitoring: false, silentDays: null, openUrgency: false }
+
+beforeEach(() => {
+  push.mockReset()
+  vi.restoreAllMocks()
+})
+
+describe("PatientContextBar (US-2603)", () => {
+  it("renders identity + back link, no flag chips when none", () => {
+    render(
+      <PatientContextBar patientId={42} name="Jean Dupont" age={34} pathology="DT1" referent="Dr House" flags={NO_FLAGS} />,
+    )
+    expect(screen.getByText("Jean Dupont")).toBeTruthy()
+    expect(screen.getByLabelText(/Retour à Ma journée/)).toBeTruthy()
+    expect(screen.queryByText(/Urgence en cours/)).toBeNull()
+    expect(screen.queryByText(/Sans saisie/)).toBeNull()
+  })
+
+  it("renders alert-flag chips consistent with « Ma journée »", () => {
+    render(
+      <PatientContextBar
+        patientId={42}
+        name="Marie Curie"
+        age={50}
+        pathology="DT2"
+        referent={null}
+        flags={{ recentHypos: true, hypoCount: 4, silentMonitoring: true, silentDays: 9, openUrgency: true }}
+      />,
+    )
+    expect(screen.getByText(/Urgence en cours/)).toBeTruthy()
+    // Le mock next-intl n'évalue pas le pluriel ICU (rend la chaîne brute) — on
+    // vérifie la présence du chip hypo ; le rendu pluriel réel est en prod.
+    expect(screen.getByText(/hypo/)).toBeTruthy()
+    expect(screen.getByText(/Sans saisie/)).toBeTruthy()
+  })
+})
+
+describe("PatientSwitcher (US-2603)", () => {
+  function stubFetch() {
+    const mock = vi.fn((url: string, opts?: { method?: string }) => {
+      if (url.startsWith("/api/patients/recent")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            recent: [{ id: 10, publicRef: "r10", name: "Alice Martin", pathology: "DT1" }],
+            pinned: [{ id: 20, publicRef: "r20", name: "Bob Durand", pathology: "DT2" }],
+          }),
+        })
+      }
+      if (url.includes("/pin")) {
+        return Promise.resolve({ ok: true, json: async () => ({ pinned: opts?.method === "POST" }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ items: [] }) })
+    })
+    vi.stubGlobal("fetch", mock)
+    return mock
+  }
+
+  it("loads recent + pinned on open and navigates on select", async () => {
+    stubFetch()
+    render(<PatientSwitcher currentPatientId={99} />)
+    fireEvent.click(screen.getByText("Changer de patient"))
+    await waitFor(() => expect(screen.getByText("Alice Martin")).toBeTruthy())
+    expect(screen.getByText("Bob Durand")).toBeTruthy() // pinned section
+    fireEvent.click(screen.getByText("Alice Martin"))
+    expect(push).toHaveBeenCalledWith("/patients/10")
+  })
+
+  it("toggles pin via the pin endpoint", async () => {
+    const fetchMock = stubFetch()
+    render(<PatientSwitcher currentPatientId={99} />)
+    fireEvent.click(screen.getByText("Changer de patient"))
+    await waitFor(() => expect(screen.getByText("Alice Martin")).toBeTruthy())
+    // Alice (récente, non épinglée) → bouton « Épingler ».
+    fireEvent.click(screen.getAllByLabelText("Épingler")[0]!)
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith("/api/patients/10/pin", expect.objectContaining({ method: "POST" })),
+    )
+  })
+})

--- a/tests/components/patient-detail-client.test.tsx
+++ b/tests/components/patient-detail-client.test.tsx
@@ -39,6 +39,11 @@ vi.mock("@/components/diabeo/DashboardHeader", () => ({
     <header><h1>{title}</h1><p>{subtitle}</p></header>
   ),
 }))
+// Barre de contexte (US-2603) stubée : le switcher tire useRouter/fetch, hors
+// périmètre de ce test (couverte par ses propres tests + tests de route).
+vi.mock("@/components/diabeo/patient/PatientContextBar", () => ({
+  PatientContextBar: ({ name }: { name: string }) => <header><h1>{name}</h1></header>,
+}))
 vi.mock("@/components/diabeo/Acronym", () => ({
   Acronym: ({ code }: { code: string }) => <abbr>{code}</abbr>,
 }))
@@ -55,6 +60,8 @@ import { PatientDetailClient, type PatientDetailData } from "@/app/(dashboard)/p
 
 const baseData: PatientDetailData = {
   id: 42,
+  publicRef: "ref-42",
+  flags: { recentHypos: false, hypoCount: 0, silentMonitoring: false, silentDays: null, openUrgency: false },
   name: "Jean Dupont",
   age: 34,
   sex: "F",


### PR DESCRIPTION
## Contexte

**PR 2/2 de US-2603** (barre de contexte patient + switcher). Consomme le backend mergé en **#560**. Clôture US-2603 (dernière sous-série navigation médecin V1 avec US-2605 — planifiée ensuite et qui réutilisera cette barre).

## Changements

### `PatientContextBar` (client) — remplace `DashboardHeader` sur le dossier
- Retour « Ma journée », identité (nom / âge / pathologie / référent).
- **Chips de drapeaux d'alerte** : urgence en cours (rouge), hypos ≥3/7j, silence saisie — **cohérents avec « Ma journée »** (même source serveur `getPatientFlags`).
- Action rapide **Message**, et le **switcher**.
- Tokens sémantiques (`feedback-error/warning`, `error/warning-fg/bg`) ; **RTL** (classes logiques `ms/me`, `rtl:rotate-180`).
- Le fallback « partage désactivé » conserve `DashboardHeader` (aucune PII).

### `PatientSwitcher` (client, Dialog)
- Recherche patient **scopée serveur** (`/api/patients/search`, même endpoint que la palette).
- Sections **Épinglés** + **Récemment vus** (`/api/patients/recent`).
- Bascule **épingle optimiste** (`POST`/`DELETE /api/patients/[id]/pin`, rollback si échec).
- Sélection → `router.push(/patients/[id])` ; la consultation est **journalisée serveur** par la page de destination.

### Wiring
- `page.tsx` : `getPatientFlags(patientId)` + `recordView` (**fail-soft**, non-VIEWER) ; `PatientDetailData` étendu (`publicRef` + `flags`).
- `PatientDetailClient` : `DashboardHeader` → `PatientContextBar`.
- i18n FR/EN/AR (namespace `patientContextBar`, **ICU plural** sur les hypos).
- ROADMAP : **US-2603 ✅ DONE**.

## Tests / vérifs
- Barre : drapeaux rendus (urgence/hypos/silence) ; switcher : récents+épinglés chargés, navigation, bascule épingle (appel endpoint).
- `tsc` ✅ · ESLint ✅ · design-system baseline **272** ✅ · i18n-parity ✅ · **suite complète 3178 verte**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)