### PR TITLE
feat(home): restyle infirmier — titres Fraunces + greeting nominatif

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1530,7 +1530,8 @@
       "kindObserveProposal": "اقتراح"
     },
     "nursePage": {
-      "title": "لوحة تحكم الممرّض"
+      "title": "لوحة تحكم الممرّض",
+      "greeting": "مرحبًا، {name}"
     }
   },
   "insulinUnits": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -1530,7 +1530,8 @@
       "kindObserveProposal": "Proposal"
     },
     "nursePage": {
-      "title": "Nurse dashboard"
+      "title": "Nurse dashboard",
+      "greeting": "Hello, {name}"
     }
   },
   "insulinUnits": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1530,7 +1530,8 @@
       "kindObserveProposal": "Proposition"
     },
     "nursePage": {
-      "title": "Tableau de bord infirmier"
+      "title": "Tableau de bord infirmier",
+      "greeting": "Bonjour, {name}"
     }
   },
   "insulinUnits": {

--- a/src/app/(dashboard)/infirmier/page.tsx
+++ b/src/app/(dashboard)/infirmier/page.tsx
@@ -10,9 +10,8 @@
 
 import { headers } from "next/headers"
 import { redirect } from "next/navigation"
-import { getLocale, getTranslations } from "next-intl/server"
-import { CABINET_TIMEZONE } from "@/lib/cabinet-time"
-import { getCurrentUserDisplayName } from "@/lib/auth/current-user-name"
+import { getTranslations } from "next-intl/server"
+import { DashboardGreeting } from "@/components/diabeo/dashboard/DashboardGreeting"
 import { NurseKpiSection } from "@/components/diabeo/dashboard/infirmier/NurseKpiSection"
 import { TodoListCard } from "@/components/diabeo/dashboard/infirmier/TodoListCard"
 import { TeamInboxCard } from "@/components/diabeo/dashboard/infirmier/TeamInboxCard"
@@ -27,44 +26,12 @@ export default async function InfirmierDashboardPage() {
 
   const t = await getTranslations("dashboardCards.nursePage")
 
-  // Greeting éditorial (mockup Home v3) — même logique que le home médecin :
-  // titre Fraunces + sous-titre « Bonjour, {nom} · {date} ». Date épinglée à
-  // Europe/Paris (CABINET_TIMEZONE). Nom via le lookup self request-cached.
-  const locale = await getLocale()
-  const today = new Intl.DateTimeFormat(locale, {
-    weekday: "long",
-    day: "numeric",
-    month: "long",
-    timeZone: CABINET_TIMEZONE,
-  }).format(new Date())
-  const todayLabel =
-    locale === "fr" || locale === "en"
-      ? today.charAt(0).toUpperCase() + today.slice(1)
-      : today
-
-  const rawUserId = headersList.get("x-user-id")
-  const userId = rawUserId ? Number(rawUserId) : NaN
-  const name =
-    Number.isInteger(userId) && userId > 0
-      ? await getCurrentUserDisplayName(userId)
-      : null
-  // Titre honorifique (« M. », « Dr ») préfixé seulement en fr/en.
-  const useTitle = locale === "fr" || locale === "en"
-  const greetingName = name?.lastname
-    ? `${useTitle && name.title ? `${name.title} ` : ""}${name.lastname}`
-    : (name?.firstname ?? null)
-  const subtitle = greetingName
-    ? `${t("greeting", { name: greetingName })} · ${todayLabel}`
-    : todayLabel
-
   return (
     <main className="flex flex-col gap-6 p-4 lg:p-6">
-      <header>
-        <h1 className="font-display text-3xl font-semibold tracking-tight">
-          {t("title")}
-        </h1>
-        <p className="mt-1 text-sm text-muted-foreground">{subtitle}</p>
-      </header>
+      <DashboardGreeting
+        title={t("title")}
+        greeting={(name) => t("greeting", { name })}
+      />
       <NurseKpiSection />
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <TodoListCard />

--- a/src/app/(dashboard)/infirmier/page.tsx
+++ b/src/app/(dashboard)/infirmier/page.tsx
@@ -10,7 +10,9 @@
 
 import { headers } from "next/headers"
 import { redirect } from "next/navigation"
-import { getTranslations } from "next-intl/server"
+import { getLocale, getTranslations } from "next-intl/server"
+import { CABINET_TIMEZONE } from "@/lib/cabinet-time"
+import { getCurrentUserDisplayName } from "@/lib/auth/current-user-name"
 import { NurseKpiSection } from "@/components/diabeo/dashboard/infirmier/NurseKpiSection"
 import { TodoListCard } from "@/components/diabeo/dashboard/infirmier/TodoListCard"
 import { TeamInboxCard } from "@/components/diabeo/dashboard/infirmier/TeamInboxCard"
@@ -25,9 +27,44 @@ export default async function InfirmierDashboardPage() {
 
   const t = await getTranslations("dashboardCards.nursePage")
 
+  // Greeting éditorial (mockup Home v3) — même logique que le home médecin :
+  // titre Fraunces + sous-titre « Bonjour, {nom} · {date} ». Date épinglée à
+  // Europe/Paris (CABINET_TIMEZONE). Nom via le lookup self request-cached.
+  const locale = await getLocale()
+  const today = new Intl.DateTimeFormat(locale, {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    timeZone: CABINET_TIMEZONE,
+  }).format(new Date())
+  const todayLabel =
+    locale === "fr" || locale === "en"
+      ? today.charAt(0).toUpperCase() + today.slice(1)
+      : today
+
+  const rawUserId = headersList.get("x-user-id")
+  const userId = rawUserId ? Number(rawUserId) : NaN
+  const name =
+    Number.isInteger(userId) && userId > 0
+      ? await getCurrentUserDisplayName(userId)
+      : null
+  // Titre honorifique (« M. », « Dr ») préfixé seulement en fr/en.
+  const useTitle = locale === "fr" || locale === "en"
+  const greetingName = name?.lastname
+    ? `${useTitle && name.title ? `${name.title} ` : ""}${name.lastname}`
+    : (name?.firstname ?? null)
+  const subtitle = greetingName
+    ? `${t("greeting", { name: greetingName })} · ${todayLabel}`
+    : todayLabel
+
   return (
     <main className="flex flex-col gap-6 p-4 lg:p-6">
-      <h1 className="font-display text-2xl font-semibold">{t("title")}</h1>
+      <header>
+        <h1 className="font-display text-3xl font-semibold tracking-tight">
+          {t("title")}
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">{subtitle}</p>
+      </header>
       <NurseKpiSection />
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <TodoListCard />

--- a/src/app/(dashboard)/medecin/page.tsx
+++ b/src/app/(dashboard)/medecin/page.tsx
@@ -14,9 +14,8 @@
 
 import { headers } from "next/headers"
 import { redirect } from "next/navigation"
-import { getLocale, getTranslations } from "next-intl/server"
-import { CABINET_TIMEZONE } from "@/lib/cabinet-time"
-import { getCurrentUserDisplayName } from "@/lib/auth/current-user-name"
+import { getTranslations } from "next-intl/server"
+import { DashboardGreeting } from "@/components/diabeo/dashboard/DashboardGreeting"
 import { EmergencyCard } from "@/components/diabeo/dashboard/medecin/EmergencyCard"
 import { AppointmentCard } from "@/components/diabeo/dashboard/medecin/AppointmentCard"
 import { PatientsAtRiskCard } from "@/components/diabeo/dashboard/medecin/PatientsAtRiskCard"
@@ -39,54 +38,12 @@ export default async function MedecinDashboardPage() {
 
   const t = await getTranslations("dashboard.medecin")
 
-  // Greeting éditorial (mockup Home v3) : titre Fraunces + date localisée.
-  // La date est une valeur formatée (non un littéral JSX) — pas de clé i18n
-  // requise ; Intl gère la locale active.
-  // timeZone épinglé à Europe/Paris (CABINET_TIMEZONE) comme tout le reste du
-  // code horaire : sinon `new Date()` se résout en zone serveur (VPS UTC) et
-  // affiche le mauvais jour entre 22 h et minuit heure de Paris.
-  const locale = await getLocale()
-  const today = new Intl.DateTimeFormat(locale, {
-    weekday: "long",
-    day: "numeric",
-    month: "long",
-    timeZone: CABINET_TIMEZONE,
-  }).format(new Date())
-  // FR/EN rendent le jour de la semaine en minuscule en début de phrase → on
-  // capitalise. Inutile/incorrect pour d'autres scripts (ar) → restreint.
-  const todayLabel =
-    locale === "fr" || locale === "en"
-      ? today.charAt(0).toUpperCase() + today.slice(1)
-      : today
-
-  // Greeting nominatif (« Bonjour, Dr Martin »). Lookup self léger, non-audité,
-  // request-cached (dédupe avec le layout). On préfère « {titre} {nom} » (ex.
-  // « Dr Martin »), sinon le prénom ; date seule si le nom est introuvable.
-  const rawUserId = headersList.get("x-user-id")
-  const userId = rawUserId ? Number(rawUserId) : NaN
-  const name =
-    Number.isInteger(userId) && userId > 0
-      ? await getCurrentUserDisplayName(userId)
-      : null
-  // Le titre (« Dr », « Mme »…) est un libellé FR non localisé → on ne le
-  // préfixe qu'en fr/en ; les autres locales (ar) affichent le nom seul pour
-  // éviter un honorifique latin dans un greeting traduit.
-  const useTitle = locale === "fr" || locale === "en"
-  const greetingName = name?.lastname
-    ? `${useTitle && name.title ? `${name.title} ` : ""}${name.lastname}`
-    : (name?.firstname ?? null)
-  const subtitle = greetingName
-    ? `${t("greeting", { name: greetingName })} · ${todayLabel}`
-    : todayLabel
-
   return (
     <main className="flex flex-col gap-6 p-4 lg:p-6">
-      <header>
-        <h1 className="font-display text-3xl font-semibold tracking-tight">
-          {t("pageTitle")}
-        </h1>
-        <p className="mt-1 text-sm text-muted-foreground">{subtitle}</p>
-      </header>
+      <DashboardGreeting
+        title={t("pageTitle")}
+        greeting={(name) => t("greeting", { name })}
+      />
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <EmergencyCard />
         <AppointmentCard />

--- a/src/components/diabeo/dashboard/DashboardGreeting.tsx
+++ b/src/components/diabeo/dashboard/DashboardGreeting.tsx
@@ -1,0 +1,63 @@
+import { headers } from "next/headers"
+import { getLocale } from "next-intl/server"
+import { CABINET_TIMEZONE } from "@/lib/cabinet-time"
+import { getCurrentUserDisplayName } from "@/lib/auth/current-user-name"
+import { buildGreetingName } from "./greeting-name"
+
+interface DashboardGreetingProps {
+  /** Already-translated page title, rendered as the h1. */
+  title: string
+  /** Formats the greeting for a name, e.g. `(n) => t("greeting", { name: n })`. */
+  greeting: (name: string) => string
+}
+
+/**
+ * Editorial dashboard header (Home v3) shared by the per-role home pages
+ * (medecin, infirmier, …) to avoid drift: Fraunces `<h1>` + a
+ * "{greeting} · {date}" subtitle.
+ *
+ * The date is pinned to `Europe/Paris` (`CABINET_TIMEZONE`) so it never drifts
+ * to the previous day in the server's UTC zone late at night.
+ *
+ * The name is the **signed-in user's own** name (self lookup, request-cached,
+ * non-audited — see `getCurrentUserDisplayName`), NOT the dashboard subject.
+ * A doctor viewing `/infirmier` is therefore greeted by their own name; this
+ * is intended (the greeting answers "who is logged in").
+ */
+export async function DashboardGreeting({
+  title,
+  greeting,
+}: DashboardGreetingProps) {
+  const locale = await getLocale()
+  const today = new Intl.DateTimeFormat(locale, {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    timeZone: CABINET_TIMEZONE,
+  }).format(new Date())
+  const todayLabel =
+    locale === "fr" || locale === "en"
+      ? today.charAt(0).toUpperCase() + today.slice(1)
+      : today
+
+  const headersList = await headers()
+  const rawUserId = headersList.get("x-user-id")
+  const userId = rawUserId ? Number(rawUserId) : NaN
+  const name =
+    Number.isInteger(userId) && userId > 0
+      ? await getCurrentUserDisplayName(userId)
+      : null
+  const greetingName = buildGreetingName(name, locale)
+  const subtitle = greetingName
+    ? `${greeting(greetingName)} · ${todayLabel}`
+    : todayLabel
+
+  return (
+    <header>
+      <h1 className="font-display text-3xl font-semibold tracking-tight">
+        {title}
+      </h1>
+      <p className="mt-1 text-sm text-muted-foreground">{subtitle}</p>
+    </header>
+  )
+}

--- a/src/components/diabeo/dashboard/greeting-name.ts
+++ b/src/components/diabeo/dashboard/greeting-name.ts
@@ -1,0 +1,27 @@
+export type GreetingNameParts = {
+  title: string | null
+  firstname: string | null
+  lastname: string | null
+}
+
+/**
+ * Pure name formatter for the dashboard greeting. Prefers `"{title} {lastname}"`
+ * (e.g. "Dr Martin"); the honorific is a FR label, so it is only prefixed for
+ * `fr`/`en` — other locales (`ar`) get the bare name to avoid a Latin honorific
+ * inside a translated/RTL greeting. Falls back to firstname, then `null` (the
+ * caller then renders the date alone).
+ *
+ * Kept in a dependency-free module (no next/headers, no Prisma) so it is unit
+ * testable in isolation.
+ */
+export function buildGreetingName(
+  name: GreetingNameParts | null,
+  locale: string,
+): string | null {
+  if (!name) return null
+  if (name.lastname) {
+    const useTitle = locale === "fr" || locale === "en"
+    return `${useTitle && name.title ? `${name.title} ` : ""}${name.lastname}`
+  }
+  return name.firstname ?? null
+}

--- a/src/components/diabeo/dashboard/infirmier/NurseKpiSection.tsx
+++ b/src/components/diabeo/dashboard/infirmier/NurseKpiSection.tsx
@@ -34,7 +34,7 @@ export function NurseKpiSection() {
   ]
   return (
     <section aria-labelledby="nurse-kpi-title">
-      <h2 id="nurse-kpi-title" className="mb-3 text-base font-semibold">
+      <h2 id="nurse-kpi-title" className="mb-3 font-display text-base font-semibold">
         {t("nurseKpiTitle")}
       </h2>
       {hasError && (

--- a/src/components/diabeo/dashboard/infirmier/TeamInboxCard.tsx
+++ b/src/components/diabeo/dashboard/infirmier/TeamInboxCard.tsx
@@ -52,7 +52,7 @@ export function TeamInboxCard() {
   return (
     <DiabeoCard role="region" aria-labelledby="card-team-title">
       <header className="flex items-center justify-between px-4 pt-4">
-        <h2 id="card-team-title" className="text-base font-semibold">
+        <h2 id="card-team-title" className="font-display text-base font-semibold">
           {t("title")}
         </h2>
         <span className="text-xs text-muted-foreground">{items.length}</span>

--- a/src/components/diabeo/dashboard/infirmier/TodoListCard.tsx
+++ b/src/components/diabeo/dashboard/infirmier/TodoListCard.tsx
@@ -35,7 +35,7 @@ export function TodoListCard() {
   return (
     <DiabeoCard role="region" aria-labelledby="card-todo-title">
       <header className="flex items-center justify-between px-4 pt-4">
-        <h2 id="card-todo-title" className="text-base font-semibold">
+        <h2 id="card-todo-title" className="font-display text-base font-semibold">
           {t("title")}
         </h2>
         <span className="text-xs text-muted-foreground">{items.length}</span>

--- a/tests/unit/greeting-name.test.ts
+++ b/tests/unit/greeting-name.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Test suite: dashboard greeting name formatting (buildGreetingName)
+ *
+ * Behavior tested:
+ * - Honorific ("Dr", "Mme"…) prefixed only for fr/en (FR label) — never for ar,
+ *   to avoid a Latin honorific inside a translated/RTL greeting.
+ * - Falls back to firstname when lastname is absent, then null (caller shows
+ *   the date alone).
+ *
+ * Risk: a wrong locale gate would render "Dr Martin" (Latin) inside an Arabic
+ * greeting, or drop the honorific in French — both degrade the UI politeness
+ * and consistency.
+ */
+import { describe, it, expect } from "vitest"
+import { buildGreetingName } from "@/components/diabeo/dashboard/greeting-name"
+
+describe("buildGreetingName", () => {
+  const martin = { title: "Dr", firstname: "Camille", lastname: "Martin" }
+
+  it("prefixes the honorific in French", () => {
+    expect(buildGreetingName(martin, "fr")).toBe("Dr Martin")
+  })
+
+  it("prefixes the honorific in English", () => {
+    expect(buildGreetingName(martin, "en")).toBe("Dr Martin")
+  })
+
+  it("omits the (Latin) honorific in Arabic — bare name", () => {
+    expect(buildGreetingName(martin, "ar")).toBe("Martin")
+  })
+
+  it("uses the lastname alone when there is no title", () => {
+    expect(
+      buildGreetingName({ title: null, firstname: "Camille", lastname: "Martin" }, "fr"),
+    ).toBe("Martin")
+  })
+
+  it("falls back to the firstname when the lastname is missing", () => {
+    expect(
+      buildGreetingName({ title: "Dr", firstname: "Camille", lastname: null }, "fr"),
+    ).toBe("Camille")
+  })
+
+  it("returns null when the name is null (caller renders the date alone)", () => {
+    expect(buildGreetingName(null, "fr")).toBeNull()
+  })
+
+  it("returns null when all name parts are empty", () => {
+    expect(
+      buildGreetingName({ title: null, firstname: null, lastname: null }, "fr"),
+    ).toBeNull()
+  })
+})


### PR DESCRIPTION
## Contexte

Restyling du home **infirmier** sur le modèle médecin (#579), en réutilisant les briques transverses déjà livrées (`font-display`, `getCurrentUserDisplayName`, accent de rôle).

## Changements
- **Titres de cartes en Fraunces** (`font-display`) : `NurseKpiSection`, `TodoListCard`, `TeamInboxCard` (`RecallListCard` déjà fait en #579).
- **Greeting éditorial** (`infirmier/page.tsx`) : `<h1>` Fraunces `text-3xl` (aligne sur médecin + H1 `typography.md`) + sous-titre « **Bonjour, M. {nom} · {date}** ».
  - clé i18n `dashboardCards.nursePage.greeting` (fr/en/ar) ;
  - date épinglée `Europe/Paris` (`CABINET_TIMEZONE`) ; honorifique préfixé fr/en seulement ; fallback à la date seule si nom introuvable ;
  - nom via le lookup self request-cached `getCurrentUserDisplayName`.

## Validation
- ✅ i18n parité fr/en/ar (`i18n-parity.test.ts`).
- ✅ `tsc` + ESLint clean.
- Pattern identique au home médecin (déjà build-vérifié) ; build complet + E2E via la CI.

## Suite
- Restyle **admin** (+ bandeau HDS) · **patient** (graph-first + fix initiales shell patient) · dark mode chaud · simulation daltonisme indigo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)