### PR TITLE
US-2641 — durcissement transverse (gate finale : grossesse unifiée, carnet GD, DRY, invariants)

### DIFF
--- a/docs/compliance/dpia-patient-detail-dossier.md
+++ b/docs/compliance/dpia-patient-detail-dossier.md
@@ -153,6 +153,18 @@ secret → pas de fuite d'énumération nouvelle. Posture acceptée.
 - Plancher capteur 0.40 g/L exclut les hypo sévères des agrégats.
 - ✅ Cibles grossesse (GD) — défauts pathology-aware (63–140) sur le calcul TIR
   et le badge (`getCgmDefaults`). **Résolu.**
+- ⚠️ **Inférence du mode grossesse depuis la cible exposée (US-2641)** — depuis
+  l'unification `getPatientThresholds` `pregnancyMode`-aware, une patiente
+  `pregnancyMode` (même non typée GD) reçoit une cible stricte 63–140 dans les
+  agrégats de la fiche. Un PS peut donc **inférer l'état de grossesse** (donnée
+  Art. 9) depuis la cible affichée. **Risque résiduel accepté** : diffusion
+  limitée aux soignants **déjà autorisés** (RBAC + `requireGdprConsent` +
+  `patientShareConsent` + opt-out sujet), la cible est nécessaire au rendu
+  clinique (base légale = prise en charge, Art. 9.2.h), et l'inférence n'entre
+  **dans aucun log d'audit** (`pregnancyMode` lu uniquement en interne pour les
+  seuils, jamais restitué en metadata). Aucune minimisation supplémentaire
+  praticable sans dégrader la sécurité clinique (la cible EST une information de
+  soin).
 - Sur-déchiffrement `email` dans `getById` (minimisation Art. 5.1.c).
 
 ## 7. Validations à obtenir
@@ -166,5 +178,7 @@ secret → pas de fuite d'énumération nouvelle. Posture acceptée.
 
 ---
 
