### PR TITLE
US-2638 slice A — détection CGM/BGM + DTO fail-closed (socle)

### DIFF
--- a/src/app/(dashboard)/patients/[id]/build-patient-record.ts
+++ b/src/app/(dashboard)/patients/[id]/build-patient-record.ts
@@ -18,6 +18,7 @@ import { patientService } from "@/lib/services/patient.service"
 import type { AuditContext } from "@/lib/services/patient.service"
 import { analyticsService } from "@/lib/services/analytics.service"
 import { glycemiaService } from "@/lib/services/glycemia.service"
+import { cgmStatusService } from "@/lib/services/cgm-status.service"
 import { insulinTherapyService } from "@/lib/services/insulin-therapy.service"
 import { documentService } from "@/lib/services/document.service"
 import { getPatientFlags } from "@/lib/services/doctor-dashboard.service"
@@ -57,8 +58,10 @@ export async function buildPatientRecordData(
   const patient = await patientService.getById(patientId, userId, ctx)
   if (!patient) return null
 
-  // Stats glycémiques — projection serveur (audité READ ANALYTICS).
-  const profile = await analyticsService.glycemicProfile(patientId, OVERVIEW_PERIOD, userId, ctx)
+  // Détection capteur (US-2638) — fail-closed : un patient SANS CGM bascule en
+  // présentation BGM (jamais de TIR-temps/GMI/AGP, trompeurs en capillaire).
+  const hasCgm = await cgmStatusService.patientHasCgm(patientId)
+  const dataSource: "cgm" | "bgm" = hasCgm ? "cgm" : "bgm"
 
   // Drapeaux d'alerte de la barre de contexte (source « Ma journée »). Fail-soft.
   const flags = await getPatientFlags(patientId).catch((e) => {
@@ -68,17 +71,58 @@ export async function buildPatientRecordData(
 
   const now = new Date()
 
-  // Onglet Glycémie : série CGM 24h (audité READ CGM_ENTRY) + signal de fraîcheur
-  // « brut » (fail-soft — ne casse jamais l'assemblage).
-  const from24h = new Date(now.getTime() - 24 * 60 * 60 * 1000)
-  const [cgmEntries, latestRaw] = await Promise.all([
-    glycemiaService.getCgmEntries(patientId, from24h, now, userId, ctx),
-    glycemiaService.getLatestCgmFreshness(patientId, from24h, now, userId, ctx).catch((e) => {
-      console.error("[build-patient-record] getLatestCgmFreshness failed", e instanceof Error ? e.message : e)
-      return null
-    }),
-  ])
-  const glycemiaView = buildGlycemiaView(cgmEntries, now, latestRaw)
+  let stats: PatientRecordData["stats"] = null
+  let bgm: PatientRecordData["bgm"] = null
+  let glycemiaView
+
+  if (dataSource === "cgm") {
+    // Vue CGM : stats agrégées (READ ANALYTICS) + série 24h (READ CGM_ENTRY).
+    const profile = await analyticsService.glycemicProfile(patientId, OVERVIEW_PERIOD, userId, ctx)
+    stats =
+      profile.readingCount > 0
+        ? {
+            avgGlucoseMgdl: profile.metrics.averageGlucoseMgdl,
+            gmi: profile.metrics.gmi,
+            cv: profile.metrics.coefficientOfVariation,
+            tir: {
+              veryLow: profile.tir.severeHypo,
+              low: profile.tir.hypo,
+              inRange: profile.tir.inRange,
+              high: profile.tir.elevated,
+              veryHigh: profile.tir.hyper,
+            },
+            readingCount: profile.readingCount,
+            captureRate: profile.captureRate,
+            insufficientCapture: profile.warning === "insufficientCgmCapture",
+          }
+        : null
+    const from24h = new Date(now.getTime() - 24 * 60 * 60 * 1000)
+    const [cgmEntries, latestRaw] = await Promise.all([
+      glycemiaService.getCgmEntries(patientId, from24h, now, userId, ctx),
+      glycemiaService.getLatestCgmFreshness(patientId, from24h, now, userId, ctx).catch((e) => {
+        console.error("[build-patient-record] getLatestCgmFreshness failed", e instanceof Error ? e.message : e)
+        return null
+      }),
+    ])
+    glycemiaView = buildGlycemiaView(cgmEntries, now, latestRaw)
+  } else {
+    // Vue BGM (capillaire) : % en cible + moyenne + fréquence (READ GLYCEMIA_ENTRY)
+    // et HbA1c LABO datée (jamais un GMI/eA1c). `stats` CGM reste `null`
+    // (fail-closed). Aucune lecture CGM (série 24h vide).
+    const [bgmStats, hba1c] = await Promise.all([
+      analyticsService.bgmStats(patientId, OVERVIEW_PERIOD, userId, ctx),
+      glycemiaService.getLastHba1c(patientId, userId, ctx),
+    ])
+    bgm = {
+      avgMgdl: bgmStats.avgMgdl,
+      inRangePercent: bgmStats.inRangePercent,
+      readingsPerDay: bgmStats.readingsPerDay,
+      targetRangeMgdl: bgmStats.targetRangeMgdl,
+      hba1c,
+      points: bgmStats.points,
+    }
+    glycemiaView = buildGlycemiaView([], now, null)
+  }
 
   // Onglet Traitements : réglages insuline réels (audité READ INSULIN_THERAPY).
   const insulinSettings = await insulinTherapyService.getSettings(patientId, userId, ctx)
@@ -112,24 +156,9 @@ export async function buildPatientRecordData(
       hypoMaxPct: CONSENSUS_HYPO_MAX_PCT,
       cvMaxPct: CONSENSUS_CV_MAX_PCT,
     },
-    stats:
-      profile.readingCount > 0
-        ? {
-            avgGlucoseMgdl: profile.metrics.averageGlucoseMgdl,
-            gmi: profile.metrics.gmi,
-            cv: profile.metrics.coefficientOfVariation,
-            tir: {
-              veryLow: profile.tir.severeHypo,
-              low: profile.tir.hypo,
-              inRange: profile.tir.inRange,
-              high: profile.tir.elevated,
-              veryHigh: profile.tir.hyper,
-            },
-            readingCount: profile.readingCount,
-            captureRate: profile.captureRate,
-            insufficientCapture: profile.warning === "insufficientCgmCapture",
-          }
-        : null,
+    stats,
+    dataSource,
+    bgm,
     glycemia: glycemiaView,
     treatment: treatmentView,
     documents,

--- a/src/app/(dashboard)/patients/[id]/build-patient-record.ts
+++ b/src/app/(dashboard)/patients/[id]/build-patient-record.ts
@@ -73,7 +73,7 @@ export async function buildPatientRecordData(
 
   let stats: PatientRecordData["stats"] = null
   let bgm: PatientRecordData["bgm"] = null
-  let glycemiaView
+  let glycemiaView: ReturnType<typeof buildGlycemiaView>
 
   if (dataSource === "cgm") {
     // Vue CGM : stats agrégées (READ ANALYTICS) + série 24h (READ CGM_ENTRY).

--- a/src/components/diabeo/patient/PatientRecord.tsx
+++ b/src/components/diabeo/patient/PatientRecord.tsx
@@ -78,6 +78,29 @@ export type PatientRecordData = {
     /** Capture CGM < 70 % → stats non représentatives (caveat clinique). */
     insufficientCapture: boolean
   } | null
+  /**
+   * Source de données de la fiche (US-2638) — dérivée de la présence d'un
+   * capteur (`patientHasCgm`). En `bgm` (glycémie capillaire), la fiche bascule
+   * de présentation : jamais d'indicateur CGM-only (TIR-temps, GMI, AGP) qui
+   * serait trompeur. Fail-closed.
+   */
+  dataSource: "cgm" | "bgm"
+  /**
+   * Stats capillaires — présent UNIQUEMENT si `dataSource === "bgm"` (sinon
+   * `null`). Substitutions : **% de relevés en cible** (≠ TIR-temps, biais
+   * d'échantillonnage) · **HbA1c labo** datée (≠ GMI/eA1c, jamais calculé en
+   * BGM) · **fréquence** (relevés/jour, ≠ taux de capture) · **nuage de points**
+   * (≠ courbe continue). Seuils pathology-aware (US-2631).
+   */
+  bgm: {
+    avgMgdl: number | null
+    inRangePercent: number | null
+    readingsPerDay: number
+    targetRangeMgdl: { low: number; high: number }
+    hba1c: { value: number; date: string; ageDays: number; stale: boolean } | null
+    /** Nuage modal-day : heure du jour (min) × mg/dL. */
+    points: { timeMinutes: number; mgdl: number }[]
+  } | null
   /** Série CGM 24h (déjà mappée serveur : mg/dL + heure Europe/Paris + fraîcheur). */
   glycemia: GlycemiaView
   /** Réglages insuline (par créneau) + traitements associés. */

--- a/src/lib/services/analytics.service.ts
+++ b/src/lib/services/analytics.service.ts
@@ -257,7 +257,7 @@ export const analyticsService = {
         date: { gte: since, lte: now },
         OR: [{ glycemiaGl: { not: null } }, { glycemiaMgdl: { not: null } }],
       },
-      select: { glycemiaGl: true, glycemiaMgdl: true },
+      select: { glycemiaGl: true, glycemiaMgdl: true, time: true },
     })
 
     // Valeur en g/L (préfère `glycemiaGl`, sinon mg/dL → g/L), filtrée sur la
@@ -265,15 +265,24 @@ export const analyticsService = {
     // écarte aussi les extrêmes « LO/HI » du lecteur (< 0,20 / > 6,00 g/L) —
     // cohérent avec les agrégats CGM et le rejet des valeurs d'erreur capteur ;
     // impact négligeable (rareté), tracé ici pour transparence (revue médicale).
-    const valuesGl = rows
+    const valid = rows
       .map((r) => {
-        if (r.glycemiaGl != null) return decimalToNumber(r.glycemiaGl)
-        if (r.glycemiaMgdl != null) return decimalToNumber(r.glycemiaMgdl) / 100
-        return NaN
+        const gl = r.glycemiaGl != null
+          ? decimalToNumber(r.glycemiaGl)
+          : r.glycemiaMgdl != null ? decimalToNumber(r.glycemiaMgdl) / 100 : NaN
+        // `time` est une heure MURALE locale (Time sans fuseau) → minutes du jour.
+        const timeMinutes = r.time ? r.time.getUTCHours() * 60 + r.time.getUTCMinutes() : null
+        return { gl, timeMinutes }
       })
-      .filter(
-        (v) => Number.isFinite(v) && v >= CGM_AGGREGATE_RANGE_GL.MIN && v <= CGM_AGGREGATE_RANGE_GL.MAX,
-      )
+      .filter((x) => Number.isFinite(x.gl) && x.gl >= CGM_AGGREGATE_RANGE_GL.MIN && x.gl <= CGM_AGGREGATE_RANGE_GL.MAX)
+
+    const valuesGl = valid.map((x) => x.gl)
+    // Nuage de points (modal-day) : relevés positionnés par heure du jour — la
+    // vue BGM remplace la courbe continue CGM par ce nuage (US-2638). Points
+    // sans heure exclus (pas de position fiable).
+    const points = valid
+      .filter((x) => x.timeMinutes !== null)
+      .map((x) => ({ timeMinutes: x.timeMinutes as number, mgdl: Math.round(glToMgdl(x.gl)) }))
 
     const total = valuesGl.length
     const inRange = valuesGl.filter((v) => v >= thresholds.low && v <= thresholds.ok).length
@@ -294,6 +303,10 @@ export const analyticsService = {
     return {
       period: { days },
       total,
+      // Moyenne des relevés capillaires (mg/dL) — `null` si aucun relevé. NB :
+      // moyenne de relevés BGM (échantillonnage non uniforme), PAS une moyenne
+      // pondérée dans le temps comme en CGM. Jamais utilisée pour un GMI/eA1c.
+      avgMgdl: total > 0 ? Math.round(glToMgdl(mean(valuesGl))) : null,
       // % de relevés en cible (≠ TIR). `null` si aucun relevé exploitable.
       inRangePercent: total > 0 ? Math.round((inRange / total) * 1000) / 10 : null,
       readingsPerDay: Math.round((total / days) * 10) / 10,
@@ -301,6 +314,7 @@ export const analyticsService = {
         low: Math.round(glToMgdl(thresholds.low)),
         high: Math.round(glToMgdl(thresholds.ok)),
       },
+      points,
     }
   },
 

--- a/tests/components/patient-record.test.tsx
+++ b/tests/components/patient-record.test.tsx
@@ -92,6 +92,8 @@ const baseData: PatientDetailData = {
     captureRate: 92,
     insufficientCapture: false,
   },
+  dataSource: "cgm",
+  bgm: null,
   glycemia: {
     points: [
       { time: "08:00", glucose: 120 },

--- a/tests/unit/build-patient-record.test.ts
+++ b/tests/unit/build-patient-record.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests — US-2638 : détection CGM/BGM dans `buildPatientRecordData`.
+ *
+ * Garde clinique AC-1 (fail-closed) : un patient SANS capteur (BGM) ne reçoit
+ * JAMAIS d'indicateur CGM-only (TIR-temps, GMI). `dataSource="bgm"`, `stats=null`,
+ * bloc `bgm` peuplé (% en cible ≠ TIR, HbA1c labo ≠ GMI). Et le cas CGM inverse.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest"
+
+const { patientHasCgm, glycemicProfile, bgmStats, getLastHba1c } = vi.hoisted(() => ({
+  patientHasCgm: vi.fn(),
+  glycemicProfile: vi.fn(),
+  bgmStats: vi.fn(),
+  getLastHba1c: vi.fn(),
+}))
+
+vi.mock("@/lib/services/cgm-status.service", () => ({ cgmStatusService: { patientHasCgm } }))
+vi.mock("@/lib/services/analytics.service", () => ({ analyticsService: { glycemicProfile, bgmStats } }))
+vi.mock("@/lib/services/glycemia.service", () => ({
+  glycemiaService: {
+    getLastHba1c,
+    getCgmEntries: vi.fn().mockResolvedValue([]),
+    getLatestCgmFreshness: vi.fn().mockResolvedValue(null),
+  },
+}))
+vi.mock("@/lib/services/patient.service", () => ({
+  patientService: {
+    getById: vi.fn().mockResolvedValue({
+      id: 42,
+      publicRef: "ref-42",
+      pathology: "DT1",
+      user: { firstname: "Jean", lastname: "Dupont", birthday: new Date("1990-01-01"), sex: "M" },
+      medicalData: { yearDiag: 2015 },
+      referent: { pro: { name: "Dr House" } },
+      cgmObjectives: null,
+      treatments: [],
+      devices: [],
+    }),
+  },
+}))
+vi.mock("@/lib/services/insulin-therapy.service", () => ({
+  insulinTherapyService: { getSettings: vi.fn().mockResolvedValue(null) },
+}))
+vi.mock("@/lib/services/document.service", () => ({ documentService: { list: vi.fn().mockResolvedValue([]) } }))
+vi.mock("@/lib/services/doctor-dashboard.service", () => ({ getPatientFlags: vi.fn().mockResolvedValue(null) }))
+
+import { buildPatientRecordData } from "@/app/(dashboard)/patients/[id]/build-patient-record"
+
+const CTX = { ipAddress: "i", userAgent: "u", requestId: "r" }
+
+describe("buildPatientRecordData — CGM/BGM detection (US-2638)", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("BGM patient: dataSource='bgm', stats=null (no TIR/GMI), bgm block populated — AC-1 fail-closed", async () => {
+    patientHasCgm.mockResolvedValue(false)
+    bgmStats.mockResolvedValue({
+      period: { days: 14 }, total: 40, avgMgdl: 158, inRangePercent: 62.5,
+      readingsPerDay: 2.9, targetRangeMgdl: { low: 70, high: 180 },
+      points: [{ timeMinutes: 480, mgdl: 120 }],
+    })
+    getLastHba1c.mockResolvedValue({ value: 7.4, date: "2026-05-01T00:00:00.000Z", ageDays: 60, stale: false })
+
+    const data = (await buildPatientRecordData(42, "DOCTOR" as never, 1, CTX))!
+    expect(data.dataSource).toBe("bgm")
+    expect(data.stats).toBeNull() // AC-1 : aucun TIR-temps/GMI en BGM
+    expect(data.bgm).toMatchObject({ avgMgdl: 158, inRangePercent: 62.5, readingsPerDay: 2.9 })
+    expect(data.bgm?.hba1c?.value).toBe(7.4) // HbA1c labo, pas un GMI
+    // Aucun GMI/eA1c nulle part dans le DTO BGM (AC-3).
+    expect(JSON.stringify(data)).not.toMatch(/"gmi"/)
+    expect(glycemicProfile).not.toHaveBeenCalled() // pas de lecture CGM en BGM
+    expect(bgmStats).toHaveBeenCalledWith(42, "14d", 1, CTX)
+  })
+
+  it("CGM patient: dataSource='cgm', stats populated, bgm=null", async () => {
+    patientHasCgm.mockResolvedValue(true)
+    glycemicProfile.mockResolvedValue({
+      readingCount: 1200, captureRate: 92, warning: null,
+      metrics: { averageGlucoseMgdl: 158, gmi: 7.1, coefficientOfVariation: 34 },
+      tir: { severeHypo: 1, hypo: 3, inRange: 75, elevated: 17, hyper: 4 },
+    })
+
+    const data = (await buildPatientRecordData(42, "DOCTOR" as never, 1, CTX))!
+    expect(data.dataSource).toBe("cgm")
+    expect(data.bgm).toBeNull()
+    expect(data.stats?.gmi).toBe(7.1)
+    expect(data.stats?.tir.inRange).toBe(75)
+    expect(bgmStats).not.toHaveBeenCalled()
+    expect(getLastHba1c).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## US-2638 slice A — Détection CGM/BGM (socle backend)

Epic **US-2630**. Story L découpée en 2 slices ; **A = socle backend fail-closed**, **B = adaptation UI des onglets** (Vue d'ensemble BGM, AGP « non dispo », nuage de points).

### Périmètre slice A
- **`dataSource: "cgm" | "bgm"`** dérivé de `cgmStatusService.patientHasCgm` dans `buildPatientRecordData`.
- **Branche BGM** : `bgmStats` (étendu : **moyenne** + **nuage de points** modal-day) + `getLastHba1c`, audités **`READ GLYCEMIA_ENTRY`** (AC-5) ; **aucune lecture CGM** en BGM.
- **Fail-closed (AC-1)** : patient BGM → `stats` CGM (TIR-temps/GMI) = `null` ; bloc `bgm` peuplé — **% en cible ≠ TIR** · **HbA1c labo ≠ GMI** (AC-3) · **fréquence ≠ capture** · **nuage ≠ courbe**. Seuils pathology-aware (AC-4, US-2631).
- Type `PatientRecordData` + `dataSource` + `bgm`.

### Pas de changement visuel majeur
L'UI (`PatientRecord`) ne lit pas encore `dataSource`/`bgm` (slice B). Pour un patient BGM, `stats=null` → état « pas de données CGM » existant (inchangé).

### AC couverts (slice A)
AC-1 fail-closed ✅ (testé) · AC-3 pas de GMI/eA1c BGM ✅ · AC-4 pathology-aware ✅ · AC-5 audit READ GLYCEMIA_ENTRY ✅. AC-2 (libellé % cible + biais) & le rendu = **slice B**.

### Tests
+2 (`build-patient-record` : AC-1 fail-closed BGM + cas CGM). Suite **3514 ✓**, design-system ✓, build ✓, tsc ✓, lint ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)