### PR TITLE
docs(US): épic US-2645 — édition insulinothérapie multi-mode (propose→valide)

### DIFF
--- a/docs/UserStory/insulinotherapie-edition/US-2645-EPIC-insulinotherapie-edition-multimode.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2645-EPIC-insulinotherapie-edition-multimode.md
@@ -1,0 +1,156 @@
+# US-2645 — EPIC : Édition de l'insulinothérapie (fiche + self-service patient) & ajustement multi-mode « propose → valide »
+
+> 📌 Épic · fiche patient + espace patient · front + back + **migration Prisma** · Taille **XL**
+> · fait suite à US-2630 (fiche patient unifiée) & US-2642 (unification ouverture) · concerne l'ADR #13
+>
+> **Statut** : 🟡 spécification (à valider) — **aucun code avant validation de l'US.**
+
+## 1. Intention (voix produit)
+
+> En tant que **médecin/infirmier**, je veux **consulter et modifier** l'insulinothérapie
+> d'un patient **directement dans sa fiche** (`/patients/[id]`), pour éviter un écran
+> séparé et garder une seule vérité.
+>
+> En tant que **patient**, je veux **voir ma thérapie** et **proposer un ajustement**
+> depuis mon espace, **notifié à mon médecin pour validation** — sans jamais que ma
+> demande ne s'applique seule.
+>
+> Le tout doit fonctionner que le patient soit sous **insulinothérapie complète**, sous
+> **doses d'insuline simples**, ou **non insuliné** — et l'algorithme d'ajustement doit
+> couvrir ces trois cas **sans jamais franchir la ligne du dosage médicamenteux**.
+
+## 2. Décisions actées (avec l'utilisateur)
+
+| # | Décision |
+|---|---|
+| D1 | **Médecin (DOCTOR)** édite en **direct** (effet immédiat). |
+| D2 | **Infirmier (NURSE)** édite via **proposition** (`pending`) → **validée par un DOCTOR**. |
+| D3 | **Patient** édite via **proposition** (`pending`) → **notifiée + validée par un DOCTOR**. Jamais d'auto-application. |
+| D4 | L'éditeur vit dans l'**onglet « Traitements »** de la fiche patient (qui passe de lecture seule à éditable) — pas d'écran séparé. La page autonome `/insulin-therapy` devient une redirection vers la fiche. |
+| D5 | Accès **patient** aussi via un **item de navigation** de l'espace patient. |
+| D6 | Feature **treatment-mode-aware** : 3 modes (voir §4). L'algorithme d'ajustement couvre les 3. |
+| D7 | **Interdiction absolue** : proposer/ajuster automatiquement une **posologie orale ou GLP-1** (frontière dispositif médical MDR/IEC 62304). Mode non-insuliné = orientation, pas dosage. |
+
+> ⚠️ **Point à reconfirmer** : lors de la décision D2/D3, l'option retenue indique
+> « validé par un **DOCTOR** », alors qu'un échange précédent évoquait « médecin **ou**
+> infirmier ». **Le validateur (accept/reject) est-il DOCTOR only, ou NURSE+DOCTOR ?**
+> Défaut retenu dans cette US : **DOCTOR only valide** (autorité clinique), NURSE peut
+> proposer. À trancher avant US-2649.
+
+## 3. Constat technique (ce qui bloque aujourd'hui)
+
+Ancré dans le code (cf. synthèse `medical-domain-validator`) :
+
+- **`AdjustmentProposal` n'a pas de provenance** — `reviewedBy` existe, mais **pas** de
+  `proposedByRole` / `proposedByUserId` (`prisma/schema.prisma`). Le flux « patient/infirmier
+  propose » **n'est pas modélisable** en l'état. `adjustmentService.createManual` est « DOCTOR only ».
+- **`enum AdjustableParameter` = 3 valeurs** seulement : `basalRate`, `insulinSensitivityFactor`,
+  `insulinToCarbRatio`. Pas de **dose fixe**, pas de cible. `validateProposedValue` / `accept()`
+  ne savent appliquer que ces 3 types.
+- **`src/lib/proposal-algorithm.ts` est mono-mode basal-bolus** (`analyzeIsfSlot`/`analyzeIcrSlot`/
+  `analyzeBasalTrend`, cap `MAX_CHANGE_PERCENT = 20`, seuil 3 événements + 2 %). Rien pour dose
+  fixe ni non-insuliné.
+- **`PatientInsulin.dosage` est du texte libre** (« 18U le soir ») → **non calculable** : une
+  proposition « +2 U » n'a pas de valeur numérique de départ fiable. Il faut une dose fixe **structurée**.
+- L'onglet **Traitements** (`treatment-view.ts`) est une **projection lecture seule** ; l'édition
+  vit sur `/insulin-therapy` (page **orpheline de nav**, cf. `docs/inventory/composants-orphelins.md`).
+- La page de **validation** `/adjustment-proposals` (accept/reject `pending`) **existe déjà** mais
+  est **orpheline** (aucun lien de nav) → à surfacer. `push.service.ts` existe pour la notification.
+
+## 4. Modes de traitement (taxonomie)
+
+| Mode | Détection (schéma actuel) | Ajustable | Le **patient** peut proposer ? |
+|---|---|---|---|
+| **(a) Basal-bolus / pompe** | `InsulinTherapySettings` présent + `sensitivityFactors[]` & `carbRatios[]` non vides. Pompe : `deliveryMethod=pump` + `PumpBasalSlot[]`. MDI : `deliveryMethod=manual`. | ISF (g/L/U), ICR (g/U), débit basal/slot (U/h) | **Non** en valeur brute (trop technique/dangereux). Peut au mieux **signaler un ressenti** → *flag*, pas une valeur. |
+| **(b) Doses simples / fixes** | `BasalConfiguration.configType = single_injection \| split_injection` (`morningDose`/`eveningDose`/`dailyDose`) ; et/ou `PatientInsulin.dosage` texte libre. ISF/ICR vides/partiels. | Dose fixe par moment (matin/midi/soir/nuit) — **après structuration numérique** | **Encadré** : ± quelques unités sur une dose fixe (voir §6), jamais une refonte de schéma. |
+| **(c) Non insuliné** | **Aucun** `InsulinTherapySettings` **et** aucun `PatientInsulin` actif bolus/basal/both. Traitement `Treatment.type=glp1` ou ADO (module médicaments) ; DT2/GD diététique. | Cible glycémique (médecin), rappels/observance, orientation. **Aucun dosage médicamenteux.** | Le patient **déclare** (glycémies, ressenti, observance), il **ne propose pas de posologie**. |
+
+> Détection : dérivable, mais l'US recommande un champ explicite **`Patient.treatmentMode`**
+> (plus sûr, auditable, évite les faux positifs sur configs incohérentes).
+
+## 5. Algorithme d'ajustement par mode — ce qu'il propose / ne propose **jamais**
+
+- **Mode (a)** : conserver les garde-fous existants (`proposal-algorithm.ts` + `adjustment.service.ts`) —
+  cap ± 20 %/proposition, min 3 événements & ≥ 2 %, confiance par volume, bornes dures
+  `CLINICAL_BOUNDS` à l'application, `status=pending`, `accept` DOCTOR-only.
+- **Mode (b)** : nouvelle mécanique — type `fixedDose` + moment cible ; base = **tendance
+  glycémique par moment** (`BGM_CARNET.MIN_READINGS_PER_MOMENT`, `MEAL_TREND` PPG 2 h) ; **bornes
+  à créer** (cap absolu ± 1–2 U ou ± 10 %, plancher/plafond absolu de dose, **cooldown 72 h**).
+  **Jamais** convertir doses fixes → basal-bolus (acte médical), ni créer ISF/ICR pour un patient
+  qui n'en a pas.
+- **Mode (c)** : **pas d'`AdjustmentProposal` de dose**. Objet = **flag/tâche d'orientation**
+  (« à revoir en consultation »), rappels observance/analyses (HbA1c périmée `HBA1C_STALE_DAYS=180`),
+  cible glycémique (médecin, bornée `TARGET_MIN/MAX_MGDL`, plus stricte en `pregnancyMode`), alertes
+  de tendance (TIR sous cible). **Interdit** : recommander/ajuster une posologie orale/GLP-1.
+
+## 6. Garde-fous « proposition patient » (obligatoires)
+
+- **Bornes cliniques dures** rejetées **à la création** (pas seulement à l'accept) — étendre
+  `validateProposedValue`.
+- **Cap variation patient resserré** (< moteur) : ex. ± 10 % ISF/ICR, ± 1–2 U dose fixe.
+- **Sens interdit patient** : refuser toute **baisse de basal/dose** (risque hyper/cétose) et toute
+  hausse qui rapproche d'une hypo — décision médecin.
+- **Anti-spam** : 1 proposition patient en attente max par paramètre/slot + cooldown (72 h).
+- **Champs obligatoires** : motif structuré (`AdjustmentReason`) + justification patient (réutiliser
+  `AdjustmentProposalAck.comment`, chiffré) + fenêtre de données support ≥ planchers de suffisance.
+- **Jamais d'auto-application** : `applyImmediately` désactivé pour toute proposition non-DOCTOR
+  (aligné ADR #13). La seule voie reste `…→ AdjustmentProposal(pending) → review DOCTOR`.
+- **Audit** : `auditService.log` sur create/accept/reject + provenance en metadata.
+
+## 7. Cas limites à border (§ risques)
+
+Grossesse/DG (`pregnancyMode` — cibles strictes, désactiver auto-proposition ou basculer cibles GD) ·
+pédiatrie (cap **absolu en U**, co-signature `PediatricCaregiver`) · **DT1 jamais traité comme mode (c)**
+(router par `pathology` + présence settings) · insuffisance rénale / sujet âgé (validation médecin
+renforcée, pas de hausse auto — pas de champ comorbidité aujourd'hui) · **config incohérente** (bloquer
+toute proposition si `hasGap`/`hasOverlap`/`bolusInconsistent` signalés par `buildTreatmentView`) ·
+toute extension d'`AdjustableParameter` **doit** ajouter sa borne dans `CLINICAL_BOUNDS` + branche
+`validateProposedValue` + test `tests/unit/clinical-bounds.test.ts`.
+
+## 8. Décomposition (sous-US)
+
+| US | Titre | Portée | Dépend de |
+|---|---|---|---|
+| **US-2646** | Socle données : provenance proposition + dose fixe structurée + enum + `treatmentMode` | back / migration | — |
+| **US-2647** | Détection du mode de traitement (a/b/c) + gating fail-closed | back | 2646 |
+| **US-2648** | Onglet « Traitements » **éditable** (fiche pro) : lecture tous / DOCTOR direct / NURSE→proposition | front/back | 2646, 2647 |
+| **US-2649** | Flux **proposition → validation** : provenance, notifications push, UI validation (surface `/adjustment-proposals`) | front/back | 2646 |
+| **US-2650** | **Self-service patient** : route `(patient)` + item de nav + lecture + proposer (bornes strictes) | front/back | 2648, 2649 |
+| **US-2651** | **Algorithme multi-mode** : router par mode ; `fixedDose` (b) ; flags/orientation (c) ; bornes | back | 2646, 2647 |
+| **US-2652** | Garde-fous cliniques & cas limites + i18n/acronymes + design-system + tests + docs | transverse | 2646→2651 |
+
+**Chemin critique** : `2646 → 2647 → {2648, 2651} → 2649 → 2650 → 2652`.
+
+## 9. Critères d'acceptation (épic)
+
+- **AC-1** Dans `/patients/[id]` onglet Traitements : lecture pour tout rôle autorisé ; **DOCTOR**
+  édite en direct ; **NURSE** et **patient** créent une **proposition** `pending` (jamais appliquée seule).
+- **AC-2** Le comportement s'adapte au **mode** (a/b/c) détecté ; un DT1 n'est jamais traité en mode (c).
+- **AC-3** L'algorithme ne propose **aucune posologie médicamenteuse** en mode (c) — uniquement
+  flags/orientation/cible.
+- **AC-4** Toute valeur hors `CLINICAL_BOUNDS` est **rejetée à la création** ; cap patient < moteur ;
+  baisse de basal/dose interdite côté patient.
+- **AC-5** Le patient accède à sa thérapie depuis son espace (nav), en lecture + proposition, **sans
+  jamais voir/énumérer l'id d'un autre patient** (scope serveur sur `user.id`).
+- **AC-6** Provenance (`proposedByRole`/`proposedByUserId`) tracée + auditée ; validation DOCTOR
+  auditée (`reviewedBy`).
+- **AC-7** Aucune migration destructive ; `db push` interdit en prod ; tests bornes cliniques verts.
+
+## 10. Hors périmètre
+
+- Dosage automatique de médicaments oraux / GLP-1 (interdit, D7).
+- Refonte de stratégie thérapeutique (doses fixes ⇄ basal-bolus) = acte médical hors app.
+- Alignement iOS (à traiter séparément via `swift-expert` si le modèle de données bouge).
+
+## 11. Validation requise avant dev
+
+- `medical-domain-validator` (bornes dose fixe, cas grossesse/pédiatrie) — **synthèse initiale faite**.
+- `healthcare-security-auditor` (scope patient own-id, audit provenance, PHI).
+- `architect-reviewer` (extension `AdjustmentProposal` vs nouvel objet pour le mode c).
+- `prisma-specialist` (migration provenance + dose fixe structurée + enum).
+
+---
+
+*Source de la synthèse clinique : agent `medical-domain-validator` (fichiers cités : `prisma/schema.prisma`,
+`src/lib/clinical-bounds.ts`, `src/lib/proposal-algorithm.ts`, `src/lib/services/adjustment.service.ts`,
+`src/lib/services/insulin.service.ts`, `src/app/(dashboard)/patients/[id]/treatment-view.ts`).*

--- a/docs/UserStory/insulinotherapie-edition/US-2646-socle-donnees-provenance-dose-fixe.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2646-socle-donnees-provenance-dose-fixe.md
@@ -1,0 +1,32 @@
+# US-2646 — Socle données : provenance de proposition + dose fixe structurée + enum + `treatmentMode`
+
+> 📌 Épic US-2645 · back · **migration Prisma** · Taille **M** · dépend de : —
+
+## Contexte
+Le flux « patient/infirmier propose » et le mode « doses fixes » ne sont pas modélisables :
+`AdjustmentProposal` n'a pas de provenance, `AdjustableParameter` ne connaît que ISF/ICR/basal,
+et `PatientInsulin.dosage` est du texte libre non calculable.
+
+## Périmètre
+- **`AdjustmentProposal`** : ajouter `proposedByRole` (`PATIENT|NURSE|DOCTOR`) + `proposedByUserId`
+  (FK `User`) — obligatoires (défaut de non-répudiation HDS sinon). Conserver `reviewedBy`/`reviewedAt`.
+- **`enum AdjustableParameter`** : ajouter `fixedDose` (et, si retenu, `glucoseTarget`). Toute nouvelle
+  valeur **doit** venir avec sa borne dans `CLINICAL_BOUNDS` (US-2652) — garde-fou `validateProposedValue`.
+- **Dose fixe structurée** : introduire une représentation **numérique par moment** (matin/midi/soir/nuit)
+  — soit exploiter `BasalConfiguration.morningDose/eveningDose/dailyDose` (déjà numériques) comme source
+  de vérité, soit une table `FixedDoseSlot` (moment, valeur U, insuline). `PatientInsulin.dosage` texte
+  libre reste **affichage**, jamais base de calcul.
+- **`Patient.treatmentMode`** (enum `basalBolus|fixedDose|nonInsulin`) — dérivable mais explicite =
+  plus sûr/auditable ; renseigné par la détection (US-2647), défaut fail-closed.
+- Migration versionnée (US-2267) — **non destructive**, `db push` interdit en prod, CI drift gate.
+
+## Critères d'acceptation
+- **AC-1** Une `AdjustmentProposal` porte toujours `proposedByRole` + `proposedByUserId` (NOT NULL).
+- **AC-2** `AdjustableParameter` étendu ; aucun type sans borne clinique associée (test).
+- **AC-3** Une dose fixe est lisible **numériquement** par moment (base d'un futur ajustement).
+- **AC-4** Migration réversible, drift check vert, seed mis à jour.
+
+## Notes
+- Valider avec `prisma-specialist` + `architect-reviewer` (réutiliser `AdjustmentProposal` vs objet dédié
+  pour le mode non-insuliné — cf. US-2651, le mode (c) ne porte **pas** de posologie).
+- Alignement iOS si le modèle bouge (`swift-expert`).

--- a/docs/UserStory/insulinotherapie-edition/US-2647-detection-mode-traitement.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2647-detection-mode-traitement.md
@@ -1,0 +1,26 @@
+# US-2647 — Détection du mode de traitement (a/b/c) + gating fail-closed
+
+> 📌 Épic US-2645 · back · Taille **S/M** · dépend de : US-2646
+
+## Contexte
+Toute la feature s'adapte au mode : basal-bolus (a), doses fixes (b), non insuliné (c).
+La détection doit être **fiable** et **fail-closed** (en cas d'ambiguïté, ne PAS activer d'édition
+insuline ni d'ajustement de dose).
+
+## Périmètre
+- Service `treatmentModeService.resolve(patientId)` → `basalBolus | fixedDose | nonInsulin`.
+  - **(a)** si `InsulinTherapySettings` présent avec `sensitivityFactors[]` **et** `carbRatios[]` non vides.
+  - **(b)** si insuline active (`PatientInsulin` bolus/basal/both **ou** `BasalConfiguration.configType ∈ {single_injection, split_injection}`) **sans** ratios complets.
+  - **(c)** si **aucune** insuline active ni settings (éventuel `Treatment.type=glp1`/ADO/diététique).
+- Router par **`pathology`** en garde-fou : un **DT1 n'est jamais classé (c)** (fail-closed → au moins mode b).
+- Bloquer l'édition/proposition si la config est **incohérente** (`hasGap`/`hasOverlap`/`bolusInconsistent`
+  déjà calculés par `buildTreatmentView`) → « corriger la couverture 24 h d'abord ».
+- Persister le résultat dans `Patient.treatmentMode` (US-2646) + recalcul à chaque changement de traitement.
+
+## Critères d'acceptation
+- **AC-1** Chaque patient est classé dans un mode déterministe ; DT1 jamais en (c).
+- **AC-2** Config incohérente → mode connu mais **édition/proposition bloquée** avec message explicite.
+- **AC-3** Le mode gouverne l'UI (US-2648/2650) et l'algorithme (US-2651) ; fail-closed en cas de doute.
+
+## Notes
+- Les patients oraux/GLP-1 (module médicaments, Phase 10) relèvent du mode (c).

--- a/docs/UserStory/insulinotherapie-edition/US-2648-onglet-traitements-editable.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2648-onglet-traitements-editable.md
@@ -1,0 +1,34 @@
+# US-2648 — Onglet « Traitements » éditable (fiche pro) : lecture tous / DOCTOR direct / NURSE→proposition
+
+> 📌 Épic US-2645 · front + back · Taille **L** · dépend de : US-2646, US-2647
+
+## Contexte
+L'onglet Traitements de `/patients/[id]` est aujourd'hui une **projection lecture seule**
+(`treatment-view.ts`) ; l'éditeur vit sur la page orpheline `/insulin-therapy`. On **fusionne** :
+l'onglet devient l'éditeur (une seule vérité, cohérent US-2630/US-2604).
+
+## Périmètre
+- Rendre l'onglet **Traitements** éditable **in place** dans `<PatientRecord variant="page">`,
+  en réutilisant la logique de `/insulin-therapy` (formulaires ISF/ICR/basal + dose fixe selon mode).
+- **RBAC / flux** (décisions D1–D3) :
+  - **DOCTOR** → écriture **directe** (effet immédiat), via `/api/insulin-therapy/*` existant.
+  - **NURSE** → l'action « enregistrer » crée une **`AdjustmentProposal` `pending`** (`proposedByRole=NURSE`),
+    n'écrit pas en direct.
+  - Lecture pour tout rôle autorisé (`canAccessPatient`).
+- **Adaptatif au mode** (US-2647) : mode (a) édite ISF/ICR/basal ; mode (b) édite les **doses fixes
+  structurées** ; mode (c) → **pas d'éditeur d'insuline**, affiche cible/orientation (lecture) +
+  renvoi vers le suivi.
+- Décommissionner la page autonome `/insulin-therapy` → **redirection** vers `/patients/[id]` (onglet
+  Traitements) pour ne pas casser les liens ; retirer le code d'écran dupliqué.
+- Fetch **transport-agnostique** (id fourni par la fiche, gardé `canAccessPatient` — pas de `?patientId`
+  construit côté client, cohérent anti-énumération US-2642).
+
+## Critères d'acceptation
+- **AC-1** DOCTOR modifie ISF/ICR/basal/dose → appliqué immédiatement + audité.
+- **AC-2** NURSE modifie → **proposition `pending`** créée (rien appliqué) + notif (US-2649).
+- **AC-3** L'éditeur affiché correspond au **mode** ; mode (c) n'expose aucun champ de dose insuline.
+- **AC-4** `/insulin-therapy` redirige vers la fiche ; aucune régression d'accès/audit.
+- **AC-5** A11y (ARIA sur formulaires), acronymes ISF/ICR explicités, design-system respecté.
+
+## Notes
+- Bornes cliniques appliquées serveur (inchangé) ; l'UI n'assouplit jamais les bornes.

--- a/docs/UserStory/insulinotherapie-edition/US-2649-flux-proposition-validation.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2649-flux-proposition-validation.md
@@ -1,0 +1,32 @@
+# US-2649 — Flux proposition → validation : provenance, notifications, UI de validation
+
+> 📌 Épic US-2645 · front + back · Taille **L** · dépend de : US-2646
+
+## Contexte
+Une proposition (patient ou infirmier) doit **notifier** le médecin et être **validée/rejetée**
+explicitement. L'écran de validation existe déjà (`/adjustment-proposals`) mais est **orphelin**
+(cf. `docs/inventory/composants-orphelins.md`) ; le service push existe (`push.service.ts`).
+
+## Périmètre
+- **Création de proposition** avec provenance (`proposedByRole`, `proposedByUserId`, US-2646),
+  `status=pending`, bornes **rejetées à la création** (`validateProposedValue` étendu), `applyImmediately`
+  **désactivé** pour non-DOCTOR.
+- **Notification** au(x) médecin(s) référent(s)/équipe via `push.service.ts` (+ éventuel in-app),
+  sans PHI dans le payload.
+- **UI de validation** : **surfacer `/adjustment-proposals`** (entrée de nav pro / badge « à valider »
+  sur la fiche) ; liste `pending` avec accept/reject, lien fiche, provenance affichée (patient vs infirmier),
+  motif + justification (`AdjustmentProposalAck.comment`).
+- **accept()** applique la valeur (mode-aware : ISF/ICR/basal **ou** dose fixe), re-vérifie les bornes,
+  écrit `reviewedBy`/`reviewedAt`, audite ; **reject()** clôt sans appliquer, audite. Accusé patient
+  (`AdjustmentProposalAck`) sur décision.
+- **Validateur = DOCTOR** (défaut D2/D3 — à reconfirmer : NURSE peut-il valider ?).
+
+## Critères d'acceptation
+- **AC-1** Une proposition patient/infirmier crée une `pending` auditée avec provenance ; jamais appliquée seule.
+- **AC-2** Le médecin reçoit une **notification** (sans PHI) et voit la proposition dans `/adjustment-proposals`.
+- **AC-3** accept → valeur appliquée (mode-aware) + re-check bornes + audit `reviewedBy` ; reject → aucun effet + audit.
+- **AC-4** Anti-spam : 1 `pending` max par paramètre/slot + cooldown (72 h) respecté.
+- **AC-5** `/adjustment-proposals` accessible via nav (n'est plus orpheline).
+
+## Notes
+- Réutiliser `AdjustmentProposalActualization` (US-2066) pour le suivi d'effet si pertinent.

--- a/docs/UserStory/insulinotherapie-edition/US-2650-self-service-patient.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2650-self-service-patient.md
@@ -1,0 +1,32 @@
+# US-2650 — Self-service patient : route `(patient)` + nav + lecture + proposer
+
+> 📌 Épic US-2645 · front + back · Taille **L** · dépend de : US-2648, US-2649
+
+## Contexte
+Le patient (VIEWER) doit **voir sa thérapie** et **proposer un ajustement** depuis son espace,
+accessible via un **item de navigation**. Aujourd'hui : `patientNavItems` = Accueil / Rendez-vous /
+Paramètres ; les API `/api/insulin-therapy/*` **bloquent VIEWER** ; `/insulin-therapy` est sous
+`(dashboard)` (redirige le VIEWER).
+
+## Périmètre
+- **Route patient** `(patient)/patient/insulin-therapy/page.tsx` (layout patient) — rendu **mode-aware**
+  (a/b/c) en **lecture** + action « proposer une modification ».
+- **Item de nav patient** « Insulinothérapie » ajouté à `patientNavItems` (visible selon mode : masqué/état
+  vide informatif pour un patient non insuliné ? — voir AC-4).
+- **Endpoint self-service scoped « own »** : nouvel accès **VIEWER → son propre patient** résolu **serveur**
+  depuis `user.id` (jamais `?patientId`, anti-énumération). Lecture des settings/doses ; **création de
+  proposition** patient (`proposedByRole=PATIENT`) avec **bornes strictes** (cap patient < moteur, sens
+  « baisse basal/dose » **interdit**, cooldown, justification obligatoire — cf. épic §6).
+- **Acronymes** ISF/ICR explicités (`Acronym` / libellé) — public patient.
+- Aucune écriture directe patient ; tout passe par proposition → validation DOCTOR (US-2649).
+
+## Critères d'acceptation
+- **AC-1** Le patient voit **sa** thérapie (jamais celle d'un autre ; scope `user.id` serveur).
+- **AC-2** Le patient peut **proposer** un ajustement borné → `pending` + notif médecin ; jamais appliqué seul.
+- **AC-3** Une proposition patient hors bornes / dans le mauvais sens est **refusée à la saisie** (message clair).
+- **AC-4** Mode (c) : le patient voit sa **cible/orientation**, **aucun** champ de dose ni proposition de posologie.
+- **AC-5** A11y + i18n (fr/en/ar) + design-system ; aucun id patient en URL.
+
+## Notes
+- Réutiliser le composant orphelin `InsulinSummary` (mis en conformité design-system) pour la vue de synthèse.
+- L'endpoint `/api/patient/insulin-settings` existant (lecture) est à **re-scoper own-id** ou remplacer.

--- a/docs/UserStory/insulinotherapie-edition/US-2651-algorithme-ajustement-multimode.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2651-algorithme-ajustement-multimode.md
@@ -1,0 +1,33 @@
+# US-2651 — Algorithme d'ajustement multi-mode
+
+> 📌 Épic US-2645 · back · Taille **L** · dépend de : US-2646, US-2647 · **validation `medical-domain-validator` obligatoire**
+
+## Contexte
+`src/lib/proposal-algorithm.ts` est **mono-mode basal-bolus**. Il faut le **router par mode** et couvrir
+doses fixes (b) et non-insuliné (c) — **sans jamais franchir la ligne du dosage médicamenteux** (D7).
+
+## Périmètre
+- **Router `generateProposals(patient)` par `treatmentMode`** (US-2647).
+- **Mode (a)** : conserver l'existant (`analyzeIsfSlot`/`analyzeIcrSlot`/`analyzeBasalTrend`, cap ± 20 %,
+  min 3 événements & ≥ 2 %, confiance par volume, bornes dures, `pending`).
+- **Mode (b) — nouveau `analyzeFixedDose*`** : base = **tendance glycémique par moment**
+  (`BGM_CARNET.MIN_READINGS_PER_MOMENT`, `MEAL_TREND` PPG 2 h). Produit une proposition `fixedDose` bornée :
+  cap **absolu** ± 1–2 U ou ± 10 % (le plus petit), plancher/plafond absolu de dose, **cooldown 72 h/moment**.
+  **Jamais** : convertir doses fixes → basal-bolus, créer ISF/ICR ex nihilo.
+- **Mode (c) — pas de proposition de dose** : produire uniquement des **flags/tâches d'orientation**
+  (« à revoir en consultation »), rappels observance/analyses (HbA1c périmée `HBA1C_STALE_DAYS=180`),
+  alertes de tendance (TIR < cible). La **cible glycémique** reste ajustable **par le médecin** (bornée
+  `TARGET_MIN/MAX_MGDL`, plus stricte en `pregnancyMode`). **Interdiction absolue** de recommander une
+  posologie orale/GLP-1 (frontière MDR/IEC 62304).
+- **Bornes** : ajouter dans `CLINICAL_BOUNDS` les bornes dose fixe + caps patient (US-2652 les verrouille par test).
+- **Grossesse/DG** : désactiver l'auto-proposition ou basculer sur cibles GD (`pregnancyMode`).
+
+## Critères d'acceptation
+- **AC-1** L'algorithme choisit sa logique selon le **mode** ; un DT1 n'est jamais traité en (c).
+- **AC-2** Mode (b) : proposition de dose fixe **bornée** (cap absolu + cooldown), jamais de refonte de schéma.
+- **AC-3** Mode (c) : **aucune** proposition de posologie ; uniquement flags/orientation/cible médecin.
+- **AC-4** Toute proposition reste `pending` (jamais auto-appliquée) ; bornes vérifiées à la création.
+- **AC-5** Couverture tests unitaires (par mode + cas limites) ≥ 80 %.
+
+## Notes
+- Le mode (c) **ne réutilise pas** `AdjustmentProposal` pour porter une dose — objet flag/tâche distinct.

--- a/docs/UserStory/insulinotherapie-edition/US-2652-gardefous-cliniques-i18n-tests.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2652-gardefous-cliniques-i18n-tests.md
@@ -1,0 +1,36 @@
+# US-2652 — Garde-fous cliniques & cas limites + i18n/acronymes + design-system + tests + docs
+
+> 📌 Épic US-2645 · transverse · Taille **M** · dépend de : US-2646 → US-2651 · **gate finale medical + HDS + a11y**
+
+## Contexte
+Story de durcissement transverse fermant l'épic : verrouiller les bornes, border les cas limites,
+et garantir conformité (clinique, HDS, a11y, i18n, design-system).
+
+## Périmètre
+- **`CLINICAL_BOUNDS`** (`src/lib/clinical-bounds.ts`) : ajouter bornes **dose fixe** (min/max absolus U,
+  cap variation U/%), **cap patient** (< moteur), **cooldown/fréquence** ; **source de vérité unique**,
+  gardée synchrone par `tests/unit/clinical-bounds.test.ts`. Garde-fou : tout nouveau `AdjustableParameter`
+  sans borne = test rouge.
+- **Cas limites bordés** : grossesse/DG (`pregnancyMode`), pédiatrie (cap **absolu en U** + co-signature
+  `PediatricCaregiver`), DT1 jamais mode (c), insuffisance rénale/âgé (validation médecin renforcée, pas de
+  hausse auto), config incohérente (bloquer si `hasGap`/`hasOverlap`/`bolusInconsistent`).
+- **Sens interdit patient** (baisse basal/dose) appliqué serveur, pas seulement UI.
+- **i18n** (fr/en/ar) : libellés proposition/validation/modes ; **acronymes** ISF/ICR/IOB explicités
+  (glossaire + `Acronym`).
+- **Design-system** : composants conformes (tokens), **mettre en conformité `InsulinSummary`** avant réemploi
+  (aujourd'hui `text-gray-*`, `var(--color-teal-500)` — cf. inventaire orphelins).
+- **Audit HDS** : `auditService.log` sur create/accept/reject + provenance ; aucun PHI en clair (logs/notif).
+- **Tests** : unitaires par mode + bornes + sens interdit + scope patient own-id ; E2E des 3 flux
+  (DOCTOR direct, NURSE→proposition, patient→proposition→validation).
+- **Docs** : ADR (extension `AdjustmentProposal` provenance + multi-mode) ; MAJ `docs/clinical-logic/`,
+  `CLAUDE.md` (logique métier), `docs/ROADMAP.md`.
+
+## Critères d'acceptation
+- **AC-1** Toute borne/cap/cooldown est dans `CLINICAL_BOUNDS` + testée ; aucun paramètre sans borne.
+- **AC-2** Chaque cas limite (grossesse, pédiatrie, DT1/DT2, rénal, config incohérente) a un test dédié.
+- **AC-3** Sens interdit patient bloqué **serveur** (pas contournable via API).
+- **AC-4** i18n complet + acronymes explicités ; design-system respecté (`InsulinSummary` conforme).
+- **AC-5** Gate finale : `medical-domain-validator` + `healthcare-security-auditor` + `accessibility-tester` PASS.
+
+## Notes
+- Réviser l'inventaire orphelins : `InsulinSummary` et `/insulin-therapy` (redirigée) sortent du statut orphelin.


### PR DESCRIPTION
Spécification (pas de code) de l'épic **US-2645** : éditeur d'insulinothérapie dans la fiche patient + self-service patient + algorithme d'ajustement **treatment-mode-aware**.

Épic + 7 sous-US (US-2646→2652) dans docs/UserStory/insulinotherapie-edition/. Ancré sur la synthèse du medical-domain-validator (taxonomie des modes, bornes, cas limites, **interdiction du dosage médicamenteux en mode non-insuliné**).

Décisions actées : DOCTOR édite direct · NURSE/patient → proposition validée · onglet Traitements devient l'éditeur · patient accède via nav. Point à reconfirmer (validateur DOCTOR only vs NURSE+DOCTOR) noté dans l'épic §2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)