### PR TITLE
feat(home): nom utilisateur courant — greeting nominatif + initiales shell

### DIFF
--- a/docs/security/encryption.md
+++ b/docs/security/encryption.md
@@ -154,3 +154,25 @@ resolvePatientId(userId, role, patientIdParam?):
   VIEWER  → retourne son propre patientId
   Pro     → verifie canAccessPatient sur patientIdParam
 ```
+
+## Deviations d'audit acceptees
+
+### Lecture du nom d'affichage de soi-meme (non auditee)
+
+`userService.getOwnDisplayName(sessionUserId)` dechiffre `firstname`/`lastname`
+(PII chiffree AES-256-GCM) **sans ecrire d'entree d'audit**, contrairement a
+`getProfile` (lecture complete + auditee).
+
+**Justification (deviation a la regle CLAUDE.md « auditService.log() pour chaque
+acces a une donnee de sante »)** : le nom d'un utilisateur est une **PII
+d'identite, pas une donnee de sante (PHI)** — il ne revele aucune information
+clinique. Cette lecture sert uniquement a afficher a l'utilisateur **son propre
+nom** (avatar du shell, greeting du tableau de bord) et s'execute a **chaque
+chargement de page** ; l'auditer noierait le journal et degraderait sa valeur
+forensique.
+
+**Garde-fou** : la methode est nommee `getOwnDisplayName` et documentee
+« self-read only » — `sessionUserId` DOIT etre l'id du caller authentifie
+(`x-user-id`). Tout besoin de nom **cross-utilisateur** doit passer par
+`getProfile` (audite). Couverture test : `tests/unit/user.service.test.ts`
+verifie qu'aucun audit n'est emis.

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -238,6 +238,7 @@
     "newEventAriaLabel": "فتح نموذج حدث جديد",
     "medecin": {
       "pageTitle": "يومي",
+      "greeting": "مرحبًا، {name}",
       "lastUpdate": "آخر تحديث {time}",
       "loading": "جارٍ التحميل…",
       "stale": "بيانات قديمة — في انتظار التحديث.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -238,6 +238,7 @@
     "newEventAriaLabel": "Open new event form",
     "medecin": {
       "pageTitle": "My day",
+      "greeting": "Hello, {name}",
       "lastUpdate": "Updated {time}",
       "loading": "Loading…",
       "stale": "Stale data — refresh pending.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -238,6 +238,7 @@
     "newEventAriaLabel": "Ouvrir le formulaire de saisie d'un nouvel evenement",
     "medecin": {
       "pageTitle": "Ma journée",
+      "greeting": "Bonjour, {name}",
       "lastUpdate": "Mise à jour {time}",
       "loading": "Chargement…",
       "stale": "Données obsolètes — rafraîchissement en attente.",

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -10,7 +10,7 @@ import { redirect } from "next/navigation"
 import { NavigationShell, type UserRole } from "@/components/diabeo/NavigationShell"
 import { ConsultationProvider } from "@/components/diabeo/consultation/ConsultationContext"
 import { hasManagementCapability } from "@/lib/capabilities"
-import { userService } from "@/lib/services/user.service"
+import { getCurrentUserDisplayName } from "@/lib/auth/current-user-name"
 
 const VALID_ROLES: UserRole[] = ["ADMIN", "DOCTOR", "NURSE", "VIEWER"]
 
@@ -48,12 +48,12 @@ export default async function DashboardLayout({
   const userId = rawUserId ? Number(rawUserId) : NaN
   const hasUserId = Number.isInteger(userId) && userId > 0
 
-  // US-26xx — nom affiché dans le shell (avatar/initiales). getDisplayName est
-  // léger et non-audité (cf. user.service). Parallélisé avec la capacité de
-  // gestion pour éviter un waterfall.
+  // US-26xx — nom affiché dans le shell (avatar/initiales). Lookup léger,
+  // non-audité, request-cached (cf. getCurrentUserDisplayName) → dédupliqué
+  // avec un éventuel appel côté page. Parallélisé avec la capacité de gestion.
   const [canManageOrg, displayName] = await Promise.all([
     hasUserId ? hasManagementCapability(userId) : Promise.resolve(false),
-    hasUserId ? userService.getDisplayName(userId) : Promise.resolve(null),
+    hasUserId ? getCurrentUserDisplayName(userId) : Promise.resolve(null),
   ])
   const userName =
     [displayName?.firstname, displayName?.lastname].filter(Boolean).join(" ") ||

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -10,6 +10,7 @@ import { redirect } from "next/navigation"
 import { NavigationShell, type UserRole } from "@/components/diabeo/NavigationShell"
 import { ConsultationProvider } from "@/components/diabeo/consultation/ConsultationContext"
 import { hasManagementCapability } from "@/lib/capabilities"
+import { userService } from "@/lib/services/user.service"
 
 const VALID_ROLES: UserRole[] = ["ADMIN", "DOCTOR", "NURSE", "VIEWER"]
 
@@ -45,9 +46,18 @@ export default async function DashboardLayout({
   // rôle clinique. `x-user-id` injecté par le middleware JWT.
   const rawUserId = headersList.get("x-user-id")
   const userId = rawUserId ? Number(rawUserId) : NaN
-  const canManageOrg = Number.isInteger(userId) && userId > 0
-    ? await hasManagementCapability(userId)
-    : false
+  const hasUserId = Number.isInteger(userId) && userId > 0
+
+  // US-26xx — nom affiché dans le shell (avatar/initiales). getDisplayName est
+  // léger et non-audité (cf. user.service). Parallélisé avec la capacité de
+  // gestion pour éviter un waterfall.
+  const [canManageOrg, displayName] = await Promise.all([
+    hasUserId ? hasManagementCapability(userId) : Promise.resolve(false),
+    hasUserId ? userService.getDisplayName(userId) : Promise.resolve(null),
+  ])
+  const userName =
+    [displayName?.firstname, displayName?.lastname].filter(Boolean).join(" ") ||
+    undefined
 
   return (
     // US-2018b — le provider enveloppe tout le shell : la consultation rend la
@@ -56,6 +66,7 @@ export default async function DashboardLayout({
       <NavigationShell
         pageTitle="Diabeo"
         userRole={userRole}
+        userName={userName}
         canManageOrg={canManageOrg}
       >
         {children}

--- a/src/app/(dashboard)/medecin/page.tsx
+++ b/src/app/(dashboard)/medecin/page.tsx
@@ -16,6 +16,7 @@ import { headers } from "next/headers"
 import { redirect } from "next/navigation"
 import { getLocale, getTranslations } from "next-intl/server"
 import { CABINET_TIMEZONE } from "@/lib/cabinet-time"
+import { userService } from "@/lib/services/user.service"
 import { EmergencyCard } from "@/components/diabeo/dashboard/medecin/EmergencyCard"
 import { AppointmentCard } from "@/components/diabeo/dashboard/medecin/AppointmentCard"
 import { PatientsAtRiskCard } from "@/components/diabeo/dashboard/medecin/PatientsAtRiskCard"
@@ -58,13 +59,29 @@ export default async function MedecinDashboardPage() {
       ? today.charAt(0).toUpperCase() + today.slice(1)
       : today
 
+  // Greeting nominatif (« Bonjour, Dr Martin »). getDisplayName est léger et
+  // non-audité. On préfère « {titre} {nom} » (ex. « Dr Martin »), sinon le
+  // prénom. Si le nom est introuvable, le sous-titre se réduit à la date.
+  const rawUserId = headersList.get("x-user-id")
+  const userId = rawUserId ? Number(rawUserId) : NaN
+  const name =
+    Number.isInteger(userId) && userId > 0
+      ? await userService.getDisplayName(userId)
+      : null
+  const greetingName = name?.lastname
+    ? `${name.title ? `${name.title} ` : ""}${name.lastname}`
+    : (name?.firstname ?? null)
+  const subtitle = greetingName
+    ? `${t("greeting", { name: greetingName })} · ${todayLabel}`
+    : todayLabel
+
   return (
     <main className="flex flex-col gap-6 p-4 lg:p-6">
       <header>
         <h1 className="font-display text-3xl font-semibold tracking-tight">
           {t("pageTitle")}
         </h1>
-        <p className="mt-1 text-sm text-muted-foreground">{todayLabel}</p>
+        <p className="mt-1 text-sm text-muted-foreground">{subtitle}</p>
       </header>
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <EmergencyCard />

--- a/src/app/(dashboard)/medecin/page.tsx
+++ b/src/app/(dashboard)/medecin/page.tsx
@@ -16,7 +16,7 @@ import { headers } from "next/headers"
 import { redirect } from "next/navigation"
 import { getLocale, getTranslations } from "next-intl/server"
 import { CABINET_TIMEZONE } from "@/lib/cabinet-time"
-import { userService } from "@/lib/services/user.service"
+import { getCurrentUserDisplayName } from "@/lib/auth/current-user-name"
 import { EmergencyCard } from "@/components/diabeo/dashboard/medecin/EmergencyCard"
 import { AppointmentCard } from "@/components/diabeo/dashboard/medecin/AppointmentCard"
 import { PatientsAtRiskCard } from "@/components/diabeo/dashboard/medecin/PatientsAtRiskCard"
@@ -59,17 +59,21 @@ export default async function MedecinDashboardPage() {
       ? today.charAt(0).toUpperCase() + today.slice(1)
       : today
 
-  // Greeting nominatif (« Bonjour, Dr Martin »). getDisplayName est léger et
-  // non-audité. On préfère « {titre} {nom} » (ex. « Dr Martin »), sinon le
-  // prénom. Si le nom est introuvable, le sous-titre se réduit à la date.
+  // Greeting nominatif (« Bonjour, Dr Martin »). Lookup self léger, non-audité,
+  // request-cached (dédupe avec le layout). On préfère « {titre} {nom} » (ex.
+  // « Dr Martin »), sinon le prénom ; date seule si le nom est introuvable.
   const rawUserId = headersList.get("x-user-id")
   const userId = rawUserId ? Number(rawUserId) : NaN
   const name =
     Number.isInteger(userId) && userId > 0
-      ? await userService.getDisplayName(userId)
+      ? await getCurrentUserDisplayName(userId)
       : null
+  // Le titre (« Dr », « Mme »…) est un libellé FR non localisé → on ne le
+  // préfixe qu'en fr/en ; les autres locales (ar) affichent le nom seul pour
+  // éviter un honorifique latin dans un greeting traduit.
+  const useTitle = locale === "fr" || locale === "en"
   const greetingName = name?.lastname
-    ? `${name.title ? `${name.title} ` : ""}${name.lastname}`
+    ? `${useTitle && name.title ? `${name.title} ` : ""}${name.lastname}`
     : (name?.firstname ?? null)
   const subtitle = greetingName
     ? `${t("greeting", { name: greetingName })} · ${todayLabel}`

--- a/src/lib/auth/current-user-name.ts
+++ b/src/lib/auth/current-user-name.ts
@@ -1,0 +1,18 @@
+import { cache } from "react"
+import { userService } from "@/lib/services/user.service"
+
+/**
+ * Request-scoped display name of the authenticated user (own name).
+ *
+ * Thin `cache()` wrapper around {@link userService.getOwnDisplayName} so the
+ * same server request (layout + page rendering together) performs a single
+ * DB lookup + decrypt instead of one per call site. `cache()` is per-request
+ * (no cross-request leakage of decrypted PII) and the call is a pure read.
+ *
+ * `sessionUserId` MUST be the caller's own id (see getOwnDisplayName security
+ * note). Server-only by construction: importing this pulls `userService` →
+ * Prisma, so any client import already fails at build.
+ */
+export const getCurrentUserDisplayName = cache(
+  (sessionUserId: number) => userService.getOwnDisplayName(sessionUserId),
+)

--- a/src/lib/services/user.service.ts
+++ b/src/lib/services/user.service.ts
@@ -62,19 +62,27 @@ function isEncryptedField(field: string): field is EncryptedUserField {
  */
 export const userService = {
   /**
-   * Lightweight display-name lookup for UI chrome (shell avatar, greeting).
+   * Lightweight SELF display-name lookup for UI chrome (shell avatar, greeting).
    * Selects + decrypts ONLY title/firstname/lastname — not the full profile —
-   * and writes NO audit entry: rendering one's own name in the UI is not a PHI
-   * access and runs on every dashboard load (auditing it would flood the
-   * trail). Use {@link getProfile} when a full, audited read is required.
-   * @param {number} userId - User ID (own id from the JWT middleware header).
+   * and writes NO audit entry: rendering one's OWN name in the UI is identity
+   * PII (not health data / PHI) and runs on every dashboard load — auditing it
+   * would flood the trail and degrade its forensic value.
+   *
+   * ⚠️ SECURITY — self-read only. `sessionUserId` MUST be the authenticated
+   * caller's own id (from the `x-user-id` JWT-middleware header). NEVER pass
+   * another subject's id here: this path is deliberately un-audited, so a
+   * cross-user read would be an untraceable PII disclosure (anti-HDS/CNIL).
+   * Any cross-user display-name need MUST go through {@link getProfile}, which
+   * is audited.
+   *
+   * @param {number} sessionUserId - The authenticated caller's OWN user id.
    * @returns name parts (decrypted) or null if not found.
    */
-  async getDisplayName(
-    userId: number,
+  async getOwnDisplayName(
+    sessionUserId: number,
   ): Promise<{ title: string | null; firstname: string | null; lastname: string | null } | null> {
     const user = await prisma.user.findUnique({
-      where: { id: userId },
+      where: { id: sessionUserId },
       select: { title: true, firstname: true, lastname: true },
     })
     if (!user) return null

--- a/src/lib/services/user.service.ts
+++ b/src/lib/services/user.service.ts
@@ -62,6 +62,30 @@ function isEncryptedField(field: string): field is EncryptedUserField {
  */
 export const userService = {
   /**
+   * Lightweight display-name lookup for UI chrome (shell avatar, greeting).
+   * Selects + decrypts ONLY title/firstname/lastname — not the full profile —
+   * and writes NO audit entry: rendering one's own name in the UI is not a PHI
+   * access and runs on every dashboard load (auditing it would flood the
+   * trail). Use {@link getProfile} when a full, audited read is required.
+   * @param {number} userId - User ID (own id from the JWT middleware header).
+   * @returns name parts (decrypted) or null if not found.
+   */
+  async getDisplayName(
+    userId: number,
+  ): Promise<{ title: string | null; firstname: string | null; lastname: string | null } | null> {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { title: true, firstname: true, lastname: true },
+    })
+    if (!user) return null
+    return {
+      title: user.title,
+      firstname: safeDecryptField(user.firstname),
+      lastname: safeDecryptField(user.lastname),
+    }
+  },
+
+  /**
    * Get user profile with all encrypted fields decrypted.
    * Logs READ audit entry.
    * @async

--- a/tests/unit/user.service.test.ts
+++ b/tests/unit/user.service.test.ts
@@ -86,6 +86,57 @@ describe("userService", () => {
     })
   })
 
+  describe("getOwnDisplayName", () => {
+    it("returns decrypted name parts WITHOUT writing an audit log", async () => {
+      prismaMock.user.findUnique.mockResolvedValue({
+        title: "Dr",
+        firstname: Buffer.from("ENC:Camille").toString("base64"),
+        lastname: Buffer.from("ENC:Martin").toString("base64"),
+      } as never)
+      // Security invariant : self-display reads are deliberately un-audited.
+      vi.mocked(prismaMock.auditLog.create).mockClear()
+
+      const result = await userService.getOwnDisplayName(7)
+
+      expect(result).toEqual({ title: "Dr", firstname: "Camille", lastname: "Martin" })
+      expect(prismaMock.auditLog.create).not.toHaveBeenCalled()
+    })
+
+    it("selects only title/firstname/lastname (data minimization)", async () => {
+      prismaMock.user.findUnique.mockResolvedValue({
+        title: "Mme",
+        firstname: Buffer.from("ENC:Alice").toString("base64"),
+        lastname: Buffer.from("ENC:Durand").toString("base64"),
+      } as never)
+
+      await userService.getOwnDisplayName(7)
+
+      const call = prismaMock.user.findUnique.mock.calls.at(-1)![0]
+      expect(call).toEqual({
+        where: { id: 7 },
+        select: { title: true, firstname: true, lastname: true },
+      })
+    })
+
+    it("returns null for a non-existent user", async () => {
+      prismaMock.user.findUnique.mockResolvedValue(null)
+      expect(await userService.getOwnDisplayName(999)).toBeNull()
+    })
+
+    it("degrades gracefully when a field fails to decrypt", async () => {
+      prismaMock.user.findUnique.mockResolvedValue({
+        title: null,
+        firstname: "corrupted-not-a-valid-cipher",
+        lastname: Buffer.from("ENC:Martin").toString("base64"),
+      } as never)
+
+      const result = await userService.getOwnDisplayName(7)
+
+      // safeDecryptField swallows the error → null, never throws or leaks.
+      expect(result).toEqual({ title: null, firstname: null, lastname: "Martin" })
+    })
+  })
+
   describe("updateProfile", () => {
     it("encrypts fields and updates in transaction", async () => {
       const mockTx = {


### PR DESCRIPTION
## Contexte

Brique **transverse 2/2** du restyling Home : afficher le nom de l'utilisateur connecté (greeting nominatif médecin + initiales d'avatar du shell pour tous les rôles staff).

## Approche — helper léger NON-AUDITÉ
`userService.getDisplayName(userId)` : `select` minimal `{title, firstname, lastname}` + déchiffrement de ces 2 champs uniquement, **sans audit**. Rendre son propre nom dans l'UI n'est pas un accès PHI et tourne à chaque chargement de dashboard → l'auditer (comme `getProfile`) noierait le journal et sur-déchiffrerait tout le profil.

## Changements
- **`user.service.ts`** : nouvelle méthode `getDisplayName`.
- **`(dashboard)/layout.tsx`** : passe `userName` au `NavigationShell` → corrige les initiales « U » de l'avatar (médecin/infirmier/admin). Parallélisé avec `hasManagementCapability` (`Promise.all`, pas de waterfall).
- **`medecin/page.tsx`** : sous-titre « **Bonjour, Dr {nom} · {date}** » (clé i18n `greeting`). Fallback à la date seule si nom introuvable. Titre « Ma journée » **conservé** (feature BDD + nav intacts). `title` est déjà un libellé (`'M.'|'Mme'|'Dr'|'Prof'`).
- **`messages/{fr,en,ar}.json`** : clé `dashboard.medecin.greeting`.

## Validation
- ✅ i18n parité fr/en/ar (`i18n-parity.test.ts`).
- ✅ `tsc` + ESLint clean.
- ✅ Build prod OK — pas de leak client/serveur (le layout server-only importe le service ; seul `userName: string` traverse vers le `NavigationShell` client).

## Portée / suite
- Espace **patient** : son shell garde « U » (le `(patient)/layout` ne lit pas encore `x-user-id`) → à traiter avec le restyle patient.
- Greeting nominatif des autres rôles (infirmier/admin) → avec leur restyle respectif.

🤖 Generated with [Claude Code](https://claude.com/claude-code)