### PR TITLE
feat(nav): US-2623 — barre de recherche visible (déclencheur palette)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -638,6 +638,7 @@ tous corrigés. Migration `20260513230000_groupe5_review_fixes` (FK + unique + p
 |----|-------|
 | US-2600 | Navigation globale (sidebar maigre, RBAC serveur, RTL, drawer) — ✅ DONE (PR #542) |
 | US-2601 | Palette de commande `Ctrl/Cmd-K` (recherche patient scopée, audit ouverture) — ✅ DONE (PR #541) |
+| US-2623 | Barre de recherche **visible** (déclencheur de la palette US-2601) — 🚧 corrige la découvrabilité/tactile : bouton header « 🔍 Rechercher… ⌘K » (desktop) / icône loupe (mobile) ouvrant la palette existante (ouverture contrôlée, zéro logique de recherche dupliquée) ; staff `pro` only, a11y (≥44px, aria-label, focus), i18n FR/EN/AR + RTL. |
 | US-2602 | « Ma journée » — worklist de tri médecin (déterministe, seuils source unique) — ✅ DONE (PR #540) |
 | US-2603 | Barre de contexte patient + switcher — ✅ DONE (backend PR #560 : modèles recently-viewed/pinned + service scopé + endpoints ; UI PR #561 : barre persistante + switcher récents/épinglés) |
 | US-2604 | Onglets-routes du dossier (deep-link, audit niveau donnée, prefetch non-PII) — ✅ DONE (chantier câblage données patient, PR #543→#546 — 4 onglets sur données réelles, scopées/auditées ; enrichi #554–#558) |

--- a/docs/UserStory/Navigation/barre-recherche-visible-us.md
+++ b/docs/UserStory/Navigation/barre-recherche-visible-us.md
@@ -1,0 +1,60 @@
+# US-2623 — Barre de recherche visible (déclencheur de la palette)
+
+> **Périmètre :** Diabeo BackOffice — navigation globale. **Complète US-2601** (palette
+> de commande & recherche `Ctrl/Cmd-K`) en lui donnant une **affordance visible**.
+> **Baselines :** `BASELINE-RBAC` · `BASELINE-DESIGN` · `BASELINE-I18N` (FR/EN/AR + RTL) · WCAG 2.1 AA.
+
+## 🐞 Problème constaté
+
+La recherche globale (US-2601) ne s'ouvre **qu'au clavier** (`Ctrl/Cmd-K`). Le header
+(`NavigationShell`) n'affiche **aucun champ ni bouton** de recherche. Conséquences :
+
+- **Découvrabilité** : un utilisateur qui ne connaît pas le raccourci ne trouve pas la recherche.
+- **Accessibilité / tactile** : sur tablette **sans clavier**, la recherche est **inatteignable**
+  (pas d'affordance pointeur).
+
+## 👤 En tant que
+
+Utilisateur backoffice (`ADMIN` / `DOCTOR` / `NURSE`).
+
+## 🎯 Je veux / Afin de
+
+Voir un **déclencheur de recherche visible** dans le header — afin d'ouvrir la recherche
+patient/destination à la souris ou au tactile, sans connaître le raccourci clavier.
+
+## 📌 Description fonctionnelle
+
+- Un **bouton de recherche** dans le header du `NavigationShell` (variant `pro` uniquement) :
+  - **Desktop** : présenté comme une **barre** « 🔍 Rechercher… » avec l'indice de raccourci
+    (`⌘K` / `Ctrl K`).
+  - **Mobile / tablette** : repli en **icône loupe** (cible ≥ 44 px).
+- Le clic **ouvre la palette existante** (US-2601) — **aucune nouvelle logique de recherche**
+  (mêmes résultats : destinations + patients du périmètre, scopé serveur).
+- Le raccourci `Ctrl/Cmd-K` continue de fonctionner (les deux coexistent).
+- `VIEWER` (espace patient, variant `patient`) : **pas** de palette → **pas** de bouton.
+
+## ✔️ Critères d'acceptation
+
+- Le bouton de recherche est **visible** dans le header pour les rôles staff (`pro`) ;
+  absent pour le variant `patient`.
+- Clic souris **et** activation tactile ouvrent la palette ; `Ctrl/Cmd-K` fonctionne toujours.
+- A11y : `aria-label` explicite, indice de raccourci `aria-hidden` (décoratif), focus visible,
+  cible ≥ 44 px (icône mobile), accessible au clavier (Tab + Entrée/Espace).
+- Le libellé passe par i18n (FR/EN/AR) ; RTL correct (loupe + indice côté logique).
+- Design system : classes sémantiques uniquement, aucun hex / Tailwind brut.
+
+## 🧩 Règles métier
+
+- **Réutilisation stricte** de la palette US-2601 (ouverture contrôlée) — pas de duplication
+  de la recherche ni de nouvel appel API.
+- Filtrage **serveur** du périmètre inchangé (la palette reste la seule source de résultats).
+- Pas de donnée de santé exposée par le bouton (il n'affiche que le libellé « Rechercher »).
+
+## 🗺️ Roadmap
+
+**V1** — finition de la sous-série navigation médecin (complète US-2600/US-2601).
+
+## 🔗 Dépendances
+
+`US-2601` (palette de commande) · `US-2600` (navigation globale / `NavigationShell`) ·
+baselines en tête.

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -102,7 +102,9 @@
     "gestionTeam": "إدارة الفريق والصلاحيات",
     "gestionBilling": "الفوترة",
     "gestionPayments": "المدفوعات",
-    "gestionSettings": "إعدادات العيادة"
+    "gestionSettings": "إعدادات العيادة",
+    "search": "بحث…",
+    "searchShortcut": "Ctrl K"
   },
   "commandPalette": {
     "ariaLabel": "لوحة الأوامر",

--- a/messages/en.json
+++ b/messages/en.json
@@ -102,7 +102,9 @@
     "gestionTeam": "Team & permissions",
     "gestionBilling": "Billing",
     "gestionPayments": "Payments",
-    "gestionSettings": "Practice settings"
+    "gestionSettings": "Practice settings",
+    "search": "Search…",
+    "searchShortcut": "Ctrl K"
   },
   "commandPalette": {
     "ariaLabel": "Command palette",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -102,7 +102,9 @@
     "gestionTeam": "Gestion de l'équipe & droits",
     "gestionBilling": "Facturation",
     "gestionPayments": "Paiements",
-    "gestionSettings": "Paramètres du cabinet"
+    "gestionSettings": "Paramètres du cabinet",
+    "search": "Rechercher…",
+    "searchShortcut": "Ctrl K"
   },
   "commandPalette": {
     "ariaLabel": "Palette de commande",

--- a/src/components/diabeo/CommandPalette.tsx
+++ b/src/components/diabeo/CommandPalette.tsx
@@ -113,19 +113,27 @@ export function CommandPalette({
     openRef.current = open
   }, [open])
 
-  // Ouverture/reset/fermeture — handler d'évènement (setState légitime).
+  // Ouverture/fermeture — handler d'évènement. Le **reset** n'est PAS ici : le
+  // bouton header (US-2623) ouvre via le parent (`setSearchOpen`) sans passer par
+  // ce handler. Le reset vit donc dans un effet sur `open` (cf. ci-dessous) →
+  // slate propre quelle que soit la source d'ouverture (bouton, Ctrl-K, parent).
   const handleOpenChange = useCallback((next: boolean) => {
     if (!isControlled) setInternalOpen(next)
     onOpenChange?.(next)
-    if (next) {
-      setQuery("")
-      setActiveIndex(0)
-      setExactHits([])
-    } else {
+    if (!next) {
       baseAbortRef.current?.abort()
       exactAbortRef.current?.abort()
     }
   }, [isControlled, onOpenChange])
+
+  // Reset à CHAQUE ouverture, indépendamment de la source (handleOpenChange ou
+  // ouverture contrôlée par le parent). Idempotent à la fermeture (no-op).
+  useEffect(() => {
+    if (!open) return
+    setQuery("")
+    setActiveIndex(0)
+    setExactHits([])
+  }, [open])
 
   // Ctrl/Cmd-K global.
   useEffect(() => {

--- a/src/components/diabeo/CommandPalette.tsx
+++ b/src/components/diabeo/CommandPalette.tsx
@@ -56,14 +56,32 @@ type DestEntry = { kind: "dest"; id: string; href: string; label: string; icon: 
 type PatientEntry = { kind: "patient"; id: string; patientId: number; name: string; pathologyLabel: string | null }
 type Entry = DestEntry | PatientEntry
 
-export function CommandPalette({ userRole }: { userRole: UserRole }) {
+export function CommandPalette({
+  userRole,
+  open: controlledOpen,
+  onOpenChange,
+}: {
+  userRole: UserRole
+  /**
+   * US-2623 — ouverture **contrôlée** optionnelle : permet au header
+   * (`NavigationShell`) d'ouvrir la palette via un bouton visible. Si non
+   * fournie, la palette gère son ouverture en interne (rétro-compat). Le
+   * raccourci `Ctrl/Cmd-K` fonctionne dans les deux modes.
+   */
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}) {
   const t = useTranslations("commandPalette")
   const tNav = useTranslations("nav")
   const tGlossary = useTranslations("glossary")
   const router = useRouter()
   const baseId = useId()
 
-  const [open, setOpen] = useState(false)
+  // Ouverture contrôlée (prop) OU interne (rétro-compat). `isControlled` fige le
+  // mode pour la durée de vie du composant (le parent fournit ou non la prop).
+  const [internalOpen, setInternalOpen] = useState(false)
+  const isControlled = controlledOpen !== undefined
+  const open = isControlled ? controlledOpen : internalOpen
   const [query, setQuery] = useState("")
   const [activeIndex, setActiveIndex] = useState(0)
   const [basePatients, setBasePatients] = useState<PatientHit[]>([])
@@ -97,7 +115,8 @@ export function CommandPalette({ userRole }: { userRole: UserRole }) {
 
   // Ouverture/reset/fermeture — handler d'évènement (setState légitime).
   const handleOpenChange = useCallback((next: boolean) => {
-    setOpen(next)
+    if (!isControlled) setInternalOpen(next)
+    onOpenChange?.(next)
     if (next) {
       setQuery("")
       setActiveIndex(0)
@@ -106,7 +125,7 @@ export function CommandPalette({ userRole }: { userRole: UserRole }) {
       baseAbortRef.current?.abort()
       exactAbortRef.current?.abort()
     }
-  }, [])
+  }, [isControlled, onOpenChange])
 
   // Ctrl/Cmd-K global.
   useEffect(() => {
@@ -226,10 +245,10 @@ export function CommandPalette({ userRole }: { userRole: UserRole }) {
   const activate = useCallback(
     (entry: Entry | undefined) => {
       if (!entry) return
-      setOpen(false)
+      handleOpenChange(false)
       router.push(entry.kind === "dest" ? entry.href : `/patients/${entry.patientId}`)
     },
-    [router],
+    [router, handleOpenChange],
   )
 
   const onKeyDown = useCallback(

--- a/src/components/diabeo/NavigationShell.tsx
+++ b/src/components/diabeo/NavigationShell.tsx
@@ -26,6 +26,7 @@ import {
   ChevronRight,
   Bell,
   RefreshCw,
+  Search,
   User,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
@@ -374,6 +375,8 @@ export function NavigationShell({
     () => false,
   )
   const [mobileOpen, setMobileOpen] = useState(false)
+  // US-2623 — ouverture contrôlée de la palette depuis le bouton de recherche visible.
+  const [searchOpen, setSearchOpen] = useState(false)
 
   // US-2600 — sidebar maigre côté pro (sous-ensemble destinations) ; la palette
   // Ctrl-K (CommandPalette) garde l'accès à toutes les sections autorisées.
@@ -418,7 +421,9 @@ export function NavigationShell({
     <UnreadCountProvider skip={!hasBadgeItem}>
     <TooltipProvider delay={300}>
       {/* US-2601 — Palette de commande Ctrl/Cmd-K (staff uniquement). */}
-      {variant === "pro" && <CommandPalette userRole={userRole} />}
+      {variant === "pro" && (
+        <CommandPalette userRole={userRole} open={searchOpen} onOpenChange={setSearchOpen} />
+      )}
       <div className="flex h-screen overflow-hidden bg-[var(--background)]">
         {/* Desktop sidebar */}
         <aside
@@ -531,6 +536,23 @@ export function NavigationShell({
             </div>
 
             <div className="flex items-center gap-2">
+              {/* US-2623 — déclencheur de recherche visible (ouvre la palette
+                  US-2601). Desktop : barre « Rechercher… ⌘K » ; mobile : loupe.
+                  Staff uniquement (la palette n'existe qu'en variant `pro`). */}
+              {variant === "pro" && (
+                <button
+                  onClick={() => setSearchOpen(true)}
+                  className="flex min-h-11 items-center gap-2 rounded-lg p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary md:min-w-56 md:justify-start md:border md:border-border md:px-3"
+                  aria-label={tNav("search")}
+                >
+                  <Search className="h-5 w-5 shrink-0" aria-hidden="true" />
+                  <span className="hidden flex-1 text-start text-sm md:inline">{tNav("search")}</span>
+                  <kbd className="hidden rounded border border-border px-1.5 py-0.5 text-xs md:inline" aria-hidden="true">
+                    {tNav("searchShortcut")}
+                  </kbd>
+                </button>
+              )}
+
               {/* Refresh button */}
               {onRefresh && (
                 <button

--- a/tests/components/command-palette.test.tsx
+++ b/tests/components/command-palette.test.tsx
@@ -129,4 +129,15 @@ describe("CommandPalette — ouverture contrôlée (US-2623)", () => {
     openWithCtrlK()
     expect(onOpenChange).toHaveBeenCalledWith(true)
   })
+
+  it("réinitialise la saisie à chaque ré-ouverture contrôlée (LOW #3)", () => {
+    const { rerender } = render(<CommandPalette userRole="DOCTOR" open onOpenChange={vi.fn()} />)
+    const input = screen.getByRole("combobox") as HTMLInputElement
+    fireEvent.change(input, { target: { value: "Dupont" } })
+    expect((screen.getByRole("combobox") as HTMLInputElement).value).toBe("Dupont")
+    // Fermeture puis ré-ouverture via la prop `open` (chemin bouton header).
+    rerender(<CommandPalette userRole="DOCTOR" open={false} onOpenChange={vi.fn()} />)
+    rerender(<CommandPalette userRole="DOCTOR" open onOpenChange={vi.fn()} />)
+    expect((screen.getByRole("combobox") as HTMLInputElement).value).toBe("")
+  })
 })

--- a/tests/components/command-palette.test.tsx
+++ b/tests/components/command-palette.test.tsx
@@ -113,3 +113,20 @@ describe("CommandPalette (US-2601)", () => {
     expect(push).toHaveBeenCalledWith("/medecin")
   })
 })
+
+// US-2623 — ouverture contrôlée (le bouton header du NavigationShell pilote `open`).
+describe("CommandPalette — ouverture contrôlée (US-2623)", () => {
+  it("affiche le dialog quand open=true, rien quand open=false", () => {
+    const { rerender } = render(<CommandPalette userRole="DOCTOR" open={false} onOpenChange={vi.fn()} />)
+    expect(screen.queryByTestId("dialog")).toBeNull()
+    rerender(<CommandPalette userRole="DOCTOR" open onOpenChange={vi.fn()} />)
+    expect(screen.getByTestId("dialog")).toBeTruthy()
+  })
+
+  it("Ctrl/Cmd-K notifie le parent via onOpenChange (mode contrôlé)", () => {
+    const onOpenChange = vi.fn()
+    render(<CommandPalette userRole="DOCTOR" open={false} onOpenChange={onOpenChange} />)
+    openWithCtrlK()
+    expect(onOpenChange).toHaveBeenCalledWith(true)
+  })
+})

--- a/tests/components/phase11/phase11-navigation.test.tsx
+++ b/tests/components/phase11/phase11-navigation.test.tsx
@@ -338,6 +338,28 @@ describe("NavigationShell", () => {
     })
   })
 
+  // US-2623 — bouton de recherche visible dans le header (ouvre la palette).
+  // Staff (variant `pro`) uniquement ; absent pour l'espace patient.
+  describe("US-2623 — bouton de recherche header", () => {
+    it("pro : le bouton de recherche est rendu (aria-label nav.search)", () => {
+      render(
+        <NavigationShell pageTitle="Dashboard" userRole="DOCTOR">
+          <div>content</div>
+        </NavigationShell>
+      )
+      expect(screen.getByRole("button", { name: "nav.search" })).toBeTruthy()
+    })
+
+    it("patient : pas de bouton de recherche", () => {
+      render(
+        <NavigationShell pageTitle="Dashboard" userRole="VIEWER" variant="patient">
+          <div>content</div>
+        </NavigationShell>
+      )
+      expect(screen.queryByRole("button", { name: "nav.search" })).toBeNull()
+    })
+  })
+
   describe("user avatar", () => {
     it("renders user initials from userName", () => {
       render(


### PR DESCRIPTION
## Contexte

La recherche globale (US-2601) ne s'ouvrait **qu'au clavier** (`Ctrl/Cmd-K`), sans aucune affordance visible dans le header → **non-découvrable** et **inatteignable au tactile** (tablette sans clavier). Cette PR ajoute un **déclencheur visible** qui ouvre la palette existante. US créée + ROADMAP mise à jour (US-2623, bloc V1).

## Changements
- **CommandPalette** : ouverture **contrôlée** optionnelle (`open`/`onOpenChange`), fallback interne (rétro-compat). `Ctrl/Cmd-K` marche dans les 2 modes ; `activate` ferme via `handleOpenChange` (sync parent).
- **NavigationShell** : bouton de recherche dans le header (**staff `pro` only**) — barre « 🔍 Rechercher… Ctrl K » en desktop, **icône loupe ≥44px** en mobile — ouvre la palette (zéro logique dupliquée).
- i18n `nav.search` / `nav.searchShortcut` **FR/EN/AR** + RTL ; a11y (aria-label, `kbd` aria-hidden, focus-visible, cible 44px).

## Tests & gates
- CommandPalette : ouverture contrôlée (`open` prop affiche/masque ; `Ctrl-K` → `onOpenChange`).
- NavigationShell : bouton présent (pro) / absent (patient).
- Suite complète **252 fichiers / 3382 tests** verte ; `tsc` / `eslint` (0 err) / `design-system` (272 = baseline) / `i18n-parity` OK.

## Périmètre
`VIEWER` (espace patient) : pas de palette → pas de bouton. Aucune nouvelle logique/route de recherche (réutilise US-2601, scoping serveur inchangé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)