### PR TITLE
feat(home): restyle médecin — titres Fraunces + greeting daté

### DIFF
--- a/src/app/(dashboard)/medecin/page.tsx
+++ b/src/app/(dashboard)/medecin/page.tsx
@@ -14,7 +14,7 @@
 
 import { headers } from "next/headers"
 import { redirect } from "next/navigation"
-import { getTranslations } from "next-intl/server"
+import { getLocale, getTranslations } from "next-intl/server"
 import { EmergencyCard } from "@/components/diabeo/dashboard/medecin/EmergencyCard"
 import { AppointmentCard } from "@/components/diabeo/dashboard/medecin/AppointmentCard"
 import { PatientsAtRiskCard } from "@/components/diabeo/dashboard/medecin/PatientsAtRiskCard"
@@ -37,9 +37,26 @@ export default async function MedecinDashboardPage() {
 
   const t = await getTranslations("dashboard.medecin")
 
+  // Greeting éditorial (mockup Home v3) : titre Fraunces + date localisée.
+  // La date est une valeur formatée (non un littéral JSX) — pas de clé i18n
+  // requise ; Intl gère la locale active. Première lettre capitalisée (FR
+  // rend « lundi » en minuscule en début de phrase).
+  const locale = await getLocale()
+  const today = new Intl.DateTimeFormat(locale, {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  }).format(new Date())
+  const todayLabel = today.charAt(0).toUpperCase() + today.slice(1)
+
   return (
     <main className="flex flex-col gap-6 p-4 lg:p-6">
-      <h1 className="font-display text-2xl font-semibold">{t("pageTitle")}</h1>
+      <header>
+        <h1 className="font-display text-3xl font-semibold tracking-tight">
+          {t("pageTitle")}
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">{todayLabel}</p>
+      </header>
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <EmergencyCard />
         <AppointmentCard />

--- a/src/app/(dashboard)/medecin/page.tsx
+++ b/src/app/(dashboard)/medecin/page.tsx
@@ -15,6 +15,7 @@
 import { headers } from "next/headers"
 import { redirect } from "next/navigation"
 import { getLocale, getTranslations } from "next-intl/server"
+import { CABINET_TIMEZONE } from "@/lib/cabinet-time"
 import { EmergencyCard } from "@/components/diabeo/dashboard/medecin/EmergencyCard"
 import { AppointmentCard } from "@/components/diabeo/dashboard/medecin/AppointmentCard"
 import { PatientsAtRiskCard } from "@/components/diabeo/dashboard/medecin/PatientsAtRiskCard"
@@ -39,15 +40,23 @@ export default async function MedecinDashboardPage() {
 
   // Greeting éditorial (mockup Home v3) : titre Fraunces + date localisée.
   // La date est une valeur formatée (non un littéral JSX) — pas de clé i18n
-  // requise ; Intl gère la locale active. Première lettre capitalisée (FR
-  // rend « lundi » en minuscule en début de phrase).
+  // requise ; Intl gère la locale active.
+  // timeZone épinglé à Europe/Paris (CABINET_TIMEZONE) comme tout le reste du
+  // code horaire : sinon `new Date()` se résout en zone serveur (VPS UTC) et
+  // affiche le mauvais jour entre 22 h et minuit heure de Paris.
   const locale = await getLocale()
   const today = new Intl.DateTimeFormat(locale, {
     weekday: "long",
     day: "numeric",
     month: "long",
+    timeZone: CABINET_TIMEZONE,
   }).format(new Date())
-  const todayLabel = today.charAt(0).toUpperCase() + today.slice(1)
+  // FR/EN rendent le jour de la semaine en minuscule en début de phrase → on
+  // capitalise. Inutile/incorrect pour d'autres scripts (ar) → restreint.
+  const todayLabel =
+    locale === "fr" || locale === "en"
+      ? today.charAt(0).toUpperCase() + today.slice(1)
+      : today
 
   return (
     <main className="flex flex-col gap-6 p-4 lg:p-6">

--- a/src/components/diabeo/dashboard/infirmier/RecallListCard.tsx
+++ b/src/components/diabeo/dashboard/infirmier/RecallListCard.tsx
@@ -38,7 +38,7 @@ export function RecallListCard() {
   return (
     <DiabeoCard role="region" aria-labelledby="card-recall-title">
       <header className="flex items-center justify-between px-4 pt-4">
-        <h2 id="card-recall-title" className="text-base font-semibold">
+        <h2 id="card-recall-title" className="font-display text-base font-semibold">
           {t("title")}
         </h2>
         <span className="text-xs text-muted-foreground">{items.length}</span>

--- a/src/components/diabeo/dashboard/medecin/AppointmentCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/AppointmentCard.tsx
@@ -45,7 +45,7 @@ export function AppointmentCard() {
   return (
     <DiabeoCard role="region" aria-labelledby="card-appointments-title">
       <header className="flex items-center justify-between px-4 pt-4">
-        <h2 id="card-appointments-title" className="text-base font-semibold">
+        <h2 id="card-appointments-title" className="font-display text-base font-semibold">
           {t("appointments.title")}
         </h2>
         <span className="text-xs text-muted-foreground">

--- a/src/components/diabeo/dashboard/medecin/EmergencyCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/EmergencyCard.tsx
@@ -39,7 +39,7 @@ export function EmergencyCard() {
   return (
     <DiabeoCard className="border-s-4 border-s-glycemia-critical" role="region" aria-labelledby="card-urgencies-title">
       <header className="flex items-center justify-between px-4 pt-4">
-        <h2 id="card-urgencies-title" className="text-base font-semibold text-glycemia-critical">
+        <h2 id="card-urgencies-title" className="font-display text-base font-semibold text-glycemia-critical">
           {t("urgencies.title")}
         </h2>
         <span className="text-xs text-muted-foreground">

--- a/src/components/diabeo/dashboard/medecin/KpiSection.tsx
+++ b/src/components/diabeo/dashboard/medecin/KpiSection.tsx
@@ -31,7 +31,7 @@ export function KpiSection() {
 
   return (
     <section aria-labelledby="kpi-section-title">
-      <h2 id="kpi-section-title" className="mb-3 text-base font-semibold">
+      <h2 id="kpi-section-title" className="mb-3 font-display text-base font-semibold">
         {t("kpi.title")}
       </h2>
       {hasError && (

--- a/src/components/diabeo/dashboard/medecin/PatientsAtRiskCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/PatientsAtRiskCard.tsx
@@ -39,7 +39,7 @@ export function PatientsAtRiskCard() {
   return (
     <DiabeoCard role="region" aria-labelledby="card-risk-title">
       <header className="flex items-center justify-between px-4 pt-4">
-        <h2 id="card-risk-title" className="text-base font-semibold">
+        <h2 id="card-risk-title" className="font-display text-base font-semibold">
           {t("risk.title")}
         </h2>
         <span className="text-xs text-muted-foreground">

--- a/src/components/diabeo/dashboard/medecin/PendingProposalsCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/PendingProposalsCard.tsx
@@ -96,7 +96,7 @@ export function PendingProposalsCard() {
   return (
     <DiabeoCard role="region" aria-labelledby="card-proposals-title">
       <header className="flex items-center justify-between px-4 pt-4">
-        <h2 id="card-proposals-title" className="text-base font-semibold">
+        <h2 id="card-proposals-title" className="font-display text-base font-semibold">
           {t("title")}
         </h2>
         <span className="text-xs text-muted-foreground">{items.length}</span>

--- a/src/components/diabeo/dashboard/medecin/UnreadMessagesCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/UnreadMessagesCard.tsx
@@ -40,7 +40,7 @@ export function UnreadMessagesCard() {
   return (
     <DiabeoCard role="region" aria-labelledby="card-messages-title">
       <header className="flex items-center justify-between px-4 pt-4">
-        <h2 id="card-messages-title" className="text-base font-semibold">
+        <h2 id="card-messages-title" className="font-display text-base font-semibold">
           {t("title")}
         </h2>
         <span className="text-xs text-muted-foreground">{items.length}</span>

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -325,3 +325,10 @@
   --role-accent-soft: var(--diabeo-role-admin-soft);
   --role-accent-line: var(--diabeo-role-admin-line);
 }
+
+/* Fraunces n'a pas de glyphes arabes : en arabe, les titres (font-display)
+   retombent sur la police UI (Hanken) plutôt qu'un serif système, pour
+   garder une typographie cohérente fr/en/ar. App-wide via le lang du <html>. */
+[lang="ar"] {
+  --diabeo-font-display: var(--diabeo-font-sans);
+}


### PR DESCRIPTION
## Contexte

Première tranche du **restyling fin des Home** vers les mockups v3, scope **médecin**. Additif, sûr, sans donnée sensible.

## Changements

### Titres de cartes en Fraunces (`font-display`)
`<h2>` des cartes du home médecin : EmergencyCard, AppointmentCard, PatientsAtRiskCard, PendingProposalsCard, UnreadMessagesCard, KpiSection + RecallListCard (partagée → l'infirmier en bénéficie aussi). En-têtes serif comme les mockups.

### Greeting éditorial
En-tête de page restructuré en bloc greeting : `<h1>` Fraunces `text-3xl` (aligne sur `typography.md` H1 + échelle mockup) + sous-titre **date localisée** (`Intl.DateTimeFormat(locale)`). Le titre « Ma journée » est inchangé (BDD `dashboard-access` toujours vert).

## Choix d'archi (volontairement hors périmètre)
Deux éléments du mockup sont **transverses**, pas médecin-spécifiques → PR dédiées à suivre :
- **Greeting nominatif** « Bonjour, Dr X » → brique « nom utilisateur courant » (helper léger non-audité), qui corrigera aussi les initiales « U » du shell.
- **Bande KPI** (rail d'accent + valeur Fraunces) → passe par `MetricCard` **partagée** (patient/admin/infirmier aussi) → 1 PR « shared » qui améliore tous les KPI.

Note : ne pas utiliser `getProfile` pour le greeting (il audite + déchiffre tout → bruit d'audit à chaque chargement).

## Validation
- ✅ `tsc --noEmit` clean ; ESLint clean.
- ✅ Aucun test n'asserte les classes/structure touchées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)