-*Dernière mise à jour : 2026-06-15 — suite à la livraison du câblage dossier
-patient (PR #543→#546) et de la convergence consentement (PR #547).*
+*Dernière mise à jour : 2026-07-01 — épopée fiche patient unifiée (US-2630,
+PR #608→#619) : ajout du risque résiduel « inférence du mode grossesse depuis la
+cible » (§6, US-2641). Précédemment : câblage dossier (PR #543→#546),
+convergence consentement (PR #547).*

--- a/src/components/diabeo/patient/PatientBgmCarnet.tsx
+++ b/src/components/diabeo/patient/PatientBgmCarnet.tsx
@@ -19,7 +19,8 @@ import { DAY_MOMENTS, type DayMoment } from "@/lib/day-moments"
 
 interface CarnetData {
   period: { days: number }
-  targetRangeMgdl: { low: number; high: number }
+  /** Seuils pathology-aware (mg/dL) — bande cible + zones sévères pour la couleur. */
+  targetRangeMgdl: { veryLow: number; low: number; high: number; veryHigh: number }
   moments: { moment: DayMoment; count: number; insufficient: boolean; avgMgdl: number | null }[]
 }
 
@@ -59,7 +60,8 @@ export function PatientBgmCarnet() {
   }
 
   const byMoment = new Map(data.moments.map((m) => [m.moment, m]))
-  const thresholds = { low: data.targetRangeMgdl.low, high: data.targetRangeMgdl.high }
+  // Coloration entièrement pathology-aware (zones sévères incluses, US-2641 B).
+  const thresholds = data.targetRangeMgdl
 
   return (
     <div className="space-y-4">

--- a/src/components/diabeo/patient/PatientMealTrendsTab.tsx
+++ b/src/components/diabeo/patient/PatientMealTrendsTab.tsx
@@ -14,16 +14,16 @@ import { bcp47 } from "@/i18n/config"
 import { usePeriodResource } from "./PatientRecordContext"
 import { PeriodSelector } from "./PeriodSelector"
 import { MealMomentCurve, type MomentCurveView } from "./MealMomentCurve"
+import { DAY_MOMENTS, type DayMoment } from "@/lib/day-moments"
 
-type Moment = "morning" | "noon" | "evening" | "night"
-const CURVE_ORDER: Moment[] = ["morning", "noon", "evening", "night"]
+const CURVE_ORDER = DAY_MOMENTS
 /** Colonnes du journal (les 3 repas principaux ; la nuit est rare au journal). */
-const JOURNAL_MOMENTS: Moment[] = ["morning", "noon", "evening"]
+const JOURNAL_MOMENTS: DayMoment[] = ["morning", "noon", "evening"]
 
 interface JournalMeal {
   mealId: string
   dayIso: string
-  moment: Moment
+  moment: DayMoment
   preMgdl: number | null
   postMgdl: number | null
   carbs: number | null
@@ -76,7 +76,7 @@ export function PatientMealTrendsTab({ dataSource = "cgm" }: { dataSource?: "cgm
   const curveByMoment = new Map(data.curve.moments.map((m) => [m.moment, m]))
   // Journal groupé par jour (desc) → { day → { moment → meal } }.
   const days: string[] = []
-  const grid = new Map<string, Partial<Record<Moment, JournalMeal>>>()
+  const grid = new Map<string, Partial<Record<DayMoment, JournalMeal>>>()
   for (const meal of data.journal) {
     if (!grid.has(meal.dayIso)) {
       grid.set(meal.dayIso, {})
@@ -160,7 +160,7 @@ export function PatientMealTrendsTab({ dataSource = "cgm" }: { dataSource?: "cgm
 
 const SUBCOLS = ["before", "after", "carbs", "bolus"] as const
 
-function SubHeaders({ t, moment }: { t: ReturnType<typeof useTranslations>; moment: Moment }) {
+function SubHeaders({ t, moment }: { t: ReturnType<typeof useTranslations>; moment: DayMoment }) {
   const keys = { before: "mealColBefore", after: "mealColAfter", carbs: "mealColCarbs", bolus: "mealColBolus" } as const
   return (
     <>
@@ -180,7 +180,7 @@ function SubHeaders({ t, moment }: { t: ReturnType<typeof useTranslations>; mome
 
 /** Cellules d'un moment ; chaque `td` associe le groupe (moment) ET la
  *  sous-colonne via `headers` (WCAG 1.3.1 — tables à en-têtes multi-niveaux). */
-function MomentCells({ moment, meal, cell }: { moment: Moment; meal: JournalMeal | null; cell: (v: number | null) => string }) {
+function MomentCells({ moment, meal, cell }: { moment: DayMoment; meal: JournalMeal | null; cell: (v: number | null) => string }) {
   const vals: Record<(typeof SUBCOLS)[number], number | null> = {
     before: meal?.preMgdl ?? null, after: meal?.postMgdl ?? null,
     carbs: meal?.carbs ?? null, bolus: meal?.bolus ?? null,

--- a/src/components/diabeo/patient/PatientRecord.tsx
+++ b/src/components/diabeo/patient/PatientRecord.tsx
@@ -99,7 +99,7 @@ export type PatientRecordData = {
     avgMgdl: number | null
     inRangePercent: number | null
     readingsPerDay: number
-    targetRangeMgdl: { low: number; high: number }
+    targetRangeMgdl: { veryLow: number; low: number; high: number; veryHigh: number }
     hba1c: { value: number; date: string; ageDays: number; stale: boolean } | null
     /** Nuage modal-day : heure du jour (min) × mg/dL. */
     points: { timeMinutes: number; mgdl: number }[]

--- a/src/lib/services/analytics.service.ts
+++ b/src/lib/services/analytics.service.ts
@@ -100,14 +100,18 @@ async function getPatientThresholds(patientId: number): Promise<CgmThresholds> {
   const cgm = await prisma.cgmObjective.findUnique({ where: { patientId } })
   if (!cgm) {
     // Pas d'objectif CGM configuré → défauts **pathology-aware** : la grossesse
-    // (GD) impose une cible plus stricte (63–140 mg/dL, Battelino 2019) que les
-    // 70–180 génériques. Sans ça, le TIR d'une patiente GD serait évalué sur une
-    // plage trop large (faux rassurement). Cf. `getCgmDefaults`.
+    // impose une cible plus stricte (63–140 mg/dL, ACOG/Battelino 2019) que les
+    // 70–180 génériques. Sans ça, le TIR/carnet serait évalué sur une plage trop
+    // large (faux rassurement). US-2641 : le durcissement grossesse s'applique
+    // aussi à une patiente `pregnancyMode` NON typée GD — cohérent avec
+    // `meal-trends` (#613 M-3), unifié ici pour tous les agrégats. Cf.
+    // `getCgmDefaults`.
     const patient = await prisma.patient.findFirst({
       where: { id: patientId, deletedAt: null },
-      select: { pathology: true },
+      select: { pathology: true, pregnancyMode: true },
     })
-    const d = getCgmDefaults(patient?.pathology ?? undefined)
+    const isPregnancy = patient?.pregnancyMode === true || patient?.pathology === "GD"
+    const d = getCgmDefaults(isPregnancy ? "GD" : (patient?.pathology ?? undefined))
     return { veryLow: d.veryLow, low: d.low, ok: d.ok, high: d.high }
   }
   return {
@@ -399,9 +403,14 @@ export const analyticsService = {
 
     return {
       period: { days },
+      // Bande cible {low, high} + zones sévères {veryLow, veryHigh} — toutes
+      // pathology-aware (US-2641 : coloration GD complète du carnet, `high` de
+      // CgmThresholds = seuil d'hyper, `ok` = plafond de cible).
       targetRangeMgdl: {
+        veryLow: Math.round(glToMgdl(thresholds.veryLow)),
         low: Math.round(glToMgdl(thresholds.low)),
         high: Math.round(glToMgdl(thresholds.ok)),
+        veryHigh: Math.round(glToMgdl(thresholds.high)),
       },
       moments,
     }

--- a/src/lib/services/analytics.service.ts
+++ b/src/lib/services/analytics.service.ts
@@ -315,9 +315,13 @@ export const analyticsService = {
       // % de relevés en cible (≠ TIR). `null` si aucun relevé exploitable.
       inRangePercent: total > 0 ? Math.round((inRange / total) * 1000) / 10 : null,
       readingsPerDay: Math.round((total / days) * 10) / 10,
+      // Bande cible + zones sévères, toutes pathology-aware — même forme que
+      // `bgmDailyPatternByMoment` (US-2641 L1 : contrat uniforme entre agrégats BGM).
       targetRangeMgdl: {
+        veryLow: Math.round(glToMgdl(thresholds.veryLow)),
         low: Math.round(glToMgdl(thresholds.low)),
         high: Math.round(glToMgdl(thresholds.ok)),
+        veryHigh: Math.round(glToMgdl(thresholds.high)),
       },
       points,
     }

--- a/tests/components/patient-bgm-overview.test.tsx
+++ b/tests/components/patient-bgm-overview.test.tsx
@@ -25,7 +25,7 @@ const BGM = {
   avgMgdl: 145,
   inRangePercent: 58,
   readingsPerDay: 3.2,
-  targetRangeMgdl: { low: 70, high: 180 },
+  targetRangeMgdl: { veryLow: 54, low: 70, high: 180, veryHigh: 250 },
   hba1c: { value: 7.4, date: "2026-05-01T00:00:00.000Z", ageDays: 60, stale: false },
   points: [{ timeMinutes: 480, mgdl: 120 }],
 }

--- a/tests/components/patient-record.test.tsx
+++ b/tests/components/patient-record.test.tsx
@@ -173,7 +173,7 @@ describe("PatientRecord — via adaptateur page PatientDetailClient (Phase 1)", 
         avgMgdl: 145,
         inRangePercent: 58,
         readingsPerDay: 3.2,
-        targetRangeMgdl: { low: 70, high: 180 },
+        targetRangeMgdl: { veryLow: 54, low: 70, high: 180, veryHigh: 250 },
         hba1c: { value: 7.4, date: "2026-05-01T00:00:00.000Z", ageDays: 60, stale: false },
         points: [
           { timeMinutes: 480, mgdl: 120 },

--- a/tests/unit/analytics.service.test.ts
+++ b/tests/unit/analytics.service.test.ts
@@ -318,7 +318,7 @@ describe("analyticsService", () => {
       expect(r.total).toBe(4)
       expect(r.inRangePercent).toBe(75) // 3/4
       expect(r.readingsPerDay).toBe(0.3) // 4/14 arrondi 0.1
-      expect(r.targetRangeMgdl).toEqual({ low: 70, high: 180 })
+      expect(r.targetRangeMgdl).toMatchObject({ low: 70, high: 180 }) // + veryLow/veryHigh (US-2641 L1)
       // audité READ GLYCEMIA_ENTRY kind=bgmStats
       const meta = prismaMock.auditLog.create.mock.calls.at(-1)![0].data as any
       expect(meta.resource).toBe("GLYCEMIA_ENTRY")

--- a/tests/unit/bgm-daily-pattern.service.test.ts
+++ b/tests/unit/bgm-daily-pattern.service.test.ts
@@ -47,10 +47,23 @@ describe("analyticsService.bgmDailyPatternByMoment (US-2639)", () => {
     expect(night.insufficient).toBe(true)
   })
 
-  it("exposes pathology-aware target range (GD 63–140)", async () => {
+  it("exposes pathology-aware thresholds incl. severe zones (GD 63–140)", async () => {
     setup([bgm(8, 1.0), bgm(8, 1.1), bgm(8, 1.2)], "GD")
     const res = await analyticsService.bgmDailyPatternByMoment(42, "14d", 1)
-    expect(res.targetRangeMgdl).toEqual({ low: 63, high: 140 })
+    expect(res.targetRangeMgdl).toMatchObject({ low: 63, high: 140 })
+    // Zones sévères pathology-aware pour la couleur (US-2641 B).
+    expect(res.targetRangeMgdl.veryLow).toBeLessThan(63)
+    expect(res.targetRangeMgdl.veryHigh).toBeGreaterThan(140)
+  })
+
+  it("applies GD-strict target for a pregnant patient NOT typed GD (US-2641 A)", async () => {
+    prismaMock.cgmObjective.findUnique.mockResolvedValue(null as any)
+    prismaMock.patient.findFirst.mockResolvedValue({ pathology: "DT1", pregnancyMode: true } as any)
+    prismaMock.userDayMoment.findMany.mockResolvedValue([] as any)
+    prismaMock.glycemiaEntry.findMany.mockResolvedValue([bgm(8, 1.0), bgm(8, 1.1), bgm(8, 1.2)] as any)
+    prismaMock.auditLog.create.mockResolvedValue({} as any)
+    const res = await analyticsService.bgmDailyPatternByMoment(42, "14d", 1)
+    expect(res.targetRangeMgdl).toMatchObject({ low: 63, high: 140 }) // cibles GD malgré DT1
   })
 
   it("audits READ GLYCEMIA_ENTRY without any clinical value in metadata (AC-5)", async () => {


### PR DESCRIPTION
## US-2641 — Durcissement transverse (gate finale de l'épopée)

Epic **US-2630**. Passe de consolidation + absorption des tickets de suivi accumulés au fil des 10 stories.

### Correctifs cliniques
- **A — `getPatientThresholds` `pregnancyMode`-aware** : une patiente `pregnancyMode` **NON typée GD** reçoit désormais les cibles **GD strictes (63–140)** dans **tous** les agrégats (carnet, `bgmStats`, TIR/AGP CGM), **unifié** sur la logique `meal-trends` (#613 M-3). N'affecte que le **fallback défaut** — un `CgmObjective` explicite reste prioritaire. Test.
- **B — carnet BGM coloration pathology-aware complète** : zones sévères `veryLow`/`veryHigh` incluses (plus seulement la bande cible). Test.
- **C — DRY** : `PatientMealTrendsTab` réutilise `DayMoment`/`DAY_MOMENTS` (`@/lib/day-moments`), fin du `type Moment` local dupliqué.

### Vérification des AC (gate)
- **AC-1** design system ✅ : ratchet à la baseline (268) ; viz via `tokens.ts` / classes sémantiques.
- **AC-2** i18n/glossaire ✅ : **BGM/AGP/GMI/ICR/HbA1c** (+ TIR/CGM/ISF/CV…) tous présents dans le namespace **`glossary`**, source unique via `<Acronym>`.
- **AC-3** a11y : validée par `accessibility-tester` à chaque PR (tablist/clavier, dialog drawer `aria-modal`+focus, cibles 44×44, contrastes) — gate finale ci-dessous.
- **AC-4** lazy-load ✅ : panels base-ui **démontés** si inactifs (aucun `display:none` React ; seuls des `aria-hidden` d'icônes).
- **AC-5** audit/perf ✅ : 1 READ par agrégat, `metadata` sans PHI (`patientId`/`period`/`surface`), action **`EXPORT`** disponible (aucun export dans la fiche à mal classer), refetch **debouncé 250 ms**.

### Tests
+2 (grossesse non-GD → cibles GD ; zones sévères pathology-aware). Suite **3544 ✓**, design-system ✓, build ✓, tsc ✓, lint ✓.

> Gate finale `accessibility-tester` + `healthcare-security-auditor` (+ `medical` pour le changement de seuils A) à lancer sur cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)