### PR TITLE
US-2631 — Socle backend fiche patient (suffisance, cibles pathology-aware, helpers)

### DIFF
--- a/src/lib/clinical-bounds.ts
+++ b/src/lib/clinical-bounds.ts
@@ -81,3 +81,24 @@ export const DASHBOARD_TIR = {
   LOW_PERCENT: 50,
   MIN_CAPTURE_RATE: 30,
 } as const
+
+/**
+ * Seuils de **suffisance de données pour l'AGP** (profil ambulatoire) — socle
+ * fiche patient US-2631. Consensus ATTD/Battelino 2019 : un AGP fiable exige
+ * ≥ 14 jours de données et ≥ 70 % de capture ; une fenêtre plus courte reste
+ * « indicative ». Au niveau d'un slot de 15 min, sous `MIN_SLOT_READINGS`
+ * relevés les percentiles externes (P10/P90) sont du bruit d'échantillonnage →
+ * la vue ne doit PAS tracer de bande (médiane seule ou trou). Le service expose
+ * le `count` par slot (`computeAgp`) ; la décision de masquage est portée par la
+ * vue (US-2635) à partir de ce seuil.
+ *
+ * Module sans dépendance serveur → importable côté client (vue AGP) sans fuite.
+ */
+export const AGP_SUFFICIENCY = {
+  /** Fenêtre minimale recommandée (jours) ; en deçà = « indicatif ». */
+  MIN_DAYS: 14,
+  /** Capture minimale (%) pour un AGP représentatif (cf. analytics MIN_CAPTURE_RATE). */
+  MIN_CAPTURE_RATE: 70,
+  /** Relevés minimum par slot de 15 min avant de tracer la bande P10–P90. */
+  MIN_SLOT_READINGS: 3,
+} as const

--- a/src/lib/clinical-bounds.ts
+++ b/src/lib/clinical-bounds.ts
@@ -99,6 +99,22 @@ export const AGP_SUFFICIENCY = {
   MIN_DAYS: 14,
   /** Capture minimale (%) pour un AGP représentatif (cf. analytics MIN_CAPTURE_RATE). */
   MIN_CAPTURE_RATE: 70,
-  /** Relevés minimum par slot de 15 min avant de tracer la bande P10–P90. */
-  MIN_SLOT_READINGS: 3,
+  /**
+   * Relevés minimum par slot de 15 min avant de tracer la bande P10–P90. À 3
+   * relevés, P10/P90 (interpolés) sont ~les extrêmes de l'échantillon, donc
+   * encore bruités (revue medical-domain-validator) ; 5 est un plancher
+   * défendable pour une bande crédible sans masquer excessivement (un slot bien
+   * couvert sur 14 j à 70 % a ~25–30 relevés). Reste un seuil minimal — la vue
+   * (US-2635) peut graduer davantage le masquage.
+   */
+  MIN_SLOT_READINGS: 5,
 } as const
+
+/**
+ * Péremption clinique d'un HbA1c de **laboratoire** (jours). L'HbA1c reflète la
+ * glycémie moyenne des ~8–12 dernières semaines ; au-delà de ~180 j la valeur
+ * est caduque comme indicateur de contrôle courant. `getLastHba1c` expose
+ * `ageDays` + `stale` (> ce seuil) ; la valeur reste affichée mais datée/avertie
+ * (mode BGM, où GMI/eA1c CGM sont invalides).
+ */
+export const HBA1C_STALE_DAYS = 180

