### PR TITLE
fix(dashboard): RDV du jour jamais affichés — bornes date-only pour @db.Date

### DIFF
--- a/src/lib/cabinet-time.ts
+++ b/src/lib/cabinet-time.ts
@@ -44,3 +44,24 @@ export function todayBounds(now = new Date()): { start: Date; end: Date } {
   end.setUTCDate(end.getUTCDate() + 1)
   return { start, end }
 }
+
+/**
+ * Bornes [start, end) **date-only** du jour calendaire cabinet, pour comparer
+ * une colonne `@db.Date` (ex. `Appointment.date`).
+ *
+ * ⚠️ NE PAS utiliser {@link todayBounds} sur une colonne `@db.Date` : ses
+ * bornes sont des `timestamptz` décalés en TZ cabinet (ex. minuit Paris =
+ * 22:00Z la veille). Prisma tronque ces valeurs à la date pour comparer une
+ * colonne `Date`, ce qui donne `[veille, aujourd'hui)` et **exclut le jour
+ * courant** dès que la TZ cabinet est à l'est d'UTC (toujours, à Paris).
+ *
+ * Ici les bornes sont à **minuit UTC** du jour calendaire cabinet, donc la
+ * troncature Prisma rend les bonnes dates : `[aujourd'hui, demain)`.
+ */
+export function todayDateBounds(now = new Date()): { start: Date; end: Date } {
+  const { year, month, day } = cabinetDateParts(now)
+  const start = new Date(`${year}-${month}-${day}T00:00:00.000Z`)
+  const end = new Date(start)
+  end.setUTCDate(end.getUTCDate() + 1)
+  return { start, end }
+}

--- a/src/lib/services/doctor-dashboard.service.ts
+++ b/src/lib/services/doctor-dashboard.service.ts
@@ -31,7 +31,7 @@ import { getAccessiblePatientIds } from "@/lib/access-control"
 import { auditService, type AuditContext } from "./audit.service"
 import { messagingService, MESSAGING_BOUNDS } from "./messaging.service"
 import { safeDecryptField } from "@/lib/crypto/fields"
-import { todayBounds } from "@/lib/cabinet-time"
+import { todayDateBounds } from "@/lib/cabinet-time"
 import type { GlucoseUnit } from "@/lib/conversions"
 import type { Role } from "@prisma/client"
 
@@ -229,7 +229,10 @@ export const appointmentsQuery = {
     const ids = await getAccessiblePatientIds(userId, role)
     const scope = patientScopeWhere(ids)
     if (scope === null) return []
-    const { start, end } = todayBounds()
+    // `Appointment.date` est une colonne @db.Date → bornes date-only (sinon
+    // les bornes timestamptz de todayBounds sont tronquées et excluent le jour
+    // courant en TZ cabinet). Cf. todayDateBounds.
+    const { start, end } = todayDateBounds()
     // code-review H1 (re-review) — `scope` already carries
     //   `patient: { deletedAt: null }` ; don't override it here. Adding a
     //   literal `patient:` below would silently drop any future sub-filter

--- a/src/lib/services/nurse-dashboard.service.ts
+++ b/src/lib/services/nurse-dashboard.service.ts
@@ -91,6 +91,27 @@ function todayBounds(now = new Date()): { start: Date; end: Date } {
   return { start, end }
 }
 
+/**
+ * Bornes date-only du jour calendaire cabinet, pour la colonne `@db.Date`
+ * `Appointment.date`. {@link todayBounds} (timestamptz décalé en TZ cabinet)
+ * est correct pour les colonnes timestamptz (createdAt/triggeredAt) mais, sur
+ * une colonne `Date`, Prisma tronque ses bornes décalées et **exclut le jour
+ * courant** (minuit Paris = 22:00Z la veille). Ici les bornes sont à minuit
+ * UTC du jour cabinet → troncature correcte. Cf. cabinet-time#todayDateBounds.
+ */
+function todayDateBounds(now = new Date()): { start: Date; end: Date } {
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone: CABINET_TIMEZONE,
+    year: "numeric", month: "2-digit", day: "2-digit",
+  })
+  const parts = fmt.formatToParts(now)
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? ""
+  const start = new Date(`${get("year")}-${get("month")}-${get("day")}T00:00:00.000Z`)
+  const end = new Date(start)
+  end.setUTCDate(end.getUTCDate() + 1)
+  return { start, end }
+}
+
 // ─────────────────────────────────────────────────────────────
 // US-2406 — KPI "Ma journée"
 // ─────────────────────────────────────────────────────────────
