### PR TITLE
feat(access): PR3 — F6 isolation patient par médecin référent

### DIFF
--- a/docs/compliance/dpia-patient-isolation.md
+++ b/docs/compliance/dpia-patient-isolation.md
@@ -1,0 +1,82 @@
+# DPIA — Isolation patient par médecin référent (US-2618 / F6)
+
+**Statut** : Brouillon — à signer DPO + RSSI avant mise en service patients réels.
+**Périmètre (PR3)** : bascule de l'enforcement clinique de « appartenance au service »
+à « médecin référent » dans `src/lib/access-control.ts` (`canAccessPatient`,
+`getAccessiblePatientIds`), alignement de la liste portefeuille (`patient.service`
+`listForCaller`/`listByService`) + routes `/api/patients`, `/api/messaging/contacts`,
+et backfill `PatientReferent`.
+**Lié à** : `dpia-access-foundations.md` (socle), `dpia-patient-detail-dossier.md`.
+
+## 1. Changement d'accès
+
+| Rôle | Avant | Après (F6) |
+|---|---|---|
+| **DOCTOR** | tous les patients des services dont il est membre | **uniquement SES patients** (`PatientReferent.pro.userId`) |
+| **NURSE** | patients de ses services | **inchangé** (périmètre service — il assiste les médecins du cabinet) |
+| **ADMIN** | bypass PHI | bypass (inchangé — risque V1 accepté, levé en V4 / F1) |
+| **VIEWER** | propre dossier | inchangé |
+
+**Responsable de traitement (RGPD)** : médecins = **contrôleurs distincts** (chacun ses
+patients via référent) ; hôpital = établissement (tenant) contrôleur. F6 matérialise
+cette frontière entre médecins d'un même cabinet de groupe.
+
+## 2. Décisions de design à valider DPO
+
+- **2.1 — DOCTOR isolé par référent** : un médecin A ne voit plus les patients du médecin
+  B du même service. Corrige une **incohérence préexistante** (la liste `listByDoctor`
+  était déjà référent, mais `canAccessPatient`/`getAccessiblePatientIds` étaient
+  service-larges → un médecin pouvait accéder en per-patient à un patient hors de son
+  portefeuille). F6 ferme cette sur-exposition.
+- **2.2 — NURSE conserve le périmètre service (décision actée)** : le référent étant un
+  médecin, isoler l'infirmier par référent le priverait de tout patient. En V1 l'infirmier
+  garde l'accès aux patients de son/ses service(s) (workflow préservé). **Résidu** : dans
+  un cabinet de groupe, un infirmier partagé voit les patients de **tous** les médecins du
+  service → à raffiner via une affectation infirmier↔médecin (post-V1).
+- **2.3 — Backfill** : pour ne pas rendre invisible un patient déjà suivi, un
+  `PatientReferent` est créé pour les patients sans référent à partir du membre assigné
+  (`PatientService.member_id`). **Patients sans référent NI membre assigné** → **fail-closed**
+  (invisibles aux médecins, seulement `ADMIN`) : ils devront être affectés via la gestion
+  (PR4). Migration data-only, idempotente.
+
+## 3. Mesures techniques
+
+- Enforcement **serveur** unique (`access-control.ts`) branché par rôle ; aucune
+  dérogation dans les routes. `resolvePatientForConsent` (anti-énumération) hérite
+  automatiquement du nouveau `canAccessPatient`.
+- Index `PatientReferent(proId)` (déjà présent) → pas de seq-scan sur `listByDoctor` /
+  `getAccessiblePatientIds(DOCTOR)`.
+- Consentement RGPD (`PROVIDER_VISIBLE_USER_WHERE`) conservé sur les listes (opt-out
+  Art. 21 honoré dès qu'une row privacy existe).
+- Audit inchangé (lecture portefeuille `READ PATIENT resourceId="list"` + metadata
+  acteur/scope).
+
+## 4. Risques résiduels
+
+- **Patients orphelins** (sans référent ni membre assigné) invisibles aux médecins après
+  bascule → atténué par le backfill ; les cas restants relèvent de l'affectation (PR4).
+  **Fail-closed assumé** (sécurité > disponibilité).
+- **Infirmier partagé** (cabinet de groupe) voit tous les médecins du service (§2.2).
+- **ADMIN PHI** : inchangé, V4 (F1).
+
+## 5. Tests
+
+- `tests/unit/access-control.test.ts` — DOCTOR référent (accès + isolation A≠B, ne
+  retombe pas sur le service) ; NURSE service ; ADMIN/VIEWER inchangés ;
+  `getAccessiblePatientIds` par rôle.
+- `tests/unit/f6-backfill-referent-sql.test.ts` — garde du backfill (idempotent, data-only).
+- Consommateurs migrés (device-supervision/sync-status/lifecycle) : DOCTOR via référent.
+- Backfill vérifié en base (recréation d'un référent supprimé depuis `member_id`).
+- Non-régression : suite complète verte.
+
+## 6. Validations à obtenir
+
+- [ ] DPO : isolation DOCTOR par référent (§2.1) + responsable de traitement (§1) ;
+  NURSE service-scope V1 + résidu infirmier partagé (§2.2).
+- [ ] RSSI : fail-closed orphelins (§2.3/§4), enforcement serveur unique.
+- [ ] Direction Médicale : un médecin ne voit que ses patients ; l'infirmier assiste le
+  cabinet (workflow).
+
+---
+
+*Dernière mise à jour : 2026-06-17 — DPIA initiale isolation par référent (PR3 / F6).*

--- a/docs/compliance/dpia-patient-isolation.md
+++ b/docs/compliance/dpia-patient-isolation.md
@@ -28,6 +28,12 @@ cette frontière entre médecins d'un même cabinet de groupe.
   était déjà référent, mais `canAccessPatient`/`getAccessiblePatientIds` étaient
   service-larges → un médecin pouvait accéder en per-patient à un patient hors de son
   portefeuille). F6 ferme cette sur-exposition.
+  - **Portée du rétrécissement** : comme tous les consommateurs cross-patient dérivent
+    leur périmètre de `getAccessiblePatientIds`, le shift s'applique **au-delà de la
+    liste/du dossier** — les **worklists du tableau de bord médecin** (urgences,
+    silencieux, propositions, RDV) et la **cohorte d'appareils** (device supervision /
+    sync) d'un DOCTOR se réduisent à ses patients référents. Comportement **voulu**
+    (un médecin pilote ses patients), à acter explicitement.
 - **2.2 — NURSE conserve le périmètre service (décision actée)** : le référent étant un
   médecin, isoler l'infirmier par référent le priverait de tout patient. En V1 l'infirmier
   garde l'accès aux patients de son/ses service(s) (workflow préservé). **Résidu** : dans
@@ -58,6 +64,10 @@ cette frontière entre médecins d'un même cabinet de groupe.
   **Fail-closed assumé** (sécurité > disponibilité).
 - **Infirmier partagé** (cabinet de groupe) voit tous les médecins du service (§2.2).
 - **ADMIN PHI** : inchangé, V4 (F1).
+- **Suivi ops (backlog PR4)** : (a) **rapport post-backfill** — lister les patients à
+  plusieurs `PatientService` (le référent dérivé prend le lien le plus ancien, à
+  reconfirmer) ; (b) **rapport patients orphelins** (sans référent) sur un écran admin,
+  pour rendre l'affectation actionnable plutôt que silencieuse. Codés en PR4 (gestion).
 
 ## 5. Tests
 

