### PR TITLE
US-2640 — toggle drawer → page plein écran

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1246,7 +1246,8 @@
       "DT2": "داء السكري من النوع الثاني (DT2)",
       "GD": "سكري الحمل (GD)"
     },
-    "openedAnnounce": "تم فتح استشارة {name}"
+    "openedAnnounce": "تم فتح استشارة {name}",
+    "openAsPage": "فتح كصفحة كاملة"
   },
   "adminDashboard": {
     "pageTitle": "لوحة تحكم المسؤول",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1246,7 +1246,8 @@
       "DT2": "Type 2 diabetes (T2D)",
       "GD": "Gestational diabetes (GD)"
     },
-    "openedAnnounce": "{name}'s consultation opened"
+    "openedAnnounce": "{name}'s consultation opened",
+    "openAsPage": "Open as full page"
   },
   "adminDashboard": {
     "pageTitle": "Admin dashboard",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1246,7 +1246,8 @@
       "DT2": "Diabète de type 2 (DT2)",
       "GD": "Diabète gestationnel (GD)"
     },
-    "openedAnnounce": "Consultation de {name} ouverte"
+    "openedAnnounce": "Consultation de {name} ouverte",
+    "openAsPage": "Ouvrir en page plein écran"
   },
   "adminDashboard": {
     "pageTitle": "Tableau de bord administrateur",

--- a/src/components/diabeo/consultation/PatientConsultationDrawer.tsx
+++ b/src/components/diabeo/consultation/PatientConsultationDrawer.tsx
@@ -41,6 +41,10 @@ interface Props {
   onToggleExpanded: () => void
 }
 
+/** Bouton-icône d'en-tête — cible tactile 44×44 (WCAG 2.5.5, revue #618 C2). */
+const ICON_BTN =
+  "inline-flex min-h-11 min-w-11 items-center justify-center rounded-md border border-border p-2 text-muted-foreground hover:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+
 export function PatientConsultationDrawer({
   patient,
   cTok,
@@ -145,12 +149,13 @@ export function PatientConsultationDrawer({
             </div>
             <p className="truncate text-xs text-muted-foreground">{subtitle}</p>
           </div>
-          {/* Bascule vers la page plein écran (dispo une fois le dossier chargé). */}
-          {data && (
+          {/* Bascule vers la page plein écran (dispo une fois le dossier chargé
+              SANS erreur — sinon le contenu affiche TabError, pas de dossier). */}
+          {data && !error && (
             <button
               type="button"
               onClick={openAsPage}
-              className="rounded-md border border-border p-2 text-muted-foreground hover:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+              className={ICON_BTN}
               aria-label={t("openAsPage")}
             >
               <ExternalLink className="h-4 w-4" />
@@ -159,7 +164,7 @@ export function PatientConsultationDrawer({
           <button
             type="button"
             onClick={onToggleExpanded}
-            className="rounded-md border border-border p-2 text-muted-foreground hover:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            className={ICON_BTN}
             aria-label={expanded ? t("collapse") : t("expand")}
           >
             {expanded ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
@@ -167,7 +172,7 @@ export function PatientConsultationDrawer({
           <button
             type="button"
             onClick={onClose}
-            className="rounded-md border border-border p-2 text-muted-foreground hover:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            className={ICON_BTN}
             aria-label={t("close")}
           >
             <X className="h-4 w-4" />

--- a/src/components/diabeo/consultation/PatientConsultationDrawer.tsx
+++ b/src/components/diabeo/consultation/PatientConsultationDrawer.tsx
@@ -18,8 +18,9 @@
  */
 
 import { useCallback, useEffect, useRef } from "react"
+import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
-import { Maximize2, Minimize2, X } from "lucide-react"
+import { ExternalLink, Maximize2, Minimize2, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { CONSULTATION_TOKEN_HEADER } from "@/lib/auth/consultation-token"
 import { PatientRecord, type PatientRecordData } from "@/components/diabeo/patient/PatientRecord"
@@ -48,10 +49,21 @@ export function PatientConsultationDrawer({
   onToggleExpanded,
 }: Props) {
   const t = useTranslations("consultation")
+  const router = useRouter()
   const headingRef = useRef<HTMLHeadingElement>(null)
 
   // Récupération du dossier unifié via le jeton éphémère (aucun id en URL).
   const { data, loading, error } = useConsultationData<PatientRecordData>("/api/patients/record", cTok)
+
+  // US-2640 — bascule drawer → page plein écran. On quitte le drawer (fermeture
+  // + révocation cTok côté provider) pour la route autorisée `/patients/[id]`
+  // (gardée par `canAccessPatient`). L'id vient du DTO résolu serveur (pas
+  // d'énumération) et n'apparaît en URL qu'en mode page, jamais dans le drawer.
+  const openAsPage = useCallback(() => {
+    if (!data) return
+    onClose()
+    router.push(`/patients/${data.id}`)
+  }, [data, onClose, router])
 
   // Transport analytique mode drawer (US-2634) : jeton en en-tête, aucun id en
   // URL — re-fetch des KPI à la période sans casser l'anti-énumération.
@@ -133,6 +145,17 @@ export function PatientConsultationDrawer({
             </div>
             <p className="truncate text-xs text-muted-foreground">{subtitle}</p>
           </div>
+          {/* Bascule vers la page plein écran (dispo une fois le dossier chargé). */}
+          {data && (
+            <button
+              type="button"
+              onClick={openAsPage}
+              className="rounded-md border border-border p-2 text-muted-foreground hover:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+              aria-label={t("openAsPage")}
+            >
+              <ExternalLink className="h-4 w-4" />
+            </button>
+          )}
           <button
             type="button"
             onClick={onToggleExpanded}

--- a/tests/components/consultation-drawer-toggle.test.tsx
+++ b/tests/components/consultation-drawer-toggle.test.tsx
@@ -59,4 +59,11 @@ describe("PatientConsultationDrawer — toggle to page (US-2640)", () => {
     renderDrawer()
     expect(screen.queryByLabelText("Ouvrir en page plein écran")).toBeNull()
   })
+
+  it("hides the toggle on a fetch error (content shows the error, not the record)", () => {
+    // Même si `data` restait renseigné, une erreur masque la bascule (C2 revue #618).
+    useConsultationData.mockReturnValue({ data: { id: 42, flags: {} }, loading: false, error: true })
+    renderDrawer()
+    expect(screen.queryByLabelText("Ouvrir en page plein écran")).toBeNull()
+  })
 })

--- a/tests/components/consultation-drawer-toggle.test.tsx
+++ b/tests/components/consultation-drawer-toggle.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Tests — US-2640 : bouton « ouvrir en page » du drawer de consultation.
+ * AC-1 : la bascule navigue vers la route page autorisée `/patients/[id]`
+ * (id du DTO résolu serveur) et ferme le drawer ; aucun id n'est en URL tant
+ * qu'on est en drawer (le bouton n'apparaît qu'une fois le dossier chargé).
+ */
+
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+
+const push = vi.fn()
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }))
+vi.mock("next-intl", async () => (await import("../helpers/nextIntlMock")).makeNextIntlMock())
+
+const useConsultationData = vi.fn()
+vi.mock("@/components/diabeo/consultation/useConsultationData", () => ({
+  useConsultationData: (...a: unknown[]) => useConsultationData(...a),
+}))
+vi.mock("@/components/diabeo/patient/PatientRecord", () => ({
+  PatientRecord: () => <div data-testid="patient-record" />,
+}))
+vi.mock("@/components/diabeo/patient/PatientRecordContext", () => ({
+  PatientRecordProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+vi.mock("@/components/diabeo/patient/PatientAlertFlags", () => ({ PatientAlertFlags: () => <div /> }))
+
+import { PatientConsultationDrawer } from "@/components/diabeo/consultation/PatientConsultationDrawer"
+
+const patient = { publicRef: "ref-42", name: "Jean Dupont", pathology: "DT1" as const, age: 34 }
+
+function renderDrawer(onClose = vi.fn()) {
+  render(
+    <PatientConsultationDrawer
+      patient={patient}
+      cTok="tok-abc"
+      expanded={false}
+      onClose={onClose}
+      onToggleExpanded={vi.fn()}
+    />,
+  )
+  return { onClose }
+}
+
+describe("PatientConsultationDrawer — toggle to page (US-2640)", () => {
+  it("navigates to the authorized page route by DTO id and closes the drawer", () => {
+    useConsultationData.mockReturnValue({ data: { id: 42, flags: {} }, loading: false, error: false })
+    const { onClose } = renderDrawer()
+    fireEvent.click(screen.getByLabelText("Ouvrir en page plein écran"))
+    expect(onClose).toHaveBeenCalled()
+    expect(push).toHaveBeenCalledWith("/patients/42")
+  })
+
+  it("hides the toggle while the record is still loading (no id available)", () => {
+    useConsultationData.mockReturnValue({ data: null, loading: true, error: false })
+    renderDrawer()
+    expect(screen.queryByLabelText("Ouvrir en page plein écran")).toBeNull()
+  })
+})


### PR DESCRIPTION
## US-2640 — Toggle page ⇄ drawer + navigation

Epic **US-2630**. Câble la présentation unique aux deux points d'entrée.

### Constat : décommission déjà faite (AC-3)
Les anciens onglets bespoke du drawer ont été **retirés en US-2633** : le drawer monte `<PatientRecord variant="drawer">`, et `consultation/tabs/` ne contient plus que `TabState` (loading/error), toujours utilisé. **Rien de mort à retirer, parité conservée.**

### Livré — bouton « ouvrir en page »
Bouton `ExternalLink` dans l'en-tête du drawer → navigue vers la route autorisée **`/patients/[id]`** (id du DTO **résolu serveur** via cTok, gardée par `canAccessPatient`) + **ferme le drawer**. Visible seulement une fois le dossier chargé (`data.id` disponible).

### AC
- **AC-1** ✅ Aucun id en URL tant qu'on est en **drawer** (transport cTok inchangé) ; la bascule **quitte** le drawer pour la page (id légitime en mode page uniquement, pas d'énumération — l'id vient du DTO serveur).
- **AC-2** ✅ Aucun nouvel audit : la page déclenche son propre `getById` (surface page) au chargement ; le drawer conserve `consultation.open`. Surfaces distinctes préservées.
- **AC-3** ✅ Aucun code mort (décommission acquise en US-2633).

### i18n / Tests
+1 clé `consultation.openAsPage` ×3. +2 tests (navigation `/patients/42` + `onClose` ; bouton absent en chargement). Suite **3542 ✓**, design-system ✓, build ✓, tsc ✓, lint ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)