### PR TITLE
feat(access): PR4a — gestion personnel & droits cabinet (service + routes)

### DIFF
--- a/docs/compliance/dpia-cabinet-management.md
+++ b/docs/compliance/dpia-cabinet-management.md
@@ -24,6 +24,11 @@ octroyer/révoquer capacités Q1/Q2, retirer un membre) + routes `/api/cabinet/[
 - **Octroi/retrait Q2** (`canManage`) = **admin principal** (ou ADMIN).
 - **`isPrincipalAdmin`** = **ADMIN uniquement** (un principal ne nomme que des délégués
   → limite la prolifération d'admins et le rayon d'un compte compromis).
+- **Cohérence d'état** : `isPrincipalAdmin = true ⇒ canManage = true` (forcé ; la combinaison
+  `isPrincipalAdmin:true + canManage:false` est rejetée `invalidState`).
+- **Anti-lockout symétrique** : on ne peut pas retirer le **dernier** admin principal d'un
+  service — ni par **retrait** (`revokeMember`) ni par **rétrogradation** (`setCapabilities`
+  `isPrincipalAdmin:false`) → `lastPrincipalAdmin`.
 - **Q1** (`clinicalRole`, PHI) = **octroyable en V1** (« considéré vérifié » ; cf. §4).
 - **Non-auto-élévation** : on ne modifie pas ses propres capacités (`selfElevation`).
 - **Anti-self-lockout** : le dernier admin principal d'un service ne peut pas être retiré.
@@ -52,6 +57,17 @@ octroyer/révoquer capacités Q1/Q2, retirer un membre) + routes `/api/cabinet/[
 - **Pas de rôle « gestionnaire non-soignant »** (F1/V4) : en V1 un membre géré est un
   utilisateur clinique (`DOCTOR`/`NURSE`). La **secrétaire pure Q2-seule** est reportée V4.
 - **`ADMIN` bypass PHI** : inchangé (V4 / F1).
+- **Rattachement d'un user existant** : un principal peut rattacher un compte Diabeo
+  **existant** (par email) à son service avec une capacité clinique → l'utilisateur gagne
+  l'accès PHI du service **sans notification** en V1 (l'action est **auditée**
+  `INVITATION_SENT`). Sa PII n'est jamais modifiée. **Backlog** : email de notification au
+  rattachement + endpoint de **renvoi d'invitation** (email d'activation échoué → compte
+  orphelin, récupérable via reset-password public). Accepté V1.
+- **Oracle d'énumération** : la réponse POST est **neutre** (`{ ok: true }`, ni `userId`
+  ni `invitedNewUser`) → pas de signal explicite d'existence d'email. **Résidu** : une
+  légère différence de **timing** (création user/bcrypt sur un nouvel email) reste
+  observable par un appelant **Q2 authentifié** ; acceptée V1 (acteur authentifié + gated Q2
+  + rate-limit auth). À égaliser si besoin (padding) en durcissement ultérieur.
 
 ## 5. Tests (PR4a)
 

--- a/docs/compliance/dpia-cabinet-management.md
+++ b/docs/compliance/dpia-cabinet-management.md
@@ -1,0 +1,73 @@
+# DPIA — Gestion du personnel & des droits du cabinet (US-2610, PR4a backend)
+
+**Statut** : Brouillon — à signer DPO + RSSI avant mise en service patients réels.
+**Périmètre (PR4a)** : service `org-membership.service` (lister/inviter membres,
+octroyer/révoquer capacités Q1/Q2, retirer un membre) + routes `/api/cabinet/[id]/members`
++ email d'invitation. UI = PR4b.
+**Lié à** : `dpia-access-foundations.md` (capacités Q1/Q2), `dpia-session-security.md`
+(révocation immédiate F7), `gestion-personnel-droits-us.md`.
+
+## 1. Données traitées
+
+| Donnée | Catégorie | Traitement |
+|---|---|---|
+| `User.email` / `firstname` / `lastname` du membre | PII | chiffrées AES-256-GCM ; déchiffrées **serveur** pour la liste (gestionnaire autorisé) |
+| Capacités `HealthcareMembership` (clinicalRole, canManage, isPrincipalAdmin) | métadonnée d'accès | en clair |
+| Token d'invitation (`VerificationToken`) | secret | single-use, TTL 1h, keyé `emailHmac` (F15 anti-énumération) |
+
+**Aucune donnée de santé** sur cet écran (gestion = régime distinct du PHI).
+
+## 2. Modèle d'autorisation (2 axes)
+
+- **Accès à la gestion** = capacité **Q2** (`canManage`) dans le **scope** du service
+  (`assertCanManage`, ADMIN bypass V1). Un médecin sans Q2 n'y accède pas.
+- **Octroi/retrait Q2** (`canManage`) = **admin principal** (ou ADMIN).
+- **`isPrincipalAdmin`** = **ADMIN uniquement** (un principal ne nomme que des délégués
+  → limite la prolifération d'admins et le rayon d'un compte compromis).
+- **Q1** (`clinicalRole`, PHI) = **octroyable en V1** (« considéré vérifié » ; cf. §4).
+- **Non-auto-élévation** : on ne modifie pas ses propres capacités (`selfElevation`).
+- **Anti-self-lockout** : le dernier admin principal d'un service ne peut pas être retiré.
+- **Révocation immédiate (F7)** : toute modif/retrait bump `User.authVersion` +
+  `invalidateAllUserSessions` → accès coupé à la requête suivante (≤ refresh sinon).
+
+## 3. Décisions de design à valider DPO
+
+- **3.1 — Invitation single-use** : réutilise `VerificationToken` (flux set-password,
+  keyé `emailHmac`, TTL 1h) → cohérent avec reset-password, anti-énumération (F15).
+  Email sans PHI (`emailService.sendStaffInvitation`).
+- **3.2 — Création de membre** : email existant → rattachement ; sinon création d'un
+  `User` clinique + invitation. Données déjà créées par un membre retiré **restent**
+  (append-only / audit).
+- **3.3 — Audit canonique (F8)** : `INVITATION_SENT` (ORG_INVITATION),
+  `CAPABILITY_GRANTED`/`CAPABILITY_REVOKED` (HEALTHCARE_MEMBERSHIP), tous scopés
+  `scopeServiceId`. **Aucun PHI** ; PII membre jamais en clair dans l'audit.
+
+## 4. ⚠️ Risques acceptés V1
+
+- **Q1 octroyable par la gestion en V1** (décision produit) : la vérification PS réelle
+  (RPPS/Ordre) est reportée en **V4** → un org-admin peut associer un rôle clinique
+  « considéré vérifié ». **Risque** : chemin d'octroi d'accès PHI avant vérification.
+  **Atténuation** : pilote maîtrisé + onboarding de soignants connus + audit. Durci en
+  V4 (gate sur `ProfessionalRegistration.status = verified`).
+- **Pas de rôle « gestionnaire non-soignant »** (F1/V4) : en V1 un membre géré est un
+  utilisateur clinique (`DOCTOR`/`NURSE`). La **secrétaire pure Q2-seule** est reportée V4.
+- **`ADMIN` bypass PHI** : inchangé (V4 / F1).
+
+## 5. Tests (PR4a)
+
+- `tests/unit/org-membership.service.test.ts` — accès Q2 (ADMIN bypass), liste déchiffrée,
+  invite (nouveau/existant/déjà-membre), principal-only Q2, ADMIN-only isPrincipalAdmin,
+  non-auto-élévation, anti-self-lockout, révocation immédiate (bump + invalidate).
+- `tests/integration/api-cabinet-members.test.ts` — RBAC + mapping erreurs (403/404/409) +
+  validation Zod.
+
+## 6. Validations à obtenir
+
+- [ ] DPO : modèle 2 axes en gestion (§2) ; **Q1 considéré-vérifié V1** (§4) + report V4.
+- [ ] RSSI : invitation single-use (§3.1), audit scopé sans PHI (§3.3), révocation immédiate.
+- [ ] Direction Médicale : gestion ≠ accès santé ; gestionnaire pur Q2 reporté V4.
+
+---
+
+*Dernière mise à jour : 2026-06-17 — DPIA initiale gestion cabinet (PR4a : service +
+routes + invitations).*

