### PR TITLE
feat(access): PR1 — fondations schéma socle d'accès (F2+F4+F8, additif)

### DIFF
--- a/docs/compliance/dpia-access-foundations.md
+++ b/docs/compliance/dpia-access-foundations.md
@@ -1,0 +1,80 @@
+# DPIA — Socle d'accès « 2 axes » (Tenant / capacités Q1-Q2 / audit scopé)
+
+**Statut** : Brouillon — à signer DPO + RSSI avant mise en service patients réels.
+**Périmètre (PR1 — fondations schéma, additif)** : modèles `Tenant`,
+`VerificationPolicy`, `HealthcareMembership`, `ProfessionalRegistration` ; champs de
+scope d'audit (`AuditLog.tenantId`/`scopeServiceId`) ; helpers `src/lib/capabilities.ts`
+(`resolveVerificationPolicy` fail-secure + lecture capacités). **L'enforcement n'est PAS
+modifié en PR1** (canAccessPatient/isOrgMember/requireRole inchangés) → la bascule
+(F7 révocation, F6 isolation, écrans Q2) arrive dans les PRs suivantes.
+**Lié à** : `gestion-personnel-droits-us.md` (US-2610), `prerequis-techniques-securite-us.md`
+(F2/F4/F6/F7/F8), `dpia-patient-detail-dossier.md`.
+
+## 1. Modèle d'accès cible (2 axes orthogonaux)
+
+- **Q1 — capacité clinique (PHI, Art. 9)** : `HealthcareMembership.clinicalRole`,
+  **scopée** au service, **gated** sur une « qualité PS vérifiée »
+  (`ProfessionalRegistration`). **Jamais octroyable par un admin** (la gestion
+  *associe* une preuve vérifiée, elle ne la *crée* pas).
+- **Q2 — capacité de gestion** : `canManage` (opérationnel) / `isPrincipalAdmin`
+  (peut déléguer Q2). **N'ouvre AUCUN accès aux données de santé.**
+- **Tenant** = frontière d'isolation + responsable de traitement RGPD (libéral/cabinet
+  = contrôleurs distincts ; hôpital = établissement contrôleur). `country` pilote la
+  méthode de vérification PS (FR : RPPS/ADELI ; DZ/autres : manuel).
+
+## 2. Politique de vérification — fail-secure (F2)
+
+`resolveVerificationPolicy` résout `tenant > pays > défaut`, **défaut `required` codé en
+dur** : base vide/corrompue → `required` (porte clinique fermée). `provisional` n'est
+honoré que **borné** (`expiresAt` futur obligatoire) et **interdit en production** sauf
+flag pilote explicite (`VERIFICATION_ALLOW_PILOT`) + DPIA. Réglée par `SYSTEM_ADMIN`
+uniquement (jamais l'org-admin → pas d'auto-bypass de la porte clinique). Tout passage
+`provisional` est **audité** (action canonique `VERIFICATION_PROVISIONAL_SET`).
+
+## 3. Décisions de design à valider DPO
+
+- **3.1 — `HealthcareMembership` nouvelle table (N-N)** plutôt que mutation de
+  `HealthcareMember` : `HealthcareMember` reste le profil praticien (RDV/booking/
+  référents) ; l'appartenance porteuse de capacités est séparée → zéro impact sur
+  l'existant, et le `userId` reste 1-1 sur `HealthcareMember` (pas de retrait de `@unique`).
+- **3.2 — Backfill miroir (PR1)** : 1 `Tenant` par service existant ; 1
+  `HealthcareMembership` par `HealthcareMember` (clinicalRole = `User.role`, Q2 =
+  manager du service). **Reflète l'accès actuel** → aucun changement de droits en PR1.
+- **3.3 — `ProfessionalRegistration` générique multi-pays** (pas de champ « RPPS » en
+  dur) : `{ country, scheme, number?, method, status, verifiedBy?, verifiedAt?, expiresAt? }`.
+- **3.4 — Audit scopé (F8)** : `tenantId`/`scopeServiceId` + index ; **jamais de
+  PHI/PII de santé** (réfs/ids uniquement, ADR #18). Set canonique d'actions ajouté
+  (octroi/révocation Q1/Q2, politique vérif, invitations, preuve PS, désactivation
+  établissement, bootstrap org-admin).
+
+## 4. ⚠️ Risques acceptés V1 (actés ROADMAP)
+
+- **F1 reporté en V4** : le bypass PHI de `ADMIN` **n'est pas retiré** et `ADMIN`
+  **n'est pas renommé** `SYSTEM_ADMIN` en V1 → la garantie « hébergeur sans PHI »
+  **n'est pas effective avant la V4**. Mesure transitoire : aucun rôle plateforme à un
+  non-soignant.
+- **Vérification PS réelle reportée en V4** (US-2611) : en V1 toute inscription est
+  « considérée vérifiée ». La porte `provisional` reste fail-secure et bornée.
+- **PR1 sans enforcement** : les modèles sont peuplés mais **non encore décisionnels** ;
+  aucune réduction ni élargissement d'accès tant que F6/F7 ne sont pas livrés.
+
+## 5. Tests (PR1)
+
+- `tests/unit/capabilities.test.ts` — `resolveVerificationPolicy` fail-secure (vide→required,
+  provisional borné/expiré/prod, fallback pays) + lecture capacités N-N.
+- `tests/unit/access-foundations-migration-sql.test.ts` — garde du backfill (tenant par
+  service, appartenance miroir avec garde-fou booléen, `ON CONFLICT`).
+- **Non-régression** : suite complète verte **sans modification** des tests d'accès
+  existants (preuve que l'enforcement est inchangé en PR1).
+
+## 6. Validations à obtenir
+
+- [ ] DPO : modèle 2 axes + responsable de traitement par tenant (§1) ; politique
+  fail-secure et bornage `provisional` (§2).
+- [ ] RSSI : audit scopé sans PHI (§3.4) ; risque accepté F1/vérif reportés V4 (§4).
+- [ ] Direction Médicale : la porte clinique reste fermée par défaut (fail-secure).
+
+---
+
+*Dernière mise à jour : 2026-06-17 — DPIA initiale socle d'accès (PR1 : fondations
+schéma additives, sans changement d'enforcement).*

--- a/prisma/migrations/20260617120000_access_foundations_pr1/migration.sql
+++ b/prisma/migrations/20260617120000_access_foundations_pr1/migration.sql
@@ -96,6 +96,9 @@ CREATE INDEX "professional_registrations_user_id_idx" ON "professional_registrat
 CREATE INDEX "audit_logs_tenant_id_created_at_idx" ON "audit_logs"("tenant_id", "created_at");
 
 -- CreateIndex
+CREATE INDEX "audit_logs_scope_service_id_created_at_idx" ON "audit_logs"("scope_service_id", "created_at");
+
+-- CreateIndex
 CREATE INDEX "healthcare_services_tenant_id_idx" ON "healthcare_services"("tenant_id");
 
 -- AddForeignKey
@@ -120,6 +123,22 @@ ALTER TABLE "professional_registrations" ADD CONSTRAINT "professional_registrati
 ALTER TABLE "professional_registrations" ADD CONSTRAINT "professional_registrations_verified_by_id_fkey" FOREIGN KEY ("verified_by_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- ═══════════════════════════════════════════════════════════════
+-- Garde-fous DB (défense en profondeur, non modélisés par Prisma → pas de drift).
+-- ═══════════════════════════════════════════════════════════════
+
+-- Une politique doit cibler un tenant OU un pays (jamais « env-wide » non scopée :
+-- une ligne (NULL, NULL) provisional serait inatteignable mais ambiguë → interdite).
+ALTER TABLE "verification_policies"
+  ADD CONSTRAINT "verification_policies_scope_check"
+  CHECK ("tenant_id" IS NOT NULL OR "country" IS NOT NULL);
+
+-- `provisional` exige une borne temporelle (`expires_at`) — empêche un INSERT manuel
+-- d'exprimer un mode provisoire non borné (le résolveur dégrade déjà en `required`).
+ALTER TABLE "verification_policies"
+  ADD CONSTRAINT "verification_policies_provisional_bounded_check"
+  CHECK ("mode" <> 'provisional' OR "expires_at" IS NOT NULL);
+
+-- ═══════════════════════════════════════════════════════════════
 -- Backfill (sans perte, comportement inchangé). Idempotent.
 -- ═══════════════════════════════════════════════════════════════
 
@@ -137,12 +156,18 @@ BEGIN
 END $$;
 
 -- (2) F4 — appartenance miroir depuis HealthcareMember (accès actuel implicite) :
---     clinical_role = User.role ; can_manage / is_principal_admin = manager du service.
---     ON CONFLICT : ré-exécution sûre (aucun doublon (user, service)).
+--     clinical_role = User.role MAIS uniquement pour un rôle clinique (DOCTOR/NURSE) ;
+--     VIEWER/ADMIN → NULL (pas une capacité clinique scopée — évite d'encoder un rôle
+--     plateforme/patient comme accès PHI de cabinet, prépare proprement F6/F7).
+--     can_manage / is_principal_admin = manager du service (garde-fou `IS NOT NULL`
+--     pour ne pas produire un NULL sur ces colonnes NOT NULL).
+--     INNER JOIN users/services : l'intégrité référentielle FK garantit que tout
+--     membre (user_id/service_id non nuls) référence des lignes existantes — aucune
+--     ligne valide n'est donc silencieusement omise. ON CONFLICT : ré-exécution sûre.
 INSERT INTO "healthcare_memberships" ("user_id", "service_id", "clinical_role", "can_manage", "is_principal_admin")
 SELECT hm."user_id",
        hm."service_id",
-       u."role",
+       (CASE WHEN u."role" IN ('DOCTOR', 'NURSE') THEN u."role" ELSE NULL END)::"Role",
        (hs."manager_id" IS NOT NULL AND hs."manager_id" = hm."user_id") AS can_manage,
        (hs."manager_id" IS NOT NULL AND hs."manager_id" = hm."user_id") AS is_principal_admin
 FROM "healthcare_members" hm

--- a/prisma/migrations/20260617120000_access_foundations_pr1/migration.sql
+++ b/prisma/migrations/20260617120000_access_foundations_pr1/migration.sql
@@ -1,0 +1,152 @@
+-- ═══════════════════════════════════════════════════════════════
+-- Socle « Accès & Cabinet » — PR1 (F2 + F4 + F8), ADDITIF
+-- ═══════════════════════════════════════════════════════════════
+-- US-2616 (F2) Tenant + politique de vérification · US-2617 (F4) appartenance
+-- N-N + enregistrement PS · US-2620 (F8) scope d'audit.
+-- 100 % additif : tables/colonnes nullables + index. AUCUN enforcement modifié
+-- ici (canAccessPatient/isOrgMember/requireRole inchangés) → zéro régression
+-- d'accès. La bascule d'enforcement se fait dans les PRs suivantes.
+-- ═══════════════════════════════════════════════════════════════
+
+-- CreateEnum
+CREATE TYPE "VerificationMode" AS ENUM ('required', 'provisional');
+
+-- CreateEnum
+CREATE TYPE "RegistrationStatus" AS ENUM ('unverified', 'verified', 'provisional');
+
+-- AlterTable
+ALTER TABLE "audit_logs" ADD COLUMN     "scope_service_id" INTEGER,
+ADD COLUMN     "tenant_id" INTEGER;
+
+-- AlterTable
+ALTER TABLE "healthcare_services" ADD COLUMN     "tenant_id" INTEGER;
+
+-- CreateTable
+CREATE TABLE "tenants" (
+    "id" SERIAL NOT NULL,
+    "name" VARCHAR(255) NOT NULL,
+    "country" CHAR(2),
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "tenants_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "verification_policies" (
+    "id" SERIAL NOT NULL,
+    "tenant_id" INTEGER,
+    "country" CHAR(2),
+    "mode" "VerificationMode" NOT NULL,
+    "expires_at" TIMESTAMPTZ,
+    "set_by_id" INTEGER NOT NULL,
+    "set_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "verification_policies_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "healthcare_memberships" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "service_id" INTEGER NOT NULL,
+    "clinical_role" "Role",
+    "can_manage" BOOLEAN NOT NULL DEFAULT false,
+    "is_principal_admin" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "healthcare_memberships_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "professional_registrations" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "country" CHAR(2) NOT NULL,
+    "scheme" VARCHAR(40) NOT NULL,
+    "number" VARCHAR(64),
+    "method" VARCHAR(40) NOT NULL,
+    "status" "RegistrationStatus" NOT NULL DEFAULT 'unverified',
+    "verified_by_id" INTEGER,
+    "verified_at" TIMESTAMPTZ,
+    "expires_at" TIMESTAMPTZ,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "professional_registrations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "tenants_country_idx" ON "tenants"("country");
+
+-- CreateIndex
+CREATE INDEX "verification_policies_tenant_id_idx" ON "verification_policies"("tenant_id");
+
+-- CreateIndex
+CREATE INDEX "verification_policies_country_idx" ON "verification_policies"("country");
+
+-- CreateIndex
+CREATE INDEX "healthcare_memberships_service_id_idx" ON "healthcare_memberships"("service_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "healthcare_memberships_user_id_service_id_key" ON "healthcare_memberships"("user_id", "service_id");
+
+-- CreateIndex
+CREATE INDEX "professional_registrations_user_id_idx" ON "professional_registrations"("user_id");
+
+-- CreateIndex
+CREATE INDEX "audit_logs_tenant_id_created_at_idx" ON "audit_logs"("tenant_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "healthcare_services_tenant_id_idx" ON "healthcare_services"("tenant_id");
+
+-- AddForeignKey
+ALTER TABLE "healthcare_services" ADD CONSTRAINT "healthcare_services_tenant_id_fkey" FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "verification_policies" ADD CONSTRAINT "verification_policies_tenant_id_fkey" FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "verification_policies" ADD CONSTRAINT "verification_policies_set_by_id_fkey" FOREIGN KEY ("set_by_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "healthcare_memberships" ADD CONSTRAINT "healthcare_memberships_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "healthcare_memberships" ADD CONSTRAINT "healthcare_memberships_service_id_fkey" FOREIGN KEY ("service_id") REFERENCES "healthcare_services"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "professional_registrations" ADD CONSTRAINT "professional_registrations_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "professional_registrations" ADD CONSTRAINT "professional_registrations_verified_by_id_fkey" FOREIGN KEY ("verified_by_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- ═══════════════════════════════════════════════════════════════
+-- Backfill (sans perte, comportement inchangé). Idempotent.
+-- ═══════════════════════════════════════════════════════════════
+
+-- (1) F2 — 1 tenant par service existant (self-tenant), lien tenant_id.
+--     RETURNING + corrélation par ligne (le nom du service n'est pas unique seul).
+DO $$
+DECLARE
+  r RECORD;
+  new_tenant_id INTEGER;
+BEGIN
+  FOR r IN SELECT "id", "name", "country" FROM "healthcare_services" WHERE "tenant_id" IS NULL LOOP
+    INSERT INTO "tenants" ("name", "country") VALUES (r."name", r."country") RETURNING "id" INTO new_tenant_id;
+    UPDATE "healthcare_services" SET "tenant_id" = new_tenant_id WHERE "id" = r."id";
+  END LOOP;
+END $$;
+
+-- (2) F4 — appartenance miroir depuis HealthcareMember (accès actuel implicite) :
+--     clinical_role = User.role ; can_manage / is_principal_admin = manager du service.
+--     ON CONFLICT : ré-exécution sûre (aucun doublon (user, service)).
+INSERT INTO "healthcare_memberships" ("user_id", "service_id", "clinical_role", "can_manage", "is_principal_admin")
+SELECT hm."user_id",
+       hm."service_id",
+       u."role",
+       (hs."manager_id" IS NOT NULL AND hs."manager_id" = hm."user_id") AS can_manage,
+       (hs."manager_id" IS NOT NULL AND hs."manager_id" = hm."user_id") AS is_principal_admin
+FROM "healthcare_members" hm
+JOIN "users" u ON u."id" = hm."user_id"
+JOIN "healthcare_services" hs ON hs."id" = hm."service_id"
+WHERE hm."user_id" IS NOT NULL AND hm."service_id" IS NOT NULL
+ON CONFLICT ("user_id", "service_id") DO NOTHING;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -449,6 +449,13 @@ model User {
   /// US-2605 — séances de revue ouvertes + comptes rendus rédigés par ce PS.
   encountersOpened                  Encounter[]                       @relation("EncounterOpener")
   consultationReportsAuthored       ConsultationReportAddendum[]      @relation("ConsultationReportAuthor")
+  /// US-2610/F4 — appartenances scopées (N-N user↔service) porteuses des capacités Q1/Q2.
+  memberships                       HealthcareMembership[]
+  /// F4 — preuves d'enregistrement PS (multi-pays) + preuves vérifiées par ce PS.
+  professionalRegistrations         ProfessionalRegistration[]        @relation("RegistrationSubject")
+  professionalRegistrationsVerified ProfessionalRegistration[]        @relation("RegistrationVerifier")
+  /// F2 — politiques de vérification posées par ce SYSTEM_ADMIN.
+  verificationPoliciesSet           VerificationPolicy[]              @relation("VerificationPolicySetter")
 
   /// US-2026 — INS unique anti-doublon RNIPP. PG default NULLS DISTINCT
   /// autorise plusieurs NULL (PS / ADMIN sans INS renseigne).
@@ -1654,8 +1661,14 @@ model HealthcareService {
   /// US-2506 V1 mock — Credits SMS prepayes (decrement par envoi reussi).
   /// Alerte ops si <10. Mock V1 = on n'achete pas vraiment.
   smsCreditBalance Int         @default(0) @map("sms_credit_balance")
+  /// US-2616/F2 — Tenant (organisation racine) d'isolation. 1 cabinet libéral =
+  /// 1 tenant ; 1 hôpital = 1 tenant à N services. Nullable le temps du backfill.
+  tenantId         Int?        @map("tenant_id")
+  tenant           Tenant?     @relation(fields: [tenantId], references: [id], onDelete: SetNull)
 
   members                    HealthcareMember[]
+  /// US-2617/F4 — appartenances scopées (N-N) porteuses des capacités Q1/Q2.
+  memberships                HealthcareMembership[]
   patientServices            PatientService[]
   referents                  PatientReferent[]
   /// US-2022 — Tags (catégorisation libre) appartenant à ce cabinet.
@@ -1683,7 +1696,117 @@ model HealthcareService {
   /// d'un sequential scan. Préventif : à 1000+ services, le scan devient
   /// notable lors de la recherche par spécialité.
   @@index([specialties], type: Gin)
+  @@index([tenantId])
   @@map("healthcare_services")
+}
+
+/// US-2616/F2 — Tenant (organisation racine) : frontière d'isolation + responsable
+/// de traitement RGPD. `country` exploitable pour la résolution de la politique de
+/// vérification (`tenant > pays > environnement`). Modèle léger V1 : promu depuis
+/// `HealthcareService` (1 tenant ↔ 1..N services).
+model Tenant {
+  id        Int      @id @default(autoincrement())
+  name      String   @db.VarChar(255)
+  /// Code pays ISO-3166-1 alpha-2 (FR, DZ, …) — pilote la méthode de vérification PS.
+  country   String?  @db.Char(2)
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz()
+
+  services           HealthcareService[]
+  verificationPolicies VerificationPolicy[]
+
+  @@index([country])
+  @@map("tenants")
+}
+
+/// US-2616/F2 — Mode d'application de la vérification « qualité PS » (porte Q1).
+enum VerificationMode {
+  /// Porte ON : accès clinique gated sur une preuve PS vérifiée.
+  required
+  /// Accès clinique autorisé sans preuve, le temps du ramp-up (pilote borné, DPIA).
+  provisional
+}
+
+/// US-2616/F2 — Table de politique de vérification. Résolue serveur dans l'ordre
+/// `tenant > pays > environnement`, **défaut `required` codé en dur** (fail-secure).
+/// Réglée par `SYSTEM_ADMIN` uniquement (jamais l'org-admin) ; `provisional` borné
+/// (`expiresAt` obligatoire) + audité.
+model VerificationPolicy {
+  id        Int              @id @default(autoincrement())
+  /// Cible : un tenant précis (prioritaire) OU un pays (fallback). Les deux nulls =
+  /// politique « environnement » (rare ; le défaut codé en dur reste `required`).
+  tenantId  Int?             @map("tenant_id")
+  country   String?          @db.Char(2)
+  mode      VerificationMode
+  /// Obligatoire si `mode = provisional` (garde-fou borné) — appliqué au service layer.
+  expiresAt DateTime?        @map("expires_at") @db.Timestamptz()
+  setById   Int              @map("set_by_id")
+  setAt     DateTime         @default(now()) @map("set_at") @db.Timestamptz()
+
+  tenant Tenant? @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  setBy  User    @relation("VerificationPolicySetter", fields: [setById], references: [id], onDelete: Restrict)
+
+  @@index([tenantId])
+  @@index([country])
+  @@map("verification_policies")
+}
+
+/// US-2617/F4 — Appartenance scopée user↔service (N-N), porteuse des **capacités**
+/// orthogonales : Q1 clinique (`clinicalRole`, gated sur qualité PS vérifiée) et Q2
+/// gestion (`canManage` opérationnel, `isPrincipalAdmin` = Q2 + droit de déléguer Q2).
+/// Distincte de `HealthcareMember` (profil praticien : RDV/booking/référents) qu'on
+/// ne touche pas. Lue en base à chaque requête sensible (prépare F7, hors JWT).
+model HealthcareMembership {
+  id              Int      @id @default(autoincrement())
+  userId          Int      @map("user_id")
+  serviceId       Int      @map("service_id")
+  /// Q1 — capacité clinique scopée (null = aucun accès PHI via ce scope).
+  clinicalRole    Role?    @map("clinical_role")
+  /// Q2 — gestion opérationnelle (personnel/facturation). N'ouvre AUCUN PHI.
+  canManage       Boolean  @default(false) @map("can_manage")
+  /// Q2 — admin principal (peut déléguer Q2). Le propriétaire bootstrap l'est.
+  isPrincipalAdmin Boolean @default(false) @map("is_principal_admin")
+  createdAt       DateTime @default(now()) @map("created_at") @db.Timestamptz()
+
+  user    User              @relation(fields: [userId], references: [id], onDelete: Cascade)
+  service HealthcareService @relation(fields: [serviceId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, serviceId])
+  @@index([serviceId])
+  @@map("healthcare_memberships")
+}
+
+/// US-2617/F4 — Statut d'une preuve d'enregistrement PS.
+enum RegistrationStatus {
+  unverified
+  verified
+  /// Accès clinique accordé en mode provisoire (jamais `verified` : on peut resserrer).
+  provisional
+}
+
+/// US-2617/F4 — Preuve d'enregistrement PS **générique multi-pays** (pas de champ
+/// « RPPS » en dur). FR : RPPS/ADELI (API V2) ; DZ/autres : manuel (Ordre/diplôme).
+/// La gate clinique Q1 s'appuie sur `status = verified` (ou `provisional` borné).
+model ProfessionalRegistration {
+  id           Int                @id @default(autoincrement())
+  userId       Int                @map("user_id")
+  /// Pays de l'enregistrement (ISO-3166-1 alpha-2).
+  country      String             @db.Char(2)
+  /// Schéma d'enregistrement : "RPPS" / "ADELI" / "Ordre" / "diplome" / …
+  scheme       String             @db.VarChar(40)
+  number       String?            @db.VarChar(64)
+  /// Méthode d'obtention : "manual" / "rpps_api" / …
+  method       String             @db.VarChar(40)
+  status       RegistrationStatus @default(unverified)
+  verifiedById Int?               @map("verified_by_id")
+  verifiedAt   DateTime?          @map("verified_at") @db.Timestamptz()
+  expiresAt    DateTime?          @map("expires_at") @db.Timestamptz()
+  createdAt    DateTime           @default(now()) @map("created_at") @db.Timestamptz()
+
+  user       User  @relation("RegistrationSubject", fields: [userId], references: [id], onDelete: Cascade)
+  verifiedBy User? @relation("RegistrationVerifier", fields: [verifiedById], references: [id], onDelete: SetNull)
+
+  @@index([userId])
+  @@map("professional_registrations")
 }
 
 model HealthcareMember {
@@ -2145,6 +2268,12 @@ model AuditLog {
   /// Correlation ID (HDS §IV.3) joining this audit row to stderr log lines.
   /// Assigned by middleware; nullable for events emitted outside the HTTP path.
   requestId  String?  @map("request_id") @db.VarChar(64)
+  /// US-2620/F8 — Scope structuré de l'action (forensics filtrable par
+  /// organisation). `tenantId` = frontière d'isolation ; `scopeServiceId` =
+  /// service concerné. Nullables (événements hors-scope : login, cron, système).
+  /// JAMAIS de PHI/PII de santé ici (réfs/ids uniquement, cf. ADR #18).
+  tenantId       Int?  @map("tenant_id")
+  scopeServiceId Int?  @map("scope_service_id")
   metadata   Json     @default("{}")
   createdAt  DateTime @default(now()) @map("created_at") @db.Timestamptz()
 
@@ -2154,6 +2283,7 @@ model AuditLog {
   @@index([resource, resourceId, createdAt])
   @@index([createdAt])
   @@index([requestId])
+  @@index([tenantId, createdAt])
   @@map("audit_logs")
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2284,6 +2284,7 @@ model AuditLog {
   @@index([createdAt])
   @@index([requestId])
   @@index([tenantId, createdAt])
+  @@index([scopeServiceId, createdAt])
   @@map("audit_logs")
 }
 

--- a/src/lib/capabilities.ts
+++ b/src/lib/capabilities.ts
@@ -15,6 +15,7 @@
 
 import type { Role, HealthcareMembership } from "@prisma/client"
 import { prisma } from "@/lib/db/client"
+import { getEnvBoolean } from "@/lib/env"
 
 /** Toutes les appartenances scopées d'un user (capacités Q1/Q2 par service). */
 export async function getMemberships(userId: number): Promise<HealthcareMembership[]> {
@@ -58,9 +59,10 @@ export type ResolvedVerification = {
   source: "tenant" | "country" | "default"
 }
 
-/** `provisional` honoré seulement si un flag pilote explicite est posé (prod). */
+/** `provisional` honoré seulement si un flag pilote explicite est posé (prod).
+ *  Lu via `getEnvBoolean` (source unique env.ts) plutôt qu'un compare brut. */
 function pilotAllowed(): boolean {
-  return process.env.VERIFICATION_ALLOW_PILOT === "true"
+  return getEnvBoolean("VERIFICATION_ALLOW_PILOT") === true
 }
 
 /**

--- a/src/lib/capabilities.ts
+++ b/src/lib/capabilities.ts
@@ -1,0 +1,111 @@
+/**
+ * @module capabilities
+ * @description Socle d'accès « 2 axes » (US-2610 / F4 / F2) — lecture des capacités
+ * scopées et résolution de la politique de vérification PS.
+ *
+ * **Q1 (clinique, PHI)** et **Q2 (gestion)** sont portées par `HealthcareMembership`
+ * (N-N user↔service). Ces helpers **lisent la base** (jamais le JWT) → ils préparent
+ * la révocation immédiate (F7, PR2). ⚠️ **PR1 : additifs, PAS encore branchés dans
+ * l'enforcement** (`canAccessPatient`/`isOrgMember`/`requireRole` restent inchangés).
+ *
+ * `resolveVerificationPolicy` est **fail-secure** : défaut `required` codé en dur ;
+ * `provisional` n'est honoré que borné (`expiresAt` futur) et hors production (sauf
+ * flag pilote documenté). Réglé par `SYSTEM_ADMIN` uniquement (jamais l'org-admin).
+ */
+
+import type { Role, HealthcareMembership } from "@prisma/client"
+import { prisma } from "@/lib/db/client"
+
+/** Toutes les appartenances scopées d'un user (capacités Q1/Q2 par service). */
+export async function getMemberships(userId: number): Promise<HealthcareMembership[]> {
+  return prisma.healthcareMembership.findMany({ where: { userId } })
+}
+
+/**
+ * Capacité clinique (Q1) du user dans un service donné, ou `null` si aucun accès
+ * PHI via ce scope. (Source unique : `HealthcareMembership.clinicalRole`.)
+ */
+export async function clinicalCapability(userId: number, serviceId: number): Promise<Role | null> {
+  const m = await prisma.healthcareMembership.findUnique({
+    where: { userId_serviceId: { userId, serviceId } },
+    select: { clinicalRole: true },
+  })
+  return m?.clinicalRole ?? null
+}
+
+/** Capacité de gestion (Q2) opérationnelle du user dans un service. */
+export async function canManageOrg(userId: number, serviceId: number): Promise<boolean> {
+  const m = await prisma.healthcareMembership.findUnique({
+    where: { userId_serviceId: { userId, serviceId } },
+    select: { canManage: true },
+  })
+  return m?.canManage ?? false
+}
+
+/** Admin principal (Q2 + droit de déléguer Q2) du user dans un service. */
+export async function isPrincipalAdmin(userId: number, serviceId: number): Promise<boolean> {
+  const m = await prisma.healthcareMembership.findUnique({
+    where: { userId_serviceId: { userId, serviceId } },
+    select: { isPrincipalAdmin: true },
+  })
+  return m?.isPrincipalAdmin ?? false
+}
+
+export type VerificationMode = "required" | "provisional"
+export type ResolvedVerification = {
+  mode: VerificationMode
+  /** D'où vient la décision : politique tenant, politique pays, ou défaut fail-secure. */
+  source: "tenant" | "country" | "default"
+}
+
+/** `provisional` honoré seulement si un flag pilote explicite est posé (prod). */
+function pilotAllowed(): boolean {
+  return process.env.VERIFICATION_ALLOW_PILOT === "true"
+}
+
+/**
+ * Résout le mode de vérification « qualité PS » (porte Q1), ordre
+ * `tenant > pays > défaut`, **fail-secure** :
+ *  - aucune politique trouvée → `required` ;
+ *  - `provisional` sans `expiresAt` futur → dégradé en `required` (borne obligatoire) ;
+ *  - en **production**, `provisional` dégradé en `required` sauf `VERIFICATION_ALLOW_PILOT`.
+ *
+ * @returns le mode effectif + sa source (pour audit / affichage).
+ */
+export async function resolveVerificationPolicy(
+  input: { tenantId?: number | null; country?: string | null },
+  now: Date = new Date(),
+): Promise<ResolvedVerification> {
+  const isProd = process.env.NODE_ENV === "production"
+
+  const honor = (mode: VerificationMode, expiresAt: Date | null, source: "tenant" | "country"): ResolvedVerification => {
+    if (mode === "required") return { mode: "required", source }
+    // provisional : borne obligatoire + interdit en prod sans flag pilote (fail-secure).
+    if (!expiresAt || expiresAt <= now) return { mode: "required", source }
+    if (isProd && !pilotAllowed()) return { mode: "required", source }
+    return { mode: "provisional", source }
+  }
+
+  // 1) Politique du tenant (prioritaire).
+  if (input.tenantId != null) {
+    const p = await prisma.verificationPolicy.findFirst({
+      where: { tenantId: input.tenantId },
+      orderBy: { setAt: "desc" },
+      select: { mode: true, expiresAt: true },
+    })
+    if (p) return honor(p.mode, p.expiresAt, "tenant")
+  }
+
+  // 2) Politique pays (fallback).
+  if (input.country) {
+    const p = await prisma.verificationPolicy.findFirst({
+      where: { tenantId: null, country: input.country },
+      orderBy: { setAt: "desc" },
+      select: { mode: true, expiresAt: true },
+    })
+    if (p) return honor(p.mode, p.expiresAt, "country")
+  }
+
+  // 3) Défaut codé en dur — fail-secure.
+  return { mode: "required", source: "default" }
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -342,6 +342,10 @@ export function assertRequiredEnv(): void {
   assertSpecs(REQUIRED_FULL)
   // US-2123 — fail-fast on misconfigured FHIR feature flag.
   assertOptionalBoolean("FHIR_ENABLED")
+  // Socle d'accès (F2) — flag pilote ouvrant le mode `provisional` de la porte
+  // clinique en prod. Fail-fast sur valeur malformée : une faute de saisie ne
+  // doit pas désactiver silencieusement le pilote (cf. capabilities.pilotAllowed).
+  assertOptionalBoolean("VERIFICATION_ALLOW_PILOT")
   // US-2270 — defense-in-depth : le gate runtime (dev-mock.ts) neutralise déjà
   // les flags de mock en prod, mais un flag résiduel est un signal de misconfig
   // qui doit remonter (ANSSI). On refuse le boot prod plutôt que de neutraliser

--- a/src/lib/services/audit.service.ts
+++ b/src/lib/services/audit.service.ts
@@ -79,6 +79,22 @@ export type AuditAction =
    * forensique faussée ("le médecin a-t-il reçu l'alerte ?" → réponse honnête).
    */
   | "EMAIL_SUBMITTED"
+  /**
+   * Socle d'accès (US-2610 / F8) — set canonique des actions sensibles du socle.
+   * Octroi/révocation de capacité Q1/Q2, politique de vérification, invitations,
+   * preuve PS, désactivation établissement, bootstrap org-admin, passage provisoire.
+   */
+  | "CAPABILITY_GRANTED"
+  | "CAPABILITY_REVOKED"
+  | "VERIFICATION_POLICY_CHANGED"
+  | "VERIFICATION_PROVISIONAL_SET"
+  | "INVITATION_SENT"
+  | "INVITATION_CONSUMED"
+  | "INVITATION_REVOKED"
+  | "PS_PROOF_VALIDATED"
+  | "PS_PROOF_REJECTED"
+  | "ESTABLISHMENT_DEACTIVATED"
+  | "ORG_ADMIN_BOOTSTRAPPED"
 
 /**
  * Audit resource type — describes what was acted upon.
@@ -230,6 +246,13 @@ export type AuditResource =
    * capture le compteur supprimé pour aggregation cross-pods. Aucun PHI.
    */
   | "ENCRYPTION_FAILURE"
+  /** Socle d'accès (US-2616/2617/2620) — organisation, appartenance scopée,
+   *  politique de vérification, preuve PS, invitation. */
+  | "TENANT"
+  | "HEALTHCARE_MEMBERSHIP"
+  | "VERIFICATION_POLICY"
+  | "PROFESSIONAL_REGISTRATION"
+  | "ORG_INVITATION"
 
 /**
  * Audit log entry — parameters for logging an action.
@@ -262,6 +285,13 @@ export interface AuditLogEntry {
   userAgent?: string
   /** Correlation ID (HDS §IV.3) to join this audit row with stderr log lines. */
   requestId?: string
+  /**
+   * US-2620/F8 — Scope structuré (forensics filtrable par organisation). JAMAIS
+   * de PHI/PII de santé (réfs/ids uniquement). Optionnels : hors-scope = login,
+   * cron, événements système.
+   */
+  tenantId?: number | null
+  scopeServiceId?: number | null
   metadata?: Prisma.InputJsonValue
 }
 
@@ -310,6 +340,8 @@ export function createAuditData(entry: AuditLogEntry): Prisma.AuditLogUncheckedC
     ipAddress: entry.ipAddress ?? null,
     userAgent: entry.userAgent ?? null,
     requestId: entry.requestId ?? null,
+    tenantId: entry.tenantId ?? null,
+    scopeServiceId: entry.scopeServiceId ?? null,
     metadata: entry.metadata ?? {},
   }
 }

--- a/tests/unit/access-foundations-migration-sql.test.ts
+++ b/tests/unit/access-foundations-migration-sql.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Garde anti-régression du backfill du socle d'accès (PR1).
+ *
+ * La migration `20260617120000_access_foundations_pr1` est **additive** et doit
+ * **peupler sans perte** : 1 tenant par service existant + 1 appartenance miroir
+ * par membre. On vérifie statiquement que le backfill est présent et correct
+ * (notamment le garde-fou booléen `manager_id IS NOT NULL` qui évite un NULL sur
+ * la colonne NOT NULL `can_manage`) — pour qu'un futur édit ne le casse pas.
+ */
+import { describe, it, expect } from "vitest"
+import { readFileSync } from "node:fs"
+
+const MIGRATION = "prisma/migrations/20260617120000_access_foundations_pr1/migration.sql"
+
+describe("access foundations PR1 — migration additive + backfill", () => {
+  const sql = readFileSync(MIGRATION, "utf8")
+
+  it("crée les tables du socle (additif)", () => {
+    for (const t of [
+      'CREATE TABLE "tenants"',
+      'CREATE TABLE "verification_policies"',
+      'CREATE TABLE "healthcare_memberships"',
+      'CREATE TABLE "professional_registrations"',
+    ]) expect(sql).toContain(t)
+    // Colonnes de scope d'audit (F8) + lien tenant (F2).
+    expect(sql).toContain('ALTER TABLE "audit_logs" ADD COLUMN')
+    expect(sql).toContain('"tenant_id"')
+    expect(sql).toContain('ALTER TABLE "healthcare_services" ADD COLUMN     "tenant_id"')
+  })
+
+  it("backfill 1 tenant par service + lien tenant_id (idempotent)", () => {
+    expect(sql).toContain('INSERT INTO "tenants"')
+    expect(sql).toContain('WHERE "tenant_id" IS NULL') // idempotent
+    expect(sql).toContain('UPDATE "healthcare_services" SET "tenant_id"')
+  })
+
+  it("backfill appartenance miroir avec garde-fou booléen + ON CONFLICT", () => {
+    expect(sql).toContain('INSERT INTO "healthcare_memberships"')
+    // Garde-fou : manager_id NULL ne doit pas produire un NULL sur can_manage (NOT NULL).
+    expect(sql).toContain('hs."manager_id" IS NOT NULL AND hs."manager_id" = hm."user_id"')
+    // Ré-exécution sûre.
+    expect(sql).toContain('ON CONFLICT ("user_id", "service_id") DO NOTHING')
+  })
+})

--- a/tests/unit/access-foundations-migration-sql.test.ts
+++ b/tests/unit/access-foundations-migration-sql.test.ts
@@ -41,4 +41,19 @@ describe("access foundations PR1 — migration additive + backfill", () => {
     // Ré-exécution sûre.
     expect(sql).toContain('ON CONFLICT ("user_id", "service_id") DO NOTHING')
   })
+
+  it("clinical_role mappé uniquement pour DOCTOR/NURSE (VIEWER/ADMIN → NULL)", () => {
+    // Anti-régression : ne pas réintroduire un rôle plateforme/patient comme
+    // capacité clinique scopée (cf. revue HSA).
+    expect(sql).toMatch(/CASE WHEN u\."role" IN \('DOCTOR', 'NURSE'\) THEN u\."role" ELSE NULL END\)::"Role"/)
+  })
+
+  it("garde-fous DB CHECK sur verification_policies (scope + provisional borné)", () => {
+    expect(sql).toContain('CHECK ("tenant_id" IS NOT NULL OR "country" IS NOT NULL)')
+    expect(sql).toMatch(/CHECK \("mode" <> 'provisional' OR "expires_at" IS NOT NULL\)/)
+  })
+
+  it("index forensics scopé service sur audit_logs (F8)", () => {
+    expect(sql).toContain('"audit_logs_scope_service_id_created_at_idx"')
+  })
 })

--- a/tests/unit/capabilities.test.ts
+++ b/tests/unit/capabilities.test.ts
@@ -49,6 +49,10 @@ describe("capabilities — lecture des capacités scopées (N-N)", () => {
   it("canManageOrg / isPrincipalAdmin renvoient des booléens (false par défaut)", async () => {
     pm.healthcareMembership.findUnique.mockResolvedValueOnce({ canManage: true })
     expect(await canManageOrg(5, 9)).toBe(true)
+    // Lookup par la clé composite (userId, serviceId).
+    expect(pm.healthcareMembership.findUnique.mock.calls[0][0]).toMatchObject({
+      where: { userId_serviceId: { userId: 5, serviceId: 9 } },
+    })
     pm.healthcareMembership.findUnique.mockResolvedValueOnce(null)
     expect(await canManageOrg(5, 9)).toBe(false)
     pm.healthcareMembership.findUnique.mockResolvedValueOnce({ isPrincipalAdmin: true })
@@ -112,5 +116,14 @@ describe("resolveVerificationPolicy — fail-secure", () => {
       .mockResolvedValueOnce({ mode: "provisional", expiresAt: FUTURE })
     expect(await resolveVerificationPolicy({ tenantId: 1, country: "FR" }, NOW))
       .toEqual({ mode: "provisional", source: "country" })
+  })
+
+  it("la branche pays dégrade AUSSI en prod sans flag (garde partagée)", async () => {
+    vi.stubEnv("NODE_ENV", "production")
+    pm.verificationPolicy.findFirst
+      .mockResolvedValueOnce(null) // pas de politique tenant
+      .mockResolvedValueOnce({ mode: "provisional", expiresAt: FUTURE })
+    expect(await resolveVerificationPolicy({ tenantId: 1, country: "FR" }, NOW))
+      .toEqual({ mode: "required", source: "country" })
   })
 })

--- a/tests/unit/capabilities.test.ts
+++ b/tests/unit/capabilities.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Test suite : capabilities (socle d'accès 2 axes — US-2610 / F4 / F2).
+ *
+ * Couvre :
+ *  - lecture des capacités scopées Q1/Q2 depuis `HealthcareMembership` (N-N) ;
+ *  - `resolveVerificationPolicy` **fail-secure** : défaut `required`, `provisional`
+ *    borné (`expiresAt` futur) et interdit en prod sans flag pilote.
+ *
+ * Risque clinique : la résolution de la porte d'accès clinique (Q1) doit
+ * **toujours** dégrader vers `required` en cas de doute (base vide, politique
+ * expirée, prod) — sinon ouverture silencieuse de l'accès PHI.
+ */
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest"
+import { prismaMock } from "../helpers/prisma-mock"
+
+import {
+  getMemberships, clinicalCapability, canManageOrg, isPrincipalAdmin,
+  resolveVerificationPolicy,
+} from "@/lib/capabilities"
+
+const pm = prismaMock as unknown as {
+  healthcareMembership: { findMany: any; findUnique: any }
+  verificationPolicy: { findFirst: any }
+}
+
+const FUTURE = new Date("2027-01-01T00:00:00Z")
+const PAST = new Date("2020-01-01T00:00:00Z")
+const NOW = new Date("2026-06-17T00:00:00Z")
+
+afterEach(() => vi.unstubAllEnvs())
+
+describe("capabilities — lecture des capacités scopées (N-N)", () => {
+  it("getMemberships retourne les appartenances du user", async () => {
+    pm.healthcareMembership.findMany.mockResolvedValue([{ id: 1, userId: 5, serviceId: 9 }])
+    const r = await getMemberships(5)
+    expect(r).toHaveLength(1)
+    expect(pm.healthcareMembership.findMany).toHaveBeenCalledWith({ where: { userId: 5 } })
+  })
+
+  it("clinicalCapability renvoie le rôle clinique du scope, ou null", async () => {
+    pm.healthcareMembership.findUnique.mockResolvedValueOnce({ clinicalRole: "DOCTOR" })
+    expect(await clinicalCapability(5, 9)).toBe("DOCTOR")
+    pm.healthcareMembership.findUnique.mockResolvedValueOnce(null)
+    expect(await clinicalCapability(5, 99)).toBeNull()
+    pm.healthcareMembership.findUnique.mockResolvedValueOnce({ clinicalRole: null })
+    expect(await clinicalCapability(5, 7)).toBeNull()
+  })
+
+  it("canManageOrg / isPrincipalAdmin renvoient des booléens (false par défaut)", async () => {
+    pm.healthcareMembership.findUnique.mockResolvedValueOnce({ canManage: true })
+    expect(await canManageOrg(5, 9)).toBe(true)
+    pm.healthcareMembership.findUnique.mockResolvedValueOnce(null)
+    expect(await canManageOrg(5, 9)).toBe(false)
+    pm.healthcareMembership.findUnique.mockResolvedValueOnce({ isPrincipalAdmin: true })
+    expect(await isPrincipalAdmin(5, 9)).toBe(true)
+    pm.healthcareMembership.findUnique.mockResolvedValueOnce(null)
+    expect(await isPrincipalAdmin(5, 9)).toBe(false)
+  })
+})
+
+describe("resolveVerificationPolicy — fail-secure", () => {
+  beforeEach(() => {
+    vi.stubEnv("NODE_ENV", "test")
+    vi.stubEnv("VERIFICATION_ALLOW_PILOT", "")
+  })
+
+  it("aucune politique → required (défaut codé en dur)", async () => {
+    pm.verificationPolicy.findFirst.mockResolvedValue(null)
+    expect(await resolveVerificationPolicy({ tenantId: 1, country: "FR" }, NOW))
+      .toEqual({ mode: "required", source: "default" })
+  })
+
+  it("politique tenant required → required (source tenant)", async () => {
+    pm.verificationPolicy.findFirst.mockResolvedValueOnce({ mode: "required", expiresAt: null })
+    expect(await resolveVerificationPolicy({ tenantId: 1 }, NOW))
+      .toEqual({ mode: "required", source: "tenant" })
+  })
+
+  it("provisional borné (expiresAt futur, hors prod) → provisional", async () => {
+    pm.verificationPolicy.findFirst.mockResolvedValueOnce({ mode: "provisional", expiresAt: FUTURE })
+    expect(await resolveVerificationPolicy({ tenantId: 1 }, NOW))
+      .toEqual({ mode: "provisional", source: "tenant" })
+  })
+
+  it("provisional sans expiresAt → dégradé en required (borne obligatoire)", async () => {
+    pm.verificationPolicy.findFirst.mockResolvedValueOnce({ mode: "provisional", expiresAt: null })
+    expect((await resolveVerificationPolicy({ tenantId: 1 }, NOW)).mode).toBe("required")
+  })
+
+  it("provisional expiré → dégradé en required", async () => {
+    pm.verificationPolicy.findFirst.mockResolvedValueOnce({ mode: "provisional", expiresAt: PAST })
+    expect((await resolveVerificationPolicy({ tenantId: 1 }, NOW)).mode).toBe("required")
+  })
+
+  it("en production, provisional dégradé en required sans flag pilote", async () => {
+    vi.stubEnv("NODE_ENV", "production")
+    pm.verificationPolicy.findFirst.mockResolvedValueOnce({ mode: "provisional", expiresAt: FUTURE })
+    expect((await resolveVerificationPolicy({ tenantId: 1 }, NOW)).mode).toBe("required")
+  })
+
+  it("en production avec VERIFICATION_ALLOW_PILOT → provisional honoré (borné)", async () => {
+    vi.stubEnv("NODE_ENV", "production")
+    vi.stubEnv("VERIFICATION_ALLOW_PILOT", "true")
+    pm.verificationPolicy.findFirst.mockResolvedValueOnce({ mode: "provisional", expiresAt: FUTURE })
+    expect((await resolveVerificationPolicy({ tenantId: 1 }, NOW)).mode).toBe("provisional")
+  })
+
+  it("fallback pays quand aucune politique tenant", async () => {
+    // 1er findFirst (tenant) → null ; 2e (pays) → provisional borné.
+    pm.verificationPolicy.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ mode: "provisional", expiresAt: FUTURE })
+    expect(await resolveVerificationPolicy({ tenantId: 1, country: "FR" }, NOW))
+      .toEqual({ mode: "provisional", source: "country" })
+  })
+})


### PR DESCRIPTION
## Socle « Accès & Cabinet » — PR1/5 (fondations schéma)

Première PR du bloc V1 restant de la série « Navigation & Accès Backoffice » (US-2610/2616/2617/2620). **100 % additif** : modèles + helpers **peuplés et testés**, mais **l'enforcement est inchangé** (`canAccessPatient`/`isOrgMember`/`requireRole`) → **zéro régression d'accès**. La bascule (F7 révocation, F6 isolation, écrans Q2) arrive dans les PRs suivantes.

### Contenu
- **F2 (US-2616)** — `Tenant` (org racine + `country`), `HealthcareService.tenantId`, `VerificationPolicy` + enum `VerificationMode`. Résolveur `resolveVerificationPolicy` **fail-secure** : défaut `required` codé en dur ; `provisional` borné (`expiresAt` futur) + interdit en prod sauf flag pilote ; ordre `tenant > pays > défaut`.
- **F4 (US-2617)** — `HealthcareMembership` **N-N** (Q1 `clinicalRole` / Q2 `canManage`+`isPrincipalAdmin`) en **nouvelle table** (`HealthcareMember` intouché → pas de retrait de `@unique`, zéro impact RDV/booking/référents) ; `ProfessionalRegistration` générique multi-pays + enum `RegistrationStatus`.
- **F8 (US-2620)** — `AuditLog.tenantId`/`scopeServiceId` + index ; **set canonique** d'actions du socle.
- Helpers `src/lib/capabilities.ts` (lecture base, prépare F7) — **non branchés** dans l'enforcement.
- **Migration** versionnée additive + **backfill idempotent** (1 tenant/service, appartenance miroir reflétant l'accès actuel). Drift = 0 (vérifié shadow DB) ; migration appliquée + backfill validé en dev.

### ⚠️ Hors scope V1 (acté ROADMAP)
- **F1** (découplage accès PHI / rôle plateforme) + renommage `ADMIN`→`SYSTEM_ADMIN` = **V4** → en V1 `ADMIN` garde le PHI (risque accepté documenté).
- **Vérification PS réelle** (US-2611) = **V4** → en V1 toute inscription est « considérée vérifiée » ; la porte `provisional` reste fail-secure et bornée.

### Sécurité / conformité
- Politique de vérification **fail-secure** (défaut `required`). Audit scopé **sans PHI** (réfs/ids, ADR #18). DPIA : `docs/compliance/dpia-access-foundations.md`.

### Tests
- `tests/unit/capabilities.test.ts` (fail-secure + lecture N-N), `tests/unit/access-foundations-migration-sql.test.ts` (garde backfill).
- **2471/2471 unit verts** sans modification des tests d'accès existants (preuve de non-régression). tsc / eslint / design-system (272) / i18n-parity verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)