### PR TITLE
feat(nav): accent par rôle sur le shell + sidebar active (2b — Piece A bis)

### DIFF
--- a/src/components/diabeo/NavigationShell.tsx
+++ b/src/components/diabeo/NavigationShell.tsx
@@ -177,7 +177,7 @@ function SidebarNav({
               "flex min-h-11 items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors relative",
               collapsed && "justify-center px-2",
               isActive
-                ? "bg-primary/10 text-primary"
+                ? "bg-role-soft text-role-text"
                 : "text-muted-foreground hover:bg-muted hover:text-foreground"
             )}
             aria-current={isActive ? "page" : undefined}
@@ -417,6 +417,18 @@ export function NavigationShell({
         .slice(0, 2)
     : "U"
 
+  // Accent par rôle (design-system §Role Accent). Pose `data-role` sur la
+  // racine du shell → résout --role-accent* (teal par défaut, nurse=indigo,
+  // admin=slate). Doctor & patient retombent sur le teal par défaut.
+  const roleSlug =
+    variant === "patient" || userRole === "VIEWER"
+      ? "patient"
+      : userRole === "ADMIN"
+        ? "admin"
+        : userRole === "NURSE"
+          ? "nurse"
+          : "doctor"
+
   return (
     <UnreadCountProvider skip={!hasBadgeItem}>
     <TooltipProvider delay={300}>
@@ -424,7 +436,7 @@ export function NavigationShell({
       {variant === "pro" && (
         <CommandPalette userRole={userRole} open={searchOpen} onOpenChange={setSearchOpen} />
       )}
-      <div className="flex h-screen overflow-hidden bg-[var(--background)]">
+      <div data-role={roleSlug} className="flex h-screen overflow-hidden bg-[var(--background)]">
         {/* Desktop sidebar */}
         <aside
           className={cn(


### PR DESCRIPTION
## Contexte

Premier **consommateur réel** des tokens d'accent par rôle livrés en #576. Branche l'accent sur le shell de navigation, sans toucher aux surfaces globales ni aux polices (flips B/C toujours gated).

## Changements (`NavigationShell.tsx`)

- Pose `data-role={doctor|nurse|admin|patient}` sur la racine du shell → résout `--role-accent*` (pro **et** patient via le même composant).
- État actif de la sidebar : `bg-primary/10 text-primary` → **`bg-role-soft text-role-text`**.

## Rendu

| Rôle | Sidebar active |
|------|----------------|
| Infirmier | indigo `#3E63A8` |
| Admin | slate `#33474E` |
| Médecin / Patient | teal (inchangé vs actuel) |

**Additif et sûr** : doctor/patient gardent exactement le rendu actuel (role-accent défaut = teal) ; seuls nurse/admin changent de teinte — conforme aux mockups Home v3 approuvés.

## Validation
- ✅ `tsc --noEmit` clean ; ESLint clean.
- ✅ Aucun test ne dépend de l'ancienne classe active (`bg-primary/10`) ; pas de collision `data-role`.
- Contraste des accents déjà validé en #576 (AA texte normal).

## Hors périmètre
- Extension de l'accent à d'autres chrome (CTA cartes Home, avatar, rail actif) — possible en suivi.
- Flips globaux B (surfaces chaudes) / C (polices) — PR dédiées après gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)