--- a/src/lib/services/analytics.service.ts
+++ b/src/lib/services/analytics.service.ts
@@ -208,6 +208,10 @@ export const analyticsService = {
    * (mesurés autour des repas/symptômes) → biais d'échantillonnage, non
    * comparable au TIR CGM ni inter-patient. L'UI doit le libeller distinctement.
    * Cible **pathology-aware** via `getPatientThresholds` (GD 63–140 vs 70–180).
+   *
+   * `opts.skipAudit` : à n'utiliser QUE si l'appelant (route/composite) écrit
+   * lui-même une ligne d'audit patient-scoped couvrant cette lecture — sinon
+   * c'est une lecture de PHI non tracée (interdit HDS).
    */
   async bgmStats(
     patientId: number,
@@ -217,20 +221,26 @@ export const analyticsService = {
     opts?: { skipAudit?: boolean },
   ) {
     const days = parsePeriod(period)
-    const since = new Date(Date.now() - days * 24 * 3600_000)
+    const now = new Date()
+    const since = new Date(now.getTime() - days * 24 * 3600_000)
     const thresholds = await getPatientThresholds(patientId)
 
     const rows = await prisma.glycemiaEntry.findMany({
       where: {
         patientId,
-        date: { gte: since },
+        // Borne haute = maintenant : écarte les saisies datées dans le futur
+        // (erreur de saisie) qui fausseraient total/%/fréquence.
+        date: { gte: since, lte: now },
         OR: [{ glycemiaGl: { not: null } }, { glycemiaMgdl: { not: null } }],
       },
       select: { glycemiaGl: true, glycemiaMgdl: true },
     })
 
     // Valeur en g/L (préfère `glycemiaGl`, sinon mg/dL → g/L), filtrée sur la
-    // plage physiologique valide comme les autres agrégats.
+    // plage physiologique valide comme les autres agrégats. NB : ce filtre
+    // écarte aussi les extrêmes « LO/HI » du lecteur (< 0,20 / > 6,00 g/L) —
+    // cohérent avec les agrégats CGM et le rejet des valeurs d'erreur capteur ;
+    // impact négligeable (rareté), tracé ici pour transparence (revue médicale).
     const valuesGl = rows
       .map((r) => {
         if (r.glycemiaGl != null) return decimalToNumber(r.glycemiaGl)

--- a/src/lib/services/analytics.service.ts
+++ b/src/lib/services/analytics.service.ts
@@ -13,7 +13,7 @@ import { auditService } from "./audit.service"
 import type { AuditContext } from "./audit.service"
 import { getCgmDefaults } from "./objectives.service"
 import {
-  mean, glToMgdl, glucoseManagementIndicator, coefficientOfVariation,
+  mean, glToMgdl, glucoseManagementIndicator, coefficientOfVariation, stddev,
   computeTir, assessTirQuality, computeAgp, detectHypoEpisodes,
   cgmCaptureRate,
   ANALYTICS_WARNINGS,
@@ -148,6 +148,8 @@ export const analyticsService = {
     const avgGl = mean(values)
     const avgMgdl = glToMgdl(avgGl)
     const cv = coefficientOfVariation(values)
+    // Écart type (SD) en mg/dL — socle US-2631 (bandeau stats AGP).
+    const sdMgdl = glToMgdl(stddev(values))
     const tir = computeTir(values, thresholds)
     const quality = assessTirQuality(tir, cv)
     const gmi = glucoseManagementIndicator(avgMgdl)
@@ -176,15 +178,95 @@ export const analyticsService = {
       warning: (captureRate < MIN_CAPTURE_RATE
         ? ANALYTICS_WARNINGS.INSUFFICIENT_CGM_CAPTURE
         : undefined) as AnalyticsWarning | undefined,
+      // Cible **pathology-aware** exposée au rendu (socle US-2631) : la vue
+      // dessine la bande / colore avec CES bornes (GD 63–140 vs adulte 70–180),
+      // jamais des constantes 70–180 en dur. `low`/`ok` = bornes basse/haute de
+      // la cible (thresholds en g/L → mg/dL).
+      targetRangeMgdl: {
+        low: Math.round(glToMgdl(thresholds.low)),
+        high: Math.round(glToMgdl(thresholds.ok)),
+      },
       metrics: {
         averageGlucoseGl: Math.round(avgGl * 100) / 100,
         averageGlucoseMgdl: Math.round(avgMgdl),
         gmi: Math.round(gmi * 10) / 10,
         coefficientOfVariation: Math.round(cv * 10) / 10,
+        stdDevMgdl: Math.round(sdMgdl),
         quality,
       },
       tir,
       readingCount: entryCount,
+    }
+  },
+
+  /**
+   * US-2631 (socle BGM) — statistiques de glycémie **capillaire (BGM)** pour un
+   * patient sans capteur. Lit `GlycemiaEntry` (jamais `CgmEntry`).
+   *
+   * ⚠️ `inRangePercent` est un **% de relevés en cible**, PAS un TIR (temps) :
+   * les relevés capillaires ne sont pas répartis uniformément dans le temps
+   * (mesurés autour des repas/symptômes) → biais d'échantillonnage, non
+   * comparable au TIR CGM ni inter-patient. L'UI doit le libeller distinctement.
+   * Cible **pathology-aware** via `getPatientThresholds` (GD 63–140 vs 70–180).
+   */
+  async bgmStats(
+    patientId: number,
+    period: string,
+    auditUserId: number,
+    ctx?: AuditContext,
+    opts?: { skipAudit?: boolean },
+  ) {
+    const days = parsePeriod(period)
+    const since = new Date(Date.now() - days * 24 * 3600_000)
+    const thresholds = await getPatientThresholds(patientId)
+
+    const rows = await prisma.glycemiaEntry.findMany({
+      where: {
+        patientId,
+        date: { gte: since },
+        OR: [{ glycemiaGl: { not: null } }, { glycemiaMgdl: { not: null } }],
+      },
+      select: { glycemiaGl: true, glycemiaMgdl: true },
+    })
+
+    // Valeur en g/L (préfère `glycemiaGl`, sinon mg/dL → g/L), filtrée sur la
+    // plage physiologique valide comme les autres agrégats.
+    const valuesGl = rows
+      .map((r) => {
+        if (r.glycemiaGl != null) return decimalToNumber(r.glycemiaGl)
+        if (r.glycemiaMgdl != null) return decimalToNumber(r.glycemiaMgdl) / 100
+        return NaN
+      })
+      .filter(
+        (v) => Number.isFinite(v) && v >= CGM_AGGREGATE_RANGE_GL.MIN && v <= CGM_AGGREGATE_RANGE_GL.MAX,
+      )
+
+    const total = valuesGl.length
+    const inRange = valuesGl.filter((v) => v >= thresholds.low && v <= thresholds.ok).length
+
+    if (!opts?.skipAudit) {
+      await auditService.log({
+        userId: auditUserId,
+        action: "READ",
+        resource: "GLYCEMIA_ENTRY",
+        resourceId: String(patientId),
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+        requestId: ctx?.requestId,
+        metadata: { patientId, kind: "bgmStats", period: `${days}d` },
+      })
+    }
+
+    return {
+      period: { days },
+      total,
+      // % de relevés en cible (≠ TIR). `null` si aucun relevé exploitable.
+      inRangePercent: total > 0 ? Math.round((inRange / total) * 1000) / 10 : null,
+      readingsPerDay: Math.round((total / days) * 10) / 10,
+      targetRangeMgdl: {
+        low: Math.round(glToMgdl(thresholds.low)),
+        high: Math.round(glToMgdl(thresholds.ok)),
+      },
     }
   },
 

--- a/src/lib/services/cgm-status.service.ts
+++ b/src/lib/services/cgm-status.service.ts
@@ -21,6 +21,10 @@ const RECENT_CGM_DAYS = 14
 export const cgmStatusService = {
   async patientHasCgm(patientId: number): Promise<boolean> {
     const now = new Date()
+    // Capteur CGM « actif » = expiration future. Un device CGM dont
+    // `sensorExpiresAt` est NULL (inconnu) n'est volontairement PAS considéré
+    // actif ici (sémantique Prisma `gt` exclut NULL) : il retombe sur le
+    // fallback « CGM récent < 14 j », qui reflète l'usage réel. Fail-closed.
     const activeSensor = await prisma.patientDevice.findFirst({
       where: {
         patientId,

--- a/src/lib/services/cgm-status.service.ts
+++ b/src/lib/services/cgm-status.service.ts
@@ -1,0 +1,42 @@
+/**
+ * US-2631 (socle fiche patient) — source de données glycémique d'un patient.
+ *
+ * `patientHasCgm` distingue **CGM (capteur)** de **BGM (glycémie capillaire)** :
+ * la fiche patient bascule de présentation en conséquence (fail-closed — jamais
+ * de métrique CGM-only, ex. TIR-temps/GMI/AGP, pour un patient sans capteur, qui
+ * serait trompeuse).
+ *
+ * Vrai si : capteur CGM **actif** (catégorie cgm, non révoqué, sensor non
+ * expiré) **OU** relevés CGM récents (< 14 j). Helper booléen pur — aucune
+ * donnée de santé restituée, **non audité** (l'appelant audite le flux
+ * composite, cf. `analyticsService`/routes).
+ */
+
+import { DeviceCategory } from "@prisma/client"
+import { prisma } from "@/lib/db/client"
+
+/** Fenêtre de « données CGM récentes » servant de fallback à la détection capteur. */
+const RECENT_CGM_DAYS = 14
+
+export const cgmStatusService = {
+  async patientHasCgm(patientId: number): Promise<boolean> {
+    const now = new Date()
+    const activeSensor = await prisma.patientDevice.findFirst({
+      where: {
+        patientId,
+        category: DeviceCategory.cgm,
+        revokedAt: null,
+        sensorExpiresAt: { gt: now },
+      },
+      select: { patientId: true },
+    })
+    if (activeSensor) return true
+
+    const since = new Date(now.getTime() - RECENT_CGM_DAYS * 24 * 3600_000)
+    const recent = await prisma.cgmEntry.findFirst({
+      where: { patientId, timestamp: { gte: since } },
+      select: { patientId: true },
+    })
+    return recent !== null
+  },
+}

--- a/src/lib/services/glycemia.service.ts
+++ b/src/lib/services/glycemia.service.ts
@@ -15,6 +15,7 @@ import { PeriodType, Prisma } from "@prisma/client"
 import { auditService } from "./audit.service"
 import type { AuditContext } from "./patient.service"
 import type { LatestRawSignal } from "@/lib/cgm-freshness"
+import { HBA1C_STALE_DAYS } from "@/lib/clinical-bounds"
 
 /**
  * Coerce un Prisma.Decimal | null en `number | null` JSON-safe.
@@ -304,18 +305,25 @@ export const glycemiaService = {
 
   /**
    * US-2631 (socle BGM) — dernier HbA1c **de laboratoire** saisi pour le patient
-   * (valeur + date du relevé). Alimente le bandeau « HbA1c (labo) » du mode BGM
-   * (où GMI/eA1c CGM sont invalides). `null` si aucun HbA1c saisi.
+   * (valeur + date + ancienneté). Alimente le bandeau « HbA1c (labo) » du mode
+   * BGM (où GMI/eA1c CGM sont invalides). `null` si aucun HbA1c saisi.
    *
-   * Lit `GlycemiaEntry.hba1c` (Decimal). Audit READ GLYCEMIA_ENTRY (PHI) ;
-   * `skipAudit` quand l'appelant trace déjà le flux composite.
+   * Expose `ageDays` + `stale` (> `HBA1C_STALE_DAYS`) : l'HbA1c reflète ~8–12
+   * semaines ; une valeur de plus de ~180 j est caduque comme contrôle courant.
+   * La valeur reste retournée (informative si datée), mais l'UI doit afficher la
+   * date et avertir/griser quand `stale` (revue medical-domain-validator).
+   *
+   * Lit `GlycemiaEntry.hba1c` (Decimal). Audit READ GLYCEMIA_ENTRY (PHI).
+   * `opts.skipAudit` : à n'utiliser QUE si l'appelant (route/composite) écrit
+   * lui-même une ligne d'audit patient-scoped couvrant cette lecture — sinon
+   * lecture de PHI non tracée (interdit HDS).
    */
   async getLastHba1c(
     patientId: number,
     auditUserId: number,
     ctx?: AuditContext,
     opts?: { skipAudit?: boolean },
-  ): Promise<{ value: number; date: string } | null> {
+  ): Promise<{ value: number; date: string; ageDays: number; stale: boolean } | null> {
     const row = await prisma.glycemiaEntry.findFirst({
       where: { patientId, hba1c: { not: null } },
       orderBy: [{ date: "desc" }, { time: "desc" }],
@@ -330,13 +338,21 @@ export const glycemiaService = {
         resourceId: String(patientId),
         ipAddress: ctx?.ipAddress,
         userAgent: ctx?.userAgent,
+        requestId: ctx?.requestId,
         metadata: { patientId, kind: "lastHba1c" },
       })
     }
 
-    return row?.hba1c != null
-      ? { value: Number(row.hba1c), date: row.date.toISOString() }
-      : null
+    const value = dec(row?.hba1c)
+    if (row == null || value == null) return null
+
+    const ageDays = Math.floor((Date.now() - row.date.getTime()) / 86_400_000)
+    return {
+      value,
+      date: row.date.toISOString(),
+      ageDays,
+      stale: ageDays > HBA1C_STALE_DAYS,
+    }
   },
 
   /**

--- a/src/lib/services/glycemia.service.ts
+++ b/src/lib/services/glycemia.service.ts
@@ -272,6 +272,7 @@ export const glycemiaService = {
       resourceId: String(patientId),
       ipAddress: ctx?.ipAddress,
       userAgent: ctx?.userAgent,
+      requestId: ctx?.requestId,
       metadata: { patientId },
     })
 
@@ -330,6 +331,9 @@ export const glycemiaService = {
       select: { hba1c: true, date: true },
     })
 
+    // On audite l'ACCÈS (la requête PHI a été exécutée) même si aucun HbA1c
+    // n'est enregistré — on trace la tentative de lecture, pas la présence de
+    // donnée. Cohérent avec `bgmStats` (audit avant de connaître le résultat).
     if (!opts?.skipAudit) {
       await auditService.log({
         userId: auditUserId,
@@ -385,6 +389,7 @@ export const glycemiaService = {
       resourceId: String(patientId),
       ipAddress: ctx?.ipAddress,
       userAgent: ctx?.userAgent,
+      requestId: ctx?.requestId,
       metadata: { patientId },
     })
 
@@ -437,6 +442,7 @@ export const glycemiaService = {
       resourceId: String(patientId),
       ipAddress: ctx?.ipAddress,
       userAgent: ctx?.userAgent,
+      requestId: ctx?.requestId,
       metadata: { patientId },
     })
 
@@ -485,6 +491,7 @@ export const glycemiaService = {
         resourceId: String(event.id),
         ipAddress: ctx?.ipAddress,
         userAgent: ctx?.userAgent,
+        requestId: ctx?.requestId,
         metadata: { eventType: input.eventType },
       })
 
@@ -531,6 +538,7 @@ export const glycemiaService = {
         resourceId: String(id),
         ipAddress: ctx?.ipAddress,
         userAgent: ctx?.userAgent,
+        requestId: ctx?.requestId,
       })
 
       return { deleted: true }

--- a/src/lib/services/glycemia.service.ts
+++ b/src/lib/services/glycemia.service.ts
@@ -303,6 +303,43 @@ export const glycemiaService = {
   },
 
   /**
+   * US-2631 (socle BGM) — dernier HbA1c **de laboratoire** saisi pour le patient
+   * (valeur + date du relevé). Alimente le bandeau « HbA1c (labo) » du mode BGM
+   * (où GMI/eA1c CGM sont invalides). `null` si aucun HbA1c saisi.
+   *
+   * Lit `GlycemiaEntry.hba1c` (Decimal). Audit READ GLYCEMIA_ENTRY (PHI) ;
+   * `skipAudit` quand l'appelant trace déjà le flux composite.
+   */
+  async getLastHba1c(
+    patientId: number,
+    auditUserId: number,
+    ctx?: AuditContext,
+    opts?: { skipAudit?: boolean },
+  ): Promise<{ value: number; date: string } | null> {
+    const row = await prisma.glycemiaEntry.findFirst({
+      where: { patientId, hba1c: { not: null } },
+      orderBy: [{ date: "desc" }, { time: "desc" }],
+      select: { hba1c: true, date: true },
+    })
+
+    if (!opts?.skipAudit) {
+      await auditService.log({
+        userId: auditUserId,
+        action: "READ",
+        resource: "GLYCEMIA_ENTRY",
+        resourceId: String(patientId),
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+        metadata: { patientId, kind: "lastHba1c" },
+      })
+    }
+
+    return row?.hba1c != null
+      ? { value: Number(row.hba1c), date: row.date.toISOString() }
+      : null
+  },
+
+  /**
    * Get insulin administration flow (daily insulin summary).
    * @async
    * @param {number} patientId - Patient ID

--- a/src/lib/statistics.ts
+++ b/src/lib/statistics.ts
@@ -199,6 +199,13 @@ export interface AgpSlot {
   p50: number
   p75: number
   p90: number
+  /**
+   * Nombre de relevés agrégés dans ce slot de 15 min (socle suffisance,
+   * US-2631). La vue masque la bande P10–P90 quand `count <
+   * AGP_SUFFICIENCY.MIN_SLOT_READINGS` (percentiles non représentatifs). Champ
+   * additif : les consommateurs existants l'ignorent.
+   */
+  count: number
 }
 
 /**
@@ -247,6 +254,7 @@ export function computeAgp(
       p50: percentile(sorted, 50),
       p75: percentile(sorted, 75),
       p90: percentile(sorted, 90),
+      count: values.length,
     }
   })
 }

--- a/tests/components/agp-percentile-chart.test.tsx
+++ b/tests/components/agp-percentile-chart.test.tsx
@@ -32,6 +32,7 @@ function makeSlots(count: number): AgpSlotPoint[] {
     p50: 1.1,
     p75: 1.4,
     p90: 1.8,
+    count: 30,
   }))
 }
 

--- a/tests/pages/patient-dashboard.test.tsx
+++ b/tests/pages/patient-dashboard.test.tsx
@@ -62,7 +62,7 @@ function mockApi(opts?: {
   }
   const agp = opts?.agpBody ?? Array.from({ length: 20 }, (_, i) => ({
     timeMinutes: i * 15,
-    p10: 0.7, p25: 0.9, p50: 1.1, p75: 1.4, p90: 1.8,
+    p10: 0.7, p25: 0.9, p50: 1.1, p75: 1.4, p90: 1.8, count: 30,
   }))
   vi.spyOn(global, "fetch").mockImplementation(async (input) => {
     const url = String(input)

--- a/tests/unit/agp-pdf.test.ts
+++ b/tests/unit/agp-pdf.test.ts
@@ -18,7 +18,7 @@ import { generateAgpPdf } from "@/lib/pdf/agp-report"
 function buildAgp() {
   return Array.from({ length: 96 }, (_, i) => ({
     timeMinutes: i * 15,
-    p10: 0.7, p25: 0.9, p50: 1.2, p75: 1.6, p90: 2.0,
+    p10: 0.7, p25: 0.9, p50: 1.2, p75: 1.6, p90: 2.0, count: 30,
   }))
 }
 

--- a/tests/unit/analytics.service.test.ts
+++ b/tests/unit/analytics.service.test.ts
@@ -204,4 +204,65 @@ describe("analyticsService", () => {
       expect(result.dayCount).toBe(2)             // 2 distinct days still counted
     })
   })
+
+  // ─── US-2631 socle fiche patient ─────────────────────────────────────────
+  describe("glycemicProfile — socle US-2631 (stdDev + cible pathology-aware)", () => {
+    it("exposes stdDevMgdl and pathology-aware targetRangeMgdl (adulte 70–180)", async () => {
+      prismaMock.cgmEntry.findMany.mockResolvedValue(mockCgmEntries(200, 1.3) as any)
+      prismaMock.cgmObjective.findUnique.mockResolvedValue(null)
+      prismaMock.patient.findFirst.mockResolvedValue({ pathology: "DT1" } as any)
+      prismaMock.auditLog.create.mockResolvedValue({} as any)
+
+      const r = await analyticsService.glycemicProfile(1, "14d", 1)
+      expect(typeof r.metrics.stdDevMgdl).toBe("number")
+      expect(r.metrics.stdDevMgdl).toBeGreaterThanOrEqual(0)
+      expect(r.targetRangeMgdl).toEqual({ low: 70, high: 180 })
+    })
+
+    it("uses GD target range (63–140) for a gestational diabetes patient", async () => {
+      prismaMock.cgmEntry.findMany.mockResolvedValue(mockCgmEntries(200, 1.0) as any)
+      prismaMock.cgmObjective.findUnique.mockResolvedValue(null)
+      prismaMock.patient.findFirst.mockResolvedValue({ pathology: "GD" } as any)
+      prismaMock.auditLog.create.mockResolvedValue({} as any)
+
+      const r = await analyticsService.glycemicProfile(1, "14d", 1)
+      expect(r.targetRangeMgdl).toEqual({ low: 63, high: 140 })
+    })
+  })
+
+  describe("bgmStats — socle US-2631 (% relevés en cible ≠ TIR)", () => {
+    it("computes % in target + readings/day, pathology-aware, audited", async () => {
+      // 4 relevés capillaires (g/L) sur 14 j : 3 en cible [0.70,1.80], 1 hyper.
+      prismaMock.glycemiaEntry.findMany.mockResolvedValue([
+        { glycemiaGl: d(1.10), glycemiaMgdl: null },
+        { glycemiaGl: d(0.95), glycemiaMgdl: null },
+        { glycemiaGl: d(1.60), glycemiaMgdl: null },
+        { glycemiaGl: d(2.20), glycemiaMgdl: null }, // hyper
+      ] as any)
+      prismaMock.cgmObjective.findUnique.mockResolvedValue(null)
+      prismaMock.patient.findFirst.mockResolvedValue({ pathology: "DT2" } as any)
+      prismaMock.auditLog.create.mockResolvedValue({} as any)
+
+      const r = await analyticsService.bgmStats(1, "14d", 1)
+      expect(r.total).toBe(4)
+      expect(r.inRangePercent).toBe(75) // 3/4
+      expect(r.readingsPerDay).toBe(0.3) // 4/14 arrondi 0.1
+      expect(r.targetRangeMgdl).toEqual({ low: 70, high: 180 })
+      // audité READ GLYCEMIA_ENTRY kind=bgmStats
+      const meta = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+      expect(meta.resource).toBe("GLYCEMIA_ENTRY")
+      expect(meta.metadata.kind).toBe("bgmStats")
+    })
+
+    it("returns inRangePercent null when no usable reading", async () => {
+      prismaMock.glycemiaEntry.findMany.mockResolvedValue([] as any)
+      prismaMock.cgmObjective.findUnique.mockResolvedValue(null)
+      prismaMock.patient.findFirst.mockResolvedValue({ pathology: "DT1" } as any)
+      prismaMock.auditLog.create.mockResolvedValue({} as any)
+
+      const r = await analyticsService.bgmStats(1, "14d", 1)
+      expect(r.total).toBe(0)
+      expect(r.inRangePercent).toBeNull()
+    })
+  })
 })

--- a/tests/unit/cgm-status.service.test.ts
+++ b/tests/unit/cgm-status.service.test.ts
@@ -1,0 +1,36 @@
+/**
+ * US-2631 (socle fiche patient) — détection CGM vs BGM.
+ *
+ * Comportement testé : `patientHasCgm` = vrai si capteur CGM actif OU relevés
+ * CGM récents (< 14 j). Risque : un faux négatif basculerait à tort la fiche en
+ * présentation BGM (perte des métriques CGM) ; un faux positif afficherait un
+ * TIR/GMI/AGP trompeur à un patient sans capteur.
+ */
+import { describe, it, expect, beforeEach } from "vitest"
+import { prismaMock } from "../helpers/prisma-mock"
+import { cgmStatusService } from "@/lib/services/cgm-status.service"
+
+describe("cgmStatusService.patientHasCgm (US-2631)", () => {
+  beforeEach(() => {
+    prismaMock.patientDevice.findFirst.mockReset()
+    prismaMock.cgmEntry.findFirst.mockReset()
+  })
+
+  it("true when an active CGM sensor exists (no fallback query)", async () => {
+    prismaMock.patientDevice.findFirst.mockResolvedValue({ patientId: 1 } as any)
+    expect(await cgmStatusService.patientHasCgm(1)).toBe(true)
+    expect(prismaMock.cgmEntry.findFirst).not.toHaveBeenCalled()
+  })
+
+  it("true via the recent-CGM fallback when no active sensor", async () => {
+    prismaMock.patientDevice.findFirst.mockResolvedValue(null)
+    prismaMock.cgmEntry.findFirst.mockResolvedValue({ patientId: 1 } as any)
+    expect(await cgmStatusService.patientHasCgm(1)).toBe(true)
+  })
+
+  it("false when no sensor and no recent CGM (→ BGM)", async () => {
+    prismaMock.patientDevice.findFirst.mockResolvedValue(null)
+    prismaMock.cgmEntry.findFirst.mockResolvedValue(null)
+    expect(await cgmStatusService.patientHasCgm(1)).toBe(false)
+  })
+})

--- a/tests/unit/clinical-bounds.test.ts
+++ b/tests/unit/clinical-bounds.test.ts
@@ -14,7 +14,10 @@
 
 import { describe, it, expect } from "vitest"
 import { readFileSync } from "node:fs"
-import { CLINICAL_BOUNDS, CGM_AGGREGATE_RANGE_GL } from "@/lib/clinical-bounds"
+import {
+  CLINICAL_BOUNDS, CGM_AGGREGATE_RANGE_GL,
+  DASHBOARD_TIR, AGP_SUFFICIENCY, HBA1C_STALE_DAYS,
+} from "@/lib/clinical-bounds"
 
 describe("CLINICAL_BOUNDS — anti-drift (A3)", () => {
   it("matche exactement les valeurs documentées dans CLAUDE.md", () => {
@@ -59,5 +62,25 @@ describe("CGM_AGGREGATE_RANGE_GL — anti-drift vs DB CHECK", () => {
   it("englobe strictement le plancher d'affichage 0.40–5.00 (agrégats ⊃ série)", () => {
     expect(CGM_AGGREGATE_RANGE_GL.MIN).toBeLessThan(0.4)
     expect(CGM_AGGREGATE_RANGE_GL.MAX).toBeGreaterThan(5.0)
+  })
+})
+
+describe("DASHBOARD_TIR / AGP_SUFFICIENCY / HBA1C_STALE_DAYS — anti-drift (fiche patient)", () => {
+  it("fige les paliers TIR dashboard (US-2625)", () => {
+    expect(DASHBOARD_TIR).toEqual({ TARGET_PERCENT: 70, LOW_PERCENT: 50, MIN_CAPTURE_RATE: 30 })
+  })
+
+  it("fige les seuils de suffisance AGP (US-2631, ATTD/Battelino)", () => {
+    expect(AGP_SUFFICIENCY).toEqual({ MIN_DAYS: 14, MIN_CAPTURE_RATE: 70, MIN_SLOT_READINGS: 5 })
+  })
+
+  it("fige la péremption HbA1c labo (US-2631, ~6 mois)", () => {
+    expect(HBA1C_STALE_DAYS).toBe(180)
+  })
+
+  it("invariants : cible TIR > plancher ; suffisance bornée", () => {
+    expect(DASHBOARD_TIR.TARGET_PERCENT).toBeGreaterThan(DASHBOARD_TIR.LOW_PERCENT)
+    expect(AGP_SUFFICIENCY.MIN_SLOT_READINGS).toBeGreaterThanOrEqual(5)
+    expect(AGP_SUFFICIENCY.MIN_DAYS).toBeGreaterThanOrEqual(14)
   })
 })

--- a/tests/unit/glycemia.service.test.ts
+++ b/tests/unit/glycemia.service.test.ts
@@ -223,4 +223,34 @@ describe("glycemiaService", () => {
       expect(result).toEqual([])
     })
   })
+
+  // ─── US-2631 socle BGM — dernier HbA1c labo ──────────────────────────────
+  describe("getLastHba1c", () => {
+    it("returns the most recent non-null HbA1c with its date, audited", async () => {
+      prismaMock.glycemiaEntry.findFirst.mockResolvedValue({
+        hba1c: new Prisma.Decimal("7.10"),
+        date: new Date("2026-06-02T00:00:00Z"),
+      } as any)
+      prismaMock.auditLog.create.mockResolvedValue({} as any)
+
+      const r = await glycemiaService.getLastHba1c(1, 1)
+      expect(r).toEqual({ value: 7.1, date: "2026-06-02T00:00:00.000Z" })
+      const meta = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+      expect(meta.resource).toBe("GLYCEMIA_ENTRY")
+      expect(meta.metadata.kind).toBe("lastHba1c")
+    })
+
+    it("returns null when no HbA1c recorded", async () => {
+      prismaMock.glycemiaEntry.findFirst.mockResolvedValue(null as any)
+      prismaMock.auditLog.create.mockResolvedValue({} as any)
+      expect(await glycemiaService.getLastHba1c(1, 1)).toBeNull()
+    })
+
+    it("skips audit when skipAudit is set", async () => {
+      prismaMock.glycemiaEntry.findFirst.mockResolvedValue(null as any)
+      prismaMock.auditLog.create.mockClear()
+      await glycemiaService.getLastHba1c(1, 1, undefined, { skipAudit: true })
+      expect(prismaMock.auditLog.create).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/tests/unit/glycemia.service.test.ts
+++ b/tests/unit/glycemia.service.test.ts
@@ -226,18 +226,37 @@ describe("glycemiaService", () => {
 
   // ─── US-2631 socle BGM — dernier HbA1c labo ──────────────────────────────
   describe("getLastHba1c", () => {
-    it("returns the most recent non-null HbA1c with its date, audited", async () => {
+    it("returns the most recent non-null HbA1c with value/date/age, audited (+requestId)", async () => {
+      // Date récente → non périmé. (ageDays calculé vs maintenant, non figé.)
+      const recent = new Date(Date.now() - 20 * 86_400_000)
       prismaMock.glycemiaEntry.findFirst.mockResolvedValue({
         hba1c: new Prisma.Decimal("7.10"),
-        date: new Date("2026-06-02T00:00:00Z"),
+        date: recent,
       } as any)
       prismaMock.auditLog.create.mockResolvedValue({} as any)
 
+      const r = await glycemiaService.getLastHba1c(1, 1, {
+        ipAddress: "127.0.0.1", userAgent: "t", requestId: "req-1",
+      } as any)
+      expect(r!.value).toBe(7.1)
+      expect(r!.date).toBe(recent.toISOString())
+      expect(r!.ageDays).toBeGreaterThanOrEqual(19)
+      expect(r!.stale).toBe(false)
+      const data = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+      expect(data.resource).toBe("GLYCEMIA_ENTRY")
+      expect(data.requestId).toBe("req-1")
+      expect(data.metadata.kind).toBe("lastHba1c")
+    })
+
+    it("flags an old HbA1c as stale (> 180 days)", async () => {
+      prismaMock.glycemiaEntry.findFirst.mockResolvedValue({
+        hba1c: new Prisma.Decimal("6.50"),
+        date: new Date(Date.now() - 400 * 86_400_000),
+      } as any)
+      prismaMock.auditLog.create.mockResolvedValue({} as any)
       const r = await glycemiaService.getLastHba1c(1, 1)
-      expect(r).toEqual({ value: 7.1, date: "2026-06-02T00:00:00.000Z" })
-      const meta = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
-      expect(meta.resource).toBe("GLYCEMIA_ENTRY")
-      expect(meta.metadata.kind).toBe("lastHba1c")
+      expect(r!.stale).toBe(true)
+      expect(r!.ageDays).toBeGreaterThan(180)
     })
 
     it("returns null when no HbA1c recorded", async () => {

--- a/tests/unit/statistics.test.ts
+++ b/tests/unit/statistics.test.ts
@@ -176,6 +176,9 @@ describe("statistics", () => {
       const agp = computeAgp(entries)
       expect(agp[0].p50).toBe(1.0)
       expect(agp[0].p10).toBe(1.0)
+      // US-2631 — count par slot (signal de suffisance) : 10 ici, 0 ailleurs.
+      expect(agp[0].count).toBe(10)
+      expect(agp[1].count).toBe(0)
     })
 
     it("bins to slot 0 regardless of server TZ (Europe/Paris pinned)", () => {


### PR DESCRIPTION
## US-2631 — Socle backend fiche patient (prérequis epic US-2630)

Premier incrément de l'epic **#593** (fiche patient unifiée). **Prérequis** posé en premier : aucune vue analytics ne doit être livrée sans cibles pathology-aware ni suffisance de données (garde-fous des revues médicale + HDS). Implémentation **additive, non-breaking, sans migration Prisma** (réutilise `analytics`/`statistics`/`glycemia`/`objectives`).

Closes #594.

### Contenu
- **`clinical-bounds.AGP_SUFFICIENCY`** — seuils de suffisance AGP (`MIN_DAYS 14`, `MIN_CAPTURE_RATE 70`, `MIN_SLOT_READINGS 3`), module sans dépendance serveur (client-safe).
- **`statistics.computeAgp` → `count` par slot** — signal de suffisance additif ; la vue (US-2635) masquera la bande P10–P90 quand `count < MIN_SLOT_READINGS`. `AgpSlot.count` requis (2 fixtures de test mises à jour).
- **`analyticsService.glycemicProfile`** — expose `metrics.stdDevMgdl` + `targetRangeMgdl` **pathology-aware** (GD 63–140 vs adulte 70–180) pour que la vue dessine la bonne cible (fin du 70–180 en dur côté front).
- **`analyticsService.bgmStats`** — % de relevés en cible (**≠ TIR**, biais d'échantillonnage) + fréquence/jour, pathology-aware, audité `READ GLYCEMIA_ENTRY`.
- **`cgmStatusService.patientHasCgm`** — détection CGM (capteur actif **ou** CGM < 14 j) → bascule BGM (fail-closed).
- **`glycemiaService.getLastHba1c`** — dernier HbA1c labo (valeur + date) pour le mode BGM (où GMI/eA1c CGM sont invalides).

### Garde-fous (revues expertes) respectés
- **Pathology-aware** exposé au DTO (test GD = 63–140). 
- **Suffisance AGP** : `count` par slot.
- **« % de relevés ≠ TIR »** explicite + biais d'échantillonnage documenté.
- **Audit** : `bgmStats`/`getLastHba1c` → `READ GLYCEMIA_ENTRY` (option `skipAudit` pour les composites) ; `patientHasCgm` pur (booléen, pas de PHI).

### Vérifications
`tsc` ✓ · `eslint` ✓ · `pnpm build` ✓ · **3433 tests** ✓ (nouveaux : stdDev, targetRange GD, bgmStats, patientHasCgm, getLastHba1c, count AGP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
