### PR TITLE
feat(design-system): MetricCard éditoriale — bande KPI (brique transverse)

### DIFF
--- a/docs/design-system/typography.md
+++ b/docs/design-system/typography.md
@@ -61,8 +61,8 @@ healthcare professionals need to see more information simultaneously.
 
 | Level | Size | Weight | Line Height | Tailwind | Usage |
 |-------|------|--------|-------------|----------|-------|
-| Display | 36px / 2.25rem | 700 | 1.25 | `text-4xl font-bold` | Dashboard hero KPIs |
-| H1 | 30px / 1.875rem | 700 | 1.25 | `text-3xl font-bold` | Page titles |
+| Display | 36px / 2.25rem | 600 | 1.25 | `font-display text-4xl font-semibold` | Dashboard hero KPIs |
+| H1 | 30px / 1.875rem | 600 | 1.25 | `font-display text-3xl font-semibold` | Page titles |
 | H2 | 24px / 1.5rem | 600 | 1.25 | `text-2xl font-semibold` | Section headings |
 | H3 | 20px / 1.25rem | 600 | 1.375 | `text-xl font-semibold` | Card titles |
 | H4 | 18px / 1.125rem | 600 | 1.375 | `text-lg font-semibold` | Subsection headings |
@@ -90,13 +90,23 @@ healthcare professionals need to see more information simultaneously.
 - Default body text is 14px. This is intentional for desktop dashboards.
 - Use `font-medium` (500) for labels, navigation items, and form labels.
 - Use `font-semibold` (600) for emphasized inline text.
-- Never use `font-bold` (700) for body text -- reserve for headings and KPIs.
+- Never use `font-bold` (700) for body text.
+- Headings, page titles and dashboard KPI values render in the **Fraunces
+  display face** (`font-display`) at **600** (`font-semibold`) — the serif is
+  loaded only at weight 600, so `font-bold`/700 would fall back. `font-bold`
+  (700) stays reserved for inline numeric data in the mono face (below).
 
 ### Numeric Data
 
-- Glucose values: `tabular-nums font-bold` -- always monospaced with bold weight.
-- Dosages (insulin units): `tabular-nums font-semibold`.
-- Percentages (TIR): `tabular-nums font-bold`.
+- **KPI / display values** (MetricCard, hero numbers) render in the Fraunces
+  display face at `font-semibold` (600) — not 700 (serif is 600-only). The
+  `MetricCard` value also carries `tabular-nums` (best-effort: the static
+  Fraunces 600 cut may not expose `tnum`, so treat it as decorative there).
+- Glucose values (inline, mono): `font-mono tabular-nums font-bold` -- Spline
+  Sans Mono has genuine tabular figures; bold is available on the mono face.
+- Dosages (insulin units): `font-mono tabular-nums font-semibold`.
+- Percentages (TIR) inline: `font-mono tabular-nums font-bold` (mono). In a KPI
+  card, the percentage follows the KPI rule above (Fraunces 600).
 - Timestamps: `text-xs text-muted-foreground`.
 - Always use `tabular-nums` (or `font-mono`) for numbers that may update or appear in columns -- this prevents layout shifts.
 