--- a/prisma/migrations/20260617180000_f6_backfill_patient_referent/migration.sql
+++ b/prisma/migrations/20260617180000_f6_backfill_patient_referent/migration.sql
@@ -1,0 +1,28 @@
+-- ═══════════════════════════════════════════════════════════════
+-- US-2618 / F6 — Backfill PatientReferent (data-only, idempotent)
+-- ═══════════════════════════════════════════════════════════════
+-- L'enforcement clinique bascule de « appartenance au service » à « médecin
+-- référent » (cf. src/lib/access-control.ts). Pour qu'aucun patient déjà suivi
+-- ne devienne invisible à son médecin assigné, on crée un PatientReferent pour
+-- les patients SANS référent, à partir du membre assigné dans PatientService
+-- (member_id = référent de fait). Patients sans référent NI member_id → restent
+-- fail-closed (invisibles aux médecins, seulement ADMIN) : à affecter via la
+-- gestion (PR4).
+--
+-- Aucune modification de schéma (DDL) → drift inchangé. Idempotent :
+--   - NOT EXISTS exclut les patients ayant déjà un référent ;
+--   - ON CONFLICT (patient_id) DO NOTHING (contrainte @unique) ;
+--   - DISTINCT ON (patient_id) choisit un seul PatientService (le plus ancien).
+-- ═══════════════════════════════════════════════════════════════
+
+INSERT INTO "patient_referent" ("patient_id", "pro_id", "service_id")
+SELECT DISTINCT ON (ps."patient_id")
+       ps."patient_id", ps."member_id", ps."service_id"
+FROM "patient_services" ps
+JOIN "patients" p ON p."id" = ps."patient_id" AND p."deleted_at" IS NULL
+WHERE ps."member_id" IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM "patient_referent" pr WHERE pr."patient_id" = ps."patient_id"
+  )
+ORDER BY ps."patient_id", ps."created_at" ASC
+ON CONFLICT ("patient_id") DO NOTHING;

--- a/src/app/api/messaging/contacts/route.ts
+++ b/src/app/api/messaging/contacts/route.ts
@@ -53,8 +53,9 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
     }
 
-    // 1. Fetch portefeuille patients du PS (déjà décrypté).
-    const patients = await patientService.listByDoctor(user.id, user.id)
+    // 1. Fetch portefeuille patients du PS (déjà décrypté). F6 — DOCTOR : référent ;
+    //    NURSE : périmètre service (cohérent avec /api/patients et l'enforcement).
+    const patients = await patientService.listForCaller(user.id, user.role, user.id)
 
     // 2. Filter via canMessage — cap N pour éviter DoS si portefeuille
     //    énorme (>>50 patients par PS = cabinet atypique, V1.5 paginer).

