### PR TITLE
US-2633 (slice 1/2) — DTO partagé + route cTok /api/patients/record

### DIFF
--- a/src/app/(dashboard)/patients/[id]/build-patient-record.ts
+++ b/src/app/(dashboard)/patients/[id]/build-patient-record.ts
@@ -1,0 +1,137 @@
+/**
+ * Assemblage **serveur** du DTO `PatientRecordData` de la fiche patient (US-2633).
+ *
+ * Source unique réutilisée par :
+ *  - la page RSC (`page.tsx`, mode page) ;
+ *  - la route `cTok` `GET /api/patients/record` (mode drawer de consultation).
+ *
+ * ⚠️ Ne fait PAS le contrôle d'accès : les GARDES (`canAccessPatient` /
+ * `patientShareConsent` ou résolution `cTok`) sont du ressort de l'APPELANT
+ * (page ou route), avant cet appel. Cette fonction ne fait que **projeter** les
+ * données déjà autorisées — chaque agrégat est audité par son service
+ * (READ PATIENT / ANALYTICS / CGM_ENTRY / INSULIN_THERAPY / MEDICAL_DOCUMENT).
+ * Aucun calcul clinique ici (délégué aux services + builders purs).
+ */
+
+import type { Role } from "@prisma/client"
+import { patientService } from "@/lib/services/patient.service"
+import type { AuditContext } from "@/lib/services/patient.service"
+import { analyticsService } from "@/lib/services/analytics.service"
+import { glycemiaService } from "@/lib/services/glycemia.service"
+import { insulinTherapyService } from "@/lib/services/insulin-therapy.service"
+import { documentService } from "@/lib/services/document.service"
+import { getPatientFlags } from "@/lib/services/doctor-dashboard.service"
+import { resolveTargetRangeMgdl } from "./overview-targets"
+import { buildGlycemiaView } from "./glycemia-view"
+import { buildTreatmentView } from "./treatment-view"
+import { buildDocumentView } from "./document-view"
+import type { PatientRecordData } from "@/components/diabeo/patient/PatientRecord"
+
+/** Période d'agrégation de la vue d'ensemble. Bornée < 90j (analytics). */
+const OVERVIEW_PERIOD = "14d"
+// Cibles consensus ADA/EASD (identiques pour tous les patients) — TIR ≥ 70 %,
+// temps < 70 mg/dL ≤ 4 %, CV ≤ 36 %.
+const CONSENSUS_TIR_TARGET_PCT = 70
+const CONSENSUS_HYPO_MAX_PCT = 4
+const CONSENSUS_CV_MAX_PCT = 36
+
+export function computeAge(birthday: Date | null | undefined, now: Date): number | null {
+  if (!birthday) return null
+  let age = now.getFullYear() - birthday.getFullYear()
+  const m = now.getMonth() - birthday.getMonth()
+  if (m < 0 || (m === 0 && now.getDate() < birthday.getDate())) age--
+  return age >= 0 && age < 150 ? age : null
+}
+
+/**
+ * Projette le DTO complet de la fiche patient. `null` si le patient n'existe
+ * pas (→ l'appelant rend un 404). Suppose l'accès déjà autorisé (cf. en-tête).
+ */
+export async function buildPatientRecordData(
+  patientId: number,
+  role: Role,
+  userId: number,
+  ctx: AuditContext,
+): Promise<PatientRecordData | null> {
+  // Profil (PII déchiffrée serveur) + objectifs + référent — audité READ PATIENT.
+  const patient = await patientService.getById(patientId, userId, ctx)
+  if (!patient) return null
+
+  // Stats glycémiques — projection serveur (audité READ ANALYTICS).
+  const profile = await analyticsService.glycemicProfile(patientId, OVERVIEW_PERIOD, userId, ctx)
+
+  // Drapeaux d'alerte de la barre de contexte (source « Ma journée »). Fail-soft.
+  const flags = await getPatientFlags(patientId).catch((e) => {
+    console.error("[build-patient-record] getPatientFlags failed", e instanceof Error ? e.message : e)
+    return null
+  })
+
+  const now = new Date()
+
+  // Onglet Glycémie : série CGM 24h (audité READ CGM_ENTRY) + signal de fraîcheur
+  // « brut » (fail-soft — ne casse jamais l'assemblage).
+  const from24h = new Date(now.getTime() - 24 * 60 * 60 * 1000)
+  const [cgmEntries, latestRaw] = await Promise.all([
+    glycemiaService.getCgmEntries(patientId, from24h, now, userId, ctx),
+    glycemiaService.getLatestCgmFreshness(patientId, from24h, now, userId, ctx).catch((e) => {
+      console.error("[build-patient-record] getLatestCgmFreshness failed", e instanceof Error ? e.message : e)
+      return null
+    }),
+  ])
+  const glycemiaView = buildGlycemiaView(cgmEntries, now, latestRaw)
+
+  // Onglet Traitements : réglages insuline réels (audité READ INSULIN_THERAPY).
+  const insulinSettings = await insulinTherapyService.getSettings(patientId, userId, ctx)
+  const treatmentView = buildTreatmentView(insulinSettings, patient.treatments ?? [], patient.devices ?? [], now)
+
+  // Onglet Documents : métadonnées scopées + auditées (READ MEDICAL_DOCUMENT).
+  const documents = buildDocumentView(await documentService.list(patientId, role, userId, ctx))
+
+  // Plage cible affichée = bornes TIR pathology-aware (cf. overview-targets).
+  const { targetLowMgdl, targetHighMgdl } = resolveTargetRangeMgdl(
+    patient.cgmObjectives,
+    patient.pathology,
+  )
+
+  const fullName = `${patient.user.firstname ?? ""} ${patient.user.lastname ?? ""}`.trim()
+
+  return {
+    id: patient.id,
+    publicRef: patient.publicRef,
+    name: fullName,
+    flags: flags ?? { recentHypos: false, hypoCount: 0, silentMonitoring: false, silentDays: null, openUrgency: false },
+    age: computeAge(patient.user.birthday ?? null, now),
+    sex: patient.user.sex ?? null,
+    pathology: patient.pathology ?? null,
+    diagYear: patient.medicalData?.yearDiag ?? null,
+    referent: patient.referent?.pro?.name ?? null,
+    objectives: {
+      targetLowMgdl,
+      targetHighMgdl,
+      tirTargetPct: CONSENSUS_TIR_TARGET_PCT,
+      hypoMaxPct: CONSENSUS_HYPO_MAX_PCT,
+      cvMaxPct: CONSENSUS_CV_MAX_PCT,
+    },
+    stats:
+      profile.readingCount > 0
+        ? {
+            avgGlucoseMgdl: profile.metrics.averageGlucoseMgdl,
+            gmi: profile.metrics.gmi,
+            cv: profile.metrics.coefficientOfVariation,
+            tir: {
+              veryLow: profile.tir.severeHypo,
+              low: profile.tir.hypo,
+              inRange: profile.tir.inRange,
+              high: profile.tir.elevated,
+              veryHigh: profile.tir.hyper,
+            },
+            readingCount: profile.readingCount,
+            captureRate: profile.captureRate,
+            insufficientCapture: profile.warning === "insufficientCgmCapture",
+          }
+        : null,
+    glycemia: glycemiaView,
+    treatment: treatmentView,
+    documents,
+  }
+}