--- a/docs/compliance/dpia-cabinet-management.md
+++ b/docs/compliance/dpia-cabinet-management.md
@@ -57,6 +57,14 @@ octroyer/révoquer capacités Q1/Q2, retirer un membre) + routes `/api/cabinet/[
 - **Pas de rôle « gestionnaire non-soignant »** (F1/V4) : en V1 un membre géré est un
   utilisateur clinique (`DOCTOR`/`NURSE`). La **secrétaire pure Q2-seule** est reportée V4.
 - **`ADMIN` bypass PHI** : inchangé (V4 / F1).
+- **TOCTOU anti-lockout** (backlog) : le décompte « autres principaux » est lu **hors
+  transaction** ; deux rétrogradations/retraits concurrents de deux principaux distincts
+  pourraient théoriquement passer tous les deux et laisser le service sans principal.
+  Race très étroite (action d'admin manuelle). **Parade réelle** = contrainte DB
+  (index partiel / trigger « ≥ 1 principal par service ») → durcissement ultérieur.
+- **No-op court-circuité** : un `PATCH` de capacités déjà en place ne déclenche ni
+  écriture, ni bump `authVersion`, ni invalidation de session, ni audit (évite un
+  force-logout / bruit d'audit par requête sémantiquement vide).
 - **Rattachement d'un user existant** : un principal peut rattacher un compte Diabeo
   **existant** (par email) à son service avec une capacité clinique → l'utilisateur gagne
   l'accès PHI du service **sans notification** en V1 (l'action est **auditée**

--- a/src/app/api/cabinet/[id]/members/[userId]/route.ts
+++ b/src/app/api/cabinet/[id]/members/[userId]/route.ts
@@ -16,6 +16,7 @@ import {
   orgMembershipErrorStatus,
 } from "@/lib/services/org-membership.service"
 import { extractRequestContext } from "@/lib/services/audit.service"
+import { logger } from "@/lib/logger"
 
 function parseId(id: string): number | null {
   const n = Number(id)
@@ -37,7 +38,7 @@ function mapError(error: unknown): NextResponse {
   if (error instanceof OrgMembershipError) {
     return NextResponse.json({ error: error.code }, { status: orgMembershipErrorStatus(error.code) })
   }
-  console.error("[cabinet/members/:userId]", error instanceof Error ? error.message : error)
+  logger.error("api/cabinet/members/:userId", "request failed", {}, error)
   return NextResponse.json({ error: "serverError" }, { status: 500 })
 }
 

--- a/src/app/api/cabinet/[id]/members/[userId]/route.ts
+++ b/src/app/api/cabinet/[id]/members/[userId]/route.ts
@@ -1,0 +1,95 @@
+/**
+ * US-2610 — Capacités / retrait d'un membre de cabinet.
+ *  - `PATCH  /api/cabinet/:id/members/:userId` → modifie les capacités Q1/Q2.
+ *  - `DELETE /api/cabinet/:id/members/:userId` → retire le membre du service.
+ *
+ * Autorisation capacité Q2 + règles (principal-only Q2, ADMIN-only isPrincipalAdmin,
+ * non-auto-élévation, anti-self-lockout, révocation immédiate) dans le service.
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireAuth, AuthError } from "@/lib/auth"
+import {
+  orgMembershipService,
+  OrgMembershipError,
+  orgMembershipErrorStatus,
+} from "@/lib/services/org-membership.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+
+function parseId(id: string): number | null {
+  const n = Number(id)
+  return Number.isInteger(n) && n > 0 ? n : null
+}
+
+const capsSchema = z
+  .object({
+    clinicalRole: z.enum(["DOCTOR", "NURSE"]).nullable().optional(),
+    canManage: z.boolean().optional(),
+    isPrincipalAdmin: z.boolean().optional(),
+  })
+  .refine((c) => Object.keys(c).length > 0, { message: "noCapabilityProvided" })
+
+function mapError(error: unknown): NextResponse {
+  if (error instanceof AuthError) {
+    return NextResponse.json({ error: error.message }, { status: error.status })
+  }
+  if (error instanceof OrgMembershipError) {
+    return NextResponse.json({ error: error.code }, { status: orgMembershipErrorStatus(error.code) })
+  }
+  console.error("[cabinet/members/:userId]", error instanceof Error ? error.message : error)
+  return NextResponse.json({ error: "serverError" }, { status: 500 })
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string; userId: string }> },
+) {
+  try {
+    const user = requireAuth(req)
+    const { id, userId } = await params
+    const serviceId = parseId(id)
+    const targetUserId = parseId(userId)
+    if (serviceId === null || targetUserId === null) {
+      return NextResponse.json({ error: "invalidId" }, { status: 400 })
+    }
+
+    const body = await req.json().catch(() => null)
+    const parsed = capsSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+
+    await orgMembershipService.setCapabilities(
+      user.id, user.role, targetUserId, serviceId, parsed.data, extractRequestContext(req),
+    )
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    return mapError(error)
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string; userId: string }> },
+) {
+  try {
+    const user = requireAuth(req)
+    const { id, userId } = await params
+    const serviceId = parseId(id)
+    const targetUserId = parseId(userId)
+    if (serviceId === null || targetUserId === null) {
+      return NextResponse.json({ error: "invalidId" }, { status: 400 })
+    }
+
+    await orgMembershipService.revokeMember(
+      user.id, user.role, targetUserId, serviceId, extractRequestContext(req),
+    )
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    return mapError(error)
+  }
+}

--- a/src/app/api/cabinet/[id]/members/route.ts
+++ b/src/app/api/cabinet/[id]/members/route.ts
@@ -17,6 +17,7 @@ import {
   orgMembershipErrorStatus,
 } from "@/lib/services/org-membership.service"
 import { extractRequestContext } from "@/lib/services/audit.service"
+import { logger } from "@/lib/logger"
 
 function parseServiceId(id: string): number | null {
   const n = Number(id)
@@ -39,7 +40,7 @@ function mapError(error: unknown): NextResponse {
   if (error instanceof OrgMembershipError) {
     return NextResponse.json({ error: error.code }, { status: orgMembershipErrorStatus(error.code) })
   }
-  console.error("[cabinet/members]", error instanceof Error ? error.message : error)
+  logger.error("api/cabinet/members", "request failed", {}, error)
   return NextResponse.json({ error: "serverError" }, { status: 500 })
 }
 
@@ -73,10 +74,12 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
       )
     }
 
-    const result = await orgMembershipService.inviteMember(
+    await orgMembershipService.inviteMember(
       user.id, user.role, serviceId, parsed.data, extractRequestContext(req),
     )
-    return NextResponse.json(result, { status: 201 })
+    // Réponse NEUTRE (anti-énumération, HSA MEDIUM) : ne pas révéler si l'email
+    // existait déjà (invitedNewUser) ni l'userId cible. L'UI re-fetch la liste.
+    return NextResponse.json({ ok: true }, { status: 201 })
   } catch (error) {
     return mapError(error)
   }

--- a/src/app/api/cabinet/[id]/members/route.ts
+++ b/src/app/api/cabinet/[id]/members/route.ts
@@ -1,0 +1,83 @@
+/**
+ * US-2610 — Gestion des membres d'un cabinet (service).
+ *  - `GET  /api/cabinet/:id/members`  → liste (gated Q2 serveur).
+ *  - `POST /api/cabinet/:id/members`  → invite/rattache un membre.
+ *
+ * L'autorisation **capacité Q2** (canManage / principal-admin) est vérifiée dans
+ * le service (`orgMembershipService`, ADMIN bypass V1). La route ne fait que
+ * authentifier + valider (Zod) + mapper les erreurs.
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireAuth, AuthError } from "@/lib/auth"
+import {
+  orgMembershipService,
+  OrgMembershipError,
+  orgMembershipErrorStatus,
+} from "@/lib/services/org-membership.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+
+function parseServiceId(id: string): number | null {
+  const n = Number(id)
+  return Number.isInteger(n) && n > 0 ? n : null
+}
+
+const inviteSchema = z.object({
+  email: z.string().trim().toLowerCase().email().max(254),
+  firstName: z.string().trim().min(1).max(100).optional(),
+  lastName: z.string().trim().min(1).max(100).optional(),
+  clinicalRole: z.enum(["DOCTOR", "NURSE"]).optional(),
+  canManage: z.boolean().optional(),
+  isPrincipalAdmin: z.boolean().optional(),
+})
+
+function mapError(error: unknown): NextResponse {
+  if (error instanceof AuthError) {
+    return NextResponse.json({ error: error.message }, { status: error.status })
+  }
+  if (error instanceof OrgMembershipError) {
+    return NextResponse.json({ error: error.code }, { status: orgMembershipErrorStatus(error.code) })
+  }
+  console.error("[cabinet/members]", error instanceof Error ? error.message : error)
+  return NextResponse.json({ error: "serverError" }, { status: 500 })
+}
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const user = requireAuth(req)
+    const serviceId = parseServiceId((await params).id)
+    if (serviceId === null) return NextResponse.json({ error: "invalidId" }, { status: 400 })
+
+    const members = await orgMembershipService.listMembers(
+      user.id, user.role, serviceId, extractRequestContext(req),
+    )
+    return NextResponse.json({ members })
+  } catch (error) {
+    return mapError(error)
+  }
+}
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const user = requireAuth(req)
+    const serviceId = parseServiceId((await params).id)
+    if (serviceId === null) return NextResponse.json({ error: "invalidId" }, { status: 400 })
+
+    const body = await req.json().catch(() => null)
+    const parsed = inviteSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validationFailed", details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      )
+    }
+
+    const result = await orgMembershipService.inviteMember(
+      user.id, user.role, serviceId, parsed.data, extractRequestContext(req),
+    )
+    return NextResponse.json(result, { status: 201 })
+  } catch (error) {
+    return mapError(error)
+  }
+}

--- a/src/lib/services/email.service.ts
+++ b/src/lib/services/email.service.ts
@@ -244,6 +244,46 @@ export const emailService = {
     })
   },
 
+  /**
+   * US-2610 — Invitation d'un membre de cabinet. Réutilise le flux set-password
+   * (`/reset-password/<token>`, VerificationToken 1h). Aucun PHI ; HTML inline CSS
+   * (contexte email, exception documentée CLAUDE.md).
+   */
+  async sendStaffInvitation(email: string, token: string): Promise<EmailResult> {
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.diabeo.fr"
+    const setupUrl = `${baseUrl}/reset-password/${token}`
+    return this.send({
+      to: email,
+      subject: "Diabeo — Invitation à rejoindre un cabinet",
+      html: `
+        <div style="font-family: 'Figtree', system-ui, sans-serif; max-width: 560px; margin: 0 auto; padding: 32px;">
+          <div style="text-align: center; margin-bottom: 24px;">
+            <h1 style="color: #0D9488; font-size: 24px; margin: 0;">Diabeo</h1>
+          </div>
+          <h2 style="color: #1F2937; font-size: 18px;">Invitation à rejoindre un cabinet</h2>
+          <p style="color: #6B7280; line-height: 1.6;">
+            Vous avez été invité(e) à rejoindre un cabinet sur Diabeo. Cliquez sur le
+            bouton ci-dessous pour définir votre mot de passe et activer votre accès.
+          </p>
+          <div style="text-align: center; margin: 32px 0;">
+            <a href="${escapeHtml(setupUrl)}" style="background: #0D9488; color: #fff; padding: 12px 32px; border-radius: 8px; text-decoration: none; font-weight: 600;">
+              Activer mon compte
+            </a>
+          </div>
+          <p style="color: #9CA3AF; font-size: 13px; line-height: 1.5;">
+            Ce lien expire dans 1 heure. Si vous n'attendiez pas cette invitation, ignorez cet email.
+          </p>
+          <hr style="border: none; border-top: 1px solid #E5E7EB; margin: 24px 0;" />
+          <p style="color: #9CA3AF; font-size: 12px; text-align: center;">
+            Diabeo — Supervision de l'insulinothérapie<br/>
+            Hébergement HDS certifié — OVHcloud GRA
+          </p>
+        </div>
+      `,
+      text: `Invitation à rejoindre un cabinet Diabeo\n\nActivez votre compte : ${setupUrl}\n\nCe lien expire dans 1 heure.`,
+    })
+  },
+
   async sendProposalNotification(email: string, action: "accepted" | "rejected"): Promise<EmailResult> {
     const actionFr = action === "accepted" ? "acceptée" : "refusée"
     return this.send({

--- a/src/lib/services/org-membership.service.ts
+++ b/src/lib/services/org-membership.service.ts
@@ -261,9 +261,18 @@ export const orgMembershipService = {
 
     const membership = await prisma.healthcareMembership.findUnique({
       where: { userId_serviceId: { userId: targetUserId, serviceId } },
-      select: { id: true, isPrincipalAdmin: true },
+      select: { id: true, clinicalRole: true, canManage: true, isPrincipalAdmin: true },
     })
     if (!membership) throw new OrgMembershipError("notFound")
+
+    // LOW (review) — court-circuit no-op : si les capacités demandées sont déjà en
+    // place, ne rien faire (pas de bump authVersion, pas d'invalidation de session,
+    // pas de ligne d'audit) → évite un force-logout / bruit d'audit par PATCH vide.
+    const changed =
+      (norm.clinicalRole !== undefined && norm.clinicalRole !== membership.clinicalRole) ||
+      (norm.canManage !== undefined && norm.canManage !== membership.canManage) ||
+      (norm.isPrincipalAdmin !== undefined && norm.isPrincipalAdmin !== membership.isPrincipalAdmin)
+    if (!changed) return
 
     // HIGH (review) — anti-lockout symétrique : ne pas retirer `isPrincipalAdmin`
     // du DERNIER admin principal du service (sinon plus personne ne peut octroyer Q2).

--- a/src/lib/services/org-membership.service.ts
+++ b/src/lib/services/org-membership.service.ts
@@ -1,0 +1,317 @@
+/**
+ * @module org-membership.service
+ * @description US-2610 — Gestion du personnel & des droits d'un cabinet (service).
+ *
+ * Modèle 2 axes (cf. `capabilities.ts`) : **Q1 clinique** (`clinicalRole`, accès PHI)
+ * et **Q2 gestion** (`canManage` opérationnel / `isPrincipalAdmin` = Q2 + droit de
+ * déléguer Q2). Les capacités vivent sur `HealthcareMembership` (N-N user↔service).
+ *
+ * Règles (BASELINE-RBAC / US-2610) :
+ *  - Accès à la gestion = **Q2** dans le scope (ADMIN bypass V1).
+ *  - Octroi/retrait **Q2** (`canManage`) = **admin principal** (ou ADMIN).
+ *  - `isPrincipalAdmin` octroyable **par ADMIN uniquement** (un principal ne nomme
+ *    que des délégués, pas d'autres principaux).
+ *  - **Q1 octroyable en V1** (« considéré vérifié » ; durci en V4 sur preuve PS).
+ *  - **Non-auto-élévation** : on ne modifie pas ses propres capacités.
+ *  - **Révocation immédiate** (F7) : bump `authVersion` + `invalidateAllUserSessions`.
+ *  - Scope obligatoire : un org-admin ne gère QUE son/ses service(s).
+ *
+ * ⚠️ V1 : pas de rôle plateforme « gestionnaire non-soignant » (découplage = F1/V4).
+ * Un membre invité est un utilisateur **clinique** (`DOCTOR`/`NURSE`). La secrétaire
+ * pure Q2-seule est reportée V4. `ADMIN` garde le bypass PHI (risque V1 accepté).
+ */
+
+import { randomBytes, randomUUID } from "crypto"
+import { hash as bcryptHash } from "bcryptjs"
+import type { Role } from "@prisma/client"
+import { prisma } from "@/lib/db/client"
+import { auditService } from "./audit.service"
+import type { AuditContext } from "./audit.service"
+import { emailService } from "./email.service"
+import { invalidateAllUserSessions } from "@/lib/auth/session"
+import { canManageOrg, isPrincipalAdmin } from "@/lib/capabilities"
+import { encryptField, safeDecryptField } from "@/lib/crypto/fields"
+import { hmacEmail, hmacField } from "@/lib/crypto/hmac"
+import { logger } from "@/lib/logger"
+
+/** Erreur typée → mappée en statut HTTP par les routes. */
+export class OrgMembershipError extends Error {
+  constructor(
+    public code:
+      | "forbidden"
+      | "notFound"
+      | "invalidState"
+      | "selfElevation"
+      | "lastPrincipalAdmin"
+      | "emailExists",
+  ) {
+    super(code)
+    this.name = "OrgMembershipError"
+  }
+}
+
+/** Statut HTTP correspondant à un code `OrgMembershipError`. */
+export function orgMembershipErrorStatus(code: OrgMembershipError["code"]): number {
+  if (code === "forbidden") return 403
+  if (code === "notFound") return 404
+  return 409 // invalidState / selfElevation / lastPrincipalAdmin / emailExists
+}
+
+/** Seuls DOCTOR/NURSE sont des capacités cliniques valides (Q1). */
+const CLINICAL_ROLES: ReadonlySet<Role> = new Set<Role>(["DOCTOR", "NURSE"])
+
+export type MemberView = {
+  userId: number
+  firstname: string | null
+  lastname: string | null
+  email: string | null
+  status: string
+  clinicalRole: Role | null
+  canManage: boolean
+  isPrincipalAdmin: boolean
+  /** V1 — toute inscription est « considérée vérifiée » (workflow PS réel = V4). */
+  psVerified: boolean
+}
+
+export type CapabilityInput = {
+  clinicalRole?: Role | null
+  canManage?: boolean
+  isPrincipalAdmin?: boolean
+}
+
+/** Accès à la gestion = Q2 dans le scope (ADMIN bypass V1). */
+async function assertCanManage(callerId: number, role: Role, serviceId: number): Promise<void> {
+  if (role === "ADMIN") return
+  if (!(await canManageOrg(callerId, serviceId))) throw new OrgMembershipError("forbidden")
+}
+
+/** Octroi Q2 (`canManage`) réservé admin principal (ou ADMIN). */
+async function assertPrincipal(callerId: number, role: Role, serviceId: number): Promise<void> {
+  if (role === "ADMIN") return
+  if (!(await isPrincipalAdmin(callerId, serviceId))) throw new OrgMembershipError("forbidden")
+}
+
+export const orgMembershipService = {
+  /** Liste les membres du service (capacités + PII déchiffrée). Gated Q2. */
+  async listMembers(
+    callerId: number, role: Role, serviceId: number, ctx?: AuditContext,
+  ): Promise<MemberView[]> {
+    await assertCanManage(callerId, role, serviceId)
+
+    const rows = await prisma.healthcareMembership.findMany({
+      where: { serviceId },
+      select: {
+        userId: true, clinicalRole: true, canManage: true, isPrincipalAdmin: true,
+        user: { select: { firstname: true, lastname: true, email: true, status: true } },
+      },
+      orderBy: { userId: "asc" },
+    })
+
+    await auditService.log({
+      userId: callerId, action: "READ", resource: "HEALTHCARE_MEMBERSHIP",
+      resourceId: String(serviceId), scopeServiceId: serviceId,
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { count: rows.length },
+    })
+
+    return rows.map((r) => ({
+      userId: r.userId,
+      firstname: safeDecryptField(r.user.firstname),
+      lastname: safeDecryptField(r.user.lastname),
+      email: safeDecryptField(r.user.email),
+      status: r.user.status,
+      clinicalRole: r.clinicalRole,
+      canManage: r.canManage,
+      isPrincipalAdmin: r.isPrincipalAdmin,
+      psVerified: true, // V1
+    }))
+  },
+
+  /**
+   * Invite/rattache un membre au service. User existant → rattache ; sinon crée
+   * le User (clinique) + token set-password single-use + email d'invitation.
+   */
+  async inviteMember(
+    callerId: number, role: Role, serviceId: number,
+    input: { email: string; firstName?: string; lastName?: string } & CapabilityInput,
+    ctx?: AuditContext,
+  ): Promise<{ userId: number; invitedNewUser: boolean }> {
+    await assertCanManage(callerId, role, serviceId)
+    // Octroi Q2 à l'invitation : mêmes gardes que setCapabilities.
+    if (input.canManage) await assertPrincipal(callerId, role, serviceId)
+    if (input.isPrincipalAdmin && role !== "ADMIN") throw new OrgMembershipError("forbidden")
+    if (input.clinicalRole && !CLINICAL_ROLES.has(input.clinicalRole)) {
+      throw new OrgMembershipError("invalidState")
+    }
+
+    const emailHmac = hmacEmail(input.email)
+    const existing = await prisma.user.findUnique({ where: { emailHmac }, select: { id: true } })
+
+    let resetToken: string | null = null
+    const result = await prisma.$transaction(async (tx) => {
+      let targetUserId: number
+      let invitedNewUser = false
+
+      if (existing) {
+        targetUserId = existing.id
+        const dup = await tx.healthcareMembership.findUnique({
+          where: { userId_serviceId: { userId: targetUserId, serviceId } },
+          select: { id: true },
+        })
+        if (dup) throw new OrgMembershipError("invalidState") // déjà membre
+      } else {
+        // Nouveau membre = utilisateur clinique en V1 → clinicalRole requis.
+        if (!input.clinicalRole) throw new OrgMembershipError("invalidState")
+        const tempPasswordHash = await bcryptHash(randomBytes(32).toString("base64url"), 12)
+        resetToken = randomUUID()
+        const user = await tx.user.create({
+          data: {
+            email: encryptField(input.email),
+            emailHmac,
+            passwordHash: tempPasswordHash,
+            ...(input.firstName && { firstname: encryptField(input.firstName), firstnameHmac: hmacField(input.firstName) }),
+            ...(input.lastName && { lastname: encryptField(input.lastName), lastnameHmac: hmacField(input.lastName) }),
+            role: input.clinicalRole,
+            status: "active",
+            language: "fr",
+            needPasswordUpdate: true,
+            needOnboarding: true,
+          },
+          select: { id: true },
+        })
+        targetUserId = user.id
+        invitedNewUser = true
+        await tx.verificationToken.deleteMany({ where: { identifier: emailHmac } })
+        await tx.verificationToken.create({
+          data: { identifier: emailHmac, token: resetToken, expires: new Date(Date.now() + 3600_000) },
+        })
+      }
+
+      await tx.healthcareMembership.create({
+        data: {
+          userId: targetUserId, serviceId,
+          clinicalRole: input.clinicalRole ?? null,
+          canManage: input.canManage ?? false,
+          isPrincipalAdmin: input.isPrincipalAdmin ?? false,
+        },
+      })
+
+      await auditService.logWithTx(tx, {
+        userId: callerId, action: "INVITATION_SENT", resource: "ORG_INVITATION",
+        resourceId: String(targetUserId), scopeServiceId: serviceId,
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: {
+          invitedNewUser,
+          clinicalRole: input.clinicalRole ?? null,
+          canManage: input.canManage ?? false,
+          isPrincipalAdmin: input.isPrincipalAdmin ?? false,
+        },
+      })
+
+      return { userId: targetUserId, invitedNewUser }
+    })
+
+    // Hors transaction : email d'invitation (nouveau user) — best-effort.
+    if (result.invitedNewUser && resetToken) {
+      void emailService.sendStaffInvitation(input.email, resetToken).catch((err) => {
+        logger.error("org-membership", "Failed to send staff invitation email", {}, err)
+      })
+    }
+
+    return result
+  },
+
+  /**
+   * Modifie les capacités d'un membre. Q2 (`canManage`) = principal-admin ;
+   * `isPrincipalAdmin` = ADMIN ; Q1 (`clinicalRole`) = V1. Non-auto-élévation.
+   * Révocation/octroi immédiat (bump authVersion + invalidate sessions).
+   */
+  async setCapabilities(
+    callerId: number, role: Role, targetUserId: number, serviceId: number,
+    caps: CapabilityInput, ctx?: AuditContext,
+  ): Promise<void> {
+    await assertCanManage(callerId, role, serviceId)
+    if (targetUserId === callerId) throw new OrgMembershipError("selfElevation")
+    if (caps.canManage !== undefined) await assertPrincipal(callerId, role, serviceId)
+    if (caps.isPrincipalAdmin !== undefined && role !== "ADMIN") throw new OrgMembershipError("forbidden")
+    if (caps.clinicalRole && !CLINICAL_ROLES.has(caps.clinicalRole)) {
+      throw new OrgMembershipError("invalidState")
+    }
+
+    const membership = await prisma.healthcareMembership.findUnique({
+      where: { userId_serviceId: { userId: targetUserId, serviceId } },
+      select: { id: true },
+    })
+    if (!membership) throw new OrgMembershipError("notFound")
+
+    await prisma.$transaction(async (tx) => {
+      await tx.healthcareMembership.update({
+        where: { userId_serviceId: { userId: targetUserId, serviceId } },
+        data: {
+          ...(caps.clinicalRole !== undefined && { clinicalRole: caps.clinicalRole }),
+          ...(caps.canManage !== undefined && { canManage: caps.canManage }),
+          ...(caps.isPrincipalAdmin !== undefined && { isPrincipalAdmin: caps.isPrincipalAdmin }),
+        },
+      })
+      // F7 — effet immédiat : bump authVersion (rejet refresh) ; invalidate sessions ci-dessous.
+      await tx.user.update({ where: { id: targetUserId }, data: { authVersion: { increment: 1 } } })
+
+      await auditService.logWithTx(tx, {
+        userId: callerId, action: "CAPABILITY_GRANTED", resource: "HEALTHCARE_MEMBERSHIP",
+        resourceId: String(targetUserId), scopeServiceId: serviceId,
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        newValue: {
+          ...(caps.clinicalRole !== undefined && { clinicalRole: caps.clinicalRole }),
+          ...(caps.canManage !== undefined && { canManage: caps.canManage }),
+          ...(caps.isPrincipalAdmin !== undefined && { isPrincipalAdmin: caps.isPrincipalAdmin }),
+        },
+      })
+    })
+
+    await invalidateAllUserSessions(targetUserId).catch((err) => {
+      logger.error("org-membership", "Failed to invalidate sessions after capability change", {}, err)
+    })
+  },
+
+  /**
+   * Retire un membre du service (appartenance supprimée). Données déjà créées
+   * conservées (append-only). Anti-self-lockout : le dernier admin principal ne
+   * peut pas se retirer. Révocation immédiate.
+   */
+  async revokeMember(
+    callerId: number, role: Role, targetUserId: number, serviceId: number, ctx?: AuditContext,
+  ): Promise<void> {
+    await assertCanManage(callerId, role, serviceId)
+
+    const membership = await prisma.healthcareMembership.findUnique({
+      where: { userId_serviceId: { userId: targetUserId, serviceId } },
+      select: { id: true, isPrincipalAdmin: true },
+    })
+    if (!membership) throw new OrgMembershipError("notFound")
+
+    // Anti-self-lockout : ne pas retirer le dernier admin principal du service.
+    if (membership.isPrincipalAdmin) {
+      const otherPrincipals = await prisma.healthcareMembership.count({
+        where: { serviceId, isPrincipalAdmin: true, userId: { not: targetUserId } },
+      })
+      if (otherPrincipals === 0) throw new OrgMembershipError("lastPrincipalAdmin")
+    }
+
+    await prisma.$transaction(async (tx) => {
+      await tx.healthcareMembership.delete({
+        where: { userId_serviceId: { userId: targetUserId, serviceId } },
+      })
+      await tx.user.update({ where: { id: targetUserId }, data: { authVersion: { increment: 1 } } })
+      await auditService.logWithTx(tx, {
+        userId: callerId, action: "CAPABILITY_REVOKED", resource: "HEALTHCARE_MEMBERSHIP",
+        resourceId: String(targetUserId), scopeServiceId: serviceId,
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: { kind: "memberRemoved" },
+      })
+    })
+
+    await invalidateAllUserSessions(targetUserId).catch((err) => {
+      logger.error("org-membership", "Failed to invalidate sessions after member revoke", {}, err)
+    })
+  },
+}

--- a/src/lib/services/org-membership.service.ts
+++ b/src/lib/services/org-membership.service.ts
@@ -60,6 +60,18 @@ export function orgMembershipErrorStatus(code: OrgMembershipError["code"]): numb
 /** Seuls DOCTOR/NURSE sont des capacités cliniques valides (Q1). */
 const CLINICAL_ROLES: ReadonlySet<Role> = new Set<Role>(["DOCTOR", "NURSE"])
 
+/**
+ * Cohérence d'état : un admin principal a **forcément** la gestion (Q2). On force
+ * `canManage = true` quand `isPrincipalAdmin = true`, et on rejette la combinaison
+ * incohérente `isPrincipalAdmin:true + canManage:false` (review HSA LOW).
+ */
+function normalizeCaps(caps: CapabilityInput): CapabilityInput {
+  if (caps.isPrincipalAdmin === true && caps.canManage === false) {
+    throw new OrgMembershipError("invalidState")
+  }
+  return caps.isPrincipalAdmin === true ? { ...caps, canManage: true } : caps
+}
+
 export type MemberView = {
   userId: number
   firstname: string | null
@@ -138,9 +150,14 @@ export const orgMembershipService = {
   ): Promise<{ userId: number; invitedNewUser: boolean }> {
     await assertCanManage(callerId, role, serviceId)
     // Octroi Q2 à l'invitation : mêmes gardes que setCapabilities.
-    if (input.canManage) await assertPrincipal(callerId, role, serviceId)
     if (input.isPrincipalAdmin && role !== "ADMIN") throw new OrgMembershipError("forbidden")
-    if (input.clinicalRole && !CLINICAL_ROLES.has(input.clinicalRole)) {
+    const caps = normalizeCaps({
+      clinicalRole: input.clinicalRole,
+      canManage: input.canManage,
+      isPrincipalAdmin: input.isPrincipalAdmin,
+    })
+    if (caps.canManage) await assertPrincipal(callerId, role, serviceId)
+    if (caps.clinicalRole && !CLINICAL_ROLES.has(caps.clinicalRole)) {
       throw new OrgMembershipError("invalidState")
     }
 
@@ -153,6 +170,9 @@ export const orgMembershipService = {
       let invitedNewUser = false
 
       if (existing) {
+        // Rattachement d'un user existant : on NE modifie PAS sa PII (firstName/
+        // lastName ignorés volontairement — son identité lui appartient) ni son
+        // mot de passe ; on crée seulement l'appartenance au service.
         targetUserId = existing.id
         const dup = await tx.healthcareMembership.findUnique({
           where: { userId_serviceId: { userId: targetUserId, serviceId } },
@@ -161,7 +181,7 @@ export const orgMembershipService = {
         if (dup) throw new OrgMembershipError("invalidState") // déjà membre
       } else {
         // Nouveau membre = utilisateur clinique en V1 → clinicalRole requis.
-        if (!input.clinicalRole) throw new OrgMembershipError("invalidState")
+        if (!caps.clinicalRole) throw new OrgMembershipError("invalidState")
         const tempPasswordHash = await bcryptHash(randomBytes(32).toString("base64url"), 12)
         resetToken = randomUUID()
         const user = await tx.user.create({
@@ -171,7 +191,7 @@ export const orgMembershipService = {
             passwordHash: tempPasswordHash,
             ...(input.firstName && { firstname: encryptField(input.firstName), firstnameHmac: hmacField(input.firstName) }),
             ...(input.lastName && { lastname: encryptField(input.lastName), lastnameHmac: hmacField(input.lastName) }),
-            role: input.clinicalRole,
+            role: caps.clinicalRole,
             status: "active",
             language: "fr",
             needPasswordUpdate: true,
@@ -190,9 +210,9 @@ export const orgMembershipService = {
       await tx.healthcareMembership.create({
         data: {
           userId: targetUserId, serviceId,
-          clinicalRole: input.clinicalRole ?? null,
-          canManage: input.canManage ?? false,
-          isPrincipalAdmin: input.isPrincipalAdmin ?? false,
+          clinicalRole: caps.clinicalRole ?? null,
+          canManage: caps.canManage ?? false,
+          isPrincipalAdmin: caps.isPrincipalAdmin ?? false,
         },
       })
 
@@ -202,9 +222,9 @@ export const orgMembershipService = {
         ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
         metadata: {
           invitedNewUser,
-          clinicalRole: input.clinicalRole ?? null,
-          canManage: input.canManage ?? false,
-          isPrincipalAdmin: input.isPrincipalAdmin ?? false,
+          clinicalRole: caps.clinicalRole ?? null,
+          canManage: caps.canManage ?? false,
+          isPrincipalAdmin: caps.isPrincipalAdmin ?? false,
         },
       })
 
@@ -232,25 +252,35 @@ export const orgMembershipService = {
   ): Promise<void> {
     await assertCanManage(callerId, role, serviceId)
     if (targetUserId === callerId) throw new OrgMembershipError("selfElevation")
-    if (caps.canManage !== undefined) await assertPrincipal(callerId, role, serviceId)
     if (caps.isPrincipalAdmin !== undefined && role !== "ADMIN") throw new OrgMembershipError("forbidden")
-    if (caps.clinicalRole && !CLINICAL_ROLES.has(caps.clinicalRole)) {
+    const norm = normalizeCaps(caps)
+    if (norm.canManage !== undefined) await assertPrincipal(callerId, role, serviceId)
+    if (norm.clinicalRole && !CLINICAL_ROLES.has(norm.clinicalRole)) {
       throw new OrgMembershipError("invalidState")
     }
 
     const membership = await prisma.healthcareMembership.findUnique({
       where: { userId_serviceId: { userId: targetUserId, serviceId } },
-      select: { id: true },
+      select: { id: true, isPrincipalAdmin: true },
     })
     if (!membership) throw new OrgMembershipError("notFound")
+
+    // HIGH (review) — anti-lockout symétrique : ne pas retirer `isPrincipalAdmin`
+    // du DERNIER admin principal du service (sinon plus personne ne peut octroyer Q2).
+    if (norm.isPrincipalAdmin === false && membership.isPrincipalAdmin) {
+      const otherPrincipals = await prisma.healthcareMembership.count({
+        where: { serviceId, isPrincipalAdmin: true, userId: { not: targetUserId } },
+      })
+      if (otherPrincipals === 0) throw new OrgMembershipError("lastPrincipalAdmin")
+    }
 
     await prisma.$transaction(async (tx) => {
       await tx.healthcareMembership.update({
         where: { userId_serviceId: { userId: targetUserId, serviceId } },
         data: {
-          ...(caps.clinicalRole !== undefined && { clinicalRole: caps.clinicalRole }),
-          ...(caps.canManage !== undefined && { canManage: caps.canManage }),
-          ...(caps.isPrincipalAdmin !== undefined && { isPrincipalAdmin: caps.isPrincipalAdmin }),
+          ...(norm.clinicalRole !== undefined && { clinicalRole: norm.clinicalRole }),
+          ...(norm.canManage !== undefined && { canManage: norm.canManage }),
+          ...(norm.isPrincipalAdmin !== undefined && { isPrincipalAdmin: norm.isPrincipalAdmin }),
         },
       })
       // F7 — effet immédiat : bump authVersion (rejet refresh) ; invalidate sessions ci-dessous.
@@ -261,9 +291,9 @@ export const orgMembershipService = {
         resourceId: String(targetUserId), scopeServiceId: serviceId,
         ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
         newValue: {
-          ...(caps.clinicalRole !== undefined && { clinicalRole: caps.clinicalRole }),
-          ...(caps.canManage !== undefined && { canManage: caps.canManage }),
-          ...(caps.isPrincipalAdmin !== undefined && { isPrincipalAdmin: caps.isPrincipalAdmin }),
+          ...(norm.clinicalRole !== undefined && { clinicalRole: norm.clinicalRole }),
+          ...(norm.canManage !== undefined && { canManage: norm.canManage }),
+          ...(norm.isPrincipalAdmin !== undefined && { isPrincipalAdmin: norm.isPrincipalAdmin }),
         },
       })
     })

--- a/tests/integration/api-cabinet-members.test.ts
+++ b/tests/integration/api-cabinet-members.test.ts
@@ -73,11 +73,11 @@ describe("GET /api/cabinet/[id]/members", () => {
 })
 
 describe("POST /api/cabinet/[id]/members (invite)", () => {
-  it("invite → 201", async () => {
+  it("invite → 201 réponse NEUTRE (anti-énumération : pas d'userId/invitedNewUser)", async () => {
     inviteMember.mockResolvedValue({ userId: 50, invitedNewUser: true })
     const res = await POST(req("/api/cabinet/9/members", "POST", { email: "n@x.fr", clinicalRole: "NURSE" }), p("9"))
     expect(res.status).toBe(201)
-    expect(await res.json()).toMatchObject({ userId: 50 })
+    expect(await res.json()).toEqual({ ok: true })
   })
   it("corps invalide (email) → 400", async () => {
     const res = await POST(req("/api/cabinet/9/members", "POST", { email: "nope" }), p("9"))

--- a/tests/integration/api-cabinet-members.test.ts
+++ b/tests/integration/api-cabinet-members.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests des routes de gestion des membres de cabinet (US-2610).
+ *  - GET/POST /api/cabinet/[id]/members
+ *  - PATCH/DELETE /api/cabinet/[id]/members/[userId]
+ *
+ * Verrouille le contrat HTTP : auth, validation Zod, mapping OrgMembershipError
+ * → statut (forbidden 403 / notFound 404 / invalidState|selfElevation 409).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { NextRequest } from "next/server"
+
+vi.mock("@/lib/auth", () => ({
+  requireAuth: vi.fn(() => ({ id: 7, role: "DOCTOR" })),
+  AuthError: class AuthError extends Error {
+    status: number
+    constructor(m: string, s = 401) { super(m); this.status = s }
+  },
+}))
+const listMembers = vi.fn()
+const inviteMember = vi.fn()
+const setCapabilities = vi.fn()
+const revokeMember = vi.fn()
+vi.mock("@/lib/services/org-membership.service", () => ({
+  orgMembershipService: {
+    listMembers: (...a: unknown[]) => listMembers(...a),
+    inviteMember: (...a: unknown[]) => inviteMember(...a),
+    setCapabilities: (...a: unknown[]) => setCapabilities(...a),
+    revokeMember: (...a: unknown[]) => revokeMember(...a),
+  },
+  OrgMembershipError: class OrgMembershipError extends Error {
+    constructor(public code: string) { super(code); this.name = "OrgMembershipError" }
+  },
+  orgMembershipErrorStatus: (code: string) =>
+    code === "forbidden" ? 403 : code === "notFound" ? 404 : 409,
+}))
+vi.mock("@/lib/services/audit.service", () => ({
+  extractRequestContext: () => ({ ipAddress: "1.2.3.4", userAgent: "vitest", requestId: "r" }),
+}))
+
+import { OrgMembershipError } from "@/lib/services/org-membership.service"
+const { GET, POST } = await import("@/app/api/cabinet/[id]/members/route")
+const { PATCH, DELETE } = await import("@/app/api/cabinet/[id]/members/[userId]/route")
+
+const req = (url: string, method: string, body?: unknown) =>
+  new NextRequest(new URL(`http://localhost${url}`), {
+    method,
+    headers: { "content-type": "application/json", "x-user-id": "7", "x-user-role": "DOCTOR" },
+    ...(body !== undefined && { body: JSON.stringify(body) }),
+  })
+
+const p = (id: string) => ({ params: Promise.resolve({ id }) })
+const pu = (id: string, userId: string) => ({ params: Promise.resolve({ id, userId }) })
+
+beforeEach(() => vi.clearAllMocks())
+
+describe("GET /api/cabinet/[id]/members", () => {
+  it("liste → 200", async () => {
+    listMembers.mockResolvedValue([{ userId: 5 }])
+    const res = await GET(req("/api/cabinet/9/members", "GET"), p("9"))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ members: [{ userId: 5 }] })
+    expect(listMembers).toHaveBeenCalledWith(7, "DOCTOR", 9, expect.any(Object))
+  })
+  it("id invalide → 400", async () => {
+    const res = await GET(req("/api/cabinet/abc/members", "GET"), p("abc"))
+    expect(res.status).toBe(400)
+  })
+  it("sans Q2 → 403 (forbidden)", async () => {
+    listMembers.mockRejectedValue(new OrgMembershipError("forbidden"))
+    const res = await GET(req("/api/cabinet/9/members", "GET"), p("9"))
+    expect(res.status).toBe(403)
+  })
+})
+
+describe("POST /api/cabinet/[id]/members (invite)", () => {
+  it("invite → 201", async () => {
+    inviteMember.mockResolvedValue({ userId: 50, invitedNewUser: true })
+    const res = await POST(req("/api/cabinet/9/members", "POST", { email: "n@x.fr", clinicalRole: "NURSE" }), p("9"))
+    expect(res.status).toBe(201)
+    expect(await res.json()).toMatchObject({ userId: 50 })
+  })
+  it("corps invalide (email) → 400", async () => {
+    const res = await POST(req("/api/cabinet/9/members", "POST", { email: "nope" }), p("9"))
+    expect(res.status).toBe(400)
+    expect(inviteMember).not.toHaveBeenCalled()
+  })
+  it("déjà membre → 409 (invalidState)", async () => {
+    inviteMember.mockRejectedValue(new OrgMembershipError("invalidState"))
+    const res = await POST(req("/api/cabinet/9/members", "POST", { email: "e@x.fr", clinicalRole: "DOCTOR" }), p("9"))
+    expect(res.status).toBe(409)
+  })
+})
+
+describe("PATCH /api/cabinet/[id]/members/[userId]", () => {
+  it("modifie capacités → 200", async () => {
+    setCapabilities.mockResolvedValue(undefined)
+    const res = await PATCH(req("/api/cabinet/9/members/5", "PATCH", { canManage: true }), pu("9", "5"))
+    expect(res.status).toBe(200)
+    expect(setCapabilities).toHaveBeenCalledWith(7, "DOCTOR", 5, 9, { canManage: true }, expect.any(Object))
+  })
+  it("corps vide → 400 (noCapabilityProvided)", async () => {
+    const res = await PATCH(req("/api/cabinet/9/members/5", "PATCH", {}), pu("9", "5"))
+    expect(res.status).toBe(400)
+  })
+  it("auto-modification → 409 (selfElevation)", async () => {
+    setCapabilities.mockRejectedValue(new OrgMembershipError("selfElevation"))
+    const res = await PATCH(req("/api/cabinet/9/members/7", "PATCH", { canManage: true }), pu("9", "7"))
+    expect(res.status).toBe(409)
+  })
+})
+
+describe("DELETE /api/cabinet/[id]/members/[userId]", () => {
+  it("retire → 200", async () => {
+    revokeMember.mockResolvedValue(undefined)
+    const res = await DELETE(req("/api/cabinet/9/members/5", "DELETE"), pu("9", "5"))
+    expect(res.status).toBe(200)
+  })
+  it("dernier principal → 409 (lastPrincipalAdmin)", async () => {
+    revokeMember.mockRejectedValue(new OrgMembershipError("lastPrincipalAdmin"))
+    const res = await DELETE(req("/api/cabinet/9/members/5", "DELETE"), pu("9", "5"))
+    expect(res.status).toBe(409)
+  })
+  it("membre inexistant → 404", async () => {
+    revokeMember.mockRejectedValue(new OrgMembershipError("notFound"))
+    const res = await DELETE(req("/api/cabinet/9/members/5", "DELETE"), pu("9", "5"))
+    expect(res.status).toBe(404)
+  })
+})

