### PR TITLE
US-2636 — vue Tableau journalier (1 ligne/jour) + service dailyStats

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1664,7 +1664,8 @@
     "dailyColInTarget": "٪ ضمن النطاق",
     "dailyColMin": "الأدنى",
     "dailyColMax": "الأعلى",
-    "dailyColCount": "القراءات"
+    "dailyColCount": "القراءات",
+    "viewAnnounce": "العرض النشط: {view}"
   },
   "patientDashboard": {
     "pageTitle": "لوحة التحكم الخاصة بي",

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1651,7 +1651,20 @@
     "agpStatCv": "معامل التغاير (CV)",
     "agpStatSd": "الانحراف المعياري",
     "agpStatCapture": "البيانات الملتقطة",
-    "agpGmiTooltip": "≠ الخضاب السكري المخبري (HbA1c) — يُتوقّع وجود فرق."
+    "agpGmiTooltip": "≠ الخضاب السكري المخبري (HbA1c) — يُتوقّع وجود فرق.",
+    "viewSelectorLabel": "العرض",
+    "viewAverage": "المتوسط",
+    "viewDaily": "جدول يومي",
+    "dailyLoading": "جارٍ تحميل الجدول اليومي…",
+    "dailyError": "تعذّر تحميل الجدول اليومي.",
+    "dailyEmpty": "لا توجد بيانات للفترة المحددة.",
+    "dailyTableCaption": "إحصائيات السكر اليومية (المتوسط، النسبة ضمن النطاق، الأدنى، الأعلى، عدد القراءات)",
+    "dailyColDay": "اليوم",
+    "dailyColAvg": "المتوسط",
+    "dailyColInTarget": "٪ ضمن النطاق",
+    "dailyColMin": "الأدنى",
+    "dailyColMax": "الأعلى",
+    "dailyColCount": "القراءات"
   },
   "patientDashboard": {
     "pageTitle": "لوحة التحكم الخاصة بي",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1664,7 +1664,8 @@
     "dailyColInTarget": "% in target",
     "dailyColMin": "Min",
     "dailyColMax": "Max",
-    "dailyColCount": "Readings"
+    "dailyColCount": "Readings",
+    "viewAnnounce": "Active view: {view}"
   },
   "patientDashboard": {
     "pageTitle": "My dashboard",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1651,7 +1651,20 @@
     "agpStatCv": "Coefficient of variation (CV)",
     "agpStatSd": "Standard deviation",
     "agpStatCapture": "Data captured",
-    "agpGmiTooltip": "≠ lab glycated haemoglobin (HbA1c) — a difference is expected."
+    "agpGmiTooltip": "≠ lab glycated haemoglobin (HbA1c) — a difference is expected.",
+    "viewSelectorLabel": "View",
+    "viewAverage": "Average",
+    "viewDaily": "Daily table",
+    "dailyLoading": "Loading daily table…",
+    "dailyError": "Unable to load the daily table.",
+    "dailyEmpty": "No data for the selected period.",
+    "dailyTableCaption": "Daily glucose statistics (average, % in target, min, max, reading count)",
+    "dailyColDay": "Day",
+    "dailyColAvg": "Average",
+    "dailyColInTarget": "% in target",
+    "dailyColMin": "Min",
+    "dailyColMax": "Max",
+    "dailyColCount": "Readings"
   },
   "patientDashboard": {
     "pageTitle": "My dashboard",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1651,7 +1651,20 @@
     "agpStatCv": "Coefficient de variation (CV)",
     "agpStatSd": "Écart type",
     "agpStatCapture": "Données capturées",
-    "agpGmiTooltip": "≠ hémoglobine glyquée de laboratoire (HbA1c) — un écart est attendu."
+    "agpGmiTooltip": "≠ hémoglobine glyquée de laboratoire (HbA1c) — un écart est attendu.",
+    "viewSelectorLabel": "Vue",
+    "viewAverage": "Moyenne",
+    "viewDaily": "Tableau journalier",
+    "dailyLoading": "Chargement du tableau journalier…",
+    "dailyError": "Impossible de charger le tableau journalier.",
+    "dailyEmpty": "Aucune donnée sur la période sélectionnée.",
+    "dailyTableCaption": "Statistiques glycémiques par jour (moyenne, % en cible, min, max, nombre de relevés)",
+    "dailyColDay": "Jour",
+    "dailyColAvg": "Moyenne",
+    "dailyColInTarget": "% en cible",
+    "dailyColMin": "Min",
+    "dailyColMax": "Max",
+    "dailyColCount": "Relevés"
   },
   "patientDashboard": {
     "pageTitle": "Mon tableau de bord",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1664,7 +1664,8 @@
     "dailyColInTarget": "% en cible",
     "dailyColMin": "Min",
     "dailyColMax": "Max",
-    "dailyColCount": "Relevés"
+    "dailyColCount": "Relevés",
+    "viewAnnounce": "Vue active : {view}"
   },
   "patientDashboard": {
     "pageTitle": "Mon tableau de bord",

--- a/src/app/api/analytics/daily-stats/route.ts
+++ b/src/app/api/analytics/daily-stats/route.ts
@@ -1,0 +1,74 @@
+/**
+ * US-2636 — GET /api/analytics/daily-stats
+ *
+ * Statistiques journalières (1 ligne/jour) pour la vue « Tableau journalier » de
+ * la fiche patient. Sert les deux contrats (`?patientId=` page / cTok drawer).
+ * Gardes alignées sur les autres routes analytics per-patient (heatmap/agp/
+ * glycemic-profile) : auth → rate-limit → consentement appelant → résolution +
+ * scope (+ trace d'accès refusé) → Zod → opt-out sujet → projection.
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireAuth, AuthError } from "@/lib/auth"
+import { checkApiRateLimit, RATE_LIMITS } from "@/lib/auth/api-rate-limit"
+import { resolvePatientIdFromQuery } from "@/lib/auth/query-helpers"
+import { requireGdprConsent } from "@/lib/gdpr"
+import { patientShareConsent } from "@/lib/consent"
+import { analyticsService } from "@/lib/services/analytics.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { auditAnalyticsAccessDenied } from "@/lib/audit/analytics-helpers"
+
+const querySchema = z.object({
+  period: z
+    .string()
+    .regex(/^[1-9]\d{0,1}d$/)
+    .refine((s) => parseInt(s, 10) <= 90, { message: "Period max 90 days" })
+    .default("14d"),
+  source: z.enum(["cgm", "bgm"]).default("cgm"),
+})
+
+export async function GET(req: NextRequest) {
+  try {
+    const user = requireAuth(req)
+
+    const rl = await checkApiRateLimit(String(user.id), RATE_LIMITS.analytics)
+    if (!rl.allowed) {
+      return NextResponse.json(
+        { error: "rateLimitExceeded" },
+        { status: 429, headers: { "Retry-After": String(rl.retryAfterSec) } },
+      )
+    }
+
+    const hasConsent = await requireGdprConsent(user.id)
+    if (!hasConsent) return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
+
+    const ctx = extractRequestContext(req)
+
+    const res = await resolvePatientIdFromQuery(req, user.id, user.role)
+    if (res.error) {
+      if (res.error === "patientNotFound") {
+        await auditAnalyticsAccessDenied({ user, ctx, resourceId: "daily-stats", metadata: { reason: res.error } })
+      }
+      return NextResponse.json({ error: res.error }, { status: res.error === "invalidPatientId" ? 400 : 404 })
+    }
+    const patientId = res.patientId
+
+    const params = Object.fromEntries(req.nextUrl.searchParams.entries())
+    const parsed = querySchema.safeParse(params)
+    if (!parsed.success) return NextResponse.json({ error: "validationFailed" }, { status: 400 })
+
+    const consent = await patientShareConsent(patientId)
+    if (!consent.ok) return NextResponse.json({ error: consent.error }, { status: consent.status })
+
+    const result = await analyticsService.dailyStats(patientId, parsed.data.period, user.id, ctx, {
+      source: parsed.data.source,
+    })
+    return NextResponse.json(result)
+  } catch (error) {
+    if (error instanceof AuthError) return NextResponse.json({ error: error.message }, { status: error.status })
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    console.error("[analytics/daily-stats]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/components/diabeo/patient/PatientAgpTab.tsx
+++ b/src/components/diabeo/patient/PatientAgpTab.tsx
@@ -28,6 +28,7 @@ import {
   usePeriodResource,
   usePatientRecordContext,
   PERIOD_LABEL_KEY,
+  VIEW_LABEL_KEY,
   SEED_PERIOD,
   type RecordPeriod,
 } from "./PatientRecordContext"
@@ -133,6 +134,11 @@ export function PatientAgpTab({
         </span>
         <ViewSelector labelledBy="agp-view-label" />
       </div>
+      {/* Annonce du changement de vue aux lecteurs d'écran (WCAG 4.1.3) — le
+          contenu du panneau change au basculement moyenne ⇄ tableau. */}
+      <p className="sr-only" role="status" aria-live="polite">
+        {t("viewAnnounce", { view: t(VIEW_LABEL_KEY[view]) })}
+      </p>
     </div>
   )
 