--- a/src/app/api/patients/route.ts
+++ b/src/app/api/patients/route.ts
@@ -28,13 +28,13 @@ const PHI_RESPONSE_HEADERS = {
  *
  * Returns `PatientListItemDto[]` for all roles (single common contract):
  * - VIEWER (patient role): single-element array with their own patient summary.
- * - NURSE / DOCTOR / ADMIN: portfolio via PatientReferent links (patients
- *   explicitly assigned to a HealthcareMember linked to this user). Filters
- *   out patients who have revoked `gdprConsent` or `shareWithProviders`
- *   (RGPD Art. 7.3 effective revocation).
- *
- * ADMINs who are not also a HealthcareMember see an empty array here; broader
- * patient access for them goes through admin-specific endpoints.
+ * - DOCTOR / ADMIN: portfolio via **PatientReferent** (US-2618/F6 — only patients
+ *   for whom this user is the médecin référent).
+ * - NURSE: **service scope** (patients of HealthcareServices this user is a member
+ *   of) — an infirmier assists the cabinet's doctors (F6 decision).
+ * All pro roles filter out patients who revoked `gdprConsent`/`shareWithProviders`
+ * (RGPD Art. 7.3). ADMINs who are not a HealthcareMember see an empty array here;
+ * broader access goes through admin-specific endpoints.
  */
 export async function GET(req: NextRequest) {
   try {
@@ -45,7 +45,9 @@ export async function GET(req: NextRequest) {
       const own = await patientService.getOwnSummary(patientId, user.id, extractRequestContext(req))
       return NextResponse.json(own ? [own] : [], { headers: PHI_RESPONSE_HEADERS })
     }
-    const patients = await patientService.listByDoctor(user.id, user.id)
+    // F6 — DOCTOR : référent ; NURSE : périmètre service ; ADMIN : référent (liste
+    // vide si non-membre, accès large via endpoints admin).
+    const patients = await patientService.listForCaller(user.id, user.role, user.id)
     return NextResponse.json(patients, { headers: PHI_RESPONSE_HEADERS })
   } catch (error) {
     if (error instanceof AuthError) return NextResponse.json({ error: error.message }, { status: error.status })

--- a/src/lib/access-control.ts
+++ b/src/lib/access-control.ts
@@ -16,10 +16,13 @@ import { prisma } from "@/lib/db/client"
 import type { Role } from "@prisma/client"
 
 /**
- * Borne de sécurité sur le périmètre cross-patient (anti-OOM + parité avec
- * `LIST_BY_DOCTOR_MAX` de patient.service). Au-delà, l'IN-list devient énorme ;
- * les consommateurs (dashboards/cohortes) devront paginer. Cap volontairement
- * généreux : un portefeuille > 5000 patients est un cabinet atypique.
+ * Borne de sécurité sur le périmètre cross-patient (anti-OOM). Au-delà, l'IN-list
+ * devient énorme ; les consommateurs (dashboards/cohortes) devront paginer. Cap
+ * volontairement plus élevé que `LIST_BY_DOCTOR_MAX` (2000) de patient.service :
+ * ici la requête ne projette que `{ patientId }` (légère), vs la liste qui
+ * déchiffre + mappe un DTO par ligne. Un portefeuille > 5000 patients reste
+ * un cabinet atypique. Troncature **fail-closed** (des patients deviennent
+ * inaccessibles, jamais sur-exposés).
  */
 const ACCESSIBLE_IDS_MAX = 5000
 

--- a/src/lib/access-control.ts
+++ b/src/lib/access-control.ts
@@ -1,8 +1,14 @@
 /**
  * @module access-control
- * @description Patient access control — RBAC enforcement by role and healthcare service links.
- * Prevents unauthorized data access. All patient reads should check access first.
- * ADMIN unrestricted, DOCTOR/NURSE via healthcare service, VIEWER = own patient only.
+ * @description Patient access control — RBAC enforcement by role.
+ * - ADMIN : unrestricted (bypass PHI — risque V1 accepté, levé en V4 / F1).
+ * - DOCTOR : **isolé par médecin référent** (US-2618/F6) — un médecin ne voit
+ *   QUE ses patients (`PatientReferent.pro.userId`), pas tous ceux du service.
+ *   Responsable de traitement RGPD : médecins = contrôleurs distincts.
+ * - NURSE : **périmètre service** (`PatientService → HealthcareService.members`) —
+ *   l'infirmier assiste les médecins de son/ses service(s) (workflow préservé V1).
+ * - VIEWER : propre dossier uniquement.
+ * Exclut toujours les patients soft-deleted.
  * @see CLAUDE.md#rbac — Role-based access control
  */
 
@@ -46,7 +52,17 @@ export async function canAccessPatient(
     return !!patient
   }
 
-  // DOCTOR / NURSE — check via PatientService → HealthcareService → HealthcareMember
+  // DOCTOR — F6 : isolé par médecin référent (PatientReferent.pro.userId).
+  if (role === "DOCTOR") {
+    const ref = await prisma.patientReferent.findFirst({
+      where: { patientId, patient: { deletedAt: null }, pro: { userId } },
+      select: { id: true },
+    })
+    return !!ref
+  }
+
+  // NURSE (rôle clinique non-DOCTOR) — périmètre service (inchangé) :
+  // PatientService → HealthcareService → HealthcareMember.
   const link = await prisma.patientService.findFirst({
     where: {
       patientId,
@@ -55,6 +71,7 @@ export async function canAccessPatient(
         members: { some: { userId } },
       },
     },
+    select: { id: true },
   })
   return !!link
 }
@@ -111,8 +128,10 @@ export async function resolvePatientId(
  *
  * - ADMIN → returns null (caller may query without restriction).
  * - VIEWER → returns [own patient id] or [] if none.
- * - DOCTOR/NURSE → returns the patient IDs of every PatientService where
- *   the caller is a member, excluding soft-deleted patients.
+ * - DOCTOR → **referent-scoped** (US-2618/F6) : patient IDs where the caller is
+ *   the médecin référent (`PatientReferent.pro.userId`), soft-deleted excluded.
+ * - NURSE → **service-scoped** (unchanged) : patient IDs of every PatientService
+ *   whose HealthcareService has the caller as a member.
  *
  * The caller MUST treat `null` as "no restriction" and an array as a hard
  * IN-list filter (empty array → no rows).
@@ -128,6 +147,16 @@ export async function getAccessiblePatientIds(
     return own ? [own] : []
   }
 
+  // DOCTOR — F6 : périmètre référent (un patient = un référent, pas de distinct).
+  if (role === "DOCTOR") {
+    const refs = await prisma.patientReferent.findMany({
+      where: { patient: { deletedAt: null }, pro: { userId } },
+      select: { patientId: true },
+    })
+    return refs.map((r) => r.patientId)
+  }
+
+  // NURSE — périmètre service (inchangé).
   const links = await prisma.patientService.findMany({
     where: {
       patient: { deletedAt: null },

--- a/src/lib/access-control.ts
+++ b/src/lib/access-control.ts
@@ -16,6 +16,14 @@ import { prisma } from "@/lib/db/client"
 import type { Role } from "@prisma/client"
 
 /**
+ * Borne de sécurité sur le périmètre cross-patient (anti-OOM + parité avec
+ * `LIST_BY_DOCTOR_MAX` de patient.service). Au-delà, l'IN-list devient énorme ;
+ * les consommateurs (dashboards/cohortes) devront paginer. Cap volontairement
+ * généreux : un portefeuille > 5000 patients est un cabinet atypique.
+ */
+const ACCESSIBLE_IDS_MAX = 5000
+
+/**
  * Check if a user can access a given patient's data — role-based access control.
  * - ADMIN: all non-deleted patients
  * - DOCTOR/NURSE: patients via healthcare service (PatientService → HealthcareService → HealthcareMember)
@@ -152,6 +160,7 @@ export async function getAccessiblePatientIds(
     const refs = await prisma.patientReferent.findMany({
       where: { patient: { deletedAt: null }, pro: { userId } },
       select: { patientId: true },
+      take: ACCESSIBLE_IDS_MAX,
     })
     return refs.map((r) => r.patientId)
   }
@@ -166,6 +175,7 @@ export async function getAccessiblePatientIds(
     },
     select: { patientId: true },
     distinct: ["patientId"],
+    take: ACCESSIBLE_IDS_MAX,
   })
   return links.map((l) => l.patientId)
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -58,6 +58,14 @@ const ALLOWED_CONTEXT_KEYS = new Set<string>([
   "cabinetId",
   // Plan B follow-up A1 round 2 — idempotency RGPD Art. 17 purge count.
   "deletedCount",
+  // patient.service — cap/audit metadata des listes portefeuille (référent / service).
+  // Étaient déclarés dans LogContext mais absents de l'allow-list → strippés à
+  // l'émission (code-reviewer n1). Ajout pour qu'ils apparaissent réellement.
+  "doctorUserId",
+  "nurseUserId",
+  "count",
+  "cap",
+  "scope",
 ])
 
 export interface LogContext {

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -94,6 +94,8 @@ export interface LogContext {
   count?: number
   cap?: number
   doctorUserId?: number
+  /** patient.service F6 — listByService cap warning (périmètre infirmier). */
+  nurseUserId?: number
 }
 
 const IS_PRODUCTION = process.env.NODE_ENV === "production"

--- a/src/lib/services/patient.service.ts
+++ b/src/lib/services/patient.service.ts
@@ -19,7 +19,7 @@ import { auditService, extractRequestContext } from "./audit.service"
 import type { PatientListItemDto } from "@/lib/dto/patient"
 import { logger } from "@/lib/logger"
 import { Prisma } from "@prisma/client"
-import type { Pathology, Sex, PatientMedicalData } from "@prisma/client"
+import type { Pathology, Sex, PatientMedicalData, Role } from "@prisma/client"
 
 /**
  * Audit context extracted from request headers (IP, User-Agent).
@@ -375,6 +375,37 @@ function encryptMedicalInput(input: MedicalDataUpdateInput): Prisma.PatientMedic
     }
   }
   return result as Prisma.PatientMedicalDataUpdateInput
+}
+
+/** Sélection minimale partagée par les listes de portefeuille (référent / service). */
+const PATIENT_LIST_SELECT = {
+  id: true,
+  publicRef: true,
+  pathology: true,
+  user: { select: { id: true, firstname: true, lastname: true, birthday: true } },
+} as const
+
+type PatientListRow = {
+  id: number
+  publicRef: string
+  pathology: Pathology
+  user: { id: number; firstname: string | null; lastname: string | null; birthday: Date | null }
+}
+
+/** Map d'une ligne patient → DTO de liste (déchiffrement fail-soft, date-only). */
+function toPatientListItem(p: PatientListRow): PatientListItemDto {
+  return {
+    id: p.id,
+    publicRef: p.publicRef,
+    pathology: p.pathology,
+    user: {
+      id: p.user.id,
+      firstname: safeDecrypt(p.user.firstname),
+      lastname: safeDecrypt(p.user.lastname),
+      // HSA L4 — date-only (YYYY-MM-DD) pour éviter la dérive timezone navigateur.
+      birthday: p.user.birthday?.toISOString().slice(0, 10) ?? null,
+    },
+  }
 }
 
 /**
@@ -1051,18 +1082,8 @@ export const patientService = {
           user: PROVIDER_VISIBLE_USER_WHERE,
         },
       },
-      select: {
-        patient: {
-          select: {
-            id: true,
-            publicRef: true, // US-2018b — ouverture consultation sans id dans l'URL
-            pathology: true,
-            // HSA L1 — `birthday` contractualisé côté DTO pour le calcul d'âge
-            // côté UI (cf. PatientListItemDto). À conserver dans la DPIA.
-            user: { select: { id: true, firstname: true, lastname: true, birthday: true } },
-          },
-        },
-      },
+      // US-2018b publicRef + HSA L1 birthday — sélection partagée (PATIENT_LIST_SELECT).
+      select: { patient: { select: PATIENT_LIST_SELECT } },
     })
 
     if (referents.length >= LIST_BY_DOCTOR_WARN_AT) {
@@ -1084,20 +1105,54 @@ export const patientService = {
       metadata: { doctorUserId, count: referents.length, capped: referents.length === LIST_BY_DOCTOR_MAX },
     })
 
-    return referents.map((r) => ({
-      id: r.patient.id,
-      publicRef: r.patient.publicRef,
-      pathology: r.patient.pathology,
-      user: {
-        id: r.patient.user.id,
-        firstname: safeDecrypt(r.patient.user.firstname),
-        lastname: safeDecrypt(r.patient.user.lastname),
-        // HSA L4 — date-only (YYYY-MM-DD) au lieu d'ISO complet : évite la
-        // dérive timezone côté navigateur (un patient né le 15/05 à 00:00 UTC
-        // apparaîtrait né le 14/05 dans un navigateur Hawaii).
-        birthday: r.patient.user.birthday?.toISOString().slice(0, 10) ?? null,
+    return referents.map((r) => toPatientListItem(r.patient))
+  },
+
+  /**
+   * US-2618/F6 — Liste du portefeuille d'un INFIRMIER : **périmètre service**
+   * (patients d'un `HealthcareService` dont l'infirmier est membre), pas le
+   * référent (un infirmier n'est pas référent). Même DTO/cap/consentement que
+   * `listByDoctor`.
+   */
+  async listByService(nurseUserId: number, auditUserId: number): Promise<PatientListItemDto[]> {
+    const patients = await prisma.patient.findMany({
+      take: LIST_BY_DOCTOR_MAX,
+      where: {
+        deletedAt: null,
+        user: PROVIDER_VISIBLE_USER_WHERE,
+        patientServices: { some: { service: { members: { some: { userId: nurseUserId } } } } },
       },
-    }))
+      select: PATIENT_LIST_SELECT,
+    })
+
+    if (patients.length >= LIST_BY_DOCTOR_WARN_AT) {
+      logger.warn("patient.service", "listByService approaching cap — paginate soon", {
+        nurseUserId,
+        count: patients.length,
+        cap: LIST_BY_DOCTOR_MAX,
+      })
+    }
+
+    await auditService.log({
+      userId: auditUserId,
+      action: "READ",
+      resource: "PATIENT",
+      resourceId: "list",
+      metadata: { nurseUserId, scope: "service", count: patients.length, capped: patients.length === LIST_BY_DOCTOR_MAX },
+    })
+
+    return patients.map(toPatientListItem)
+  },
+
+  /**
+   * US-2618/F6 — Liste du portefeuille selon le rôle de l'appelant :
+   * `NURSE` → périmètre service (`listByService`) ; `DOCTOR`/`ADMIN` → référent
+   * (`listByDoctor`, un ADMIN non-membre obtient une liste vide — accès large via
+   * endpoints admin). `VIEWER` est géré en amont (route, propre dossier).
+   */
+  async listForCaller(userId: number, role: Role, auditUserId: number): Promise<PatientListItemDto[]> {
+    if (role === "NURSE") return this.listByService(userId, auditUserId)
+    return this.listByDoctor(userId, auditUserId)
   },
 
   /**

--- a/tests/e2e/patients-list-api.spec.ts
+++ b/tests/e2e/patients-list-api.spec.ts
@@ -10,8 +10,9 @@ import { loginAs } from "./helpers/auth"
  *
  * Prerequisites: the test database is seeded with the standard data
  * (prisma/seed.ts). The seed creates 5 patients linked via PatientReferent
- * to `memberDoctor` (Dr Sophie Martin). `memberNurse` (Marie Dupont IDE)
- * has no PatientReferent rows by default — nurse sees the empty state.
+ * to `memberDoctor` (Dr Sophie Martin) AND via PatientService to the shared
+ * "Service Diabétologie". US-2618/F6 : le DOCTOR voit ses patients référents ;
+ * le NURSE (`memberNurse`, membre du service) voit les patients du service.
  */
 test.describe("Patients list — /patients (real API connection)", () => {
   test("DOCTOR → sees the 5 seeded patients with real names", async ({
@@ -38,7 +39,7 @@ test.describe("Patients list — /patients (real API connection)", () => {
     await expect(page.getByText("Gestationnel").first()).toBeVisible()
   })
 
-  test("NURSE → sees empty list (no PatientReferent in seed)", async ({
+  test("NURSE → sees the service's patients (F6 service scope)", async ({
     page,
     context,
     request,
@@ -46,14 +47,13 @@ test.describe("Patients list — /patients (real API connection)", () => {
     await loginAs(context, request, "nurse")
     await page.goto("/patients")
 
-    // The seed only wires PatientReferent to memberDoctor. memberNurse has
-    // none → listByDoctor() returns []. The table shows the empty-state row.
-    // Once a nurse referent seed is added (V1.5), this test should mirror
-    // the DOCTOR assertions above.
-    // Locale-agnostic match: fr "Aucun patient trouve" or en "No patients found".
-    await expect(
-      page.getByText(/Aucun patient trouv|No patients found/).first(),
-    ).toBeVisible({ timeout: 10_000 })
+    // US-2618/F6 : un infirmier n'est pas référent, mais garde le périmètre
+    // SERVICE — il voit les patients du/des service(s) dont il est membre.
+    // `memberNurse` est membre du "Service Diabétologie" qui porte les 5 patients.
+    const rows = page.locator("table tbody tr")
+    await expect(rows).toHaveCount(5, { timeout: 10_000 })
+    await expect(page.getByText("Jean Durand")).toBeVisible()
+    await expect(page.getByText("Amélie Rousseau")).toBeVisible()
   })
 
   test("VIEWER (patient) → redirected away from the pro patient list", async ({

--- a/tests/integration/api-messaging-contacts.test.ts
+++ b/tests/integration/api-messaging-contacts.test.ts
@@ -29,7 +29,7 @@ vi.mock("@/lib/gdpr", () => ({
 }))
 vi.mock("@/lib/services/patient.service", () => ({
   patientService: {
-    listByDoctor: vi.fn(),
+    listForCaller: vi.fn(),
   },
 }))
 vi.mock("@/lib/services/messaging.service", () => ({
@@ -91,7 +91,7 @@ describe("GET /api/messaging/contacts (Fix HSA H2 round 1 PR #444)", () => {
   it("happy path : filter canMessage → 2 contacts messageables", async () => {
     vi.mocked(requireRole).mockReturnValue({ id: 1, role: "NURSE" } as never)
     vi.mocked(requireGdprConsent).mockResolvedValue(true)
-    vi.mocked(patientService.listByDoctor).mockResolvedValue([
+    vi.mocked(patientService.listForCaller).mockResolvedValue([
       { id: 100, pathology: "DT1", user: { id: 1000, firstname: null, lastname: null, birthday: null } },
       { id: 200, pathology: "DT2", user: { id: 2000, firstname: null, lastname: null, birthday: null } },
       { id: 300, pathology: "DT1", user: { id: 3000, firstname: null, lastname: null, birthday: null } },
@@ -119,7 +119,7 @@ describe("GET /api/messaging/contacts (Fix HSA H2 round 1 PR #444)", () => {
   it("Cache-Control no-store + private (anti-cache préférences)", async () => {
     vi.mocked(requireRole).mockReturnValue({ id: 1, role: "NURSE" } as never)
     vi.mocked(requireGdprConsent).mockResolvedValue(true)
-    vi.mocked(patientService.listByDoctor).mockResolvedValue([])
+    vi.mocked(patientService.listForCaller).mockResolvedValue([])
     const res = await GET(makeReq())
     expect(res.headers.get("Cache-Control")).toBe("no-store, private")
   })
@@ -127,7 +127,7 @@ describe("GET /api/messaging/contacts (Fix HSA H2 round 1 PR #444)", () => {
   it("Audit log emit avec metadata.kind + portfolioSize + messageable", async () => {
     vi.mocked(requireRole).mockReturnValue({ id: 42, role: "NURSE" } as never)
     vi.mocked(requireGdprConsent).mockResolvedValue(true)
-    vi.mocked(patientService.listByDoctor).mockResolvedValue([
+    vi.mocked(patientService.listForCaller).mockResolvedValue([
       { id: 1, pathology: "DT1", user: { id: 100, firstname: null, lastname: null, birthday: null } },
       { id: 2, pathology: "DT1", user: { id: 200, firstname: null, lastname: null, birthday: null } },
     ] as never)
@@ -159,7 +159,7 @@ describe("GET /api/messaging/contacts (Fix HSA H2 round 1 PR #444)", () => {
       pathology: "DT1",
       user: { id: (i + 1) * 10, firstname: null, lastname: null, birthday: null },
     }))
-    vi.mocked(patientService.listByDoctor).mockResolvedValue(bigList as never)
+    vi.mocked(patientService.listForCaller).mockResolvedValue(bigList as never)
     vi.mocked(canMessage).mockResolvedValue({ allowed: true, patientId: 1 })
 
     const res = await GET(makeReq())
@@ -179,7 +179,7 @@ describe("GET /api/messaging/contacts (Fix HSA H2 round 1 PR #444)", () => {
   it("canMessage throw → skip silencieusement (UX dégradée vs 500)", async () => {
     vi.mocked(requireRole).mockReturnValue({ id: 1, role: "NURSE" } as never)
     vi.mocked(requireGdprConsent).mockResolvedValue(true)
-    vi.mocked(patientService.listByDoctor).mockResolvedValue([
+    vi.mocked(patientService.listForCaller).mockResolvedValue([
       { id: 1, pathology: "DT1", user: { id: 100, firstname: null, lastname: null, birthday: null } },
       { id: 2, pathology: "DT1", user: { id: 200, firstname: null, lastname: null, birthday: null } },
     ] as never)

--- a/tests/unit/access-control.test.ts
+++ b/tests/unit/access-control.test.ts
@@ -90,18 +90,71 @@ describe("canAccessPatient", () => {
     expect(result).toBe(false)
   })
 
-  it("DOCTOR can access patient from their service", async () => {
-    prismaMock.patientService.findFirst.mockResolvedValue({
-      id: 1, patientId: 5, serviceId: 1, joinedAt: new Date(),
-    } as never)
+  // US-2618/F6 — DOCTOR isolé par médecin référent (PatientReferent.pro.userId).
+  it("DOCTOR can access a patient they are the referent of", async () => {
+    prismaMock.patientReferent.findFirst.mockResolvedValue({ id: 1 } as never)
     const result = await canAccessPatient(10, "DOCTOR", 5)
     expect(result).toBe(true)
+    // Vérifie qu'on interroge bien le référent (pas le service) pour un DOCTOR.
+    expect(prismaMock.patientReferent.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ patientId: 5, pro: { userId: 10 } }) }),
+    )
   })
 
-  it("DOCTOR cannot access patient outside their service", async () => {
-    prismaMock.patientService.findFirst.mockResolvedValue(null)
-    const result = await canAccessPatient(10, "DOCTOR", 5)
+  it("DOCTOR cannot access a patient of another doctor in the same service (F6)", async () => {
+    // Médecin B n'est pas le référent → aucune row référent pour (patient, B).
+    prismaMock.patientReferent.findFirst.mockResolvedValue(null)
+    const result = await canAccessPatient(99, "DOCTOR", 5)
     expect(result).toBe(false)
+    // F6 : on ne retombe PAS sur l'appartenance au service pour un DOCTOR.
+    expect(prismaMock.patientService.findFirst).not.toHaveBeenCalled()
+  })
+
+  // NURSE garde le périmètre service (inchangé).
+  it("NURSE can access a patient of their service", async () => {
+    prismaMock.patientService.findFirst.mockResolvedValue({ id: 1 } as never)
+    const result = await canAccessPatient(20, "NURSE", 5)
+    expect(result).toBe(true)
+    expect(prismaMock.patientReferent.findFirst).not.toHaveBeenCalled()
+  })
+
+  it("NURSE cannot access a patient outside their service", async () => {
+    prismaMock.patientService.findFirst.mockResolvedValue(null)
+    const result = await canAccessPatient(20, "NURSE", 5)
+    expect(result).toBe(false)
+  })
+})
+
+describe("getAccessiblePatientIds", () => {
+  let getAccessiblePatientIds: typeof import("@/lib/access-control").getAccessiblePatientIds
+
+  beforeEach(async () => {
+    getAccessiblePatientIds = (await import("@/lib/access-control")).getAccessiblePatientIds
+  })
+
+  it("ADMIN → null (no restriction)", async () => {
+    expect(await getAccessiblePatientIds(1, "ADMIN")).toBeNull()
+  })
+
+  it("DOCTOR → referent-scoped patient IDs (F6)", async () => {
+    prismaMock.patientReferent.findMany.mockResolvedValue([
+      { patientId: 5 }, { patientId: 7 },
+    ] as never)
+    const ids = await getAccessiblePatientIds(10, "DOCTOR")
+    expect(ids).toEqual([5, 7])
+    expect(prismaMock.patientReferent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ pro: { userId: 10 } }) }),
+    )
+    expect(prismaMock.patientService.findMany).not.toHaveBeenCalled()
+  })
+
+  it("NURSE → service-scoped patient IDs (unchanged)", async () => {
+    prismaMock.patientService.findMany.mockResolvedValue([
+      { patientId: 5 }, { patientId: 6 },
+    ] as never)
+    const ids = await getAccessiblePatientIds(20, "NURSE")
+    expect(ids).toEqual([5, 6])
+    expect(prismaMock.patientReferent.findMany).not.toHaveBeenCalled()
   })
 })
 

--- a/tests/unit/device-lifecycle.service.test.ts
+++ b/tests/unit/device-lifecycle.service.test.ts
@@ -128,7 +128,7 @@ describe("supportedDeviceService.create", () => {
 
 describe("deviceLifecycleService.revoke", () => {
   it("revokes device (cabinet PS)", async () => {
-    prismaMock.patientService.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.patientReferent.findFirst.mockResolvedValue({ id: 1 } as any)
     prismaMock.patientDevice.findFirst.mockResolvedValue({ id: 10, revokedAt: null } as any)
     prismaMock.patientDevice.updateMany.mockResolvedValue({ count: 1 } as any)
     const out = await deviceLifecycleService.revoke(
@@ -148,7 +148,7 @@ describe("deviceLifecycleService.revoke", () => {
   })
 
   it("idempotent : revoke 2× = alreadyRevoked=true (no DB write)", async () => {
-    prismaMock.patientService.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.patientReferent.findFirst.mockResolvedValue({ id: 1 } as any)
     prismaMock.patientDevice.findFirst.mockResolvedValue({
       id: 10, revokedAt: new Date("2026-01-01"),
     } as any)
@@ -158,7 +158,7 @@ describe("deviceLifecycleService.revoke", () => {
   })
 
   it("404 si device n'appartient pas au patient", async () => {
-    prismaMock.patientService.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.patientReferent.findFirst.mockResolvedValue({ id: 1 } as any)
     prismaMock.patientDevice.findFirst.mockResolvedValue(null)
     await expect(
       deviceLifecycleService.revoke(42, 99, "x", 9, "DOCTOR", ctx),
@@ -166,7 +166,7 @@ describe("deviceLifecycleService.revoke", () => {
   })
 
   it("403 si DOCTOR pas membre du cabinet du patient", async () => {
-    prismaMock.patientService.findFirst.mockResolvedValue(null)
+    prismaMock.patientReferent.findFirst.mockResolvedValue(null)
     await expect(
       deviceLifecycleService.revoke(42, 10, "x", 9, "DOCTOR", ctx),
     ).rejects.toBeInstanceOf(DeviceLifecycleAccessError)
@@ -224,7 +224,7 @@ describe("deviceLifecycleService.revoke", () => {
   })
 
   it("atomic CAS — race lost (updateMany count=0) = alreadyRevoked=true", async () => {
-    prismaMock.patientService.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.patientReferent.findFirst.mockResolvedValue({ id: 1 } as any)
     prismaMock.patientDevice.findFirst.mockResolvedValue({ id: 10, revokedAt: null } as any)
     prismaMock.patientDevice.updateMany.mockResolvedValue({ count: 0 } as any)
     const out = await deviceLifecycleService.revoke(42, 10, "x", 9, "DOCTOR", ctx)
@@ -232,7 +232,7 @@ describe("deviceLifecycleService.revoke", () => {
   })
 
   it("audit kind=device.revoked + pivot patientId", async () => {
-    prismaMock.patientService.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.patientReferent.findFirst.mockResolvedValue({ id: 1 } as any)
     prismaMock.patientDevice.findFirst.mockResolvedValue({ id: 10, revokedAt: null } as any)
     prismaMock.patientDevice.updateMany.mockResolvedValue({ count: 1 } as any)
     await deviceLifecycleService.revoke(42, 10, "Replaced", 9, "DOCTOR", ctx)
@@ -248,7 +248,7 @@ describe("deviceLifecycleService.revoke", () => {
 
 describe("deviceLifecycleService.listHistory", () => {
   it("lists all devices (active + revoked) for cabinet member, tri createdAt DESC", async () => {
-    prismaMock.patientService.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.patientReferent.findFirst.mockResolvedValue({ id: 1 } as any)
     // Round 2 : tri sur createdAt strict — ordre fourni par Prisma (mock).
     prismaMock.patientDevice.findMany.mockResolvedValue([
       { id: 2, patientId: 42, brand: "Abbott", model: "FreeStyle 3", category: "cgm",
@@ -268,7 +268,7 @@ describe("deviceLifecycleService.listHistory", () => {
   })
 
   it("403 si pas membre cabinet", async () => {
-    prismaMock.patientService.findFirst.mockResolvedValue(null)
+    prismaMock.patientReferent.findFirst.mockResolvedValue(null)
     await expect(
       deviceLifecycleService.listHistory(42, 9, "DOCTOR", ctx),
     ).rejects.toBeInstanceOf(DeviceLifecycleAccessError)
@@ -280,7 +280,7 @@ describe("deviceLifecycleService.listHistory", () => {
   })
 
   it("includeRevoked=false filter actifs only", async () => {
-    prismaMock.patientService.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.patientReferent.findFirst.mockResolvedValue({ id: 1 } as any)
     prismaMock.patientDevice.findMany.mockResolvedValue([] as any)
     await deviceLifecycleService.listHistory(42, 9, "DOCTOR", ctx, { includeRevoked: false })
     const where = prismaMock.patientDevice.findMany.mock.calls[0]![0]!.where as any
@@ -288,7 +288,7 @@ describe("deviceLifecycleService.listHistory", () => {
   })
 
   it("audit kind=device.history + resourceId=list + pivot patientId + count", async () => {
-    prismaMock.patientService.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.patientReferent.findFirst.mockResolvedValue({ id: 1 } as any)
     prismaMock.patientDevice.findMany.mockResolvedValue([
       { id: 1, patientId: 42, brand: null, model: null, category: null,
         sn: null, date: null, revokedAt: null, revokedBy: null, revokedReasonEnc: null,
@@ -320,7 +320,7 @@ describe("deviceLifecycleService.listHistory", () => {
 
   // CR C2 — PS+ reçoit revokedReason déchiffré (ou null si decrypt fail).
   it("CR C2 — DOCTOR voit le champ revokedReason (déchiffré)", async () => {
-    prismaMock.patientService.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.patientReferent.findFirst.mockResolvedValue({ id: 1 } as any)
     const fakeEnc = Buffer.from("fake").toString("base64")
     prismaMock.patientDevice.findMany.mockResolvedValue([
       { id: 1, patientId: 42, brand: null, model: null, category: null,
@@ -339,7 +339,7 @@ describe("deviceLifecycleService.listHistory", () => {
   it("CR M6 — encrypt→decrypt roundtrip réel : DOCTOR voit reason déchiffrée", async () => {
     const { encryptField } = await import("@/lib/crypto/fields")
     const realCiphertext = encryptField("Remplacé suite à dysfonctionnement")
-    prismaMock.patientService.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.patientReferent.findFirst.mockResolvedValue({ id: 1 } as any)
     prismaMock.patientDevice.findMany.mockResolvedValue([
       { id: 1, patientId: 42, brand: null, model: null, category: null,
         sn: null, date: null,
@@ -375,7 +375,7 @@ describe("deviceLifecycleService.listHistory", () => {
   // id unique = keyset valide. Le tri "révoqués en premier" est abandonné
   // pour préserver l'intégrité de la pagination.
   it("H1 round 2 — orderBy simplifié (createdAt, id) DESC", async () => {
-    prismaMock.patientService.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.patientReferent.findFirst.mockResolvedValue({ id: 1 } as any)
     prismaMock.patientDevice.findMany.mockResolvedValue([] as any)
     await deviceLifecycleService.listHistory(42, 9, "DOCTOR", ctx)
     const orderBy = prismaMock.patientDevice.findMany.mock.calls[0]![0]!.orderBy as any
@@ -385,7 +385,7 @@ describe("deviceLifecycleService.listHistory", () => {
   })
 
   it("limit capped at MAX_HISTORY_PAGE", async () => {
-    prismaMock.patientService.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.patientReferent.findFirst.mockResolvedValue({ id: 1 } as any)
     prismaMock.patientDevice.findMany.mockResolvedValue([] as any)
     await deviceLifecycleService.listHistory(42, 9, "DOCTOR", ctx, { limit: 9999 })
     // take = limit + 1 pour détection hasMore.
@@ -395,7 +395,7 @@ describe("deviceLifecycleService.listHistory", () => {
 
   // HSA L1 review — cursor pagination.
   it("HSA L1 — cursor pagination : nextCursor non-null si hasMore", async () => {
-    prismaMock.patientService.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.patientReferent.findFirst.mockResolvedValue({ id: 1 } as any)
     // Retourne 3 rows pour limit=2 (limit+1=3 → hasMore=true).
     prismaMock.patientDevice.findMany.mockResolvedValue([
       { id: 100, patientId: 42, brand: null, model: null, category: null,
@@ -414,7 +414,7 @@ describe("deviceLifecycleService.listHistory", () => {
   })
 
   it("HSA L1 — cursor passe `cursor: {id}` + `skip: 1` à Prisma", async () => {
-    prismaMock.patientService.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.patientReferent.findFirst.mockResolvedValue({ id: 1 } as any)
     prismaMock.patientDevice.findMany.mockResolvedValue([] as any)
     await deviceLifecycleService.listHistory(42, 9, "DOCTOR", ctx, { cursorId: 50 })
     const call = prismaMock.patientDevice.findMany.mock.calls[0]![0]!
@@ -424,7 +424,7 @@ describe("deviceLifecycleService.listHistory", () => {
 
   // I2 round 2 review — cursor pointant sur un id inexistant → items vide.
   it("I2 round 2 — cursor inexistant (999999) → items: [], nextCursor: null", async () => {
-    prismaMock.patientService.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.patientReferent.findFirst.mockResolvedValue({ id: 1 } as any)
     prismaMock.patientDevice.findMany.mockResolvedValue([] as any)
     const out = await deviceLifecycleService.listHistory(42, 9, "DOCTOR", ctx, {
       cursorId: 999999,
@@ -435,7 +435,7 @@ describe("deviceLifecycleService.listHistory", () => {
 
   // CR L3 review — audit revoke metadata contient brand/model.
   it("CR L3 — audit revoke metadata contient brand+model du device", async () => {
-    prismaMock.patientService.findFirst.mockResolvedValue({ id: 1 } as any)
+    prismaMock.patientReferent.findFirst.mockResolvedValue({ id: 1 } as any)
     prismaMock.patientDevice.findFirst.mockResolvedValue({
       id: 10, revokedAt: null, brand: "Dexcom", model: "G7",
     } as any)

--- a/tests/unit/device-supervision.service.test.ts
+++ b/tests/unit/device-supervision.service.test.ts
@@ -49,8 +49,8 @@ describe("listByPatient (US-2243)", () => {
       .rejects.toBeInstanceOf(DeviceSupervisionAccessError)
   })
 
-  it("DOCTOR without PatientService link — throws", async () => {
-    prismaMock.patientService.findFirst.mockResolvedValue(null)
+  it("DOCTOR without referent link — throws (F6)", async () => {
+    prismaMock.patientReferent.findFirst.mockResolvedValue(null)
     await expect(deviceSupervisionService.listByPatient(42, 9, "DOCTOR"))
       .rejects.toBeInstanceOf(DeviceSupervisionAccessError)
   })
@@ -136,8 +136,8 @@ describe("listCohort (US-2243)", () => {
     expect((call.where as any).patientId).toBeUndefined()
   })
 
-  it("DOCTOR cohort = patients via PatientService", async () => {
-    prismaMock.patientService.findMany.mockResolvedValue([
+  it("DOCTOR cohort = patients via PatientReferent (F6)", async () => {
+    prismaMock.patientReferent.findMany.mockResolvedValue([
       { patientId: 42 }, { patientId: 99 },
     ] as any)
     prismaMock.patientDevice.findMany.mockResolvedValue([] as any)
@@ -194,7 +194,7 @@ describe("listCohort (US-2243)", () => {
 
   // M4 — scope=scoped pour DOCTOR/NURSE avec accessibleCount.
   it("M4 — audit metadata.scope='scoped' + accessibleCount pour DOCTOR", async () => {
-    prismaMock.patientService.findMany.mockResolvedValue([
+    prismaMock.patientReferent.findMany.mockResolvedValue([
       { patientId: 42 }, { patientId: 99 },
     ] as any)
     prismaMock.patientDevice.findMany.mockResolvedValue([] as any)
@@ -322,7 +322,7 @@ describe("NEW-M2 — listCohort soft-cap accessible 2000 patients", () => {
   it("audit metadata.accessibleTruncated=true quand > 2000 patients", async () => {
     // Mock DOCTOR avec 3000 patients accessibles → cap à 2000.
     const ids = Array.from({ length: 3000 }, (_, i) => ({ patientId: i + 1 }))
-    prismaMock.patientService.findMany.mockResolvedValue(ids as any)
+    prismaMock.patientReferent.findMany.mockResolvedValue(ids as any)
     prismaMock.patientDevice.findMany.mockResolvedValue([] as any)
     await deviceSupervisionService.listCohort({}, 9, "DOCTOR")
     const meta = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
@@ -334,7 +334,7 @@ describe("NEW-M2 — listCohort soft-cap accessible 2000 patients", () => {
 
   it("audit metadata.accessibleTruncated absent quand ≤ 2000", async () => {
     const ids = Array.from({ length: 1500 }, (_, i) => ({ patientId: i + 1 }))
-    prismaMock.patientService.findMany.mockResolvedValue(ids as any)
+    prismaMock.patientReferent.findMany.mockResolvedValue(ids as any)
     prismaMock.patientDevice.findMany.mockResolvedValue([] as any)
     await deviceSupervisionService.listCohort({}, 9, "DOCTOR")
     const meta = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any

--- a/tests/unit/device-sync-status.service.test.ts
+++ b/tests/unit/device-sync-status.service.test.ts
@@ -85,7 +85,7 @@ describe("getStatus (US-2244)", () => {
   })
 
   it("DOCTOR without link — throws", async () => {
-    prismaMock.patientService.findFirst.mockResolvedValue(null)
+    prismaMock.patientReferent.findFirst.mockResolvedValue(null)
     await expect(deviceSyncStatusService.getStatus(42, 9, "DOCTOR"))
       .rejects.toBeInstanceOf(SyncStatusAccessError)
   })
@@ -123,8 +123,8 @@ describe("cohortStatus (US-2244)", () => {
     expect(call.where.patientId).toBeUndefined()
   })
 
-  it("DOCTOR cohort = patients via PatientService", async () => {
-    prismaMock.patientService.findMany.mockResolvedValue([
+  it("DOCTOR cohort = patients via PatientReferent (F6)", async () => {
+    prismaMock.patientReferent.findMany.mockResolvedValue([
       { patientId: 42 }, { patientId: 99 },
     ] as any)
     pmGroupBy.mockResolvedValue([] as any)
@@ -187,7 +187,7 @@ describe("cohortStatus (US-2244)", () => {
 
   // H3 (review re-1 PR #408) — patients sans device apparaissent comme never_synced.
   it("H3 — DOCTOR cohort inclut les patients sans device (never_synced)", async () => {
-    prismaMock.patientService.findMany.mockResolvedValue([
+    prismaMock.patientReferent.findMany.mockResolvedValue([
       { patientId: 42 }, { patientId: 99 }, { patientId: 100 },
     ] as any)
     // groupBy ne retourne que les patients ayant ≥1 device.
@@ -203,7 +203,7 @@ describe("cohortStatus (US-2244)", () => {
   })
 
   it("H3 — audit scope=scoped + accessibleCount pour DOCTOR", async () => {
-    prismaMock.patientService.findMany.mockResolvedValue([
+    prismaMock.patientReferent.findMany.mockResolvedValue([
       { patientId: 42 }, { patientId: 99 },
     ] as any)
     pmGroupBy.mockResolvedValue([] as any)
@@ -219,7 +219,7 @@ describe("cohortStatus (US-2244)", () => {
   it("NEW-M2 — audit accessibleTruncated=true quand DOCTOR > 2000 patients", async () => {
     // 3000 patients accessibles → cap à 2000 côté enumeration.
     const ids = Array.from({ length: 3000 }, (_, i) => ({ patientId: i + 1 }))
-    prismaMock.patientService.findMany.mockResolvedValue(ids as any)
+    prismaMock.patientReferent.findMany.mockResolvedValue(ids as any)
     pmGroupBy.mockResolvedValue([] as any)
     await deviceSyncStatusService.cohortStatus({}, 9, "DOCTOR")
     const meta = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any

--- a/tests/unit/f6-backfill-referent-sql.test.ts
+++ b/tests/unit/f6-backfill-referent-sql.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Garde anti-régression du backfill F6 (US-2618).
+ *
+ * La bascule de l'enforcement clinique (service → médecin référent) exige que
+ * tout patient déjà suivi ait un `PatientReferent` (sinon invisible à son
+ * médecin). On vérifie statiquement que la migration de backfill est présente,
+ * idempotente (NOT EXISTS + ON CONFLICT), et data-only (aucune DDL).
+ */
+import { describe, it, expect } from "vitest"
+import { readFileSync } from "node:fs"
+
+const MIGRATION = "prisma/migrations/20260617180000_f6_backfill_patient_referent/migration.sql"
+
+describe("F6 — backfill PatientReferent (migration)", () => {
+  const sql = readFileSync(MIGRATION, "utf8")
+
+  it("insère les référents manquants depuis PatientService.member_id", () => {
+    expect(sql).toContain('INSERT INTO "patient_referent"')
+    expect(sql).toContain('FROM "patient_services"')
+    expect(sql).toContain('ps."member_id" IS NOT NULL')
+  })
+
+  it("idempotent : NOT EXISTS + ON CONFLICT DO NOTHING + DISTINCT ON", () => {
+    expect(sql).toMatch(/NOT EXISTS[\s\S]*patient_referent/)
+    expect(sql).toContain('ON CONFLICT ("patient_id") DO NOTHING')
+    expect(sql).toContain('DISTINCT ON (ps."patient_id")')
+  })
+
+  it("data-only : aucune DDL (pas de CREATE/ALTER/DROP TABLE)", () => {
+    expect(sql).not.toMatch(/\b(CREATE|ALTER|DROP)\s+TABLE\b/i)
+  })
+})

--- a/tests/unit/patient.service.test.ts
+++ b/tests/unit/patient.service.test.ts
@@ -381,6 +381,63 @@ describe("patientService.listByDoctor", () => {
   })
 })
 
+describe("patientService.listByService (NURSE — F6 service scope)", () => {
+  it("returns patients of services the nurse is a member of (deduped, capped, consent-filtered)", async () => {
+    const { encrypt } = await import("@/lib/crypto/health-data")
+    prismaMock.patient.findMany.mockResolvedValue([
+      {
+        id: 11, publicRef: "ref-11", pathology: "DT2",
+        user: {
+          id: 21,
+          firstname: Buffer.from(encrypt("Anne")).toString("base64"),
+          lastname: Buffer.from(encrypt("Leroy")).toString("base64"),
+          birthday: new Date("1985-03-02T00:00:00.000Z"),
+        },
+      },
+    ] as any)
+    prismaMock.auditLog.create.mockResolvedValue({} as any)
+
+    const result = await patientService.listByService(7, 1)
+
+    const call = prismaMock.patient.findMany.mock.calls[0][0] as any
+    expect(call.take).toBe(2000)
+    expect(call.where).toMatchObject({
+      deletedAt: null,
+      patientServices: { some: { service: { members: { some: { userId: 7 } } } } },
+    })
+    // Filtre consentement partagé (PROVIDER_VISIBLE_USER_WHERE).
+    expect(call.where.user.OR).toEqual([
+      { privacySettings: null },
+      { privacySettings: { gdprConsent: true, shareWithProviders: true } },
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe(11)
+    expect(result[0].user.firstname).toBe("Anne")
+    expect(result[0].user.birthday).toBe("1985-03-02")
+    // Audit scope=service.
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.metadata).toMatchObject({ nurseUserId: 7, scope: "service" })
+  })
+})
+
+describe("patientService.listForCaller (dispatch par rôle — F6)", () => {
+  it("NURSE → listByService (périmètre service)", async () => {
+    prismaMock.patient.findMany.mockResolvedValue([] as any)
+    prismaMock.auditLog.create.mockResolvedValue({} as any)
+    await patientService.listForCaller(7, "NURSE", 7)
+    expect(prismaMock.patient.findMany).toHaveBeenCalled()
+    expect(prismaMock.patientReferent.findMany).not.toHaveBeenCalled()
+  })
+
+  it("DOCTOR → listByDoctor (référent)", async () => {
+    prismaMock.patientReferent.findMany.mockResolvedValue([] as any)
+    prismaMock.auditLog.create.mockResolvedValue({} as any)
+    await patientService.listForCaller(5, "DOCTOR", 5)
+    expect(prismaMock.patientReferent.findMany).toHaveBeenCalled()
+    expect(prismaMock.patient.findMany).not.toHaveBeenCalled()
+  })
+})
+
 describe("patientService.delete (soft delete)", () => {
   it("performs soft delete and anonymizes user data", async () => {
     let capturedUserUpdate: any = null

--- a/tests/unit/patient.service.test.ts
+++ b/tests/unit/patient.service.test.ts
@@ -418,6 +418,21 @@ describe("patientService.listByService (NURSE — F6 service scope)", () => {
     const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
     expect(audit.metadata).toMatchObject({ nurseUserId: 7, scope: "service" })
   })
+
+  it("audit metadata.capped=true quand on atteint le cap (2000)", async () => {
+    // Renvoie exactement LIST_BY_DOCTOR_MAX lignes → capped flag à true.
+    const rows = Array.from({ length: 2000 }, (_, i) => ({
+      id: i + 1, publicRef: `r-${i}`, pathology: "DT1",
+      user: { id: i + 1, firstname: null, lastname: null, birthday: null },
+    }))
+    prismaMock.patient.findMany.mockResolvedValue(rows as any)
+    prismaMock.auditLog.create.mockResolvedValue({} as any)
+
+    await patientService.listByService(7, 1)
+
+    const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+    expect(audit.metadata).toMatchObject({ scope: "service", count: 2000, capped: true })
+  })
 })
 
 describe("patientService.listForCaller (dispatch par rôle — F6)", () => {
@@ -433,6 +448,15 @@ describe("patientService.listForCaller (dispatch par rôle — F6)", () => {
     prismaMock.patientReferent.findMany.mockResolvedValue([] as any)
     prismaMock.auditLog.create.mockResolvedValue({} as any)
     await patientService.listForCaller(5, "DOCTOR", 5)
+    expect(prismaMock.patientReferent.findMany).toHaveBeenCalled()
+    expect(prismaMock.patient.findMany).not.toHaveBeenCalled()
+  })
+
+  it("ADMIN → listByDoctor (référent ; liste vide si non-membre, by-design)", async () => {
+    prismaMock.patientReferent.findMany.mockResolvedValue([] as any)
+    prismaMock.auditLog.create.mockResolvedValue({} as any)
+    const r = await patientService.listForCaller(1, "ADMIN", 1)
+    expect(r).toEqual([])
     expect(prismaMock.patientReferent.findMany).toHaveBeenCalled()
     expect(prismaMock.patient.findMany).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
## Socle « Accès & Cabinet » — PR3/5 (F6 isolation par référent)

1ᵉʳ vrai changement d'enforcement clinique. Corrige une **incohérence préexistante** : la liste `listByDoctor` était déjà référent, mais `canAccessPatient`/`getAccessiblePatientIds` étaient **service-larges** → un médecin pouvait accéder en per-patient à un patient hors de son portefeuille. F6 ferme cette sur-exposition.

### Enforcement (`src/lib/access-control.ts`) — branché par rôle
- **DOCTOR** → isolé par **médecin référent** (`PatientReferent.pro.userId`) : médecin A ≠ patients du médecin B du même service.
- **NURSE** → **périmètre service** (inchangé) : l'infirmier assiste les médecins du cabinet (décision actée).
- **ADMIN** bypass / **VIEWER** propre dossier : inchangés (risque V1 ADMIN/PHI → V4).

### Listes alignées
- `patient.service` : `listByService` (NURSE) + `listForCaller` (dispatch par rôle), mapper DTO partagé. Routes `/api/patients` + `/api/messaging/contacts` → un infirmier ne récupère plus une **liste vide** (avant : `listByDoctor` référent pour tous).

### Backfill (data-only, idempotent)
- `PatientReferent` créé depuis `PatientService.member_id` pour les patients **sans référent** (sinon invisibles après bascule). Orphelins (ni référent ni membre) = **fail-closed** (ADMIN only) → à affecter via la gestion (PR4). Vérifié en base (recréation depuis `member_id`).

### Conformité
- **Responsable de traitement** : médecins = contrôleurs distincts. DPIA : `docs/compliance/dpia-patient-isolation.md`. Résidu documenté : infirmier partagé voit tous les médecins du service (à raffiner post-V1).

### Tests
- `access-control` (DOCTOR référent + isolation A≠B + ne retombe pas sur le service ; NURSE service ; `getAccessiblePatientIds` par rôle) ; garde backfill SQL ; consommateurs device migrés (DOCTOR via référent).
- **3266/3266 tests verts** ; tsc / eslint / design-system (272) verts ; drift 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)