--- a/tests/unit/org-membership.service.test.ts
+++ b/tests/unit/org-membership.service.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Test suite : org-membership.service (US-2610 — gestion personnel & droits).
+ *
+ * Couvre les règles RBAC capacité (2 axes) :
+ *  - accès gestion = Q2 (canManage) dans le scope (ADMIN bypass) ;
+ *  - octroi Q2 = principal-admin ; isPrincipalAdmin = ADMIN only ;
+ *  - non-auto-élévation ; anti-self-lockout (dernier principal) ;
+ *  - invite (user existant/nouveau) ; révocation immédiate (bump + invalidate).
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { prismaMock } from "../helpers/prisma-mock"
+
+vi.mock("@/lib/capabilities", () => ({
+  canManageOrg: vi.fn(),
+  isPrincipalAdmin: vi.fn(),
+}))
+vi.mock("@/lib/auth/session", () => ({ invalidateAllUserSessions: vi.fn().mockResolvedValue(undefined) }))
+vi.mock("@/lib/services/email.service", () => ({
+  emailService: { sendStaffInvitation: vi.fn().mockResolvedValue({ ok: true }) },
+}))
+vi.mock("@/lib/crypto/fields", () => ({
+  encryptField: (v: string) => `enc:${v}`,
+  safeDecryptField: (v: string | null) => (v ? v.replace(/^enc:/, "dec:") : v),
+}))
+vi.mock("@/lib/crypto/hmac", () => ({
+  hmacEmail: (v: string) => `hmac:${v}`,
+  hmacField: (v: string) => `hmacf:${v}`,
+}))
+vi.mock("bcryptjs", () => ({ hash: vi.fn().mockResolvedValue("hashed") }))
+
+import { orgMembershipService } from "@/lib/services/org-membership.service"
+import { canManageOrg, isPrincipalAdmin } from "@/lib/capabilities"
+import { invalidateAllUserSessions } from "@/lib/auth/session"
+import { emailService } from "@/lib/services/email.service"
+
+const mCanManage = vi.mocked(canManageOrg)
+const mPrincipal = vi.mocked(isPrincipalAdmin)
+const pm = prismaMock as unknown as {
+  healthcareMembership: { findMany: any; findUnique: any; create: any; update: any; delete: any; count: any }
+  user: { findUnique: any; create: any; update: any }
+  verificationToken: { deleteMany: any; create: any }
+  auditLog: { create: any }
+  $transaction: any
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mCanManage.mockResolvedValue(true)
+  mPrincipal.mockResolvedValue(true)
+  prismaMock.auditLog.create.mockResolvedValue({} as any)
+  pm.$transaction.mockImplementation((cb: any) => cb(prismaMock))
+})
+
+describe("assertCanManage (accès gestion)", () => {
+  it("non-ADMIN sans Q2 → forbidden", async () => {
+    mCanManage.mockResolvedValue(false)
+    await expect(orgMembershipService.listMembers(1, "NURSE", 9)).rejects.toMatchObject({ code: "forbidden" })
+  })
+  it("ADMIN bypass (pas de check canManage)", async () => {
+    pm.healthcareMembership.findMany.mockResolvedValue([])
+    await orgMembershipService.listMembers(1, "ADMIN", 9)
+    expect(mCanManage).not.toHaveBeenCalled()
+  })
+})
+
+describe("listMembers", () => {
+  it("renvoie les membres avec PII déchiffrée + capacités", async () => {
+    pm.healthcareMembership.findMany.mockResolvedValue([
+      {
+        userId: 5, clinicalRole: "DOCTOR", canManage: true, isPrincipalAdmin: false,
+        user: { firstname: "enc:Marie", lastname: "enc:Martin", email: "enc:m@x.fr", status: "active" },
+      },
+    ])
+    const out = await orgMembershipService.listMembers(1, "DOCTOR", 9)
+    expect(out[0]).toMatchObject({
+      userId: 5, firstname: "dec:Marie", clinicalRole: "DOCTOR", canManage: true, psVerified: true,
+    })
+  })
+})
+
+describe("inviteMember", () => {
+  it("nouveau user → crée user + token + membership + email d'invitation", async () => {
+    pm.user.findUnique.mockResolvedValue(null)
+    pm.user.create.mockResolvedValue({ id: 50 })
+    pm.healthcareMembership.create.mockResolvedValue({ id: 1 })
+    const r = await orgMembershipService.inviteMember(1, "DOCTOR", 9, { email: "n@x.fr", clinicalRole: "NURSE" })
+    expect(r).toEqual({ userId: 50, invitedNewUser: true })
+    expect(pm.user.create.mock.calls[0][0].data.role).toBe("NURSE")
+    expect(pm.verificationToken.create).toHaveBeenCalled()
+    expect(pm.healthcareMembership.create).toHaveBeenCalled()
+    expect(emailService.sendStaffInvitation).toHaveBeenCalledWith("n@x.fr", expect.any(String))
+  })
+
+  it("user existant → rattache (pas de création/email)", async () => {
+    pm.user.findUnique.mockResolvedValue({ id: 7 })
+    pm.healthcareMembership.findUnique.mockResolvedValue(null) // pas encore membre
+    pm.healthcareMembership.create.mockResolvedValue({ id: 2 })
+    const r = await orgMembershipService.inviteMember(1, "DOCTOR", 9, { email: "e@x.fr", clinicalRole: "DOCTOR" })
+    expect(r).toEqual({ userId: 7, invitedNewUser: false })
+    expect(pm.user.create).not.toHaveBeenCalled()
+    expect(emailService.sendStaffInvitation).not.toHaveBeenCalled()
+  })
+
+  it("déjà membre → invalidState", async () => {
+    pm.user.findUnique.mockResolvedValue({ id: 7 })
+    pm.healthcareMembership.findUnique.mockResolvedValue({ id: 99 })
+    await expect(
+      orgMembershipService.inviteMember(1, "DOCTOR", 9, { email: "e@x.fr", clinicalRole: "DOCTOR" }),
+    ).rejects.toMatchObject({ code: "invalidState" })
+  })
+
+  it("octroi canManage par non-principal → forbidden", async () => {
+    mPrincipal.mockResolvedValue(false)
+    await expect(
+      orgMembershipService.inviteMember(1, "NURSE", 9, { email: "e@x.fr", clinicalRole: "NURSE", canManage: true }),
+    ).rejects.toMatchObject({ code: "forbidden" })
+  })
+
+  it("octroi isPrincipalAdmin par non-ADMIN → forbidden", async () => {
+    await expect(
+      orgMembershipService.inviteMember(1, "DOCTOR", 9, { email: "e@x.fr", clinicalRole: "NURSE", isPrincipalAdmin: true }),
+    ).rejects.toMatchObject({ code: "forbidden" })
+  })
+})
+
+describe("setCapabilities", () => {
+  beforeEach(() => {
+    pm.healthcareMembership.findUnique.mockResolvedValue({ id: 1 })
+    pm.healthcareMembership.update.mockResolvedValue({})
+    pm.user.update.mockResolvedValue({})
+  })
+
+  it("modifie les capacités + bump authVersion + invalide les sessions (immédiat)", async () => {
+    await orgMembershipService.setCapabilities(1, "DOCTOR", 5, 9, { canManage: true })
+    expect(pm.healthcareMembership.update.mock.calls[0][0].data).toMatchObject({ canManage: true })
+    expect(pm.user.update.mock.calls[0][0].data).toEqual({ authVersion: { increment: 1 } })
+    expect(invalidateAllUserSessions).toHaveBeenCalledWith(5)
+  })
+
+  it("auto-modification → selfElevation", async () => {
+    await expect(orgMembershipService.setCapabilities(5, "DOCTOR", 5, 9, { canManage: true }))
+      .rejects.toMatchObject({ code: "selfElevation" })
+  })
+
+  it("canManage par non-principal → forbidden", async () => {
+    mPrincipal.mockResolvedValue(false)
+    await expect(orgMembershipService.setCapabilities(1, "NURSE", 5, 9, { canManage: true }))
+      .rejects.toMatchObject({ code: "forbidden" })
+  })
+
+  it("isPrincipalAdmin par non-ADMIN → forbidden", async () => {
+    await expect(orgMembershipService.setCapabilities(1, "DOCTOR", 5, 9, { isPrincipalAdmin: true }))
+      .rejects.toMatchObject({ code: "forbidden" })
+  })
+
+  it("membre inexistant → notFound", async () => {
+    pm.healthcareMembership.findUnique.mockResolvedValue(null)
+    await expect(orgMembershipService.setCapabilities(1, "ADMIN", 5, 9, { clinicalRole: "DOCTOR" }))
+      .rejects.toMatchObject({ code: "notFound" })
+  })
+})
+
+describe("revokeMember", () => {
+  it("supprime l'appartenance + bump + invalidate", async () => {
+    pm.healthcareMembership.findUnique.mockResolvedValue({ id: 1, isPrincipalAdmin: false })
+    pm.healthcareMembership.delete.mockResolvedValue({})
+    pm.user.update.mockResolvedValue({})
+    await orgMembershipService.revokeMember(1, "DOCTOR", 5, 9)
+    expect(pm.healthcareMembership.delete).toHaveBeenCalled()
+    expect(invalidateAllUserSessions).toHaveBeenCalledWith(5)
+  })
+
+  it("dernier admin principal → lastPrincipalAdmin (pas de suppression)", async () => {
+    pm.healthcareMembership.findUnique.mockResolvedValue({ id: 1, isPrincipalAdmin: true })
+    pm.healthcareMembership.count.mockResolvedValue(0) // aucun autre principal
+    await expect(orgMembershipService.revokeMember(1, "ADMIN", 5, 9))
+      .rejects.toMatchObject({ code: "lastPrincipalAdmin" })
+    expect(pm.healthcareMembership.delete).not.toHaveBeenCalled()
+  })
+
+  it("membre inexistant → notFound", async () => {
+    pm.healthcareMembership.findUnique.mockResolvedValue(null)
+    await expect(orgMembershipService.revokeMember(1, "ADMIN", 5, 9))
+      .rejects.toMatchObject({ code: "notFound" })
+  })
+})

