### PR TITLE
feat(home): restyle patient — initiales shell + titres Fraunces

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -10,7 +10,7 @@ import { redirect } from "next/navigation"
 import { NavigationShell, type UserRole } from "@/components/diabeo/NavigationShell"
 import { ConsultationProvider } from "@/components/diabeo/consultation/ConsultationContext"
 import { hasManagementCapability } from "@/lib/capabilities"
-import { getCurrentUserDisplayName } from "@/lib/auth/current-user-name"
+import { getShellUserName } from "@/lib/auth/current-user-name"
 
 const VALID_ROLES: UserRole[] = ["ADMIN", "DOCTOR", "NURSE", "VIEWER"]
 
@@ -49,15 +49,13 @@ export default async function DashboardLayout({
   const hasUserId = Number.isInteger(userId) && userId > 0
 
   // US-26xx — nom affiché dans le shell (avatar/initiales). Lookup léger,
-  // non-audité, request-cached (cf. getCurrentUserDisplayName) → dédupliqué
-  // avec un éventuel appel côté page. Parallélisé avec la capacité de gestion.
-  const [canManageOrg, displayName] = await Promise.all([
+  // non-audité, request-cached → dédupliqué avec un éventuel appel côté page.
+  // Parallélisé avec la capacité de gestion (getShellUserName gère lui-même
+  // l'absence d'id → undefined).
+  const [canManageOrg, userName] = await Promise.all([
     hasUserId ? hasManagementCapability(userId) : Promise.resolve(false),
-    hasUserId ? getCurrentUserDisplayName(userId) : Promise.resolve(null),
+    getShellUserName(headersList),
   ])
-  const userName =
-    [displayName?.firstname, displayName?.lastname].filter(Boolean).join(" ") ||
-    undefined
 
   return (
     // US-2018b — le provider enveloppe tout le shell : la consultation rend la

--- a/src/app/(patient)/layout.tsx
+++ b/src/app/(patient)/layout.tsx
@@ -21,6 +21,7 @@ import { headers } from "next/headers"
 import { redirect } from "next/navigation"
 import { NavigationShell } from "@/components/diabeo/NavigationShell"
 import { isKnownRoleString, resolveHomeForRole } from "@/lib/auth/role-home"
+import { getCurrentUserDisplayName } from "@/lib/auth/current-user-name"
 
 export default async function PatientLayout({
   children,
@@ -42,10 +43,23 @@ export default async function PatientLayout({
     redirect(resolveHomeForRole(rawRole))
   }
 
+  // Nom affiché dans le shell (avatar/initiales) — lookup self léger,
+  // non-audité, request-cached. Corrige les initiales « U » de l'espace patient.
+  const rawUserId = headersList.get("x-user-id")
+  const userId = rawUserId ? Number(rawUserId) : NaN
+  const displayName =
+    Number.isInteger(userId) && userId > 0
+      ? await getCurrentUserDisplayName(userId)
+      : null
+  const userName =
+    [displayName?.firstname, displayName?.lastname].filter(Boolean).join(" ") ||
+    undefined
+
   return (
     <NavigationShell
       pageTitle="Diabeo"
       userRole={rawRole}
+      userName={userName}
       variant="patient"
     >
       {children}

--- a/src/app/(patient)/layout.tsx
+++ b/src/app/(patient)/layout.tsx
@@ -21,7 +21,7 @@ import { headers } from "next/headers"
 import { redirect } from "next/navigation"
 import { NavigationShell } from "@/components/diabeo/NavigationShell"
 import { isKnownRoleString, resolveHomeForRole } from "@/lib/auth/role-home"
-import { getCurrentUserDisplayName } from "@/lib/auth/current-user-name"
+import { getShellUserName } from "@/lib/auth/current-user-name"
 
 export default async function PatientLayout({
   children,
@@ -45,15 +45,7 @@ export default async function PatientLayout({
 
   // Nom affiché dans le shell (avatar/initiales) — lookup self léger,
   // non-audité, request-cached. Corrige les initiales « U » de l'espace patient.
-  const rawUserId = headersList.get("x-user-id")
-  const userId = rawUserId ? Number(rawUserId) : NaN
-  const displayName =
-    Number.isInteger(userId) && userId > 0
-      ? await getCurrentUserDisplayName(userId)
-      : null
-  const userName =
-    [displayName?.firstname, displayName?.lastname].filter(Boolean).join(" ") ||
-    undefined
+  const userName = await getShellUserName(headersList)
 
   return (
     <NavigationShell

--- a/src/app/(patient)/patient/dashboard/page.tsx
+++ b/src/app/(patient)/patient/dashboard/page.tsx
@@ -243,7 +243,7 @@ export default function PatientDashboardPage() {
     <div className="space-y-6">
       <header className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div>
-          <h1 className="text-2xl font-semibold text-foreground">{t("pageTitle")}</h1>
+          <h1 className="font-display text-3xl font-semibold tracking-tight text-foreground">{t("pageTitle")}</h1>
           <p className="text-sm text-muted-foreground mt-1">
             {t("periodSubtitle", { days })}
           </p>
@@ -264,7 +264,7 @@ export default function PatientDashboardPage() {
 
       {/* US-3361 — 24h CGM section + 4 KPI metrics. */}
       <section aria-labelledby="glycemia-section" className="space-y-4">
-        <h2 id="glycemia-section" className="text-lg font-medium text-foreground">
+        <h2 id="glycemia-section" className="font-display text-lg font-semibold text-foreground">
           {t("glycemiaSectionTitle")}
         </h2>
         {/* Sécurité clinique : un relevé hors plage plus récent que l'affiché a
@@ -335,7 +335,7 @@ export default function PatientDashboardPage() {
 
       {/* US-3362 — AGP 7d résumé. */}
       <section aria-labelledby="agp-section" className="space-y-3">
-        <h2 id="agp-section" className="text-lg font-medium text-foreground">
+        <h2 id="agp-section" className="font-display text-lg font-semibold text-foreground">
           {t("agpSectionTitle")}
         </h2>
         {agpState.error ? (

--- a/src/lib/auth/current-user-name.ts
+++ b/src/lib/auth/current-user-name.ts
@@ -16,3 +16,35 @@ import { userService } from "@/lib/services/user.service"
 export const getCurrentUserDisplayName = cache(
   (sessionUserId: number) => userService.getOwnDisplayName(sessionUserId),
 )
+
+type NameParts = {
+  title: string | null
+  firstname: string | null
+  lastname: string | null
+}
+
+/**
+ * Shell display name (avatar/dropdown): `"firstname lastname"`, empty parts
+ * dropped, `undefined` when nothing usable (the shell then falls back to its
+ * default initials). No honorific — unlike the greeting. Pure — exported for
+ * unit testing.
+ */
+export function formatShellName(name: NameParts | null): string | undefined {
+  if (!name) return undefined
+  return [name.firstname, name.lastname].filter(Boolean).join(" ") || undefined
+}
+
+/**
+ * Shell user name for the authenticated user, read from the request headers
+ * (`x-user-id`, the caller's OWN id). Returns `undefined` when there is no
+ * valid id. Wraps the request-cached self lookup, so calling it from several
+ * layouts in the same request hits the DB only once.
+ */
+export async function getShellUserName(
+  headersList: { get(name: string): string | null },
+): Promise<string | undefined> {
+  const rawUserId = headersList.get("x-user-id")
+  const userId = rawUserId ? Number(rawUserId) : NaN
+  if (!Number.isInteger(userId) || userId <= 0) return undefined
+  return formatShellName(await getCurrentUserDisplayName(userId))
+}

--- a/tests/unit/shell-name.test.ts
+++ b/tests/unit/shell-name.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Test suite: shell display-name formatting (formatShellName)
+ *
+ * Behavior tested:
+ * - "firstname lastname" for the shell avatar/dropdown (drives initials),
+ *   empty/null parts dropped, no honorific.
+ * - undefined when nothing usable → the shell falls back to default initials
+ *   instead of rendering a blank/“U” for an empty string.
+ *
+ * Note: `prisma-mock` is imported first so that loading
+ * `@/lib/auth/current-user-name` (which transitively pulls userService →
+ * Prisma) is safe; `formatShellName` itself is pure and touches neither.
+ */
+import { describe, it, expect } from "vitest"
+import "../helpers/prisma-mock"
+import { formatShellName } from "@/lib/auth/current-user-name"
+
+describe("formatShellName", () => {
+  it("joins firstname and lastname", () => {
+    expect(
+      formatShellName({ title: "Dr", firstname: "Camille", lastname: "Martin" }),
+    ).toBe("Camille Martin")
+  })
+
+  it("ignores the honorific (unlike the greeting)", () => {
+    const out = formatShellName({ title: "Dr", firstname: "Camille", lastname: "Martin" })
+    expect(out).not.toContain("Dr")
+  })
+
+  it("uses lastname alone when firstname is missing", () => {
+    expect(
+      formatShellName({ title: null, firstname: null, lastname: "Martin" }),
+    ).toBe("Martin")
+  })
+
+  it("uses firstname alone when lastname is missing", () => {
+    expect(
+      formatShellName({ title: null, firstname: "Camille", lastname: null }),
+    ).toBe("Camille")
+  })
+
+  it("returns undefined when both parts are empty (shell shows default initials)", () => {
+    expect(
+      formatShellName({ title: "Dr", firstname: null, lastname: null }),
+    ).toBeUndefined()
+  })
+
+  it("returns undefined for a null lookup result", () => {
+    expect(formatShellName(null)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Contexte

Dernier rôle aligné sur la direction Home v3. L'accent **teal** s'applique déjà via `data-role="patient"` (corail réservé aux alertes).

## Changements
- **Fix initiales « U » du shell patient** : `(patient)/layout.tsx` lit `x-user-id` et passe `userName` au `NavigationShell` (lookup self request-cached, non-audité — même pattern que le layout staff `(dashboard)`).
- **Titres éditoriaux** : h1 `font-display text-3xl` + sections glycémie/AGP en `font-display`.

## Contrainte / suivi
La page patient (`patient/dashboard/page.tsx`) est un **composant client** ; `<DashboardGreeting>` est un composant **serveur**. Le **greeting nominatif** (« Bonjour, … · date ») demande donc un **split server-wrapper** (page serveur qui rend le greeting + `<PatientDashboardClient>`). Volontairement **différé en PR de suivi dédiée** pour ne pas mêler un refactor structurel à ce restyle.

## Validation
- ✅ `tsc` + ESLint clean.
- ✅ Build prod OK (le layout serveur importe le service ; pas de leak — seul `userName: string` traverse vers le shell client).

## État
Les 4 rôles (médecin/infirmier/admin/patient) sont restylés. Reste : greeting nominatif patient (split server-wrapper), dark mode chaud, simulation daltonisme indigo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)