### PR TITLE
feat(design-system): surfaces chaudes + polices éditoriales (2b — B + C)

### DIFF
--- a/src/app/(dashboard)/admin/page.tsx
+++ b/src/app/(dashboard)/admin/page.tsx
@@ -29,7 +29,7 @@ export default async function AdminDashboardPage() {
 
   return (
     <main className="flex flex-col gap-6 p-4 lg:p-6">
-      <h1 className="text-2xl font-semibold">{t("adminDashboard.pageTitle")}</h1>
+      <h1 className="font-display text-2xl font-semibold">{t("adminDashboard.pageTitle")}</h1>
       <AdminKpiSection />
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <BillingCard />

--- a/src/app/(dashboard)/infirmier/page.tsx
+++ b/src/app/(dashboard)/infirmier/page.tsx
@@ -27,7 +27,7 @@ export default async function InfirmierDashboardPage() {
 
   return (
     <main className="flex flex-col gap-6 p-4 lg:p-6">
-      <h1 className="text-2xl font-semibold">{t("title")}</h1>
+      <h1 className="font-display text-2xl font-semibold">{t("title")}</h1>
       <NurseKpiSection />
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <TodoListCard />

--- a/src/app/(dashboard)/medecin/page.tsx
+++ b/src/app/(dashboard)/medecin/page.tsx
@@ -39,7 +39,7 @@ export default async function MedecinDashboardPage() {
 
   return (
     <main className="flex flex-col gap-6 p-4 lg:p-6">
-      <h1 className="text-2xl font-semibold">{t("pageTitle")}</h1>
+      <h1 className="font-display text-2xl font-semibold">{t("pageTitle")}</h1>
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <EmergencyCard />
         <AppointmentCard />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,9 +9,10 @@
   /* --- shadcn/ui semantic mappings --- */
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-sans);
-  --font-mono: var(--font-geist-mono);
-  --font-heading: var(--font-sans);
+  --font-sans: var(--diabeo-font-sans);
+  --font-mono: var(--diabeo-font-mono);
+  --font-heading: var(--diabeo-font-display);
+  --font-display: var(--diabeo-font-display);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -268,24 +269,26 @@
 @utility z-critical-alert  { z-index: var(--diabeo-z-critical-alert); }
 
 :root {
-  /* Palette "Serenite Active" -- Diabeo */
-  --background: #FAFAFA;
-  --foreground: #1F2937;
-  --card: #FFFFFF;
-  --card-foreground: #1F2937;
-  --popover: #FFFFFF;
-  --popover-foreground: #1F2937;
+  /* Palette "Serenite Active" -- Diabeo.
+     Surfaces/texte/bordures = tokens chauds (editorial, voir colors.md
+     §Warm Surfaces) ; brand teal, coral, et couleurs cliniques inchangés. */
+  --background: var(--diabeo-paper);        /* #FAFAF7 — was #FAFAFA */
+  --foreground: var(--diabeo-ink);          /* #1A2A2E — was #1F2937 */
+  --card: var(--diabeo-white);
+  --card-foreground: var(--diabeo-ink);
+  --popover: var(--diabeo-white);
+  --popover-foreground: var(--diabeo-ink);
   --primary: #0D9488;           /* teal -- actions principales */
   --primary-foreground: #FFFFFF;
-  --secondary: #F3F4F6;
-  --secondary-foreground: #1F2937;
-  --muted: #F3F4F6;
-  --muted-foreground: #6B7280;
+  --secondary: var(--diabeo-paper-2);       /* #F4F2EC — was #F3F4F6 */
+  --secondary-foreground: var(--diabeo-ink);
+  --muted: var(--diabeo-paper-2);
+  --muted-foreground: var(--diabeo-ink-soft); /* #586A6B — was #6B7280 */
   --accent: #F97316;            /* corail -- alertes, actions secondaires */
   --accent-foreground: #FFFFFF;
   --destructive: #EF4444;       /* glycemie critique */
-  --border: #E5E7EB;
-  --input: #E5E7EB;
+  --border: var(--diabeo-line);             /* #E7E4DB — was #E5E7EB */
+  --input: var(--diabeo-line);
   --ring: #0D9488;
   --chart-1: #10B981;           /* glycemie normale -- vert emeraude */
   --chart-2: #F59E0B;           /* glycemie haute -- orange ambre */
@@ -293,13 +296,13 @@
   --chart-4: #0D9488;           /* teal primaire */
   --chart-5: #F97316;           /* corail secondaire */
   --radius: 0.625rem;
-  --sidebar: #FFFFFF;
-  --sidebar-foreground: #1F2937;
+  --sidebar: var(--diabeo-white);
+  --sidebar-foreground: var(--diabeo-ink);
   --sidebar-primary: #0D9488;
   --sidebar-primary-foreground: #FFFFFF;
-  --sidebar-accent: #F3F4F6;
-  --sidebar-accent-foreground: #1F2937;
-  --sidebar-border: #E5E7EB;
+  --sidebar-accent: var(--diabeo-paper-2);
+  --sidebar-accent-foreground: var(--diabeo-ink);
+  --sidebar-border: var(--diabeo-line);
   --sidebar-ring: #0D9488;
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,18 +1,32 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Fraunces, Hanken_Grotesk, Spline_Sans_Mono } from "next/font/google";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages } from "next-intl/server";
 import { isRtlLocale, type Locale } from "@/i18n/config";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+// Direction éditoriale (docs/design-system/typography.md). next/font self-host
+// + subset automatiquement (pas de requête Google au runtime). display:swap
+// évite le FOIT. Fraunces = titres/KPI ; Hanken = UI ; Spline Mono = chiffres.
+const hankenSans = Hanken_Grotesk({
+  variable: "--font-hanken",
   subsets: ["latin"],
+  display: "swap",
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const splineMono = Spline_Sans_Mono({
+  variable: "--font-spline",
   subsets: ["latin"],
+  display: "swap",
+});
+
+const fraunces = Fraunces({
+  variable: "--font-fraunces",
+  subsets: ["latin"],
+  display: "swap",
+  // La typo n'utilise Fraunces qu'en 600 (titres/KPI) — un seul cut statique
+  // au lieu du variable complet, pour limiter le poids. Voir typography.md.
+  weight: ["600"],
 });
 
 export const metadata: Metadata = {
@@ -39,7 +53,7 @@ export default async function RootLayout({
     <html
       lang={locale}
       dir={dir}
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${hankenSans.variable} ${splineMono.variable} ${fraunces.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">
         <NextIntlClientProvider locale={locale} messages={messages}>

--- a/src/design-system/tokens.ts
+++ b/src/design-system/tokens.ts
@@ -120,6 +120,15 @@ export const COLOR_TOKEN_CSS = {
   "role-admin-line": "#D7DEDF",
   // Pur blanc — fonds de masquage des bandes de charts (≠ neutral-50 #FAFAFA).
   "white": "#FFFFFF",
+  // Warm surfaces (editorial) — back the shadcn base tokens. Clinical/brand
+  // colors unaffected. Voir docs/design-system/colors.md §Warm Surfaces.
+  "paper": "#FAFAF7",
+  "paper-2": "#F4F2EC",
+  "ink": "#1A2A2E",
+  "ink-soft": "#586A6B",
+  "ink-faint": "#9AA8A6",
+  "line": "#E7E4DB",
+  "line-soft": "#EFEDE6",
   // Hover / active shades (dark-mode safe — rebindable via CSS var)
   "primary-hover": "#0F766E",       // teal-700, identique à primary-700
   "primary-active": "#115E59",      // teal-800
@@ -211,4 +220,10 @@ export const tokens = {
   },
   /** Pur blanc (#FFFFFF) — fonds de masquage des bandes de charts. */
   white: C["white"],
+  /** Surfaces chaudes (editorial) — fonds/texte/lignes. */
+  surface: {
+    paper: C["paper"], paper2: C["paper-2"], ink: C["ink"],
+    inkSoft: C["ink-soft"], inkFaint: C["ink-faint"],
+    line: C["line"], lineSoft: C["line-soft"],
+  },
 } as const

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -57,6 +57,17 @@
   /* Pure white — chart band masking (distinct from neutral-50 #FAFAFA) */
   --diabeo-white: #FFFFFF;
 
+  /* Warm surfaces (editorial direction) — back the shadcn base tokens
+     (--background/--card/--border…). Clinical/glycemia/brand colors are
+     unaffected. See docs/design-system/colors.md §Warm Surfaces. */
+  --diabeo-paper: #FAFAF7;        /* page background */
+  --diabeo-paper-2: #F4F2EC;      /* muted/secondary fills */
+  --diabeo-ink: #1A2A2E;          /* primary text */
+  --diabeo-ink-soft: #586A6B;     /* secondary text */
+  --diabeo-ink-faint: #9AA8A6;    /* hints/placeholders */
+  --diabeo-line: #E7E4DB;         /* borders/dividers */
+  --diabeo-line-soft: #EFEDE6;    /* subtle inner dividers */
+
   /* ----------------------------------------------------------------
    * 2. COLOR TOKENS — Glycemia (clinical)
    * ---------------------------------------------------------------- */
@@ -172,8 +183,11 @@
    * 6. TYPOGRAPHY TOKENS
    * ---------------------------------------------------------------- */
 
-  --diabeo-font-sans: var(--font-geist-sans, "Geist", ui-sans-serif, system-ui, -apple-system, sans-serif);
-  --diabeo-font-mono: var(--font-geist-mono, "Geist Mono", ui-monospace, "Cascadia Code", monospace);
+  /* Editorial trio (see docs/design-system/typography.md). next/font sets the
+     --font-* variables in layout.tsx ; the literal names are SSR fallbacks. */
+  --diabeo-font-display: var(--font-fraunces, "Fraunces", ui-serif, Georgia, serif);
+  --diabeo-font-sans: var(--font-hanken, "Hanken Grotesk", ui-sans-serif, system-ui, -apple-system, sans-serif);
+  --diabeo-font-mono: var(--font-spline, "Spline Sans Mono", ui-monospace, "Cascadia Code", monospace);
 
   /* Font sizes — rem scale */
   --diabeo-text-xs: 0.75rem;         /* 12px */


### PR DESCRIPTION
## Contexte

Bascule l'**aspect global** de l'app vers la direction éditoriale Home v3 (officialisée doc-only en #575). Dernière étape « flips globaux » de 2b. Couleurs **cliniques / glycémie / brand (teal, coral) inchangées**.

## B — Surfaces chaudes
- `tokens.css` / `tokens.ts` : 7 tokens `--diabeo-{paper,paper-2,ink,ink-soft,ink-faint,line,line-soft}` (parité bidirectionnelle 7/7) + groupe `tokens.surface`.
- `globals.css :root` : `--background`/`--card`/`--popover`/`--secondary`/`--muted`/`--border`/`--input`/`--sidebar*` remappés sur les tokens chauds.

| Var | Avant | Après |
|---|---|---|
| `--background` | `#FAFAFA` | `#FAFAF7` |
| `--foreground` | `#1F2937` | `#1A2A2E` |
| `--muted-foreground` | `#6B7280` | `#586A6B` |
| `--border` | `#E5E7EB` | `#E7E4DB` |

## C — Polices
- `layout.tsx` : Geist → **Fraunces** (titres/KPI, graisse **600 only**) + **Hanken Grotesk** (UI) + **Spline Sans Mono** (chiffres), via `next/font` (self-host + subset, `display:swap`).
- `tokens.css` + `globals.css @theme` : `--font-{display,sans,mono,heading}` recâblés proprement sur les tokens (fin du câblage auto-référentiel).
- `font-display` appliqué aux `<h1>` Home médecin/infirmier/admin.

## Perf (mesuré)
| Config | Poids polices woff2 (latin) |
|---|---|
| Fraunces 4 graisses | 388 K |
| **Fraunces 600 seul (retenu)** | **180 K** |

Self-hostées (pas de round-trip Google), `display:swap`, sous-ensemble chargé par page. **Build prod ✅**, `tsc` + ESLint clean, parité tokens 7/7.

## Réserves / hors périmètre
- ⚠️ Changement **visuel global** — à regarder en vrai. (Option screenshots dispo si besoin avant merge.)
- **Dark mode** (`.dark`) non retouché — garde les oklch neutres actuels (étape séparée).
- Restyling fin des cartes Home (greeting, bande KPI, layout exact mockup) = chantier suivant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)