--- a/tests/unit/org-membership.service.test.ts
+++ b/tests/unit/org-membership.service.test.ts
@@ -183,6 +183,16 @@ describe("setCapabilities", () => {
       orgMembershipService.setCapabilities(1, "ADMIN", 5, 9, { isPrincipalAdmin: true, canManage: false }),
     ).rejects.toMatchObject({ code: "invalidState" })
   })
+
+  it("no-op (capacité déjà en place) → ni écriture, ni bump, ni invalidation, ni audit", async () => {
+    pm.healthcareMembership.findUnique.mockResolvedValue({
+      id: 1, clinicalRole: "DOCTOR", canManage: true, isPrincipalAdmin: false,
+    })
+    await orgMembershipService.setCapabilities(1, "DOCTOR", 5, 9, { canManage: true }) // déjà true
+    expect(pm.healthcareMembership.update).not.toHaveBeenCalled()
+    expect(pm.user.update).not.toHaveBeenCalled()
+    expect(invalidateAllUserSessions).not.toHaveBeenCalled()
+  })
 })
 
 describe("revokeMember", () => {

--- a/tests/unit/org-membership.service.test.ts
+++ b/tests/unit/org-membership.service.test.ts
@@ -158,6 +158,31 @@ describe("setCapabilities", () => {
     await expect(orgMembershipService.setCapabilities(1, "ADMIN", 5, 9, { clinicalRole: "DOCTOR" }))
       .rejects.toMatchObject({ code: "notFound" })
   })
+
+  it("rétrograder le DERNIER admin principal → lastPrincipalAdmin (HIGH review)", async () => {
+    pm.healthcareMembership.findUnique.mockResolvedValue({ id: 1, isPrincipalAdmin: true })
+    pm.healthcareMembership.count.mockResolvedValue(0) // aucun autre principal
+    await expect(orgMembershipService.setCapabilities(1, "ADMIN", 5, 9, { isPrincipalAdmin: false }))
+      .rejects.toMatchObject({ code: "lastPrincipalAdmin" })
+    expect(pm.healthcareMembership.update).not.toHaveBeenCalled()
+  })
+
+  it("cohérence : isPrincipalAdmin=true force canManage=true", async () => {
+    pm.healthcareMembership.findUnique.mockResolvedValue({ id: 1, isPrincipalAdmin: false })
+    pm.healthcareMembership.update.mockResolvedValue({})
+    pm.user.update.mockResolvedValue({})
+    await orgMembershipService.setCapabilities(1, "ADMIN", 5, 9, { isPrincipalAdmin: true })
+    expect(pm.healthcareMembership.update.mock.calls[0][0].data).toMatchObject({
+      isPrincipalAdmin: true, canManage: true,
+    })
+  })
+
+  it("cohérence : isPrincipalAdmin=true + canManage=false → invalidState", async () => {
+    pm.healthcareMembership.findUnique.mockResolvedValue({ id: 1, isPrincipalAdmin: false })
+    await expect(
+      orgMembershipService.setCapabilities(1, "ADMIN", 5, 9, { isPrincipalAdmin: true, canManage: false }),
+    ).rejects.toMatchObject({ code: "invalidState" })
+  })
 })
 
 describe("revokeMember", () => {


### PR DESCRIPTION
## Socle « Accès & Cabinet » — PR4a/5 (US-2610 backend)

Backend de la gestion du personnel & des droits d'un cabinet (l'UI = PR4b). Modèle 2 axes sur `HealthcareMembership` (PR1) ; **aucune nouvelle table**.

### Service `org-membership.service`
- `listMembers` / `inviteMember` / `setCapabilities` / `revokeMember`.
- **Règles RBAC capacité** : accès gestion = **Q2** (`canManage`, ADMIN bypass) ; octroi **Q2** = **admin principal** ; **`isPrincipalAdmin` = ADMIN only** (un principal ne nomme que des délégués) ; **Q1** octroyable en V1 (« considéré vérifié ») ; **non-auto-élévation** ; **anti-self-lockout** (dernier principal) ; **révocation immédiate** (`authVersion++` + `invalidateAllUserSessions`, F7).
- **Invitation single-use** : réutilise `VerificationToken` (set-password, `emailHmac`, TTL 1h — F15 anti-énumération). User existant → rattache ; nouveau → crée un user clinique + `emailService.sendStaffInvitation` (sans PHI).

### Routes
- `/api/cabinet/[id]/members` (GET liste / POST invite) + `/[userId]` (PATCH capacités / DELETE retrait) — **gated Q2 serveur**, Zod, mapping `OrgMembershipError` → 403/404/409, audit scopé (`INVITATION_SENT`, `CAPABILITY_GRANTED`/`REVOKED`, `scopeServiceId`).

### ⚠️ V1 (documenté DPIA)
- **Q1 octroyable en V1** (considéré vérifié) → durci en V4 (gate sur preuve PS). Risque pilote maîtrisé.
- Pas de rôle plateforme « gestionnaire non-soignant » (F1/V4) → un membre géré est clinique (`DOCTOR`/`NURSE`) ; secrétaire pure Q2 reportée V4. `ADMIN` bypass PHI inchangé.

### Tests
- `org-membership.service` (16 : RBAC capacité, invite nouveau/existant/déjà-membre, principal-only, ADMIN-only, non-auto-élévation, anti-lockout, révocation immédiate) + routes (12 : RBAC + mapping erreurs + Zod).
- **3299/3299 tests verts** ; tsc / eslint / design-system (272) verts. Pas de migration (drift inchangé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)