### PR TITLE
feat(design-system): tokens d'accent par rôle (2b — Piece A)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -62,6 +62,15 @@
   --color-teal-900: var(--diabeo-primary-900);
   --color-teal-950: var(--diabeo-primary-950);
 
+  /* --- Diabeo Design System: Role accent (resolves per [data-role]) ---
+     Usage: bg-role, text-role-text, bg-role-soft, border-role-line.
+     Defaults to teal (doctor/patient); nurse=indigo, admin=slate.
+     Kept separate from shadcn's --color-accent on purpose. */
+  --color-role: var(--role-accent);
+  --color-role-text: var(--role-accent-text);
+  --color-role-soft: var(--role-accent-soft);
+  --color-role-line: var(--role-accent-line);
+
   /* --- Diabeo Design System: Coral secondary scale --- */
   --color-coral-50: var(--diabeo-secondary-50);
   --color-coral-100: var(--diabeo-secondary-100);

--- a/src/design-system/tokens.ts
+++ b/src/design-system/tokens.ts
@@ -106,6 +106,18 @@ export const COLOR_TOKEN_CSS = {
   "dt2-bg": "#EFF6FF",
   "gd": "#EC4899",
   "gd-bg": "#FDF2F8",
+  // Role accents (Home dashboards). Doctor & Patient réutilisent le teal
+  // (primary-*) ; seuls Nurse (indigo) et Admin (slate) introduisent de
+  // nouvelles teintes. Chrome de rôle UNIQUEMENT — jamais un sens clinique.
+  // Contraste WCAG AA texte normal vérifié (voir docs/design-system/colors.md).
+  "role-nurse": "#3E63A8",          // fill / brand
+  "role-nurse-text": "#2E4C84",     // texte sur clair — AA ≥8:1
+  "role-nurse-soft": "#EEF3FB",     // fond teinté
+  "role-nurse-line": "#D5E0F2",     // bordure teintée
+  "role-admin": "#33474E",
+  "role-admin-text": "#2B3B41",
+  "role-admin-soft": "#EEF1F2",
+  "role-admin-line": "#D7DEDF",
   // Pur blanc — fonds de masquage des bandes de charts (≠ neutral-50 #FAFAFA).
   "white": "#FFFFFF",
   // Hover / active shades (dark-mode safe — rebindable via CSS var)
@@ -185,6 +197,17 @@ export const tokens = {
   },
   pathology: {
     DT1: C["dt1"], DT2: C["dt2"], GD: C["gd"],
+  },
+  /** Accents par rôle (Home). Doctor/Patient = teal (brand.primary). */
+  role: {
+    nurse: {
+      brand: C["role-nurse"], text: C["role-nurse-text"],
+      soft: C["role-nurse-soft"], line: C["role-nurse-line"],
+    },
+    admin: {
+      brand: C["role-admin"], text: C["role-admin-text"],
+      soft: C["role-admin-soft"], line: C["role-admin-line"],
+    },
   },
   /** Pur blanc (#FFFFFF) — fonds de masquage des bandes de charts. */
   white: C["white"],

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -143,6 +143,32 @@
   --diabeo-gd-bg: #FDF2F8;
 
   /* ----------------------------------------------------------------
+   * 5b. COLOR TOKENS — Role accents (Home dashboards)
+   *   Doctor & Patient reuse the teal brand (primary-*). Only Nurse
+   *   (indigo) and Admin (slate) add new hues. These drive role chrome
+   *   ONLY (active nav, greeting, primary CTA, focus ring) — never
+   *   clinical / pathology / feedback meaning.
+   *   Contrast: all pass WCAG AA for normal text. Colorblind sim still
+   *   recommended. See docs/design-system/colors.md.
+   * ---------------------------------------------------------------- */
+  --diabeo-role-nurse: #3E63A8;
+  --diabeo-role-nurse-text: #2E4C84;
+  --diabeo-role-nurse-soft: #EEF3FB;
+  --diabeo-role-nurse-line: #D5E0F2;
+  --diabeo-role-admin: #33474E;
+  --diabeo-role-admin-text: #2B3B41;
+  --diabeo-role-admin-soft: #EEF1F2;
+  --diabeo-role-admin-line: #D7DEDF;
+
+  /* Active role accent — defaults to teal (doctor/patient). Switched by
+     [data-role="nurse"|"admin"] on the dashboard shell (see end of file).
+     NB: distinct from shadcn's --accent (do not hijack it). */
+  --role-accent: var(--diabeo-primary-600);
+  --role-accent-text: var(--diabeo-primary-700);
+  --role-accent-soft: var(--diabeo-primary-50);
+  --role-accent-line: var(--diabeo-primary-100);
+
+  /* ----------------------------------------------------------------
    * 6. TYPOGRAPHY TOKENS
    * ---------------------------------------------------------------- */
 
@@ -267,4 +293,21 @@
   --diabeo-glucose-target-max: 180;  /* mg/dL */
   --diabeo-glucose-high: 250;        /* mg/dL */
   --diabeo-glucose-very-high: 400;   /* mg/dL */
+}
+
+/* ------------------------------------------------------------------
+ * Role accent switch — set data-role on the dashboard shell element.
+ * Doctor/Patient inherit the teal default from :root above.
+ * ------------------------------------------------------------------ */
+[data-role="nurse"] {
+  --role-accent: var(--diabeo-role-nurse);
+  --role-accent-text: var(--diabeo-role-nurse-text);
+  --role-accent-soft: var(--diabeo-role-nurse-soft);
+  --role-accent-line: var(--diabeo-role-nurse-line);
+}
+[data-role="admin"] {
+  --role-accent: var(--diabeo-role-admin);
+  --role-accent-text: var(--diabeo-role-admin-text);
+  --role-accent-soft: var(--diabeo-role-admin-soft);
+  --role-accent-line: var(--diabeo-role-admin-line);
 }