--- a/src/components/diabeo/patient/PatientAgpTab.tsx
+++ b/src/components/diabeo/patient/PatientAgpTab.tsx
@@ -32,6 +32,8 @@ import {
   type RecordPeriod,
 } from "./PatientRecordContext"
 import { PeriodSelector } from "./PeriodSelector"
+import { ViewSelector } from "./ViewSelector"
+import { PatientDailyTable } from "./PatientDailyTable"
 import {
   Tooltip,
   TooltipContent,
@@ -114,42 +116,30 @@ export function PatientAgpTab({
   // l'ancienne fenêtre) → on le signale, jamais silencieusement (revue #611).
   const refetchError = (agp.error || stats.error) && !!agp.data
 
-  // Sélecteur de période — synchronisé avec les autres onglets via le contexte.
-  const selector = (
-    <div className="flex flex-wrap items-center justify-between gap-2">
-      <span id="agp-period-label" className="text-sm font-medium text-muted-foreground">
-        {t("periodSelectorLabel")}
-      </span>
-      <PeriodSelector labelledBy="agp-period-label" />
+  const view = recordCtx?.view ?? "average"
+
+  // Sélecteurs période + vue — synchronisés entre onglets via le contexte.
+  const selectors = (
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <div className="flex items-center gap-2">
+        <span id="agp-period-label" className="text-sm font-medium text-muted-foreground">
+          {t("periodSelectorLabel")}
+        </span>
+        <PeriodSelector labelledBy="agp-period-label" />
+      </div>
+      <div className="flex items-center gap-2">
+        <span id="agp-view-label" className="text-sm font-medium text-muted-foreground">
+          {t("viewSelectorLabel")}
+        </span>
+        <ViewSelector labelledBy="agp-view-label" />
+      </div>
     </div>
   )
 
-  if (agp.loading && !agp.data) {
-    return (
-      <div className="space-y-4">
-        {selector}
-        <p role="status" className="py-10 text-center text-sm text-muted-foreground">
-          {t("agpLoading")}
-        </p>
-      </div>
-    )
-  }
-  if (!agp.data) {
-    return (
-      <div className="space-y-4">
-        {selector}
-        <p role="alert" className="rounded-md border border-feedback-error bg-error-bg px-4 py-3 text-sm text-error-fg">
-          {t("agpError")}
-        </p>
-      </div>
-    )
-  }
-
-  const slots = maskSparseAgpSlots(agp.data, AGP_SUFFICIENCY.MIN_SLOT_READINGS)
-
-  return (
-    <div className="space-y-4">
-      {selector}
+  // Résumé période (erreur re-fetch + notes de suffisance + bandeau stats) —
+  // affiché dans les deux vues (moyenne/AGP et tableau journalier).
+  const summary = (
+    <>
       {/* Échec de re-fetch : la donnée affichée reste la fenêtre précédente
           (`shownLabel`) — on l'annonce, jamais un libellé trompeur. */}
       {refetchError && (
@@ -157,7 +147,6 @@ export function PatientAgpTab({
           {t("periodRefetchError", { requested: requestedLabel, shown: shownLabel })}
         </p>
       )}
-      {/* Notes de suffisance / inertie (US-2631/2635). */}
       {shownPeriod === "7d" && (
         <p role="status" className="rounded-md border border-feedback-warning bg-warning-bg px-4 py-2 text-sm text-warning-fg">
           {t("agp7dNote")}
@@ -173,23 +162,58 @@ export function PatientAgpTab({
           {t("lowCaptureWarning", { rate: Math.round(stats.data.captureRate) })}
         </p>
       )}
-
-      {/* Bandeau stats glucométriques — masqué si aucune donnée CGM sur la
-          fenêtre (pas de « 0 mg/dL / GMI 0 % » trompeur). */}
+      {/* Bandeau stats — masqué si aucune donnée CGM (pas de « 0 mg/dL »). */}
       {stats.data && stats.data.readingCount > 0 && (
         <dl className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
           <AgpStat label={t("agpStatAvg")} value={`${stats.data.avgMgdl} mg/dL`} />
-          <AgpStat
-            label={t("agpStatGmi")}
-            value={`${stats.data.gmi}%`}
-            tooltip={t("agpGmiTooltip")}
-          />
+          <AgpStat label={t("agpStatGmi")} value={`${stats.data.gmi}%`} tooltip={t("agpGmiTooltip")} />
           <AgpStat label={t("agpStatCv")} value={`${stats.data.cv}%`} />
           <AgpStat label={t("agpStatSd")} value={`${stats.data.sdMgdl} mg/dL`} />
           <AgpStat label={t("agpStatCapture")} value={`${Math.round(stats.data.captureRate)}%`} />
         </dl>
       )}
+    </>
+  )
 
+  // ── Vue « Tableau journalier » (US-2636) — indépendante de l'état AGP. ──
+  if (view === "daily") {
+    return (
+      <div className="space-y-4">
+        {selectors}
+        {summary}
+        <PatientDailyTable />
+      </div>
+    )
+  }
+
+  // ── Vue « Moyenne » (AGP percentile). ──
+  if (agp.loading && !agp.data) {
+    return (
+      <div className="space-y-4">
+        {selectors}
+        <p role="status" className="py-10 text-center text-sm text-muted-foreground">
+          {t("agpLoading")}
+        </p>
+      </div>
+    )
+  }
+  if (!agp.data) {
+    return (
+      <div className="space-y-4">
+        {selectors}
+        <p role="alert" className="rounded-md border border-feedback-error bg-error-bg px-4 py-3 text-sm text-error-fg">
+          {t("agpError")}
+        </p>
+      </div>
+    )
+  }
+
+  const slots = maskSparseAgpSlots(agp.data, AGP_SUFFICIENCY.MIN_SLOT_READINGS)
+
+  return (
+    <div className="space-y-4">
+      {selectors}
+      {summary}
       {/* Profil percentile 24 h — bande cible pathology-aware. `aria-busy` +
           opacité pendant un re-fetch (cohérent « Vue d'ensemble », WCAG 4.1.3). */}
       <div

--- a/src/components/diabeo/patient/PatientDailyTable.tsx
+++ b/src/components/diabeo/patient/PatientDailyTable.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+/**
+ * US-2636 — Vue « Tableau journalier » : 1 ligne par jour calendaire
+ * (Europe/Paris) pour la période sélectionnée. Données **projetées serveur**
+ * (`/api/analytics/daily-stats`, ≤ 90 lignes triées desc) — aucun calcul
+ * clinique ici. Piloté par la période du contexte (`usePeriodResource`, lazy).
+ *
+ * Le % en cible est **pathology-aware** (calculé serveur avec les bornes du
+ * patient). L'onglet parent porte le sélecteur de période/vue et la bande cible.
+ */
+
+import { useLocale, useTranslations } from "next-intl"
+import { bcp47 } from "@/i18n/config"
+import { usePeriodResource } from "./PatientRecordContext"
+
+/** Miroir de `DailyStat` (analytics.service) — projeté serveur, mg/dL. */
+interface DailyStat {
+  day: string
+  avgMgdl: number
+  minMgdl: number
+  maxMgdl: number
+  count: number
+  inTargetPct: number
+}
+
+export function PatientDailyTable() {
+  const t = useTranslations("patientDetail")
+  const locale = useLocale()
+  const { data, loading, error } = usePeriodResource<DailyStat[]>({
+    endpoint: "/api/analytics/daily-stats",
+    map: (raw) => raw as DailyStat[],
+  })
+
+  if (loading && !data) {
+    return (
+      <p role="status" className="py-10 text-center text-sm text-muted-foreground">
+        {t("dailyLoading")}
+      </p>
+    )
+  }
+  if (error || !data) {
+    return (
+      <p role="alert" className="rounded-md border border-feedback-error bg-error-bg px-4 py-3 text-sm text-error-fg">
+        {t("dailyError")}
+      </p>
+    )
+  }
+  if (data.length === 0) {
+    return (
+      <p role="status" className="py-10 text-center text-sm text-muted-foreground">
+        {t("dailyEmpty")}
+      </p>
+    )
+  }
+
+  const fmtDay = (day: string) =>
+    // Midi local pour éviter tout décalage de jour à la conversion.
+    new Date(`${day}T12:00:00`).toLocaleDateString(bcp47(locale), {
+      weekday: "short", day: "2-digit", month: "2-digit", year: "numeric", timeZone: "Europe/Paris",
+    })
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <caption className="sr-only">{t("dailyTableCaption")}</caption>
+        <thead>
+          <tr className="border-b border-border text-left text-xs text-muted-foreground">
+            <th scope="col" className="py-2 pe-3 font-medium">{t("dailyColDay")}</th>
+            <th scope="col" className="py-2 pe-3 text-right font-medium">{t("dailyColAvg")}</th>
+            <th scope="col" className="py-2 pe-3 text-right font-medium">{t("dailyColInTarget")}</th>
+            <th scope="col" className="py-2 pe-3 text-right font-medium">{t("dailyColMin")}</th>
+            <th scope="col" className="py-2 pe-3 text-right font-medium">{t("dailyColMax")}</th>
+            <th scope="col" className="py-2 text-right font-medium">{t("dailyColCount")}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((d) => (
+            <tr key={d.day} className="border-b border-border/60 tabular-nums">
+              <th scope="row" className="py-2 pe-3 text-left font-normal text-foreground">{fmtDay(d.day)}</th>
+              <td className="py-2 pe-3 text-right font-medium">{d.avgMgdl} mg/dL</td>
+              <td className="py-2 pe-3 text-right">{d.inTargetPct}%</td>
+              <td className="py-2 pe-3 text-right text-muted-foreground">{d.minMgdl}</td>
+              <td className="py-2 pe-3 text-right text-muted-foreground">{d.maxMgdl}</td>
+              <td className="py-2 text-right text-muted-foreground">{d.count}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/components/diabeo/patient/PatientRecordContext.tsx
+++ b/src/components/diabeo/patient/PatientRecordContext.tsx
@@ -20,6 +20,16 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 export type RecordPeriod = "7d" | "14d" | "30d" | "90d"
 export const RECORD_PERIODS: readonly RecordPeriod[] = ["7d", "14d", "30d", "90d"] as const
 
+/** Vue des onglets analytiques (US-2636) : agrégat (AGP) vs 1 ligne/jour. */
+export type RecordView = "average" | "daily"
+export const RECORD_VIEWS: readonly RecordView[] = ["average", "daily"] as const
+
+/** Clé i18n du libellé de chaque vue (namespace `patientDetail`). */
+export const VIEW_LABEL_KEY: Record<RecordView, string> = {
+  average: "viewAverage",
+  daily: "viewDaily",
+}
+
 /**
  * Période d'amorce (RSC). **DOIT** rester synchrone avec `OVERVIEW_PERIOD` de
  * `build-patient-record.ts` (projection serveur) : la fiche est rendue sur cette
@@ -54,6 +64,9 @@ export type AnalyticsFetcher = (
 interface PatientRecordContextValue {
   period: RecordPeriod
   setPeriod: (p: RecordPeriod) => void
+  /** Vue analytique partagée (moyenne/AGP vs tableau journalier) — US-2636. */
+  view: RecordView
+  setView: (v: RecordView) => void
   fetchAnalytics: AnalyticsFetcher
   /** Période de l'amorce serveur (pas de re-fetch tant que `period` y est égal). */
   seedPeriod: RecordPeriod
@@ -76,9 +89,10 @@ export function PatientRecordProvider({
   children: React.ReactNode
 }) {
   const [period, setPeriod] = useState<RecordPeriod>(seedPeriod)
+  const [view, setView] = useState<RecordView>("average")
   const value = useMemo<PatientRecordContextValue>(
-    () => ({ period, setPeriod, fetchAnalytics, seedPeriod }),
-    [period, fetchAnalytics, seedPeriod],
+    () => ({ period, setPeriod, view, setView, fetchAnalytics, seedPeriod }),
+    [period, view, fetchAnalytics, seedPeriod],
   )
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>
 }

--- a/src/components/diabeo/patient/ViewSelector.tsx
+++ b/src/components/diabeo/patient/ViewSelector.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+/**
+ * US-2636 — Sélecteur de vue de la fiche patient (Moyenne / Tableau journalier),
+ * synchronisé entre onglets via `PatientRecordContext`.
+ *
+ * Même pattern a11y que `PeriodSelector` : **`radiogroup`** (sélection unique),
+ * navigation ←/→/Home/End + roving tabindex, `aria-checked` sur l'option active.
+ */
+
+import { useRef, type KeyboardEvent } from "react"
+import { useTranslations } from "next-intl"
+import { cn } from "@/lib/utils"
+import {
+  RECORD_VIEWS,
+  VIEW_LABEL_KEY,
+  usePatientRecordContext,
+} from "./PatientRecordContext"
+
+export function ViewSelector({ labelledBy }: { labelledBy?: string } = {}) {
+  const t = useTranslations("patientDetail")
+  const ctx = usePatientRecordContext()
+  const refs = useRef<Array<HTMLButtonElement | null>>([])
+
+  if (!ctx) return null
+  const { view, setView } = ctx
+
+  function onKeyDown(e: KeyboardEvent, index: number) {
+    let next = index
+    if (e.key === "ArrowRight" || e.key === "ArrowDown") next = (index + 1) % RECORD_VIEWS.length
+    else if (e.key === "ArrowLeft" || e.key === "ArrowUp") next = (index - 1 + RECORD_VIEWS.length) % RECORD_VIEWS.length
+    else if (e.key === "Home") next = 0
+    else if (e.key === "End") next = RECORD_VIEWS.length - 1
+    else return
+    e.preventDefault()
+    setView(RECORD_VIEWS[next])
+    refs.current[next]?.focus()
+  }
+
+  return (
+    <div
+      role="radiogroup"
+      aria-labelledby={labelledBy}
+      aria-label={labelledBy ? undefined : t("viewSelectorLabel")}
+      className="inline-flex items-center gap-1 rounded-lg border border-border bg-muted/40 p-1"
+    >
+      {RECORD_VIEWS.map((v, i) => {
+        const active = v === view
+        return (
+          <button
+            key={v}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            tabIndex={active ? 0 : -1}
+            ref={(el) => {
+              refs.current[i] = el
+            }}
+            onClick={() => setView(v)}
+            onKeyDown={(e) => onKeyDown(e, i)}
+            className={cn(
+              "min-h-8 rounded-md px-3 py-1 text-sm font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
+              active
+                ? "bg-card text-foreground shadow-diabeo-xs"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {t(VIEW_LABEL_KEY[v])}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/lib/services/analytics.service.ts
+++ b/src/lib/services/analytics.service.ts
@@ -117,6 +117,28 @@ async function getPatientThresholds(patientId: number): Promise<CgmThresholds> {
   }
 }
 
+/** Ligne brute renvoyée par la requête d'agrégation journalière (US-2636). */
+interface RawDailyRow {
+  day: string
+  avg_gl: number
+  min_gl: number
+  max_gl: number
+  n: number
+  in_target: number
+}
+
+/** Statistique journalière projetée (mg/dL) — 1 ligne par jour (US-2636). */
+export interface DailyStat {
+  /** Jour calendaire Europe/Paris, ISO `YYYY-MM-DD`. */
+  day: string
+  avgMgdl: number
+  minMgdl: number
+  maxMgdl: number
+  count: number
+  /** % de relevés du jour en cible pathology-aware (`[low, ok]`). */
+  inTargetPct: number
+}
+
 /**
  * Analytics service — glycemic metrics and trends.
  * @namespace analyticsService
@@ -363,6 +385,88 @@ export const analyticsService = {
     }
 
     return computeAgp(withTimestamp)
+  },
+
+  /**
+   * US-2636 — Statistiques **journalières** (1 ligne par jour calendaire
+   * Europe/Paris) : moyenne, min, max, nombre de relevés, % en cible.
+   *
+   * Perf (AC-3) : agrégation **en base** (`GROUP BY` sur la journée locale),
+   * bornée par l'index `[patientId, timestamp]` (CGM) / `[patientId, date]`
+   * (BGM) et plafonnée à 90 lignes — jamais de chargement de 90 j en mémoire.
+   * % en cible **pathology-aware** (AC-1) : bornes `[low, ok]` du patient (g/L),
+   * GD 63–140 vs 70–180. Projection serveur pure (AC-2) : le front n'affiche
+   * que ces lignes déjà triées desc.
+   */
+  async dailyStats(
+    patientId: number,
+    period: string,
+    auditUserId: number,
+    ctx?: AuditContext,
+    opts?: { source?: "cgm" | "bgm"; skipAudit?: boolean },
+  ): Promise<DailyStat[]> {
+    const days = parsePeriod(period)
+    const to = new Date()
+    const from = new Date(to.getTime() - days * 24 * 3600_000)
+    const thresholds = await getPatientThresholds(patientId) // g/L, pathology-aware
+    const source = opts?.source ?? "cgm"
+
+    if (!opts?.skipAudit) {
+      await auditService.log({
+        userId: auditUserId,
+        action: "READ",
+        resource: "ANALYTICS",
+        resourceId: String(patientId),
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+        requestId: ctx?.requestId,
+        metadata: { patientId, kind: "dailyStats", period, windowDays: days, source },
+      })
+    }
+
+    const rows =
+      source === "bgm"
+        ? await prisma.$queryRaw<RawDailyRow[]>`
+            SELECT to_char(date, 'YYYY-MM-DD') AS day,
+                   AVG(glycemia_gl)::float8 AS avg_gl,
+                   MIN(glycemia_gl)::float8 AS min_gl,
+                   MAX(glycemia_gl)::float8 AS max_gl,
+                   COUNT(*)::int AS n,
+                   COUNT(*) FILTER (
+                     WHERE glycemia_gl >= ${thresholds.low} AND glycemia_gl <= ${thresholds.ok}
+                   )::int AS in_target
+            FROM glycemia_entries
+            WHERE patient_id = ${patientId}
+              AND date >= ${from} AND date <= ${to}
+              AND glycemia_gl IS NOT NULL
+            GROUP BY day
+            ORDER BY day DESC
+            LIMIT 90`
+        : await prisma.$queryRaw<RawDailyRow[]>`
+            SELECT to_char((timestamp AT TIME ZONE 'Europe/Paris')::date, 'YYYY-MM-DD') AS day,
+                   AVG(value_gl)::float8 AS avg_gl,
+                   MIN(value_gl)::float8 AS min_gl,
+                   MAX(value_gl)::float8 AS max_gl,
+                   COUNT(*)::int AS n,
+                   COUNT(*) FILTER (
+                     WHERE value_gl >= ${thresholds.low} AND value_gl <= ${thresholds.ok}
+                   )::int AS in_target
+            FROM cgm_entries
+            WHERE patient_id = ${patientId}
+              AND timestamp >= ${from} AND timestamp <= ${to}
+              AND value_gl >= ${CGM_AGGREGATE_RANGE_GL.MIN} AND value_gl <= ${CGM_AGGREGATE_RANGE_GL.MAX}
+            GROUP BY day
+            ORDER BY day DESC
+            LIMIT 90`
+
+    return rows.map((r) => ({
+      day: r.day,
+      avgMgdl: Math.round(glToMgdl(r.avg_gl)),
+      minMgdl: Math.round(glToMgdl(r.min_gl)),
+      maxMgdl: Math.round(glToMgdl(r.max_gl)),
+      count: r.n,
+      inTargetPct: r.n > 0 ? Math.round((r.in_target / r.n) * 100) : 0,
+    }))
   },
 
   /**

--- a/src/lib/services/analytics.service.ts
+++ b/src/lib/services/analytics.service.ts
@@ -426,19 +426,26 @@ export const analyticsService = {
 
     const rows =
       source === "bgm"
-        ? await prisma.$queryRaw<RawDailyRow[]>`
-            SELECT to_char(date, 'YYYY-MM-DD') AS day,
-                   AVG(glycemia_gl)::float8 AS avg_gl,
-                   MIN(glycemia_gl)::float8 AS min_gl,
-                   MAX(glycemia_gl)::float8 AS max_gl,
+        ? // Revue #612 : (1) `${from}::date` — sinon `date >= timestamptz`
+          // caste la COLONNE (premier jour exclu + index inutilisable) ;
+          // (2) COALESCE `glycemia_gl` / `glycemia_mgdl` (relevés mg/dL-only,
+          // cf. `bgmStats`) ; (3) filtre plage physiologique `CGM_AGGREGATE_
+          // RANGE_GL` (les valeurs LO/HI lecteur ne polluent pas min/max).
+          await prisma.$queryRaw<RawDailyRow[]>`
+            SELECT to_char(day, 'YYYY-MM-DD') AS day,
+                   AVG(v)::float8 AS avg_gl,
+                   MIN(v)::float8 AS min_gl,
+                   MAX(v)::float8 AS max_gl,
                    COUNT(*)::int AS n,
-                   COUNT(*) FILTER (
-                     WHERE glycemia_gl >= ${thresholds.low} AND glycemia_gl <= ${thresholds.ok}
-                   )::int AS in_target
-            FROM glycemia_entries
-            WHERE patient_id = ${patientId}
-              AND date >= ${from} AND date <= ${to}
-              AND glycemia_gl IS NOT NULL
+                   COUNT(*) FILTER (WHERE v >= ${thresholds.low} AND v <= ${thresholds.ok})::int AS in_target
+            FROM (
+              SELECT date AS day, COALESCE(glycemia_gl, glycemia_mgdl / 100.0) AS v
+              FROM glycemia_entries
+              WHERE patient_id = ${patientId}
+                AND date >= ${from}::date AND date <= ${to}::date
+                AND (glycemia_gl IS NOT NULL OR glycemia_mgdl IS NOT NULL)
+            ) s
+            WHERE v >= ${CGM_AGGREGATE_RANGE_GL.MIN} AND v <= ${CGM_AGGREGATE_RANGE_GL.MAX}
             GROUP BY day
             ORDER BY day DESC
             LIMIT 90`

--- a/tests/components/patient-daily-table.test.tsx
+++ b/tests/components/patient-daily-table.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Tests — US-2636 : vue « Tableau journalier » (`PatientDailyTable`) +
+ * `ViewSelector` + bascule de vue dans l'onglet AGP.
+ */
+
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+
+vi.mock("next-intl", async () => (await import("../helpers/nextIntlMock")).makeNextIntlMock())
+// Chart AGP stubé (recharts lourd) — non pertinent pour la vue journalière.
+vi.mock("@/components/diabeo/AgpPercentileChart", () => ({
+  AgpPercentileChart: () => <div data-testid="agp-chart" />,
+}))
+vi.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}))
+
+import { PatientDailyTable } from "@/components/diabeo/patient/PatientDailyTable"
+import { PatientAgpTab } from "@/components/diabeo/patient/PatientAgpTab"
+import {
+  PatientRecordProvider,
+  type AnalyticsFetcher,
+} from "@/components/diabeo/patient/PatientRecordContext"
+
+const DAILY = [
+  { day: "2026-07-01", avgMgdl: 150, minMgdl: 70, maxMgdl: 240, count: 288, inTargetPct: 75 },
+  { day: "2026-06-30", avgMgdl: 132, minMgdl: 64, maxMgdl: 210, count: 275, inTargetPct: 82 },
+]
+const okJson = (data: unknown): Response => ({ ok: true, json: async () => data }) as unknown as Response
+
+function renderWith(children: React.ReactNode, fetcher: AnalyticsFetcher) {
+  return render(
+    <PatientRecordProvider fetchAnalytics={fetcher} seedPeriod="14d">
+      {children}
+    </PatientRecordProvider>,
+  )
+}
+
+describe("PatientDailyTable (US-2636)", () => {
+  it("renders one row per day with server-projected stats (avg, % in target, min, max, count)", async () => {
+    const fetcher: AnalyticsFetcher = () => Promise.resolve(okJson(DAILY))
+    renderWith(<PatientDailyTable />, fetcher)
+    await waitFor(() => expect(screen.getByRole("table")).toBeTruthy())
+    expect(screen.getAllByRole("row").length).toBe(3) // header + 2 jours
+    expect(screen.getByText("150 mg/dL")).toBeTruthy()
+    expect(screen.getByText("75%")).toBeTruthy()
+    expect(screen.getByText("82%")).toBeTruthy()
+  })
+
+  it("shows the empty state when there is no data for the period", async () => {
+    const fetcher: AnalyticsFetcher = () => Promise.resolve(okJson([]))
+    renderWith(<PatientDailyTable />, fetcher)
+    await waitFor(() => expect(screen.getByText(/Aucune donnée/)).toBeTruthy())
+    expect(screen.queryByRole("table")).toBeNull()
+  })
+})
+
+describe("ViewSelector — bascule Moyenne / Tableau journalier (US-2636)", () => {
+  it("switches the AGP tab from the percentile chart to the daily table", async () => {
+    const fetcher: AnalyticsFetcher = (endpoint) => {
+      if (endpoint.includes("/daily-stats")) return Promise.resolve(okJson(DAILY))
+      if (endpoint.includes("/agp")) return Promise.resolve(okJson([{ timeMinutes: 0, p10: 1, p25: 1.1, p50: 1.2, p75: 1.3, p90: 1.4, count: 30 }]))
+      return Promise.resolve(okJson({ captureRate: 92, readingCount: 1200, metrics: { averageGlucoseMgdl: 158, gmi: 7.1, coefficientOfVariation: 34, stdDevMgdl: 52 } }))
+    }
+    renderWith(<PatientAgpTab targetLowMgdl={70} targetHighMgdl={180} />, fetcher)
+
+    // Vue par défaut = Moyenne → chart AGP.
+    await screen.findByTestId("agp-chart")
+    expect(screen.queryByRole("table")).toBeNull()
+
+    // Bascule vers « Tableau journalier ».
+    fireEvent.click(screen.getByRole("radio", { name: "Tableau journalier" }))
+    await waitFor(() => expect(screen.getByRole("table")).toBeTruthy())
+    expect(screen.queryByTestId("agp-chart")).toBeNull()
+    expect(screen.getByText("150 mg/dL")).toBeTruthy()
+  })
+})

--- a/tests/unit/analytics.service.test.ts
+++ b/tests/unit/analytics.service.test.ts
@@ -136,6 +136,42 @@ describe("analyticsService", () => {
     })
   })
 
+  describe("dailyStats — US-2636 (1 ligne/jour)", () => {
+    it("maps raw daily rows → mg/dL + % en cible, audite kind=dailyStats + période", async () => {
+      prismaMock.cgmObjective.findUnique.mockResolvedValue(null)
+      prismaMock.patient.findFirst.mockResolvedValue({ pathology: "DT1" } as any)
+      prismaMock.auditLog.create.mockResolvedValue({} as any)
+      ;(prismaMock.$queryRaw as any).mockResolvedValue([
+        { day: "2026-07-01", avg_gl: 1.5, min_gl: 0.7, max_gl: 2.4, n: 288, in_target: 216 },
+      ])
+
+      const res = await analyticsService.dailyStats(1, "30d", 1, {
+        ipAddress: "i", userAgent: "u", requestId: "r",
+      })
+
+      // g/L → mg/dL (×100), % en cible = in_target/n.
+      expect(res).toEqual([
+        { day: "2026-07-01", avgMgdl: 150, minMgdl: 70, maxMgdl: 240, count: 288, inTargetPct: 75 },
+      ])
+      const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+      expect(audit.action).toBe("READ")
+      expect(audit.metadata).toMatchObject({ kind: "dailyStats", period: "30d", windowDays: 30, source: "cgm" })
+      expect(JSON.stringify(audit.metadata)).not.toMatch(/glucose|mgdl/i)
+    })
+
+    it("queries GlycemiaEntry (BGM) when source=bgm", async () => {
+      prismaMock.cgmObjective.findUnique.mockResolvedValue(null)
+      prismaMock.patient.findFirst.mockResolvedValue({ pathology: "DT1" } as any)
+      prismaMock.auditLog.create.mockResolvedValue({} as any)
+      ;(prismaMock.$queryRaw as any).mockResolvedValue([])
+
+      const res = await analyticsService.dailyStats(1, "14d", 1, undefined, { source: "bgm" })
+      expect(res).toEqual([])
+      const audit = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
+      expect(audit.metadata).toMatchObject({ kind: "dailyStats", source: "bgm" })
+    })
+  })
+
   describe("timeInRange", () => {
     it("returns TIR with quality assessment", async () => {
       prismaMock.cgmEntry.findMany.mockResolvedValue(mockCgmEntries(500) as any)

--- a/tests/unit/daily-stats-route.test.ts
+++ b/tests/unit/daily-stats-route.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Test — GET /api/analytics/daily-stats : gardes US-2636 (garde-fou épopée). Opt-out du
+ * sujet (`patientShareConsent`), trace d'accès refusé (US-2265), et validation
+ * Zod avant lecture consentement. Alignée sur glycemic-profile.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+vi.mock("@/lib/auth", () => ({
+  requireAuth: vi.fn(),
+  AuthError: class AuthError extends Error {
+    status = 401
+  },
+}))
+vi.mock("@/lib/auth/api-rate-limit", () => ({
+  checkApiRateLimit: vi.fn(),
+  RATE_LIMITS: { analytics: { points: 1, durationSec: 1 } },
+}))
+vi.mock("@/lib/gdpr", () => ({ requireGdprConsent: vi.fn() }))
+vi.mock("@/lib/consent", () => ({ patientShareConsent: vi.fn() }))
+vi.mock("@/lib/auth/query-helpers", () => ({ resolvePatientIdFromQuery: vi.fn() }))
+vi.mock("@/lib/services/analytics.service", () => ({ analyticsService: { dailyStats: vi.fn() } }))
+vi.mock("@/lib/services/audit.service", () => ({
+  extractRequestContext: vi.fn(() => ({ ipAddress: "i", userAgent: "u", requestId: "r" })),
+}))
+vi.mock("@/lib/audit/analytics-helpers", () => ({ auditAnalyticsAccessDenied: vi.fn() }))
+
+import { GET } from "@/app/api/analytics/daily-stats/route"
+import { requireAuth } from "@/lib/auth"
+import { checkApiRateLimit } from "@/lib/auth/api-rate-limit"
+import { requireGdprConsent } from "@/lib/gdpr"
+import { patientShareConsent } from "@/lib/consent"
+import { resolvePatientIdFromQuery } from "@/lib/auth/query-helpers"
+import { analyticsService } from "@/lib/services/analytics.service"
+import { auditAnalyticsAccessDenied } from "@/lib/audit/analytics-helpers"
+
+const makeReq = (period = "30d") => ({ nextUrl: { searchParams: new URLSearchParams({ period }) } }) as any
+const mAuth = vi.mocked(requireAuth)
+const mRate = vi.mocked(checkApiRateLimit)
+const mGdpr = vi.mocked(requireGdprConsent)
+const mShare = vi.mocked(patientShareConsent)
+const mResolve = vi.mocked(resolvePatientIdFromQuery)
+const mDaily = vi.mocked(analyticsService.dailyStats)
+const mDenied = vi.mocked(auditAnalyticsAccessDenied)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mAuth.mockReturnValue({ id: 1, role: "DOCTOR" } as any)
+  mRate.mockResolvedValue({ allowed: true } as any)
+  mGdpr.mockResolvedValue(true)
+  mResolve.mockResolvedValue({ patientId: 42 } as any)
+  mShare.mockResolvedValue({ ok: true } as any)
+  mDaily.mockResolvedValue([] as any)
+})
+
+describe("GET /api/analytics/daily-stats — gardes US-2636", () => {
+  it("blocks a patient who opted out of provider sharing (before projection)", async () => {
+    mShare.mockResolvedValue({ ok: false, status: 403, error: "sharingDisabled" } as any)
+    const r = await GET(makeReq())
+    expect(r.status).toBe(403)
+    expect(mDaily).not.toHaveBeenCalled()
+  })
+
+  it("passes through when consent is granted", async () => {
+    const r = await GET(makeReq())
+    expect(r.status).toBe(200)
+    expect(mShare).toHaveBeenCalledWith(42)
+    expect(mDaily).toHaveBeenCalledWith(42, "30d", 1, expect.any(Object), { source: "cgm" })
+  })
+
+  it("audits accessDenied on out-of-scope resolution (US-2265)", async () => {
+    mResolve.mockResolvedValue({ error: "patientNotFound" } as any)
+    const r = await GET(makeReq())
+    expect(r.status).toBe(404)
+    expect(mDenied).toHaveBeenCalledTimes(1)
+    expect(mShare).not.toHaveBeenCalled()
+  })
+
+  it("validates the period (400) BEFORE reading share consent", async () => {
+    const r = await GET(makeReq("bogus"))
+    expect(r.status).toBe(400)
+    expect(mShare).not.toHaveBeenCalled()
+    expect(mDaily).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## US-2636 — Vue « Tableau journalier » + service `dailyStats`

Epic **US-2630**. Sélecteur de **vue** (Moyenne / Tableau journalier) synchronisé + vue « 1 ligne par jour calendaire Europe/Paris ».

### Back
- **`analyticsService.dailyStats(patientId, period, userId, ctx, {source})`** : agrégation **en base** via `$queryRaw`.
  - CGM : `to_char((timestamp AT TIME ZONE 'Europe/Paris')::date, …)`, `GROUP BY` jour local, **bornée par l'index `[patient_id, timestamp]`**, `LIMIT 90` → **AC-2/3** (pas de fetch-all-in-memory sur 90 j).
  - BGM : `glycemia_entries` groupé par `date`.
  - **% en cible pathology-aware** (`[low, ok]` du patient, GD 63–140) → **AC-1**.
  - Audit `READ ANALYTICS kind="dailyStats"` + `metadata.period`/`windowDays`/`source` → **AC-4** (sans PHI).
- Route **`/api/analytics/daily-stats`** : gardes alignées (auth → rate-limit → consentement appelant → résolution + `accessDenied` → Zod → `patientShareConsent` → projection), param `source`.

### Front
- **`PatientRecordContext`** : état `{ view }` (`average`/`daily`) + `setView`, synchronisé entre onglets.
- **`ViewSelector`** : segmented `radiogroup` (Moyenne / Tableau journalier), même pattern a11y que `PeriodSelector`.
- **`PatientDailyTable`** : table accessible (`caption`, `th scope`), fetch **lazy** période (`usePeriodResource`), ≤ 90 lignes triées desc, états loading/empty/error.
- Onglet AGP (Profil glycémique) : sélecteur de vue + **bascule chart AGP ↔ tableau journalier** ; résumé période (notes de suffisance + bandeau stats) partagé entre les deux vues.

### Critères d'acceptation
AC-1 % cible pathology-aware ✅ · AC-2 projection serveur ≤ 90 lignes desc ✅ · AC-3 requête bornée index (pas de fetch-all) ✅ · AC-4 audit `kind="dailyStats"` + période ✅

### i18n / Tests
+13 clés × FR/EN/AR. +8 tests (service map + audit CGM & BGM, garde route consent/accessDenied/Zod, table rows/empty, bascule de vue). Suite **3497 ✓**, design-system ✓, build ✓, tsc ✓, lint ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)