### PR TITLE
docs: clôture épopée fiche patient unifiée (US-2630) — archi, QA, roadmap, ADR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -614,6 +614,7 @@ au prochain `--update` tant que les fichiers source n'ont pas bougé.
 | 18 | `auditLog.resourceId` plat + `metadata.patientId` pivot (US-2268) | Forensics CNIL/ANS impossible avec composite. GIN index partiel garantit < 100ms à 10M logs. Helper `getByPatient` retrouve tous les events patient-scoped. |
 | 19 | Prisma 7 driver adapter `@prisma/adapter-pg` | Prisma 7 a supprimé l'engine "library" — `new PrismaClient()` exige désormais un driver adapter ou `accelerateUrl`. `node-postgres` (pg) élimine le binaire Rust, améliore cold-start serverless. Voir `src/lib/db/client.ts` et `prisma/seed.ts`. |
 | 20 | Early-fail env validation au boot (`src/lib/env.ts` + `instrumentation.ts`) | Sans ça, un secret manquant produit un 503 mystérieux au login. `assertRequiredEnv()` (serveur) + `assertSeedEnv()` (seed) crashent avec un message clair pointant vers `docs/local-development.md` §3. |
+| 21 | Fiche patient unifiée `<PatientRecord>` — 1 composant présentational, 2 transports (page `?patientId` / drawer `cTok`) (epic US-2630) | Supprime la divergence page bespoke ⇄ onglets drawer bespoke. Le composant ne construit jamais d'URL porteuse d'id (anti-énumération) : `fetchAnalytics` injecté par le contexte. Modes CGM/BGM **fail-closed** (gating sur `dataSource`, pas sur l'absence de données). Voir `docs/architecture/fiche-patient-unifiee.md`. |
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap Diabeo Backoffice — User Stories intégrées
 
-> **Mise à jour 2026-06-30 — EPIC US-2630 Fiche patient unifiée (cadrage design-stage)** : maquette `docs/mockups/fiche-patient-fusion-v1.html` (branche `design/fiche-patient-fusion`) fusionnant la page dossier `/patients/[id]` et le drawer de consultation (US-2018b) en un composant unique, + AGP percentiles, sélecteurs période/vue, **Tendances de repas** (mini-courbes alignées + journal repas avant/après/glucides/bolus), adaptation **CGM ⇄ BGM**. Cadrée par **4 revues expertes** (architecture/découpage, domaine médical, sécurité HDS, données/backend) → **epic + 11 US (US-2631→2641)** avec garde-fous cliniques (pathology-aware GD, suffisance AGP, mealtime, GMI≠HbA1c) et HDS (lazy-load, anti-énumération drawer, audit par agrégat, texte libre repas) en AC. **Aucune migration Prisma**. Voir section **« Série Fiche patient unifiée »**. *Non comptée dans les stats globales (design-stage).*
+> **Mise à jour 2026-07-01 — ✅ EPIC US-2630 Fiche patient unifiée LIVRÉE (11/11)** : composant unique `<PatientRecord variant="page"|"drawer">` fusionnant la page dossier `/patients/[id]` et le drawer de consultation (US-2018b), + AGP percentiles, sélecteurs période/vue, **Tendances de repas** (mini-courbes alignées + journal repas avant/après/glucides/bolus), adaptation **CGM ⇄ BGM** (carnet BGM par moment, carnet repas capillaire), toggle drawer⇄page. **11 US mergées (PR #608→#619)**, chacune passée par une revue multi-agents (code + medical + HDS + a11y) et une **gate finale PASS** (medical/HDS/a11y). Garde-fous cliniques (pathology-aware GD + grossesse, suffisance AGP, mealtime, GMI≠HbA1c) et HDS (lazy-load, anti-énumération drawer, audit par agrégat, texte libre repas jamais lu) tenus. **Aucune migration Prisma**. Voir `docs/architecture/fiche-patient-unifiee.md` + section **« Série Fiche patient unifiée »**.
 
 > **Mise à jour 2026-06-29 — US-2625 Home médecin (maquette Home v3 + TIR par patient)** : refonte triage-first de `/medecin` alignée sur `docs/mockups/home-roles-v3.html` (Alertes pleine largeur en tête → grille 2×2 → Patients à suivre + KPI conservés) ; 3 primitives partagées (DashboardCardHeader/Row/Pill) ; **TIR par patient** sur les alertes — pathology-aware (GD 0,63–1,40 vs adulte 0,70–1,80 via `getCgmDefaults`), plancher de suffisance (`cgmCaptureRate ≥ 30 %` → `null`), bi-palier <50 % « TIR bas » / 50–70 % « sous-cible » (paliers centralisés `clinical-bounds.DASHBOARD_TIR`) ; sous-titre triage (`triageSummaryQuery` count-only, 1 audit + contexte réseau) ; contraste WCAG AA (tokens `-fg`). Revue multi-agents (code-reviewer + healthcare-security-auditor + medical-domain-validator + accessibility-tester) = **GO**. tsc/eslint/build verts, suite unitaire verte. **Suivi** : US-2626 (BUG RDV `@db.Time`, V1), US-2627 + US-2628 (TECH-DEBT TIR, V2). Affine US-2602. *Non comptée dans les stats globales (série Navigation, design-stage).*
 
@@ -692,29 +692,31 @@ tous corrigés. Migration `20260513230000_groupe5_review_fixes` (FK + unique + p
 
 ---
 
-## Série Fiche patient unifiée (cadrage — design-stage)
+## Série Fiche patient unifiée (✅ LIVRÉE — 2026-07-01)
 
 > Source : branche `design/fiche-patient-fusion` · maquette `docs/mockups/fiche-patient-fusion-v1.html` · US dans `docs/UserStory/fiche-patient-fusion/`.
-> Cadrée par 4 revues expertes (architecture/découpage, domaine médical, sécurité HDS, données/backend). **Non comptée dans le tableau de stats global** (design-stage). Aucune migration Prisma requise (réutilise `analytics`/`food-monitoring`/`DiabetesEvent`).
+> Cadrée par 4 revues expertes (architecture/découpage, domaine médical, sécurité HDS, données/backend). **✅ Livrée 11/11 US** (PR #608→#619, 2026-07-01). Aucune migration Prisma (réutilise `analytics`/`food-monitoring`/`DiabetesEvent`). Doc : `docs/architecture/fiche-patient-unifiee.md` · QA : `docs/qa/13-fiche-patient.md`.
 > **Epic US-2630** — fusionner la page dossier `/patients/[id]` et le drawer de consultation (US-2018b) en un composant présentational unique (rendu page **ET** drawer, sans unifier le modèle d'accès), et enrichir : onglets unifiés, sélecteurs **période** (1s/2s/1m/3m) + **vue** (Moyenne/Tableau journalier), **AGP** percentiles, **Tendances de repas** (mini-courbes alignées + journal repas avant/après/glucides/bolus), adaptation **CGM ⇄ BGM**.
 > 🔴 Garde-fous bloquants intégrés en AC : **pathology-aware** (cible GD 63–140 sinon faux rassurement), **suffisance AGP** (≥14j/70 %, min relevés/slot), définition **mealtime** (borne au repas suivant), **GMI ≠ « HbA1c estimée »**, suggestions non prescriptives (`AdjustmentProposal`) ; HDS : **lazy-load par onglet**, drawer sans id en URL (`cTok`), audit par agrégat sans PHI, texte libre repas chiffré/masqué.
 
-| US | Titre | Type | Dépend de | Taille |
-|----|-------|------|-----------|--------|
-| US-2630 | **EPIC** — Fiche patient unifiée (page + drawer) + analytics enrichies | — | — | — |
-| US-2631 | Socle données : suffisance + cibles pathology-aware + helpers backend *(prérequis)* | back | — | M |
-| US-2632 | Composant présentational `<PatientRecord>` + contrat de données | front | — | M |
-| US-2633 | `PatientContextBar` page/drawer + adaptateur drawer | front/sécu | 2632 | L |
-| US-2634 | Sélecteur de période (1s/2s/1m/3m) synchronisé + `PatientRecordContext` | front/back | 2632 | M |
-| US-2635 | Onglet AGP (percentiles) + bandeau stats glucométriques | front/back | 2631, 2634 | M |
-| US-2636 | Vue Tableau journalier (1 ligne/jour) + service `dailyStats` | front/back | 2631, 2634 | M |
-| US-2637 | Onglet Tendances de repas (mini-courbes alignées + journal repas) | front/back | 2631, 2636 | L |
-| US-2638 | Détection CGM/BGM + adaptation Vue d'ensemble & Glycémie | front/back | 2631 | L |
-| US-2639 | BGM : AGP→Carnet + carnet repas + HbA1c labo | front/back | 2635, 2637, 2638 | M |
-| US-2640 | Toggle page ⇄ drawer + nav + décommission anciens onglets drawer | front | 2633, 2635, 2637, 2638 | M |
-| US-2641 | Durcissement transverse : tokens, i18n/glossaire, a11y, audit/perf, lazy-load | transverse | 2635→2639 | M |
+| US | Titre | Type | Dépend de | Taille | Statut |
+|----|-------|------|-----------|--------|--------|
+| US-2630 | **EPIC** — Fiche patient unifiée (page + drawer) + analytics enrichies | — | — | — | ✅ **DONE** (#608→#619) |
+| US-2631 | Socle données : suffisance + cibles pathology-aware + helpers backend *(prérequis)* | back | — | M | ✅ DONE |
+| US-2632 | Composant présentational `<PatientRecord>` + contrat de données | front | — | M | ✅ DONE |
+| US-2633 | `PatientContextBar` page/drawer + adaptateur drawer | front/sécu | 2632 | L | ✅ DONE (#608, #609) |
+| US-2634 | Sélecteur de période (1s/2s/1m/3m) synchronisé + `PatientRecordContext` | front/back | 2632 | M | ✅ DONE (#610) |
+| US-2635 | Onglet AGP (percentiles) + bandeau stats glucométriques | front/back | 2631, 2634 | M | ✅ DONE (#611) |
+| US-2636 | Vue Tableau journalier (1 ligne/jour) + service `dailyStats` | front/back | 2631, 2634 | M | ✅ DONE (#612) |
+| US-2637 | Onglet Tendances de repas (mini-courbes alignées + journal repas) | front/back | 2631, 2636 | L | ✅ DONE (#613) |
+| US-2638 | Détection CGM/BGM + adaptation Vue d'ensemble & Glycémie | front/back | 2631 | L | ✅ DONE (#614, #615) |
+| US-2639 | BGM : AGP→Carnet + carnet repas + HbA1c labo | front/back | 2635, 2637, 2638 | M | ✅ DONE (#616, #617) |
+| US-2640 | Toggle page ⇄ drawer + nav + décommission anciens onglets drawer | front | 2633, 2635, 2637, 2638 | M | ✅ DONE (#618) |
+| US-2641 | Durcissement transverse : tokens, i18n/glossaire, a11y, audit/perf, lazy-load | transverse | 2635→2639 | M | ✅ DONE (#619) |
 
-> Chemin critique : `2631 → 2632 → 2633` (fin de la divergence) → `2634 → 2635 → 2636` → `2637` → `2638 → 2639` (BGM, le plus risqué) → `2640 → 2641`.
+> Chemin critique (respecté) : `2631 → 2632 → 2633` (fin de la divergence) → `2634 → 2635 → 2636` → `2637` → `2638 → 2639` (BGM, le plus risqué) → `2640 → 2641`.
+>
+> **Suivi (tickets différés, non bloquants)** : PPG 1 h grossesse · sur-fetch `/agp` en vue daily · granularité audit `GLYCEMIA_ENTRY`/`CGM_ENTRY` · `showZoneLabel` autres usages de `GlycemiaValue` · contrastes design-system (gate axe-core CI).
 
 ---
 

--- a/docs/architecture/fiche-patient-unifiee.md
+++ b/docs/architecture/fiche-patient-unifiee.md
@@ -1,0 +1,119 @@
+# Fiche patient unifiée (`<PatientRecord>`) — Architecture
+
+> Epic **US-2630** — livrée 2026-07-01 (US-2631→2641, PR #608→#619). Aucune
+> migration Prisma. Ce document décrit l'architecture **telle que livrée**.
+
+## 1. Objectif
+
+Un **composant présentational unique** `<PatientRecord>` rend le dossier patient
+à l'identique dans **deux points d'entrée** :
+
+- **Page** — route `/patients/[id]` (RSC gardé par `canAccessPatient`).
+- **Drawer de consultation** — workspace éphémère par-dessus la liste (US-2018b),
+  sans id patient en URL (jeton `cTok`).
+
+```
+<PatientRecord variant="page" | "drawer" data={PatientRecordData} />
+```
+
+Le composant ne connaît **pas** le modèle d'accès : les données lui arrivent déjà
+projetées et autorisées. La divergence historique (page bespoke vs onglets drawer
+bespoke) est supprimée.
+
+## 2. Double transport (injection)
+
+Le composant ne construit **jamais** d'URL porteuse d'id (anti-énumération
+US-2265). Le contexte `PatientRecordProvider` reçoit un `fetchAnalytics` injecté :
+
+| Mode | Assemblage DTO | Transport analytics (re-fetch période) |
+|------|----------------|----------------------------------------|
+| Page | RSC `buildPatientRecordData` (via `?patientId=`, `canAccessPatient`) | `usePagePatientFetcher` → `?patientId=` en query |
+| Drawer | `GET /api/patients/record` (en-tête `x-consultation-token`) | en-tête `cTok`, **aucun id en URL** |
+
+- `build-patient-record.ts` = **source unique** du DTO (`PatientRecordData`),
+  réutilisée par la page RSC ET la route `cTok`. Chaque agrégat est audité par son
+  service (READ PATIENT / ANALYTICS / GLYCEMIA_ENTRY / INSULIN_THERAPY /
+  MEDICAL_DOCUMENT).
+- **Toggle drawer → page** (US-2640) : bouton « ouvrir en page » →
+  `router.push('/patients/${data.id}')` + fermeture drawer. L'`id` vient du DTO
+  résolu serveur (pas d'énumération) ; il n'apparaît en URL qu'en mode page.
+
+## 3. Onglets & sélecteurs
+
+Onglets (base-ui `Tabs`, panels **démontés si inactifs** → lazy-load, AC HDS) :
+Vue d'ensemble · Profil glycémique (AGP / Carnet BGM) · Tendances de repas ·
+Glycémie · Traitements · Documents.
+
+- **Sélecteur de période** (7j/14j/30j/90j) + **vue** (Moyenne/Journalier),
+  synchronisés via `PatientRecordContext`. Hooks : `usePeriodAnalytics`
+  (seed serveur + re-fetch) et `usePeriodResource` (lazy, seedless). Debounce
+  250 ms, `AbortController`.
+- **« Label follows data »** (`valuePeriod`) : la donnée porte TOUJOURS le libellé
+  de la période réellement affichée, jamais la période demandée pendant un
+  chargement/erreur (sécurité clinique — pas de faux rassurement, revue #610).
+
+## 4. CGM vs BGM (fail-closed)
+
+`dataSource = patientHasCgm(patientId) ? "cgm" : "bgm"` (détection : capteur actif
+OU relevés CGM < 14 j). **Fail-closed** : un patient BGM ne voit **jamais**
+d'indicateur CGM-only (TIR-temps, GMI, AGP) — le gating est sur `dataSource`, pas
+sur l'absence de données.
+
+| Indicateur | CGM | BGM (glycémie capillaire) |
+|-----------|-----|---------------------------|
+| Temps dans la cible | TIR (temps) | **% de relevés en cible** (≠ TIR, + caveat biais d'échantillonnage) |
+| Contrôle long terme | GMI (jamais « HbA1c estimée ») | **HbA1c laboratoire** datée (jamais un eA1c dérivé) |
+| Profil | **AGP** (percentiles) | **Carnet par moment** (moyenne Nuit/Matin/Midi/Soir) |
+| Série glycémie | courbe 24 h continue | **nuage de points** modal-day (pas d'interpolation) |
+| Tendances de repas | mini-courbes alignées + journal | **carnet avant/après** (journal seul) |
+| Fréquence | taux de capture | relevés/jour |
+
+## 5. Invariants cliniques (AC bloquants)
+
+- **Pathology-aware** : cibles via `getPatientThresholds` → `getCgmDefaults` — GD
+  63–140 vs 70–180. **Grossesse** (`pregnancyMode`, même non typée GD) → cibles GD
+  strictes, unifié sur tous les agrégats (US-2641). Un `CgmObjective` explicite du
+  clinicien reste prioritaire.
+- **Suffisance AGP** : ≥ 14 j / 70 % capture ; sous `MIN_SLOT_READINGS` relevés
+  par slot 15 min, pas de bande P10–P90 (bruit). Slot vide → `null`, jamais un
+  faux 0 (hypo trompeuse).
+- **Mealtime** (`mealtimePattern`) : pré = dernier relevé `[t0−30, t0]` ; excursion
+  bornée au **prochain apport glucidique** ; pic « non évaluable » si fenêtre
+  < 90 min ; post PPG 2 h ; delta **signé** ; plancher ≥ 3 repas appariés ;
+  **zéro interpolation** ; libellés **non prescriptifs** (aucun `AdjustmentProposal`).
+- **Carnet BGM** : plancher `MIN_READINGS_PER_MOMENT = 3` ; coloration
+  pathology-aware complète (zones sévères incluses).
+- **Fuseau** : moment/jour dérivés de l'heure **Europe/Paris** ; appariement
+  repas↔relevé BGM en **espace heure-murale locale** (`localWallMs`/`matchMs`,
+  DST-safe — US-2639).
+
+## 6. Invariants HDS (AC bloquants)
+
+- **Lazy-load** : aucune donnée d'onglet inactif dans le payload/DOM (panels
+  base-ui démontés ; jamais de `display:none` React).
+- **Anti-énumération** : transport injecté (cTok drawer / `?patientId` page,
+  gardé `canAccessPatient`) ; aucun id en URL en drawer.
+- **Audit** : 1 `READ` par agrégat, `resourceId=patientId` + pivot
+  `metadata.patientId`, metadata **sans valeur clinique** (`period`/`kind`/`source`
+  seulement). Action `EXPORT` réservée à l'export RGPD.
+- **Texte libre repas** (`DiabetesEvent.comment`, `GlycemiaEntry.mealDescription`)
+  **jamais lu ni sélectionné** par les projections de la fiche (AC-6). Le journal
+  est **numérique uniquement**.
+
+## 7. Carte des fichiers
+
+| Couche | Fichiers |
+|--------|----------|
+| Composant | `src/components/diabeo/patient/PatientRecord.tsx` (+ `PatientRecordContext`, `PatientAgpTab`, `PatientDailyTable`, `PatientMealTrendsTab`, `MealMomentCurve`, `PatientBgmOverview`, `PatientBgmScatter`, `PatientBgmCarnet`, `PeriodSelector`, `ViewSelector`) |
+| DTO | `src/app/(dashboard)/patients/[id]/build-patient-record.ts` |
+| Drawer | `src/components/diabeo/consultation/PatientConsultationDrawer.tsx` |
+| Services | `analytics.service.ts` (`glycemicProfile`, `agp`, `dailyStats`, `bgmStats`, `bgmDailyPatternByMoment`, `getPatientThresholds`), `meal-trends.service.ts` (`mealtimePattern`), `cgm-status.service.ts` (`patientHasCgm`), `glycemia.service.ts` (`getLastHba1c`) |
+| Routes | `src/app/api/analytics/{glycemic-profile,agp,daily-stats,meal-trends,bgm-stats,bgm-daily-pattern}/route.ts`, `src/app/api/patients/record/route.ts` |
+| Modules purs (client-safe) | `src/lib/clinical-bounds.ts`, `src/lib/insulin-slots.ts`, `src/lib/day-moments.ts` |
+| DPIA | `docs/compliance/dpia-patient-detail-dossier.md` |
+
+## 8. Suivi (tickets différés, non bloquants)
+
+PPG 1 h grossesse · sur-fetch `/agp` en vue daily · granularité audit
+`GLYCEMIA_ENTRY`/`CGM_ENTRY` (vs ancre `DIABETES_EVENT`) · `showZoneLabel` sur les
+autres usages de `GlycemiaValue` · contrastes design-system (gate axe-core CI).

--- a/docs/qa/03-patients.md
+++ b/docs/qa/03-patients.md
@@ -3,12 +3,14 @@
 Écrans : `/patients`, `/patients/[id]`, `/patients/new`.
 Voir [conventions](README.md#3-conventions--légende).
 
-> ⚠️ **Important QA** : les écrans **liste** et **détail** affichent actuellement
-> des **DEMO_DATA** synthétiques (`src/app/(dashboard)/patients/page.tsx`,
-> `.../[id]/page.tsx`). Les routes API réelles existent et sont testables au
-> niveau **contrat** (auth, RBAC, chiffrement, audit), mais l'UI ne les consomme
-> pas encore. → Tester en 2 volets : *affichage (demo)* et *contrat API (réel)*.
-> Le **wizard de création** (`/patients/new`), lui, appelle la **vraie** API.
+> ⚠️ **Important QA** : l'écran **liste** (`/patients`) affiche encore des
+> **DEMO_DATA** synthétiques pour l'affichage (route `GET /api/patients/search`
+> réelle au niveau contrat). Le **wizard de création** (`/patients/new`) appelle
+> la **vraie** API.
+> ✅ **Le détail `/patients/[id]` est désormais RÉEL** : c'est la **fiche patient
+> unifiée** `<PatientRecord>` (epic US-2630, livrée), qui consomme les vraies
+> routes analytics + le DTO serveur. Sa QA détaillée (CGM/BGM, AGP/carnet,
+> tendances de repas, drawer) est dans [`13-fiche-patient.md`](13-fiche-patient.md).
 
 ---
 

--- a/docs/qa/13-fiche-patient.md
+++ b/docs/qa/13-fiche-patient.md
@@ -1,0 +1,194 @@
+# QA — Fiche patient unifiée (`<PatientRecord>`)
+
+Écrans : `/patients/[id]` (mode **page**) et **drawer de consultation** (ouvert
+depuis `/patients`). Même composant `<PatientRecord>`, mêmes onglets.
+Voir [conventions](README.md#3-conventions--légende).
+
+> Epic **US-2630** (livrée, PR #608→#619). Architecture :
+> `docs/architecture/fiche-patient-unifiee.md`.
+> **Réel** 🟢 : la fiche consomme les vraies routes analytics (`/api/analytics/*`)
+> et le DTO serveur (`build-patient-record`). Tester en 2 contextes : **page**
+> (`?patientId`) et **drawer** (`cTok`, aucun id en URL) — rendu identique.
+
+---
+
+## 0. Prérequis jeux de données
+
+Prévoir **3 patients** pour couvrir les branches :
+
+| Patient | Profil | Attendu |
+|---|---|---|
+| P-CGM | capteur actif OU relevés CGM < 14 j | mode **CGM** (AGP, TIR, GMI, courbe continue) |
+| P-BGM | pas de capteur, relevés capillaires (`GlycemiaEntry`) + repas | mode **BGM** (carnet, % en cible, HbA1c labo, nuage) |
+| P-GD / grossesse | `pathology=GD` **ou** `pregnancyMode=true` (DT1/DT2) sans `CgmObjective` | cibles **63–140** partout (pas 70–180) |
+
+---
+
+## Écran : Vue d'ensemble 🟢
+
+**Rôle / RBAC** : NURSE+ ; accès via `canAccessPatient` (page) ou `cTok` résolu
+serveur (drawer). Consentement de partage **fail-closed** (retiré → « partage
+désactivé »).
+
+### Affichage attendu — CGM
+
+| Élément | État attendu |
+|---|---|
+| Sélecteur période | segments **7j / 14j / 30j / 90j** (`role=radiogroup`), 14j par défaut |
+| KPI (grille) | Moyenne (mg/dL) · **TIR** (% en cible) · **GMI** (%) · CV (%) |
+| Caveat < 14 j | bandeau « fenêtre courte → indicatif » si période = 7j |
+| Caveat capture | bandeau si capture CGM < 70 % |
+| Donut TIR | anneau des zones (veryLow→veryHigh) |
+| Carte profil | pathologie (badge), diagnostic, sexe, âge, référent, moyenne, objectifs |
+
+### Affichage attendu — BGM (fail-closed)
+
+| Élément | État attendu |
+|---|---|
+| Bandeau | « Mode glycémie capillaire (BGM)… » (pas de TIR-temps/GMI/AGP) |
+| KPI | **Moyenne des relevés** · **% de relevés en cible** · **Fréquence** (/jour) · **HbA1c (laboratoire)** datée |
+| Caveat % cible | « ≠ temps dans la cible… biais d'échantillonnage » |
+| HbA1c ancienne | badge « valeur ancienne (> 180 j) » si stale |
+| Donut TIR | **absent** ; carte profil pleine largeur ; **aucun GMI** nulle part |
+
+### Actions & effets
+
+| Action | Endpoint | Effet visuel | Effet base |
+|---|---|---|---|
+| Changer la période | CGM `GET /api/analytics/glycemic-profile` · BGM `GET /api/analytics/bgm-stats` | KPI re-fetchés (debounce 250 ms), libellé = période **réellement affichée** | 1 audit READ par requête, metadata `{patientId, period}` **sans valeur clinique** |
+| Retirer le consentement patient | (garde route) | « partage désactivé », aucune donnée rendue | 403 fail-closed |
+
+**🔴 À vérifier** : un patient **BGM** n'expose JAMAIS TIR-temps / GMI / donut /
+AGP, même si d'anciens relevés CGM existent (gating sur `dataSource`).
+
+---
+
+## Écran : Profil glycémique — AGP (CGM) 🟢
+
+| Élément | État attendu |
+|---|---|
+| Onglet | libellé **« Profil glycémique (AGP) »** en CGM |
+| Graphe | bandes percentiles **P10/P25/P50/P75/P90** + bande cible pathology-aware |
+| Suffisance | slot < seuil relevés → **pas de bande** (médiane seule / trou), jamais un faux 0 |
+| Empty-state | < 14 j / capture faible → mention « indicatif » |
+| Vue Journalier | bascule Moyenne ⇄ **Tableau journalier** (1 ligne/jour) |
+| Lazy-load | **aucun** appel `/agp` tant que l'onglet n'est pas ouvert |
+
+## Écran : Profil glycémique — Carnet (BGM) 🟢
+
+| Élément | État attendu |
+|---|---|
+| Onglet | libellé **« Carnet glycémique »** (jamais « AGP ») |
+| Grille | 4 moments **Nuit / Matin / Midi / Soir** — moyenne colorée pathology-aware + nb relevés |
+| Plancher | < 3 relevés/moment → **« Données insuffisantes »** (pas de moyenne) |
+| Caveat | « moyenne de relevés… non comparable à un temps dans la cible » |
+| Endpoint | `GET /api/analytics/bgm-daily-pattern` (audit READ GLYCEMIA_ENTRY) |
+
+---
+
+## Écran : Tendances de repas 🟢
+
+### CGM
+
+| Élément | État attendu |
+|---|---|
+| Mini-courbes | 4 courbes alignées sur l'heure du repas (Nuit/Matin/Midi/Soir), bande cible |
+| Insuffisant | < 3 repas appariés → « données insuffisantes » (pas de courbe) |
+| Journal | table jour × Matin/Midi/Soir × **Avant / Après / Glucides / Bolus** (numérique) |
+| Non prescriptif | flag excursion « à corréler à l'ICR/timing/repas » (jamais « augmenter X ») |
+
+### BGM
+
+| Élément | État attendu |
+|---|---|
+| Bandeau | « Carnet capillaire… pas de courbe continue » |
+| Courbes | **absentes** (journal seul) |
+| Journal | avant/après capillaires réels ou « — » (**zéro interpolation**) |
+
+**🔴 À vérifier** : le **texte libre repas** n'apparaît nulle part (journal =
+numérique). Appariement BGM correct **été ET hiver** (pas de décalage 1–2 h).
+
+---
+
+## Écran : Glycémie 🟢
+
+| Contexte | Attendu |
+|---|---|
+| CGM | courbe 24 h + dernière glycémie + note relevés hors plage d'affichage |
+| BGM | **nuage de points** modal-day (heure du jour × mg/dL), bande cible, résumé sr-only |
+
+---
+
+## Drawer ⇄ Page (US-2640)
+
+| Action | Effet |
+|---|---|
+| Clic ligne patient (liste) | ouvre le **drawer** (overlay), URL reste `/patients` (aucun id) |
+| Bouton **« ouvrir en page »** (en-tête drawer) | ferme le drawer + navigue `/patients/[id]` (route gardée `canAccessPatient`) |
+| Bouton agrandir | drawer plein écran (in-place) |
+| Boutons d'en-tête | cibles tactiles **44×44** ; `role=dialog` + `aria-modal` ; focus au titre à l'ouverture |
+
+---
+
+## Accessibilité (gate AC-3) ✅
+
+- Segments période/vue : `role=radiogroup`/`radio`, clavier ←/→/Home/End.
+- Onglets : `tablist` + `aria-label`, navigation clavier.
+- Viz (AGP, mini-courbes, nuage BGM) : `role=figure` + **alternative sr-only**.
+- `GlycemiaValue` : `showZoneLabel` (info pas seulement couleur) dans le carnet.
+- Tables (journal repas, journalier) : `caption` sr-only + en-têtes multi-niveaux
+  (`scope`/`headers`/`id`).
+- `prefers-reduced-motion` respecté (AGP).
+
+---
+
+## Scénarios (Gherkin)
+
+```gherkin
+Feature: Fiche patient unifiée — CGM vs BGM
+
+  Scenario: Patient CGM — vue d'ensemble
+    Given un patient avec capteur actif
+    When j'ouvre sa fiche (page ou drawer)
+    Then je vois Moyenne, TIR, GMI, CV et le donut TIR
+    And l'onglet Profil s'intitule "Profil glycémique (AGP)"
+
+  Scenario: Patient BGM — fail-closed
+    Given un patient sans capteur, avec relevés capillaires
+    When j'ouvre sa fiche
+    Then je ne vois NI TIR-temps NI GMI NI donut NI AGP
+    And je vois "% de relevés en cible", HbA1c laboratoire, fréquence, carnet par moment
+    And l'onglet Profil s'intitule "Carnet glycémique"
+
+  Scenario: Grossesse — cibles strictes
+    Given une patiente pregnancyMode=true typée DT1 sans CgmObjective
+    When j'ouvre sa fiche
+    Then la cible affichée est 63–140 mg/dL (et non 70–180)
+
+  Scenario: Lazy-load d'un onglet
+    Given une fiche patient ouverte sur "Vue d'ensemble"
+    When je n'ai pas encore cliqué l'onglet "Tendances de repas"
+    Then aucun appel à /api/analytics/meal-trends n'a été émis
+
+  Scenario: Drawer sans id en URL
+    Given la liste des patients
+    When j'ouvre un patient en drawer
+    Then l'URL reste /patients et aucune requête analytics ne porte l'id en URL
+
+  Scenario: Toggle drawer vers page
+    Given un patient ouvert en drawer (dossier chargé)
+    When je clique "ouvrir en page plein écran"
+    Then le drawer se ferme et je navigue vers /patients/[id]
+```
+
+---
+
+## Points de non-régression (checklist rapide)
+
+- [ ] BGM : aucun indicateur CGM-only visible (gating `dataSource`).
+- [ ] Libellé de période = donnée réellement affichée (pas de faux libellé).
+- [ ] Onglet inactif = aucun fetch (lazy-load).
+- [ ] Drawer = aucun id patient en URL.
+- [ ] Journal repas = numérique (pas de texte libre).
+- [ ] Cibles GD/grossesse = 63–140 partout.
+- [ ] Audit : 1 READ/agrégat, metadata sans valeur clinique.

--- a/docs/qa/README.md
+++ b/docs/qa/README.md
@@ -46,6 +46,7 @@ Les tests sont joués **soit par un humain** (le tableau + les `Then` suffisent)
 | [`10-devices-documents-events.md`](10-devices-documents-events.md) | `/devices`, `/devices/pair`, `/documents`, `/events/new` |
 | [`11-clinical.md`](11-clinical.md) | `/insulin-therapy`, `/adjustment-proposals`, `/medications`, `/import` |
 | [`12-communication.md`](12-communication.md) | `/messages`, `/patient/appointments`, `/users` (legacy) |
+| [`13-fiche-patient.md`](13-fiche-patient.md) | Fiche patient unifiée `<PatientRecord>` (page `/patients/[id]` + drawer) — CGM/BGM, AGP/carnet, tendances de repas |
 
 ## 2bis. Anomalies relevées (à trier par l'équipe)
 

--- a/src/components/diabeo/patient/MealMomentCurve.tsx
+++ b/src/components/diabeo/patient/MealMomentCurve.tsx
@@ -16,18 +16,33 @@ import {
 } from "recharts"
 import { tokens } from "@/design-system/tokens"
 
+/** Projection serveur d'une courbe de moment (déjà agrégée, buckets ≥ 3 relevés). */
 export interface MomentCurveView {
   moment: "morning" | "noon" | "evening" | "night"
+  /** Nb de repas appariés contribuant à la courbe (< 3 → `insufficient`). */
   pairedMeals: number
   insufficient: boolean
+  /** Points alignés t−t0 (min) × moyenne (mg/dL) ; trous = pas d'interpolation. */
   buckets: { offsetMin: number; avgMgdl: number }[]
   avgPreMgdl: number | null
+  /** Moyenne PPG 2 h (« après »). */
   avgPostMgdl: number | null
   avgPeakMgdl: number | null
+  /** Plafond post-prandial pathology-aware (mg/dL). */
   targetHighMgdl: number
+  /** `avgPost` > plafond → flag descriptif (jamais prescriptif). */
   highExcursion: boolean
 }
 
+/**
+ * Mini-courbe glycémique moyenne d'un moment (repas aligné à t=0), read-only.
+ *
+ * @param props.curve - Projection serveur du moment ({@link MomentCurveView}) :
+ *   buckets moyennés, moyennes pré/après/pic, plafond pathology-aware, flag
+ *   d'excursion. `insufficient` → empty-state « données insuffisantes ».
+ * @returns Un `role="figure"` (courbe recharts + bande cible + repas à t=0) avec
+ *   alternative sr-only, ou l'empty-state sous 3 repas appariés.
+ */
 export function MealMomentCurve({ curve }: { curve: MomentCurveView }) {
   const t = useTranslations("patientDetail")
   const momentLabel = t(`meal_${curve.moment}`)

--- a/src/components/diabeo/patient/PatientAgpTab.tsx
+++ b/src/components/diabeo/patient/PatientAgpTab.tsx
@@ -89,6 +89,15 @@ export function maskSparseAgpSlots(slots: AgpSlot[], minReadings: number): AgpSl
   )
 }
 
+/**
+ * Onglet « Profil glycémique » (mode CGM) : sélecteurs période + vue, bandeau
+ * stats, et bascule AGP (percentiles) ⇄ Tableau journalier. Lazy, fetch via
+ * `usePeriodResource`. Empty-states de suffisance (< 14 j / capture faible).
+ *
+ * @param props.targetLowMgdl - Borne basse de la cible (pathology-aware) — bande AGP.
+ * @param props.targetHighMgdl - Borne haute de la cible (pathology-aware) — bande AGP.
+ * @returns L'onglet AGP (average) ou le tableau journalier selon la vue.
+ */
 export function PatientAgpTab({
   targetLowMgdl,
   targetHighMgdl,

--- a/src/components/diabeo/patient/PatientBgmCarnet.tsx
+++ b/src/components/diabeo/patient/PatientBgmCarnet.tsx
@@ -24,6 +24,16 @@ interface CarnetData {
   moments: { moment: DayMoment; count: number; insufficient: boolean; avgMgdl: number | null }[]
 }
 
+/**
+ * Carnet glycémique capillaire par moment de la journée (remplace l'AGP en BGM).
+ *
+ * Sans props : lazy, pilotée par la période via `usePeriodResource` sur
+ * `/api/analytics/bgm-daily-pattern` (l'onglet est démonté quand inactif). Rend
+ * une moyenne colorée pathology-aware par moment (Nuit/Matin/Midi/Soir), ou
+ * « données insuffisantes » sous le plancher de relevés.
+ *
+ * @returns L'onglet Carnet (sélecteur période + grille 4 moments + caveat).
+ */
 export function PatientBgmCarnet() {
   const t = useTranslations("patientDetail")
   const { data, loading, error } = usePeriodResource<CarnetData>({

--- a/src/components/diabeo/patient/PatientBgmOverview.tsx
+++ b/src/components/diabeo/patient/PatientBgmOverview.tsx
@@ -29,6 +29,15 @@ type Bgm = NonNullable<PatientRecordData["bgm"]>
 // Glycémie depuis l'amorce, pas ici — on ne le re-fetch donc pas).
 type BgmPeriodView = Pick<Bgm, "avgMgdl" | "inRangePercent" | "readingsPerDay" | "targetRangeMgdl">
 
+/**
+ * Vue d'ensemble d'un patient **BGM** (glycémie capillaire).
+ *
+ * @param props.bgm - Bloc BGM du DTO (`PatientRecordData["bgm"]`, non-null) :
+ *   moyenne, % en cible, fréquence, HbA1c labo, points modal-day. Les KPI sont
+ *   re-fetchés par période via `/api/analytics/bgm-stats` ; l'HbA1c (valeur
+ *   unique non fenêtrée) vient de l'amorce serveur.
+ * @returns Le bloc KPI capillaires + caveats de la vue d'ensemble en mode BGM.
+ */
 export function PatientBgmOverview({ bgm }: { bgm: Bgm }) {
   const t = useTranslations("patientDetail")
   const locale = useLocale()

--- a/src/components/diabeo/patient/PatientBgmScatter.tsx
+++ b/src/components/diabeo/patient/PatientBgmScatter.tsx
@@ -17,6 +17,7 @@ import {
 } from "recharts"
 import { tokens } from "@/design-system/tokens"
 
+/** Point du nuage capillaire : heure du jour (minutes locales) × glycémie (mg/dL). */
 export interface BgmScatterPoint {
   timeMinutes: number
   mgdl: number
@@ -24,6 +25,17 @@ export interface BgmScatterPoint {
 
 const fmtHour = (m: number) => `${Math.floor(m / 60)}h`
 
+/**
+ * Nuage de points capillaires (modal-day) — remplace la courbe continue CGM en
+ * mode BGM. Aucune interpolation (relevés discrets positionnés par heure locale).
+ *
+ * @param props.points - Relevés `{timeMinutes, mgdl}` sur la période. Vide →
+ *   empty-state « aucun relevé ».
+ * @param props.targetLowMgdl - Borne basse de la cible (pathology-aware) — bande cible.
+ * @param props.targetHighMgdl - Borne haute de la cible (pathology-aware) — bande cible
+ *   ET dénominateur du décompte « en cible » du résumé sr-only.
+ * @returns Un `role="figure"` (scatter recharts) + un résumé textuel sr-only.
+ */
 export function PatientBgmScatter({
   points,
   targetLowMgdl,

--- a/src/components/diabeo/patient/PatientDailyTable.tsx
+++ b/src/components/diabeo/patient/PatientDailyTable.tsx
@@ -24,6 +24,15 @@ interface DailyStat {
   inTargetPct: number
 }
 
+/**
+ * Vue « Tableau journalier » (1 ligne/jour) de l'onglet Profil glycémique.
+ *
+ * Sans props : lazy, pilotée par la période via `usePeriodResource` sur
+ * `/api/analytics/daily-stats`. Rend une table accessible (min/moy/max, TIR,
+ * relevés par jour), états loading/error/empty inclus.
+ *
+ * @returns Le tableau journalier.
+ */
 export function PatientDailyTable() {
   const t = useTranslations("patientDetail")
   const locale = useLocale()

--- a/src/components/diabeo/patient/PatientMealTrendsTab.tsx
+++ b/src/components/diabeo/patient/PatientMealTrendsTab.tsx
@@ -34,6 +34,14 @@ interface MealTrendsData {
   journal: JournalMeal[]
 }
 
+/**
+ * Onglet « Tendances de repas », lazy et piloté par la période.
+ *
+ * @param props.dataSource - `"cgm"` (défaut) : 4 mini-courbes alignées + journal.
+ *   `"bgm"` : fetch `source=bgm` + **carnet avant/après** (journal seul, pas de
+ *   courbe interpolée) + bannière capillaire.
+ * @returns L'onglet Tendances de repas (états loading/error/empty inclus).
+ */
 export function PatientMealTrendsTab({ dataSource = "cgm" }: { dataSource?: "cgm" | "bgm" }) {
   const t = useTranslations("patientDetail")
   const locale = useLocale()

--- a/src/components/diabeo/patient/PatientRecordContext.tsx
+++ b/src/components/diabeo/patient/PatientRecordContext.tsx
@@ -18,10 +18,12 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 
 /** Périodes supportées (cf. `analyticsService.parsePeriod` — 7/14/30/90 j). */
 export type RecordPeriod = "7d" | "14d" | "30d" | "90d"
+/** Périodes sélectionnables, dans l'ordre d'affichage du sélecteur. */
 export const RECORD_PERIODS: readonly RecordPeriod[] = ["7d", "14d", "30d", "90d"] as const
 
 /** Vue des onglets analytiques (US-2636) : agrégat (AGP) vs 1 ligne/jour. */
 export type RecordView = "average" | "daily"
+/** Vues sélectionnables, dans l'ordre d'affichage du sélecteur. */
 export const RECORD_VIEWS: readonly RecordView[] = ["average", "daily"] as const
 
 /** Clé i18n du libellé de chaque vue (namespace `patientDetail`). */
@@ -79,6 +81,17 @@ export function usePatientRecordContext(): PatientRecordContextValue | null {
   return useContext(Ctx)
 }
 
+/**
+ * Fournit l'état période/vue + le transport analytique **injecté** à tout le
+ * sous-arbre de la fiche (partagé entre page et drawer).
+ *
+ * @param props.fetchAnalytics - Adaptateur de transport ({@link AnalyticsFetcher})
+ *   fourni par l'appelant : `?patientId` en mode page, en-tête `cTok` en drawer.
+ *   Le composant ne construit ainsi jamais d'URL porteuse d'id (anti-énumération).
+ * @param props.seedPeriod - Période d'amorce (défaut `"14d"`) = celle de la
+ *   projection serveur initiale ; les hooks re-fetchent au-delà.
+ * @param props.children - Sous-arbre de la fiche.
+ */
 export function PatientRecordProvider({
   fetchAnalytics,
   seedPeriod = SEED_PERIOD,
@@ -97,6 +110,7 @@ export function PatientRecordProvider({
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>
 }
 
+/** État renvoyé par {@link usePeriodAnalytics} (donnée amorcée + fenêtrée). */
 export interface PeriodAnalyticsState<T> {
   value: T
   loading: boolean
@@ -185,6 +199,7 @@ export function usePeriodAnalytics<T>(args: {
   return state
 }
 
+/** État renvoyé par {@link usePeriodResource} (donnée lazy, sans amorce). */
 export interface PeriodResourceState<T> {
   data: T | null
   loading: boolean

--- a/src/components/diabeo/patient/PeriodSelector.tsx
+++ b/src/components/diabeo/patient/PeriodSelector.tsx
@@ -19,6 +19,13 @@ import {
   usePatientRecordContext,
 } from "./PatientRecordContext"
 
+/**
+ * Sélecteur de période (7j/14j/30j/90j) — `radiogroup` accessible au clavier,
+ * synchronisé via `PatientRecordContext`. `null` hors provider.
+ *
+ * @param props.labelledBy - `id` de l'étiquette visible associée (`aria-labelledby`).
+ * @returns Le groupe de segments de période, ou `null` hors contexte.
+ */
 export function PeriodSelector({ labelledBy }: { labelledBy?: string } = {}) {
   const t = useTranslations("patientDetail")
   const ctx = usePatientRecordContext()

--- a/src/components/diabeo/patient/ViewSelector.tsx
+++ b/src/components/diabeo/patient/ViewSelector.tsx
@@ -17,6 +17,13 @@ import {
   usePatientRecordContext,
 } from "./PatientRecordContext"
 
+/**
+ * Sélecteur de vue (Moyenne/AGP ⇄ Tableau journalier) — `radiogroup` accessible
+ * au clavier, synchronisé via `PatientRecordContext`. `null` hors provider.
+ *
+ * @param props.labelledBy - `id` de l'étiquette visible associée (`aria-labelledby`).
+ * @returns Le groupe de segments de vue, ou `null` hors contexte.
+ */
 export function ViewSelector({ labelledBy }: { labelledBy?: string } = {}) {
   const t = useTranslations("patientDetail")
   const ctx = usePatientRecordContext()

--- a/src/lib/day-moments.ts
+++ b/src/lib/day-moments.ts
@@ -8,7 +8,9 @@
  * (heures MURALES locales, colonne `Time` sans fuseau).
  */
 
+/** Un des quatre moments de la journée. */
 export type DayMoment = "morning" | "noon" | "evening" | "night"
+/** Les quatre moments, dans l'ordre d'affichage (Matin → Nuit). */
 export const DAY_MOMENTS: readonly DayMoment[] = ["morning", "noon", "evening", "night"] as const
 
 /** Défauts si le patient n'a pas de `UserDayMoment` : Nuit 22–04 / Matin 04–10 /


### PR DESCRIPTION
## Clôture documentaire — épopée « Fiche patient unifiée » (US-2630)

Épopée livrée (11/11 US, PR #608→#619). Consolidation de la documentation, de la QA, de la roadmap et du board.

### Documentation
- **`docs/architecture/fiche-patient-unifiee.md`** (NOUVEAU) : architecture telle que livrée — double transport page (`?patientId`) / drawer (`cTok`), onglets lazy, modes **CGM/BGM fail-closed**, invariants cliniques (pathology-aware + grossesse, suffisance AGP, mealtime, GMI≠HbA1c) et HDS (lazy-load, anti-énumération, audit par agrégat, texte libre jamais lu), carte des fichiers, tickets de suivi.
- **`CLAUDE.md`** : **ADR #21** (composant unifié, 2 transports, fail-closed CGM/BGM).

### QA
- **`docs/qa/13-fiche-patient.md`** (NOUVEAU) : spec QA complète (affichage CGM/BGM, AGP/carnet, tendances de repas, drawer⇄page, a11y, **scénarios Gherkin**, checklist de non-régression) + entrée d'index `qa/README`.
- **`docs/qa/03-patients.md`** : correction de la note obsolète — le détail `/patients/[id]` **n'est plus DEMO_DATA** (fiche réelle) → pointe vers `13`.

### Roadmap & board
- **`docs/ROADMAP.md`** : épopée marquée **✅ LIVRÉE**, colonne **Statut** avec PR par US, note « suivi » (tickets différés).
- **Board projet** : EPIC US-2630 + les 11 US → **Done** (via API projet, hors git).

### Portée
Docs uniquement — **aucun code touché** (tsc/tests inchangés). Pas de markdown-lint dans la CI actuelle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)