### PR DESCRIPTION
## Contexte

Étape **2b — Piece A** de la direction éditoriale Home v3 (la doc a été officialisée en #575). Implémente **uniquement** les **accents par rôle**, partie **additive et sûre** : aucun rendu existant n'est modifié, aucune police ni surface globale touchée.

> Les deux flips globaux restants — **surfaces chaudes** (remap `--background`/`--card`/`--border`) et **swap polices** (Geist → Fraunces/Hanken/Spline) — sont **hors périmètre** ici : ils changent l'apparence de toute l'app et restent gated (sign-off visuel + mesure perf). Ils feront l'objet de PR séparées.

## Changements

- **`tokens.css`** — 8 tokens bruts `--diabeo-role-{nurse,admin}{,-text,-soft,-line}` + variables sémantiques `--role-accent*` (défaut teal) + switch `[data-role="nurse"|"admin"]`.
- **`tokens.ts`** — miroir dans `COLOR_TOKEN_CSS` + groupe `tokens.role` (pour SVG/Recharts).
- **`globals.css` `@theme`** — classes `bg-role` / `text-role-text` / `bg-role-soft` / `border-role-line`. Namespace `role` **distinct** du `--accent` shadcn (non détourné, pas de régression composants).

Modèle : Doctor & Patient héritent du teal ; **Nurse = indigo `#3E63A8`**, **Admin = slate `#33474E`**.

## Validation

- ✅ Parité bidirectionnelle `tokens.ts` ↔ `tokens.css` (`design-tokens.test.ts`, 7/7).
- ✅ `tsc --noEmit` clean ; ESLint sans erreur.
- ✅ **Contraste WCAG AA texte normal** : nurse `#2E4C84` 8,46:1 · fill `#3E63A8` 5,91:1 · admin ≥ 9,7:1.
- ⚠️ Simulation **daltonisme** (protanopie/deutéranopie) recommandée avant usage massif — non bloquante pour le contraste.

## Hors périmètre (étapes suivantes)
- B — remap surfaces chaudes · C — swap polices (PR dédiées, après levée des gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)