@@ -118,12 +139,14 @@ export const nurseKpiQuery = {
       return zero
     }
     const { start, end } = todayBounds()
+    // Appointment.date = @db.Date → bornes date-only (cf. todayDateBounds).
+    const { start: dayStart, end: dayEnd } = todayDateBounds()
     const [rdvToPrepare, eventsToValidate, openUrgencies, proposalsPending]
       = await Promise.all([
         prisma.appointment.count({
           where: {
             ...scope,
-            date: { gte: start, lt: end },
+            date: { gte: dayStart, lt: dayEnd },
             status: { in: [AppointmentStatus.scheduled, AppointmentStatus.pending_validation] },
           },
         }),
@@ -203,6 +226,8 @@ export const nurseTodoQuery = {
     const scope = patientScopeWhere(ids)
     if (scope === null) return []
     const { start, end } = todayBounds()
+    // Appointment.date = @db.Date → bornes date-only (cf. todayDateBounds).
+    const { start: dayStart, end: dayEnd } = todayDateBounds()
 
     const include = {
       patient: {
@@ -217,7 +242,7 @@ export const nurseTodoQuery = {
       prisma.appointment.findMany({
         where: {
           ...scope,
-          date: { gte: start, lt: end },
+          date: { gte: dayStart, lt: dayEnd },
           status: { in: [AppointmentStatus.scheduled, AppointmentStatus.pending_validation] },
         },
         include,

--- a/src/lib/services/nurse-dashboard.service.ts
+++ b/src/lib/services/nurse-dashboard.service.ts
@@ -36,6 +36,7 @@ import { prisma } from "@/lib/db/client"
 import { getAccessiblePatientIds } from "@/lib/access-control"
 import { auditService, type AuditContext } from "./audit.service"
 import { safeDecryptField } from "@/lib/crypto/fields"
+import { todayBounds, todayDateBounds } from "@/lib/cabinet-time"
 import type { Role } from "@prisma/client"
 
 // ─────────────────────────────────────────────────────────────
@@ -57,60 +58,13 @@ function patientScopeWhere(
 
 const CABINET_TIMEZONE = "Europe/Paris"
 
-/**
- * code-review H3 (re-review) — return [start, end) for "today" in the
- * cabinet timezone, **as UTC instants** that correctly correspond to
- * Paris midnight boundaries (incl. DST).
- *
- * Earlier impl built `${YYYY-MM-DD}T00:00:00Z` which is UTC midnight of
- * the Paris-local date string — off by the Paris→UTC offset (1h CET /
- * 2h CEST). For `@db.Date` columns this happens to work (only date
- * portion compared) but for `@db.Timestamptz()` columns (DiabetesEvent.createdAt,
- * EmergencyAlert.triggeredAt) the filter silently excludes events from
- * the first 1-2h of the Paris day.
- *
- * Fix : extract the live offset via `longOffset` Intl part, embed it
- * in the ISO literal, let JS parse correctly to UTC.
- */
-function todayBounds(now = new Date()): { start: Date; end: Date } {
-  const fmt = new Intl.DateTimeFormat("en-CA", {
-    timeZone: CABINET_TIMEZONE,
-    year: "numeric", month: "2-digit", day: "2-digit",
-    timeZoneName: "longOffset",
-  })
-  const parts = fmt.formatToParts(now)
-  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? ""
-  const year = get("year")
-  const month = get("month")
-  const day = get("day")
-  // `longOffset` → "GMT+02:00" / "GMT-05:00" ; ISO literal accepts ±HH:MM.
-  const offset = get("timeZoneName").replace(/^GMT/, "") || "+00:00"
-  const start = new Date(`${year}-${month}-${day}T00:00:00${offset}`)
-  const end = new Date(start)
-  end.setUTCDate(end.getUTCDate() + 1)
-  return { start, end }
-}
-
-/**
- * Bornes date-only du jour calendaire cabinet, pour la colonne `@db.Date`
- * `Appointment.date`. {@link todayBounds} (timestamptz décalé en TZ cabinet)
- * est correct pour les colonnes timestamptz (createdAt/triggeredAt) mais, sur
- * une colonne `Date`, Prisma tronque ses bornes décalées et **exclut le jour
- * courant** (minuit Paris = 22:00Z la veille). Ici les bornes sont à minuit
- * UTC du jour cabinet → troncature correcte. Cf. cabinet-time#todayDateBounds.
- */
-function todayDateBounds(now = new Date()): { start: Date; end: Date } {
-  const fmt = new Intl.DateTimeFormat("en-CA", {
-    timeZone: CABINET_TIMEZONE,
-    year: "numeric", month: "2-digit", day: "2-digit",
-  })
-  const parts = fmt.formatToParts(now)
-  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? ""
-  const start = new Date(`${get("year")}-${get("month")}-${get("day")}T00:00:00.000Z`)
-  const end = new Date(start)
-  end.setUTCDate(end.getUTCDate() + 1)
-  return { start, end }
-}
+// Bornes « aujourd'hui » importées de @/lib/cabinet-time (source unique testée,
+// cf. cabinet-time.test.ts) :
+//  - todayBounds()      → timestamptz décalés TZ cabinet, pour les colonnes
+//    @db.Timestamptz (DiabetesEvent.createdAt, EmergencyAlert.triggeredAt).
+//  - todayDateBounds()  → minuit UTC du jour cabinet, pour la colonne @db.Date
+//    Appointment.date (sinon Prisma tronque les bornes décalées et exclut le
+//    jour courant). Plus de copie locale → plus de dérive.
 
 // ─────────────────────────────────────────────────────────────
 // US-2406 — KPI "Ma journée"

--- a/tests/unit/cabinet-time.test.ts
+++ b/tests/unit/cabinet-time.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Test suite: cabinet-time bounds (Europe/Paris).
+ *
+ * Comportement testé : `todayDateBounds()` produit des bornes **date-only**
+ * (minuit UTC du jour calendaire cabinet) pour comparer une colonne `@db.Date`
+ * (ex. `Appointment.date`), là où `todayBounds()` produit des `timestamptz`
+ * décalés en TZ cabinet (corrects pour les colonnes timestamptz).
+ *
+ * Risque couvert : un RDV du jour n'apparaît pas si la query compare une
+ * colonne `@db.Date` avec les bornes timestamptz de `todayBounds()` — Prisma
+ * tronque ces bornes à la date et exclut le jour courant dès que la TZ cabinet
+ * est à l'est d'UTC (toujours, à Paris). Bug réel des dashboards médecin/infirmier.
+ */
+import { describe, it, expect } from "vitest"
+import { todayBounds, todayDateBounds } from "@/lib/cabinet-time"
+
+/** Date-part comparée par Postgres pour une colonne @db.Date. */
+const datePart = (d: Date) => d.toISOString().slice(0, 10)
+
+describe("todayDateBounds (cabinet Europe/Paris)", () => {
+  it("renvoie des bornes minuit-UTC du jour calendaire cabinet (été, +02)", () => {
+    const now = new Date("2026-06-28T12:00:00Z") // Paris 14:00 → 28 juin
+    const { start, end } = todayDateBounds(now)
+    expect(start.toISOString()).toBe("2026-06-28T00:00:00.000Z")
+    expect(end.toISOString()).toBe("2026-06-29T00:00:00.000Z")
+  })
+
+  it("renvoie le bon jour en hiver (+01)", () => {
+    const now = new Date("2026-01-15T12:00:00Z") // Paris 13:00 → 15 janv
+    expect(todayDateBounds(now).start.toISOString()).toBe("2026-01-15T00:00:00.000Z")
+  })
+
+  it("inclut le jour cabinet pour une colonne @db.Date — là où todayBounds l'exclut (le bug)", () => {
+    // Soir UTC : Paris a déjà basculé au jour calendaire suivant.
+    const now = new Date("2026-06-28T23:30:00Z") // Paris 2026-06-29T01:30 → jour cabinet = 29
+    const cabinetToday = "2026-06-29"
+
+    // todayDateBounds : la troncature date inclut bien le jour cabinet.
+    const day = todayDateBounds(now)
+    expect(datePart(day.start) <= cabinetToday && cabinetToday < datePart(day.end)).toBe(true)
+
+    // todayBounds : bornes timestamptz tronquées → le jour cabinet est EXCLU.
+    const tz = todayBounds(now)
+    expect(datePart(tz.start) <= cabinetToday && cabinetToday < datePart(tz.end)).toBe(false)
+    expect(datePart(tz.start)).toBe("2026-06-28") // start tombe la veille
+  })
+
+  it("end vaut exactement start + 24 h", () => {
+    const { start, end } = todayDateBounds(new Date("2026-03-10T09:00:00Z"))
+    expect(end.getTime() - start.getTime()).toBe(24 * 3600 * 1000)
+  })
+})

--- a/tests/unit/doctor-dashboard.service.test.ts
+++ b/tests/unit/doctor-dashboard.service.test.ts
@@ -123,6 +123,13 @@ describe("appointmentsQuery (US-2402)", () => {
     expect(out[0]!.location).toBe("video")
     const callArg = prismaMock.appointment.findMany.mock.calls[0]![0]
     expect(callArg!.take).toBe(3)
+    // Régression bug RDV du jour : la colonne `Appointment.date` (@db.Date)
+    // DOIT être comparée à des bornes minuit-UTC (date-only). `todayBounds`
+    // (timestamptz Paris) donnerait 22h/23h UTC → Prisma tronque et exclut le
+    // jour courant. `getUTCHours()===0` distingue le fix du bug (tz-indépendant).
+    const gte = (callArg!.where as { date: { gte: Date } }).date.gte
+    expect(gte.getUTCHours()).toBe(0)
+    expect(gte.toISOString().endsWith("T00:00:00.000Z")).toBe(true)
   })
 })
 

--- a/tests/unit/nurse-dashboard.service.test.ts
+++ b/tests/unit/nurse-dashboard.service.test.ts
@@ -60,6 +60,13 @@ describe("nurseKpiQuery (US-2406)", () => {
     expect(byCode.proposalsPending).toBe(2)
     const meta = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
     expect(meta.metadata.kind).toBe("dashboard.infirmier.kpi")
+    // Régression : `appointment.date` (@db.Date) → bornes date-only (minuit
+    // UTC) ; `diabetesEvent.createdAt` (timestamptz) → bornes décalées TZ
+    // cabinet (≠ minuit UTC). Verrouille la séparation chirurgicale du fix.
+    const apptWhere = prismaMock.appointment.count.mock.calls[0]![0]!.where as { date: { gte: Date } }
+    expect(apptWhere.date.gte.getUTCHours()).toBe(0)
+    const evtWhere = prismaMock.diabetesEvent.count.mock.calls[0]![0]!.where as { createdAt: { gte: Date } }
+    expect(evtWhere.createdAt.gte.getUTCHours()).not.toBe(0)
   })
 })
 
@@ -97,6 +104,9 @@ describe("nurseTodoQuery (US-2407)", () => {
     expect(out).toHaveLength(3)
     expect(out[0]!.kind).toBe("prepareAppointment") // highest score
     expect(out[2]!.kind).toBe("observeProposal")    // lowest score (read-only)
+    // Régression : todo appointment.date (@db.Date) → bornes minuit-UTC.
+    const apptWhere = prismaMock.appointment.findMany.mock.calls[0]![0]!.where as { date: { gte: Date } }
+    expect(apptWhere.date.gte.getUTCHours()).toBe(0)
   })
 })
 


### PR DESCRIPTION
## Bug

« Rendez-vous du jour » (médecin) et « RDV à préparer » / todo (infirmier) **n'affichent jamais les RDV du jour courant** en production.

La query compare la colonne `Appointment.date` (**`@db.Date`**) avec les bornes **timestamptz** de `todayBounds()` (minuit cabinet Paris = `22:00Z` la veille). Prisma **tronque** ces bornes à la date pour une colonne `Date` → intervalle `[veille, aujourd'hui)` qui **exclut le jour courant** dès que la TZ cabinet est à l'est d'UTC — donc **toujours** à Europe/Paris.

Découvert en peuplant le seed : un RDV `scheduled` daté d'aujourd'hui ne remontait pas. Preuve SQL : bornes pleines → 2 RDV ; bornes tronquées (comportement Prisma) → 0.

## Fix

- **`cabinet-time.ts`** : nouveau **`todayDateBounds()`** — bornes à **minuit UTC** du jour calendaire cabinet → la troncature Prisma rend les bonnes dates `[aujourd'hui, demain)`.
- **`doctor-dashboard`** : la query RDV utilise `todayDateBounds` (colonne `@db.Date`).
- **`nurse-dashboard`** : `appointment.date` (KPI `rdvToPrepare` + todo) utilise des bornes date-only ; **`diabetesEvent.createdAt`** (timestamptz) **garde** `todayBounds` (les bornes tz précises y sont correctes). Fix chirurgical.

## Tests
- `cabinet-time.test.ts` (4) : démontre que `todayBounds` exclut le jour cabinet pour une colonne `@db.Date`, là où `todayDateBounds` l'inclut (cas du soir UTC où Paris a basculé au jour suivant).
- Non-régression dashboards : **48/48** (doctor + nurse + admin + cabinet-time).
- ✅ `tsc` + ESLint clean.
- ✅ Vérifié **en local** : `/api/dashboard/medecin/appointments` renvoie désormais les RDV du jour (capture à l'appui).

🤖 Generated with [Claude Code](https://claude.com/claude-code)