--- a/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/src/app/(dashboard)/patients/[id]/page.tsx
@@ -86,8 +86,11 @@ export default async function PatientDetailPage({
   if (!data) notFound()
 
   // US-2603 — enregistre la consultation du dossier (switcher « récemment vus »).
-  // Fail-soft : un échec ne casse jamais le rendu ; réservé aux PS (VIEWER n'atteint
-  // pas cette route — défense en profondeur).
+  // Placement APRÈS l'assemblage volontaire : on n'enregistre une consultation
+  // que si le dossier a réellement pu être projeté (si un agrégat lève, le throw
+  // remonte avant et aucune « consultation » fantôme n'est tracée).
+  // Fail-soft : un échec d'enregistrement ne casse jamais le rendu ; réservé aux
+  // PS (VIEWER n'atteint pas cette route — défense en profondeur).
   if (role !== "VIEWER") {
     void recentPatientsService.recordView(userId, patientId).catch((e) => {
       console.error("[patient-detail] recordView failed", e instanceof Error ? e.message : e)

--- a/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/src/app/(dashboard)/patients/[id]/page.tsx
@@ -19,36 +19,11 @@ import { headers } from "next/headers"
 import { notFound, redirect } from "next/navigation"
 import type { Role } from "@prisma/client"
 import { patientShareConsent } from "@/lib/consent"
-import { patientService } from "@/lib/services/patient.service"
-import { analyticsService } from "@/lib/services/analytics.service"
-import { glycemiaService } from "@/lib/services/glycemia.service"
-import { insulinTherapyService } from "@/lib/services/insulin-therapy.service"
-import { documentService } from "@/lib/services/document.service"
 import { auditService } from "@/lib/services/audit.service"
-import { getPatientFlags } from "@/lib/services/doctor-dashboard.service"
 import { recentPatientsService } from "@/lib/services/recent-patients.service"
 import { canAccessPatient } from "@/lib/access-control"
-import { resolveTargetRangeMgdl } from "./overview-targets"
-import { buildGlycemiaView } from "./glycemia-view"
-import { buildTreatmentView } from "./treatment-view"
-import { buildDocumentView } from "./document-view"
-import { PatientDetailClient, type PatientDetailData } from "./PatientDetailClient"
-
-// Période d'agrégation de la vue d'ensemble. Bornée < 90j (analytics).
-const OVERVIEW_PERIOD = "14d"
-// Cibles consensus ADA/EASD (identiques pour tous les patients, pas des champs
-// patient) — TIR ≥ 70 %, temps < 70 mg/dL ≤ 4 %, CV ≤ 36 % (stabilité glycémique).
-const CONSENSUS_TIR_TARGET_PCT = 70
-const CONSENSUS_HYPO_MAX_PCT = 4
-const CONSENSUS_CV_MAX_PCT = 36
-
-function computeAge(birthday: Date | null | undefined, now: Date): number | null {
-  if (!birthday) return null
-  let age = now.getFullYear() - birthday.getFullYear()
-  const m = now.getMonth() - birthday.getMonth()
-  if (m < 0 || (m === 0 && now.getDate() < birthday.getDate())) age--
-  return age >= 0 && age < 150 ? age : null
-}
+import { buildPatientRecordData } from "./build-patient-record"
+import { PatientDetailClient } from "./PatientDetailClient"
 
 export default async function PatientDetailPage({
   params,
@@ -104,108 +79,19 @@ export default async function PatientDetailPage({
     return <PatientDetailClient data={null} sharingDisabled />
   }
 
-  // Profil (PII déchiffrée serveur) + objectifs + référent — audité (READ PATIENT).
-  const patient = await patientService.getById(patientId, userId, ctx)
-  if (!patient) notFound()
+  // Projection du DTO — source unique partagée avec la route cTok du drawer
+  // (`/api/patients/record`, US-2633). Les gardes RBAC + consentement ci-dessus
+  // restent côté page ; l'assemblage audite chaque agrégat.
+  const data = await buildPatientRecordData(patientId, role, userId, ctx)
+  if (!data) notFound()
 
   // US-2603 — enregistre la consultation du dossier (switcher « récemment vus »).
-  // Fail-soft : un échec ne doit JAMAIS casser le rendu du dossier ; réservé aux
-  // PS (un VIEWER n'atteint pas cette route — défense en profondeur).
+  // Fail-soft : un échec ne casse jamais le rendu ; réservé aux PS (VIEWER n'atteint
+  // pas cette route — défense en profondeur).
   if (role !== "VIEWER") {
     void recentPatientsService.recordView(userId, patientId).catch((e) => {
       console.error("[patient-detail] recordView failed", e instanceof Error ? e.message : e)
     })
-  }
-
-  // Stats glycémiques — projection serveur (audité READ ANALYTICS).
-  const profile = await analyticsService.glycemicProfile(patientId, OVERVIEW_PERIOD, userId, ctx)
-
-  // US-2603 — drapeaux d'alerte de la barre de contexte (source unique « Ma
-  // journée »). Fail-soft : signal secondaire, ne casse pas le dossier.
-  const flags = await getPatientFlags(patientId).catch((e) => {
-    console.error("[patient-detail] getPatientFlags failed", e instanceof Error ? e.message : e)
-    return null
-  })
-
-  const now = new Date()
-
-  // Phase 2 — Onglet Glycémie : série CGM des dernières 24h (audité READ CGM_ENTRY).
-  // Mapping déterministe (g/L→mg/dL, heure Europe/Paris, fraîcheur) extrait dans
-  // `buildGlycemiaView` (pur, unit-testé).
-  const from24h = new Date(now.getTime() - 24 * 60 * 60 * 1000)
-  // Signal de fraîcheur « brut » : détecte un relevé plus récent hors plage
-  // (hypo sévère < 40 / capteur LOW-HIGH) exclu de la série affichée. Fail-soft :
-  // ce signal secondaire ne doit JAMAIS faire planter le dossier (on dégrade en
-  // « pas de caveat » et on trace l'erreur pour le SOC).
-  const [cgmEntries, latestRaw] = await Promise.all([
-    glycemiaService.getCgmEntries(patientId, from24h, now, userId, ctx),
-    glycemiaService.getLatestCgmFreshness(patientId, from24h, now, userId, ctx).catch((e) => {
-      console.error("[patient-detail] getLatestCgmFreshness failed", e instanceof Error ? e.message : e)
-      return null
-    }),
-  ])
-  const glycemiaView = buildGlycemiaView(cgmEntries, now, latestRaw)
-
-  // Phase 3 — Onglet Traitements : réglages insuline réels (audité
-  // READ INSULIN_THERAPY) + traitements associés (déjà chargés via getById).
-  const insulinSettings = await insulinTherapyService.getSettings(patientId, userId, ctx)
-  // `patient.devices` (chargé par getById) → pompe active dans l'onglet Traitements.
-  const treatmentView = buildTreatmentView(insulinSettings, patient.treatments ?? [], patient.devices ?? [], now)
-
-  // Phase 4 — Onglet Documents : documents médicaux (audité READ MEDICAL_DOCUMENT,
-  // scopé serveur, `fileUrl` omis). Téléchargement via /api/documents/[id]/download.
-  const documents = buildDocumentView(await documentService.list(patientId, role, userId, ctx))
-  // Plage cible affichée = bornes TIR (cgm.low/ok), défauts pathology-aware,
-  // clampée dans les zones sévères. Helper serveur testé (overview-targets) →
-  // badge cohérent avec le donut/TIR (cf. revue PR #550).
-  const { targetLowMgdl, targetHighMgdl } = resolveTargetRangeMgdl(
-    patient.cgmObjectives,
-    patient.pathology,
-  )
-
-  const fullName = `${patient.user.firstname ?? ""} ${patient.user.lastname ?? ""}`.trim()
-
-  const data: PatientDetailData = {
-    id: patient.id,
-    publicRef: patient.publicRef,
-    name: fullName,
-    flags: flags ?? { recentHypos: false, hypoCount: 0, silentMonitoring: false, silentDays: null, openUrgency: false },
-    age: computeAge(patient.user.birthday ?? null, now),
-    sex: patient.user.sex ?? null,
-    pathology: patient.pathology ?? null,
-    diagYear: patient.medicalData?.yearDiag ?? null,
-    // Référent = médecin référent uniquement (le libellé est « Médecin référent »).
-    referent: patient.referent?.pro?.name ?? null,
-    objectives: {
-      targetLowMgdl,
-      targetHighMgdl,
-      tirTargetPct: CONSENSUS_TIR_TARGET_PCT,
-      hypoMaxPct: CONSENSUS_HYPO_MAX_PCT,
-      cvMaxPct: CONSENSUS_CV_MAX_PCT,
-    },
-    stats:
-      profile.readingCount > 0
-        ? {
-            avgGlucoseMgdl: profile.metrics.averageGlucoseMgdl,
-            gmi: profile.metrics.gmi,
-            cv: profile.metrics.coefficientOfVariation,
-            tir: {
-              veryLow: profile.tir.severeHypo,
-              low: profile.tir.hypo,
-              inRange: profile.tir.inRange,
-              high: profile.tir.elevated,
-              veryHigh: profile.tir.hyper,
-            },
-            readingCount: profile.readingCount,
-            captureRate: profile.captureRate,
-            // Sécurité clinique : sous 70 % de capture CGM, GMI/TIR/moyenne ne
-            // sont pas représentatifs (consensus ADA/EASD) → caveat UI.
-            insufficientCapture: profile.warning === "insufficientCgmCapture",
-          }
-        : null,
-    glycemia: glycemiaView,
-    treatment: treatmentView,
-    documents,
   }
 
   return <PatientDetailClient data={data} />

--- a/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/src/app/(dashboard)/patients/[id]/page.tsx
@@ -68,13 +68,14 @@ export default async function PatientDetailPage({
   const consent = await patientShareConsent(patientId)
   if (!consent.ok) {
     if (consent.status === 404) notFound()
-    // Traçabilité HDS : l'accès refusé pour « partage désactivé » (opt-out Art. 21
-    // / gdprConsent absent) est désormais audité (auparavant silencieux) — permet
-    // de distinguer un refus de partage d'un simple 404.
+    // Traçabilité HDS : l'accès refusé pour « partage désactivé » (opt-out Art. 21)
+    // ou « consentement absent » (gdprConsent) est audité — permet de distinguer
+    // un refus de partage d'un simple 404. `kind` = motif exact (sharingDisabled /
+    // patientConsentMissing), aligné sur la route /api/patients/record.
     await auditService.accessDenied({
       userId, resource: "PATIENT", resourceId: String(patientId),
       ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
-      metadata: { patientId, surface: "patient-detail-page", kind: "sharingDisabled" },
+      metadata: { patientId, surface: "patient-detail-page", kind: consent.error },
     })
     return <PatientDetailClient data={null} sharingDisabled />
   }

--- a/src/app/api/patients/record/route.ts
+++ b/src/app/api/patients/record/route.ts
@@ -132,8 +132,9 @@ export async function GET(req: NextRequest) {
     if (error instanceof AuthError) {
       return NextResponse.json({ error: error.message }, { status: error.status })
     }
-    const msg = error instanceof Error ? error.message : "Unknown error"
-    console.error("[patients/record GET]", msg)
+    // logger.error redacte la PHI éventuelle du message d'erreur (≠ console.error
+    // brut) — pertinent sur une route qui assemble des données de santé.
+    logger.error("api", "[patients/record GET] handler error", {}, error)
     return NextResponse.json({ error: "serverError" }, { status: 500 })
   }
 }

--- a/src/app/api/patients/record/route.ts
+++ b/src/app/api/patients/record/route.ts
@@ -34,11 +34,13 @@ export async function GET(req: NextRequest) {
     if (e instanceof AuthError) {
       const u = getAuthUser(req)
       if (u && e.status === 403) {
-        await auditService.accessDenied({
-          userId: u.id, resource: "PATIENT", resourceId: "record",
-          ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
-          metadata: { surface: "api", kind: "patientRecord" },
-        })
+        await auditService
+          .accessDenied({
+            userId: u.id, resource: "PATIENT", resourceId: "record",
+            ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+            metadata: { surface: "api", kind: "patientRecord" },
+          })
+          .catch((err) => console.error("[patients/record] accessDenied audit failed", err instanceof Error ? err.message : err))
       }
       return NextResponse.json({ error: e.message }, { status: e.status })
     }
@@ -48,6 +50,15 @@ export async function GET(req: NextRequest) {
   try {
     const rl = await checkApiRateLimit(String(user.id), RATE_LIMITS.analytics)
     if (!rl.allowed) {
+      // Saturation rate-limit auditée (US-2265 — burst detection : ADMIN compromis
+      // / boucle UI). Fail-soft, sans PHI. Action RATE_LIMITED ≠ UNAUTHORIZED.
+      await auditService
+        .rateLimited({
+          userId: user.id, resource: "PATIENT", resourceId: "record",
+          ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+          metadata: { surface: "api", kind: "patientRecord" },
+        })
+        .catch((err) => console.error("[patients/record] rateLimited audit failed", err instanceof Error ? err.message : err))
       return NextResponse.json(
         { error: "rateLimitExceeded" },
         { status: 429, headers: { "Retry-After": String(rl.retryAfterSec) } },
@@ -65,12 +76,14 @@ export async function GET(req: NextRequest) {
       // `?patientId=` brut récupéré best-effort pour le forensic ; jamais de PHI.
       if (res.error === "patientNotFound") {
         const raw = req.nextUrl.searchParams.get("patientId")
-        await auditService.accessDenied({
-          userId: user.id, resource: "PATIENT",
-          resourceId: raw && /^\d+$/.test(raw) ? raw : "unknown",
-          ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
-          metadata: { surface: "api", kind: "patientRecord", reason: res.error },
-        })
+        await auditService
+          .accessDenied({
+            userId: user.id, resource: "PATIENT",
+            resourceId: raw && /^\d+$/.test(raw) ? raw : "unknown",
+            ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+            metadata: { surface: "api", kind: "patientRecord", reason: res.error },
+          })
+          .catch((err) => console.error("[patients/record] accessDenied audit failed", err instanceof Error ? err.message : err))
       }
       return NextResponse.json(
         { error: res.error },
@@ -84,6 +97,19 @@ export async function GET(req: NextRequest) {
     // partage n'est pas exposé, même à un PS RBAC-autorisé.
     const consent = await patientShareConsent(patientId)
     if (!consent.ok) {
+      // Symétrie avec la page RSC (page.tsx) : un refus de partage du SUJET
+      // (opt-out Art. 21 / gdprConsent absent) est tracé pour le distinguer d'un
+      // simple 404. Le cas 404 (patient absent/soft-deleted) reste silencieux
+      // (déjà couvert, uniforme). Fail-soft, sans PHI.
+      if (consent.status === 403) {
+        await auditService
+          .accessDenied({
+            userId: user.id, resource: "PATIENT", resourceId: String(patientId),
+            ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+            metadata: { patientId, surface: "api", kind: consent.error },
+          })
+          .catch((err) => console.error("[patients/record] sharing accessDenied audit failed", err instanceof Error ? err.message : err))
+      }
       return NextResponse.json({ error: consent.error }, { status: consent.status })
     }
 

--- a/src/app/api/patients/record/route.ts
+++ b/src/app/api/patients/record/route.ts
@@ -1,0 +1,67 @@
+/**
+ * US-2633 — GET /api/patients/record
+ *
+ * Renvoie le DTO complet de la fiche patient (`PatientRecordData`) pour
+ * alimenter le composant présentational `<PatientRecord>` côté client. Sert les
+ * **deux** stratégies de résolution (cf. `resolvePatientIdFromQuery`) :
+ *  - drawer de consultation : jeton `x-consultation-token` (aucun id en URL) ;
+ *  - mode page / refetch : `?patientId=` (scope route pro).
+ *
+ * Gardes : `requireAuth` → `requireGdprConsent` → résolution + scope patient
+ * (RBAC portefeuille / jeton) AVANT toute projection. L'assemblage
+ * (`buildPatientRecordData`) audite chaque agrégat (READ PATIENT / ANALYTICS /
+ * CGM_ENTRY / INSULIN_THERAPY / MEDICAL_DOCUMENT) ; on ajoute une ligne « surface »
+ * pour distinguer l'accès drawer/route de l'accès page RSC (forensique HDS).
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { requireAuth, AuthError } from "@/lib/auth"
+import { resolvePatientIdFromQuery } from "@/lib/auth/query-helpers"
+import { requireGdprConsent } from "@/lib/gdpr"
+import { auditService, extractRequestContext } from "@/lib/services/audit.service"
+import { buildPatientRecordData } from "@/app/(dashboard)/patients/[id]/build-patient-record"
+
+export async function GET(req: NextRequest) {
+  try {
+    const user = requireAuth(req)
+
+    const hasConsent = await requireGdprConsent(user.id)
+    if (!hasConsent) {
+      return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
+    }
+
+    const res = await resolvePatientIdFromQuery(req, user.id, user.role)
+    if (res.error) {
+      return NextResponse.json(
+        { error: res.error },
+        { status: res.error === "invalidPatientId" ? 400 : 404 },
+      )
+    }
+
+    const ctx = extractRequestContext(req)
+    const data = await buildPatientRecordData(res.patientId, user.role, user.id, ctx)
+    if (!data) return NextResponse.json({ error: "notFound" }, { status: 404 })
+
+    // Ligne d'audit « surface » (sans PHI) : distingue l'accès via cette route
+    // (drawer/refetch) de l'accès page RSC ; les agrégats sont déjà audités.
+    await auditService.log({
+      userId: user.id,
+      action: "READ",
+      resource: "PATIENT",
+      resourceId: String(res.patientId),
+      ipAddress: ctx.ipAddress,
+      userAgent: ctx.userAgent,
+      requestId: ctx.requestId,
+      metadata: { patientId: res.patientId, kind: "patientRecord", surface: "api" },
+    })
+
+    return NextResponse.json(data)
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    console.error("[patients/record GET]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/app/api/patients/record/route.ts
+++ b/src/app/api/patients/record/route.ts
@@ -7,23 +7,52 @@
  *  - drawer de consultation : jeton `x-consultation-token` (aucun id en URL) ;
  *  - mode page / refetch : `?patientId=` (scope route pro).
  *
- * Gardes : `requireAuth` → `requireGdprConsent` → résolution + scope patient
- * (RBAC portefeuille / jeton) AVANT toute projection. L'assemblage
- * (`buildPatientRecordData`) audite chaque agrégat (READ PATIENT / ANALYTICS /
- * CGM_ENTRY / INSULIN_THERAPY / MEDICAL_DOCUMENT) ; on ajoute une ligne « surface »
- * pour distinguer l'accès drawer/route de l'accès page RSC (forensique HDS).
+ * Gardes (alignées sur les routes patient riches en PHI — heatmap/compare/agp) :
+ * `requireAuth` → rate-limit → `requireGdprConsent` (appelant) → résolution +
+ * scope patient (RBAC / jeton) → **`patientShareConsent`** (opt-out du SUJET,
+ * RGPD Art. 7.3/21, fail-closed) AVANT toute projection. L'assemblage
+ * (`buildPatientRecordData`) audite chaque agrégat ; une ligne « surface »
+ * (fail-soft, sans PHI) distingue l'accès route/drawer de l'accès page RSC.
  */
 
 import { NextResponse, type NextRequest } from "next/server"
-import { requireAuth, AuthError } from "@/lib/auth"
+import { requireAuth, getAuthUser, AuthError } from "@/lib/auth"
+import { checkApiRateLimit, RATE_LIMITS } from "@/lib/auth/api-rate-limit"
 import { resolvePatientIdFromQuery } from "@/lib/auth/query-helpers"
 import { requireGdprConsent } from "@/lib/gdpr"
+import { patientShareConsent } from "@/lib/consent"
 import { auditService, extractRequestContext } from "@/lib/services/audit.service"
 import { buildPatientRecordData } from "@/app/(dashboard)/patients/[id]/build-patient-record"
 
 export async function GET(req: NextRequest) {
+  const ctx = extractRequestContext(req)
+
+  let user
   try {
-    const user = requireAuth(req)
+    user = requireAuth(req)
+  } catch (e) {
+    if (e instanceof AuthError) {
+      const u = getAuthUser(req)
+      if (u && e.status === 403) {
+        await auditService.accessDenied({
+          userId: u.id, resource: "PATIENT", resourceId: "record",
+          ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+          metadata: { surface: "api", kind: "patientRecord" },
+        })
+      }
+      return NextResponse.json({ error: e.message }, { status: e.status })
+    }
+    throw e
+  }
+
+  try {
+    const rl = await checkApiRateLimit(String(user.id), RATE_LIMITS.analytics)
+    if (!rl.allowed) {
+      return NextResponse.json(
+        { error: "rateLimitExceeded" },
+        { status: 429, headers: { "Retry-After": String(rl.retryAfterSec) } },
+      )
+    }
 
     const hasConsent = await requireGdprConsent(user.id)
     if (!hasConsent) {
@@ -32,28 +61,44 @@ export async function GET(req: NextRequest) {
 
     const res = await resolvePatientIdFromQuery(req, user.id, user.role)
     if (res.error) {
+      // Détection d'énumération (US-2265) : tracer la tentative hors périmètre.
+      // `?patientId=` brut récupéré best-effort pour le forensic ; jamais de PHI.
+      if (res.error === "patientNotFound") {
+        const raw = req.nextUrl.searchParams.get("patientId")
+        await auditService.accessDenied({
+          userId: user.id, resource: "PATIENT",
+          resourceId: raw && /^\d+$/.test(raw) ? raw : "unknown",
+          ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+          metadata: { surface: "api", kind: "patientRecord", reason: res.error },
+        })
+      }
       return NextResponse.json(
         { error: res.error },
         { status: res.error === "invalidPatientId" ? 400 : 404 },
       )
     }
+    const patientId = res.patientId
 
-    const ctx = extractRequestContext(req)
-    const data = await buildPatientRecordData(res.patientId, user.role, user.id, ctx)
-    if (!data) return NextResponse.json({ error: "notFound" }, { status: 404 })
+    // Opt-out du SUJET (gdprConsent + shareWithProviders, fail-closed) — même
+    // garde que la page RSC et les routes analytics : un patient en opt-out de
+    // partage n'est pas exposé, même à un PS RBAC-autorisé.
+    const consent = await patientShareConsent(patientId)
+    if (!consent.ok) {
+      return NextResponse.json({ error: consent.error }, { status: consent.status })
+    }
 
-    // Ligne d'audit « surface » (sans PHI) : distingue l'accès via cette route
-    // (drawer/refetch) de l'accès page RSC ; les agrégats sont déjà audités.
-    await auditService.log({
-      userId: user.id,
-      action: "READ",
-      resource: "PATIENT",
-      resourceId: String(res.patientId),
-      ipAddress: ctx.ipAddress,
-      userAgent: ctx.userAgent,
-      requestId: ctx.requestId,
-      metadata: { patientId: res.patientId, kind: "patientRecord", surface: "api" },
-    })
+    const data = await buildPatientRecordData(patientId, user.role, user.id, ctx)
+    if (!data) return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+
+    // Ligne d'audit « surface » (sans PHI) — fail-soft : un échec ne doit pas
+    // transformer une lecture réussie (déjà auditée par agrégat) en 500.
+    await auditService
+      .log({
+        userId: user.id, action: "READ", resource: "PATIENT", resourceId: String(patientId),
+        ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+        metadata: { patientId, kind: "patientRecord", surface: "api" },
+      })
+      .catch((e) => console.error("[patients/record] surface audit failed", e instanceof Error ? e.message : e))
 
     return NextResponse.json(data)
   } catch (error) {

--- a/src/app/api/patients/record/route.ts
+++ b/src/app/api/patients/record/route.ts
@@ -22,6 +22,7 @@ import { resolvePatientIdFromQuery } from "@/lib/auth/query-helpers"
 import { requireGdprConsent } from "@/lib/gdpr"
 import { patientShareConsent } from "@/lib/consent"
 import { auditService, extractRequestContext } from "@/lib/services/audit.service"
+import { logger } from "@/lib/logger"
 import { buildPatientRecordData } from "@/app/(dashboard)/patients/[id]/build-patient-record"
 
 export async function GET(req: NextRequest) {
@@ -40,7 +41,7 @@ export async function GET(req: NextRequest) {
             ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
             metadata: { surface: "api", kind: "patientRecord" },
           })
-          .catch((err) => console.error("[patients/record] accessDenied audit failed", err instanceof Error ? err.message : err))
+          .catch((err) => logger.error("audit", "[patients/record] accessDenied audit failed", {}, err))
       }
       return NextResponse.json({ error: e.message }, { status: e.status })
     }
@@ -58,7 +59,7 @@ export async function GET(req: NextRequest) {
           ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
           metadata: { surface: "api", kind: "patientRecord" },
         })
-        .catch((err) => console.error("[patients/record] rateLimited audit failed", err instanceof Error ? err.message : err))
+        .catch((err) => logger.error("audit", "[patients/record] rateLimited audit failed", {}, err))
       return NextResponse.json(
         { error: "rateLimitExceeded" },
         { status: 429, headers: { "Retry-After": String(rl.retryAfterSec) } },
@@ -83,7 +84,7 @@ export async function GET(req: NextRequest) {
             ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
             metadata: { surface: "api", kind: "patientRecord", reason: res.error },
           })
-          .catch((err) => console.error("[patients/record] accessDenied audit failed", err instanceof Error ? err.message : err))
+          .catch((err) => logger.error("audit", "[patients/record] accessDenied audit failed", {}, err))
       }
       return NextResponse.json(
         { error: res.error },
@@ -108,7 +109,7 @@ export async function GET(req: NextRequest) {
             ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
             metadata: { patientId, surface: "api", kind: consent.error },
           })
-          .catch((err) => console.error("[patients/record] sharing accessDenied audit failed", err instanceof Error ? err.message : err))
+          .catch((err) => logger.error("audit", "[patients/record] sharing accessDenied audit failed", {}, err))
       }
       return NextResponse.json({ error: consent.error }, { status: consent.status })
     }
@@ -124,7 +125,7 @@ export async function GET(req: NextRequest) {
         ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
         metadata: { patientId, kind: "patientRecord", surface: "api" },
       })
-      .catch((e) => console.error("[patients/record] surface audit failed", e instanceof Error ? e.message : e))
+      .catch((e) => logger.error("audit", "[patients/record] surface audit failed", {}, e))
 
     return NextResponse.json(data)
   } catch (error) {

--- a/tests/unit/patients-record-route.test.ts
+++ b/tests/unit/patients-record-route.test.ts
@@ -2,24 +2,34 @@
  * Test suite — GET /api/patients/record (US-2633).
  *
  * Surface de sécurité : la route alimente la fiche patient (page + drawer cTok).
- * On vérifie la chaîne de gardes AVANT projection (consentement RGPD →
- * résolution + scope patient) et le câblage (assemblage + audit « surface »).
- * Les gardes sous-jacentes (`requireAuth`, `resolvePatientIdFromQuery`,
- * `requireGdprConsent`) ont leurs propres suites — ici on mocke pour isoler le
- * contrat de la route.
+ * On vérifie la chaîne de gardes AVANT projection — rate-limit → consentement
+ * appelant (RGPD) → résolution + scope patient → **opt-out du sujet**
+ * (`patientShareConsent`) — et le câblage (assemblage + audit « surface » sans
+ * PHI + trace `accessDenied` sur refus pour la détection US-2265). Les gardes
+ * sous-jacentes ont leurs propres suites — ici on mocke pour isoler le contrat.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest"
 
 vi.mock("@/lib/auth", () => ({
   requireAuth: vi.fn(),
+  getAuthUser: vi.fn(),
   AuthError: class AuthError extends Error {
-    status = 401
+    status: number
+    constructor(message = "unauthorized", status = 401) {
+      super(message)
+      this.status = status
+    }
   },
 }))
+vi.mock("@/lib/auth/api-rate-limit", () => ({
+  checkApiRateLimit: vi.fn(),
+  RATE_LIMITS: { analytics: { points: 1, durationSec: 1 } },
+}))
 vi.mock("@/lib/gdpr", () => ({ requireGdprConsent: vi.fn() }))
+vi.mock("@/lib/consent", () => ({ patientShareConsent: vi.fn() }))
 vi.mock("@/lib/auth/query-helpers", () => ({ resolvePatientIdFromQuery: vi.fn() }))
 vi.mock("@/lib/services/audit.service", () => ({
-  auditService: { log: vi.fn() },
+  auditService: { log: vi.fn(), accessDenied: vi.fn() },
   extractRequestContext: vi.fn(() => ({ ipAddress: "i", userAgent: "u", requestId: "r" })),
 }))
 vi.mock("@/app/(dashboard)/patients/[id]/build-patient-record", () => ({
@@ -27,62 +37,131 @@ vi.mock("@/app/(dashboard)/patients/[id]/build-patient-record", () => ({
 }))
 
 import { GET } from "@/app/api/patients/record/route"
-import { requireAuth } from "@/lib/auth"
+import { requireAuth, getAuthUser, AuthError } from "@/lib/auth"
+import { checkApiRateLimit } from "@/lib/auth/api-rate-limit"
 import { requireGdprConsent } from "@/lib/gdpr"
+import { patientShareConsent } from "@/lib/consent"
 import { resolvePatientIdFromQuery } from "@/lib/auth/query-helpers"
 import { buildPatientRecordData } from "@/app/(dashboard)/patients/[id]/build-patient-record"
 import { auditService } from "@/lib/services/audit.service"
 
-const req = {} as any
+const makeReq = (patientId?: string) =>
+  ({ nextUrl: { searchParams: new URLSearchParams(patientId ? { patientId } : {}) } }) as any
+
 const mAuth = vi.mocked(requireAuth)
+const mGetUser = vi.mocked(getAuthUser)
+const mRate = vi.mocked(checkApiRateLimit)
 const mConsent = vi.mocked(requireGdprConsent)
+const mShare = vi.mocked(patientShareConsent)
 const mResolve = vi.mocked(resolvePatientIdFromQuery)
 const mBuild = vi.mocked(buildPatientRecordData)
 const mLog = vi.mocked(auditService.log)
+const mDenied = vi.mocked(auditService.accessDenied)
 
 beforeEach(() => {
   vi.clearAllMocks()
   mAuth.mockReturnValue({ id: 1, role: "DOCTOR" } as any)
+  mRate.mockResolvedValue({ allowed: true } as any)
   mConsent.mockResolvedValue(true)
   mResolve.mockResolvedValue({ patientId: 42 } as any)
+  mShare.mockResolvedValue({ ok: true } as any)
   mBuild.mockResolvedValue({ id: 42, name: "X" } as any)
+  mLog.mockResolvedValue(undefined as any)
+  mDenied.mockResolvedValue(undefined as any)
 })
 
 describe("GET /api/patients/record", () => {
+  it("401 when unauthenticated (audits accessDenied only on 403)", async () => {
+    mAuth.mockImplementation(() => {
+      throw new (AuthError as any)("unauthorized", 401)
+    })
+    const r = await GET(makeReq())
+    expect(r.status).toBe(401)
+    expect(mDenied).not.toHaveBeenCalled()
+    expect(mBuild).not.toHaveBeenCalled()
+  })
+
+  it("403 forbidden token → audits accessDenied", async () => {
+    mAuth.mockImplementation(() => {
+      throw new (AuthError as any)("forbidden", 403)
+    })
+    mGetUser.mockReturnValue({ id: 7, role: "DOCTOR" } as any)
+    const r = await GET(makeReq())
+    expect(r.status).toBe(403)
+    expect(mDenied).toHaveBeenCalledTimes(1)
+  })
+
+  it("429 when rate limited (before any patient resolution)", async () => {
+    mRate.mockResolvedValue({ allowed: false, retryAfterSec: 30 } as any)
+    const r = await GET(makeReq())
+    expect(r.status).toBe(429)
+    expect(r.headers.get("Retry-After")).toBe("30")
+    expect(mResolve).not.toHaveBeenCalled()
+    expect(mBuild).not.toHaveBeenCalled()
+  })
+
   it("403 when the caller has no GDPR consent (before any patient resolution)", async () => {
     mConsent.mockResolvedValue(false)
-    const r = await GET(req)
+    const r = await GET(makeReq())
     expect(r.status).toBe(403)
     expect(mResolve).not.toHaveBeenCalled()
     expect(mBuild).not.toHaveBeenCalled()
   })
 
-  it("400 when patientId is malformed", async () => {
+  it("400 when patientId is malformed (no accessDenied audit)", async () => {
     mResolve.mockResolvedValue({ error: "invalidPatientId" } as any)
-    const r = await GET(req)
+    const r = await GET(makeReq("abc"))
     expect(r.status).toBe(400)
+    expect(mBuild).not.toHaveBeenCalled()
+    expect(mDenied).not.toHaveBeenCalled()
+  })
+
+  it("404 (uniform) on access denied / no patient → audits accessDenied (US-2265)", async () => {
+    mResolve.mockResolvedValue({ error: "patientNotFound" } as any)
+    const r = await GET(makeReq("99"))
+    expect(r.status).toBe(404)
+    expect(mBuild).not.toHaveBeenCalled()
+    expect(mDenied).toHaveBeenCalledTimes(1)
+    const arg = mDenied.mock.calls[0]![0] as any
+    expect(arg.resourceId).toBe("99")
+    expect(arg.metadata).toMatchObject({ surface: "api", kind: "patientRecord" })
+  })
+
+  it("blocks a patient who opted out of provider sharing (patientShareConsent fail-closed)", async () => {
+    mShare.mockResolvedValue({ ok: false, status: 403, error: "sharingDisabled" } as any)
+    const r = await GET(makeReq())
+    expect(r.status).toBe(403)
+    expect(await r.json()).toEqual({ error: "sharingDisabled" })
     expect(mBuild).not.toHaveBeenCalled()
   })
 
-  it("404 (uniform) when access is denied / no patient / bad token", async () => {
-    mResolve.mockResolvedValue({ error: "patientNotFound" } as any)
-    const r = await GET(req)
+  it("404 (uniform) when the patient record cannot be built (deleted patient)", async () => {
+    mBuild.mockResolvedValue(null)
+    const r = await GET(makeReq())
     expect(r.status).toBe(404)
+    expect(await r.json()).toEqual({ error: "patientNotFound" })
   })
 
-  it("404 when the patient record cannot be built (deleted patient)", async () => {
-    mBuild.mockResolvedValue(null)
-    const r = await GET(req)
-    expect(r.status).toBe(404)
+  it("500 when assembly throws — without leaking the internal message", async () => {
+    mBuild.mockRejectedValue(new Error("db boom secret"))
+    const r = await GET(makeReq())
+    expect(r.status).toBe(500)
+    expect(await r.json()).toEqual({ error: "serverError" })
   })
 
   it("200 returns the DTO and writes a surface audit row (no PHI in metadata)", async () => {
-    const r = await GET(req)
+    const r = await GET(makeReq())
     expect(r.status).toBe(200)
     expect(await r.json()).toEqual({ id: 42, name: "X" })
     expect(mBuild).toHaveBeenCalledWith(42, "DOCTOR", 1, expect.any(Object))
     const data = mLog.mock.calls.at(-1)![0]
     expect(data.resource).toBe("PATIENT")
     expect(data.metadata).toEqual({ patientId: 42, kind: "patientRecord", surface: "api" })
+  })
+
+  it("still returns 200 if the surface audit write fails (fail-soft)", async () => {
+    mLog.mockRejectedValue(new Error("audit down"))
+    const r = await GET(makeReq())
+    expect(r.status).toBe(200)
   })
 })

--- a/tests/unit/patients-record-route.test.ts
+++ b/tests/unit/patients-record-route.test.ts
@@ -147,7 +147,9 @@ describe("GET /api/patients/record", () => {
     expect(await r.json()).toEqual({ error: "sharingDisabled" })
     expect(mBuild).not.toHaveBeenCalled()
     expect(mDenied).toHaveBeenCalledTimes(1)
-    expect((mDenied.mock.calls[0]![0] as any).metadata).toMatchObject({ kind: "sharingDisabled", surface: "api" })
+    const arg = mDenied.mock.calls[0]![0] as any
+    expect(arg.resourceId).toBe("42") // pivot forensique ADR#18
+    expect(arg.metadata).toMatchObject({ patientId: 42, kind: "sharingDisabled", surface: "api" })
   })
 
   it("blocks a patient with missing GDPR consent (patientConsentMissing, fail-closed)", async () => {
@@ -155,7 +157,7 @@ describe("GET /api/patients/record", () => {
     const r = await GET(makeReq())
     expect(r.status).toBe(403)
     expect(await r.json()).toEqual({ error: "patientConsentMissing" })
-    expect((mDenied.mock.calls[0]![0] as any).metadata).toMatchObject({ kind: "patientConsentMissing" })
+    expect((mDenied.mock.calls[0]![0] as any).metadata).toMatchObject({ patientId: 42, kind: "patientConsentMissing" })
   })
 
   it("does not audit a sharing-consent 404 (patient soft-deleted at consent check)", async () => {

--- a/tests/unit/patients-record-route.test.ts
+++ b/tests/unit/patients-record-route.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Test suite — GET /api/patients/record (US-2633).
+ *
+ * Surface de sécurité : la route alimente la fiche patient (page + drawer cTok).
+ * On vérifie la chaîne de gardes AVANT projection (consentement RGPD →
+ * résolution + scope patient) et le câblage (assemblage + audit « surface »).
+ * Les gardes sous-jacentes (`requireAuth`, `resolvePatientIdFromQuery`,
+ * `requireGdprConsent`) ont leurs propres suites — ici on mocke pour isoler le
+ * contrat de la route.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+vi.mock("@/lib/auth", () => ({
+  requireAuth: vi.fn(),
+  AuthError: class AuthError extends Error {
+    status = 401
+  },
+}))
+vi.mock("@/lib/gdpr", () => ({ requireGdprConsent: vi.fn() }))
+vi.mock("@/lib/auth/query-helpers", () => ({ resolvePatientIdFromQuery: vi.fn() }))
+vi.mock("@/lib/services/audit.service", () => ({
+  auditService: { log: vi.fn() },
+  extractRequestContext: vi.fn(() => ({ ipAddress: "i", userAgent: "u", requestId: "r" })),
+}))
+vi.mock("@/app/(dashboard)/patients/[id]/build-patient-record", () => ({
+  buildPatientRecordData: vi.fn(),
+}))
+
+import { GET } from "@/app/api/patients/record/route"
+import { requireAuth } from "@/lib/auth"
+import { requireGdprConsent } from "@/lib/gdpr"
+import { resolvePatientIdFromQuery } from "@/lib/auth/query-helpers"
+import { buildPatientRecordData } from "@/app/(dashboard)/patients/[id]/build-patient-record"
+import { auditService } from "@/lib/services/audit.service"
+
+const req = {} as any
+const mAuth = vi.mocked(requireAuth)
+const mConsent = vi.mocked(requireGdprConsent)
+const mResolve = vi.mocked(resolvePatientIdFromQuery)
+const mBuild = vi.mocked(buildPatientRecordData)
+const mLog = vi.mocked(auditService.log)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mAuth.mockReturnValue({ id: 1, role: "DOCTOR" } as any)
+  mConsent.mockResolvedValue(true)
+  mResolve.mockResolvedValue({ patientId: 42 } as any)
+  mBuild.mockResolvedValue({ id: 42, name: "X" } as any)
+})
+
+describe("GET /api/patients/record", () => {
+  it("403 when the caller has no GDPR consent (before any patient resolution)", async () => {
+    mConsent.mockResolvedValue(false)
+    const r = await GET(req)
+    expect(r.status).toBe(403)
+    expect(mResolve).not.toHaveBeenCalled()
+    expect(mBuild).not.toHaveBeenCalled()
+  })
+
+  it("400 when patientId is malformed", async () => {
+    mResolve.mockResolvedValue({ error: "invalidPatientId" } as any)
+    const r = await GET(req)
+    expect(r.status).toBe(400)
+    expect(mBuild).not.toHaveBeenCalled()
+  })
+
+  it("404 (uniform) when access is denied / no patient / bad token", async () => {
+    mResolve.mockResolvedValue({ error: "patientNotFound" } as any)
+    const r = await GET(req)
+    expect(r.status).toBe(404)
+  })
+
+  it("404 when the patient record cannot be built (deleted patient)", async () => {
+    mBuild.mockResolvedValue(null)
+    const r = await GET(req)
+    expect(r.status).toBe(404)
+  })
+
+  it("200 returns the DTO and writes a surface audit row (no PHI in metadata)", async () => {
+    const r = await GET(req)
+    expect(r.status).toBe(200)
+    expect(await r.json()).toEqual({ id: 42, name: "X" })
+    expect(mBuild).toHaveBeenCalledWith(42, "DOCTOR", 1, expect.any(Object))
+    const data = mLog.mock.calls.at(-1)![0]
+    expect(data.resource).toBe("PATIENT")
+    expect(data.metadata).toEqual({ patientId: 42, kind: "patientRecord", surface: "api" })
+  })
+})

--- a/tests/unit/patients-record-route.test.ts
+++ b/tests/unit/patients-record-route.test.ts
@@ -29,7 +29,7 @@ vi.mock("@/lib/gdpr", () => ({ requireGdprConsent: vi.fn() }))
 vi.mock("@/lib/consent", () => ({ patientShareConsent: vi.fn() }))
 vi.mock("@/lib/auth/query-helpers", () => ({ resolvePatientIdFromQuery: vi.fn() }))
 vi.mock("@/lib/services/audit.service", () => ({
-  auditService: { log: vi.fn(), accessDenied: vi.fn() },
+  auditService: { log: vi.fn(), accessDenied: vi.fn(), rateLimited: vi.fn() },
   extractRequestContext: vi.fn(() => ({ ipAddress: "i", userAgent: "u", requestId: "r" })),
 }))
 vi.mock("@/app/(dashboard)/patients/[id]/build-patient-record", () => ({
@@ -57,6 +57,7 @@ const mResolve = vi.mocked(resolvePatientIdFromQuery)
 const mBuild = vi.mocked(buildPatientRecordData)
 const mLog = vi.mocked(auditService.log)
 const mDenied = vi.mocked(auditService.accessDenied)
+const mRateLimited = vi.mocked(auditService.rateLimited)
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -68,6 +69,7 @@ beforeEach(() => {
   mBuild.mockResolvedValue({ id: 42, name: "X" } as any)
   mLog.mockResolvedValue(undefined as any)
   mDenied.mockResolvedValue(undefined as any)
+  mRateLimited.mockResolvedValue(undefined as any)
 })
 
 describe("GET /api/patients/record", () => {
@@ -89,15 +91,18 @@ describe("GET /api/patients/record", () => {
     const r = await GET(makeReq())
     expect(r.status).toBe(403)
     expect(mDenied).toHaveBeenCalledTimes(1)
+    expect((mDenied.mock.calls[0]![0] as any).resourceId).toBe("record")
   })
 
-  it("429 when rate limited (before any patient resolution)", async () => {
+  it("429 when rate limited → audits RATE_LIMITED, no resolution/projection", async () => {
     mRate.mockResolvedValue({ allowed: false, retryAfterSec: 30 } as any)
     const r = await GET(makeReq())
     expect(r.status).toBe(429)
     expect(r.headers.get("Retry-After")).toBe("30")
+    expect(mRateLimited).toHaveBeenCalledTimes(1)
     expect(mResolve).not.toHaveBeenCalled()
     expect(mBuild).not.toHaveBeenCalled()
+    expect(mLog).not.toHaveBeenCalled() // pas de ligne « surface » sur échec
   })
 
   it("403 when the caller has no GDPR consent (before any patient resolution)", async () => {
@@ -116,7 +121,7 @@ describe("GET /api/patients/record", () => {
     expect(mDenied).not.toHaveBeenCalled()
   })
 
-  it("404 (uniform) on access denied / no patient → audits accessDenied (US-2265)", async () => {
+  it("404 (uniform) on access denied / no patient via ?patientId= → audits the raw id (US-2265)", async () => {
     mResolve.mockResolvedValue({ error: "patientNotFound" } as any)
     const r = await GET(makeReq("99"))
     expect(r.status).toBe(404)
@@ -124,15 +129,40 @@ describe("GET /api/patients/record", () => {
     expect(mDenied).toHaveBeenCalledTimes(1)
     const arg = mDenied.mock.calls[0]![0] as any
     expect(arg.resourceId).toBe("99")
-    expect(arg.metadata).toMatchObject({ surface: "api", kind: "patientRecord" })
+    expect(arg.metadata).toMatchObject({ surface: "api", kind: "patientRecord", reason: "patientNotFound" })
+    expect(mLog).not.toHaveBeenCalled() // pas de ligne « surface » sur échec
   })
 
-  it("blocks a patient who opted out of provider sharing (patientShareConsent fail-closed)", async () => {
+  it("404 on the cTok drawer path (no ?patientId=) → audits resourceId 'unknown'", async () => {
+    mResolve.mockResolvedValue({ error: "patientNotFound" } as any)
+    const r = await GET(makeReq()) // pas de ?patientId= → résolution par jeton
+    expect(r.status).toBe(404)
+    expect((mDenied.mock.calls[0]![0] as any).resourceId).toBe("unknown")
+  })
+
+  it("blocks a patient who opted out of provider sharing → 403 + audits accessDenied", async () => {
     mShare.mockResolvedValue({ ok: false, status: 403, error: "sharingDisabled" } as any)
     const r = await GET(makeReq())
     expect(r.status).toBe(403)
     expect(await r.json()).toEqual({ error: "sharingDisabled" })
     expect(mBuild).not.toHaveBeenCalled()
+    expect(mDenied).toHaveBeenCalledTimes(1)
+    expect((mDenied.mock.calls[0]![0] as any).metadata).toMatchObject({ kind: "sharingDisabled", surface: "api" })
+  })
+
+  it("blocks a patient with missing GDPR consent (patientConsentMissing, fail-closed)", async () => {
+    mShare.mockResolvedValue({ ok: false, status: 403, error: "patientConsentMissing" } as any)
+    const r = await GET(makeReq())
+    expect(r.status).toBe(403)
+    expect(await r.json()).toEqual({ error: "patientConsentMissing" })
+    expect((mDenied.mock.calls[0]![0] as any).metadata).toMatchObject({ kind: "patientConsentMissing" })
+  })
+
+  it("does not audit a sharing-consent 404 (patient soft-deleted at consent check)", async () => {
+    mShare.mockResolvedValue({ ok: false, status: 404, error: "patientNotFound" } as any)
+    const r = await GET(makeReq())
+    expect(r.status).toBe(404)
+    expect(mDenied).not.toHaveBeenCalled()
   })
 
   it("404 (uniform) when the patient record cannot be built (deleted patient)", async () => {


### PR DESCRIPTION
## US-2633 — slice 1/2 : DTO partagé + route cTok `/api/patients/record`

Première tranche d'US-2633 (monter `<PatientRecord>` dans le drawer). **Fondation sécurisée du chemin de données** ; le câblage UI du drawer suit en slice 2.

Réf. epic #593 · US #596.

### Contenu
- **`build-patient-record.ts`** (nouveau) — extrait l'assemblage du DTO `PatientRecordData` de `page.tsx` en **fonction serveur partagée**, réutilisée par la page RSC **et** la route cTok. Refactor **à comportement constant** : les gardes RBAC + consentement restent côté appelant ; chaque agrégat est audité par son service.
- **`GET /api/patients/record`** (nouveau) — route **consolidée** servant les deux résolutions via `resolvePatientIdFromQuery` : drawer (`x-consultation-token`, **aucun id en URL**) **et** `?patientId=` (mode page/refetch). Gardes `requireAuth → requireGdprConsent → scope patient` **avant** projection ; ligne d'audit « surface » sans PHI.
- **`page.tsx`** allégée (délègue l'assemblage) — parité stricte.

### Sécurité (préparation drawer)
- La route applique le consentement + le scope (via `resolvePatientIdFromQuery`) avant toute projection — défense en profondeur côté route.
- `metadata` d'audit = `{ patientId, kind, surface }`, **aucune valeur de santé**.

### Vérifications
`tsc` ✓ · `eslint` ✓ · `pnpm build` ✓ · **3444 tests** ✓ (5 nouveaux : gardes 403/400/404/404/200 + audit).

### Slice 2 (à suivre)
Câblage UI du drawer : monter `<PatientRecord>` (fetch `/api/patients/record` via cTok) + `PatientContextBar` mode **éphémère** (bandeau + agrandir/fermer) + `documentHref` cTok + retrait des onglets bespoke, en préservant `inert`/`aria-modal`/plafond 60 min/beacon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