--- a/src/components/diabeo/MetricCard.tsx
+++ b/src/components/diabeo/MetricCard.tsx
@@ -122,7 +122,7 @@ function MetricCardSkeleton() {
   return (
     <div className="space-y-2" aria-busy="true" aria-label={t("loading")}>
       <Skeleton className="h-3.5 w-24" />
-      <Skeleton className="h-8 w-16" />
+      <Skeleton className="h-9 w-20" />
       <Skeleton className="h-3 w-12" />
     </div>
   )
@@ -170,9 +170,12 @@ export const MetricCard = forwardRef<HTMLDivElement, MetricCardProps>(
         clickable={isClickable}
         onClick={onClick}
         className={cn(
-          // Inline-start border accent when status is set
-          status && "border-s-4",
-          status && statusBorderClasses[status],
+          // Rail inline-start : couleur clinique du status si défini, sinon
+          // l'accent de rôle (--color-role, résolu par [data-role] sur le
+          // shell). Donne la « bande KPI » éditoriale des mockups Home v3.
+          // Le status (clinique) prime toujours sur l'accent de rôle.
+          "border-s-4",
+          status ? statusBorderClasses[status] : "border-s-role",
           className
         )}
         role={isClickable ? "button" : "region"}
@@ -199,7 +202,7 @@ export const MetricCard = forwardRef<HTMLDivElement, MetricCardProps>(
           <>
             {/* Top row: title + icon */}
             <div className="flex items-start justify-between gap-2">
-              <p className="text-xs font-medium text-muted-foreground truncate">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground truncate">
                 {title}
               </p>
               {icon && (
@@ -214,7 +217,7 @@ export const MetricCard = forwardRef<HTMLDivElement, MetricCardProps>(
 
             {/* Value row */}
             <div className="flex items-baseline gap-1 mt-1">
-              <span className="text-2xl font-bold text-foreground tabular-nums">
+              <span className="font-display text-3xl font-semibold text-foreground tabular-nums">
                 {value}
               </span>
               {unit && (

--- a/src/components/diabeo/MetricCard.tsx
+++ b/src/components/diabeo/MetricCard.tsx
@@ -215,7 +215,11 @@ export const MetricCard = forwardRef<HTMLDivElement, MetricCardProps>(
               )}
             </div>
 
-            {/* Value row */}
+            {/* Value row — valeur en Fraunces (font-display, chargé en 600 →
+                font-semibold ; font-bold/700 ferait un fallback). tabular-nums
+                est best-effort : le cut statique Fraunces 600 peut ne pas
+                exposer `tnum`, donc largeur non strictement garantie (KPI en
+                polling). Cf. docs/design-system/typography.md §Numeric Data. */}
             <div className="flex items-baseline gap-1 mt-1">
               <span className="font-display text-3xl font-semibold text-foreground tabular-nums">
                 {value}


### PR DESCRIPTION
## Contexte

Brique **transverse** du restyling Home : aligne la `MetricCard` **partagée** sur la bande KPI des mockups v3. Bénéficie d'un coup à **tous les rôles** (médecin/infirmier/admin/patient) qui consomment ce composant. UI pure, pas de donnée sensible.

> Correctif description : `SystemHealthClient` n'est **pas** impacté — il définit son propre `MetricCard` local et n'importe pas le composant partagé.

## Changements (`MetricCard.tsx`)
- **Rail inline-start toujours présent** : couleur clinique du `status` si défini, sinon **accent de rôle** (`border-s-role`, résolu par `[data-role]` sur le shell ; défaut teal dans `:root`). Le clinique prime toujours sur l'accent.
- **Valeur KPI en Fraunces** : `font-display text-3xl font-semibold` (600 — Fraunces n'est chargé qu'en 600 ; commentaire ajouté sur le `tabular-nums` best-effort).
- **Label** en capitales espacées (`uppercase tracking-wide`).
- Skeleton ajusté (`h-9`).

## Revue (code-reviewer + accessibility-tester)
- ✅ `border-s-role` compile (build OK, défaut teal `:root`).
- ✅ Contrastes : label `#586A6B`/blanc **5,69:1** · valeur `#1A2A2E` **14,85:1** → AA.
- ✅ `uppercase` = CSS (texte DOM inchangé, lecteurs d'écran OK) ; rail couleur redondant avec l'`aria-label`.
- 🔧 **Corrigé** : `typography.md` synchronisé (Display/H1/KPI = `font-semibold` 600, note Fraunces 700-indispo) ; commentaire `tabular-nums`.
- ⏳ Non bloquant : reflow zoom 200 % / rendu arabe 30px → test manuel ultérieur (`truncate` + `aria-label` couvrent l'overflow).

## Validation
- ✅ Build prod OK ; tests `MetricCard` 36/36 ; `tsc` + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)