### PR TITLE
docs(US): révision épic US-2645 suite revues archi + HDS

### DIFF
--- a/docs/UserStory/insulinotherapie-edition/US-2645-EPIC-insulinotherapie-edition-multimode.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2645-EPIC-insulinotherapie-edition-multimode.md
@@ -31,11 +31,11 @@
 | D6 | Feature **treatment-mode-aware** : 3 modes (voir §4). L'algorithme d'ajustement couvre les 3. |
 | D7 | **Interdiction absolue** : proposer/ajuster automatiquement une **posologie orale ou GLP-1** (frontière dispositif médical MDR/IEC 62304). Mode non-insuliné = orientation, pas dosage. |
 
-> ⚠️ **Point à reconfirmer** : lors de la décision D2/D3, l'option retenue indique
-> « validé par un **DOCTOR** », alors qu'un échange précédent évoquait « médecin **ou**
-> infirmier ». **Le validateur (accept/reject) est-il DOCTOR only, ou NURSE+DOCTOR ?**
-> Défaut retenu dans cette US : **DOCTOR only valide** (autorité clinique), NURSE peut
-> proposer. À trancher avant US-2649.
+> ✅ **Verrouillé (décision utilisateur)** : le validateur (accept/reject) est **DOCTOR
+> only** — et plus précisément **rôle exactement DOCTOR** (pas `hasMinRole`, donc **ADMIN
+> exclu** : rôle technique, non clinicien) **+ `canAccessPatient`**. NURSE et patient
+> **proposent** uniquement. Un DOCTOR édite en direct (D1) et n'a pas à passer par une
+> proposition.
 
 ## 3. Constat technique (ce qui bloque aujourd'hui)
 
@@ -149,8 +149,78 @@ toute extension d'`AdjustableParameter` **doit** ajouter sa borne dans `CLINICAL
 - `architect-reviewer` (extension `AdjustmentProposal` vs nouvel objet pour le mode c).
 - `prisma-specialist` (migration provenance + dose fixe structurée + enum).
 
+## 12. Revue archi + HDS — changements **imposés** (source unique)
+
+> Consolidé des revues `architect-reviewer` (B/A/N) et `healthcare-security-auditor`
+> (CRITICAL/HIGH/MEDIUM/LOW). **Ces points ne sont pas optionnels** — chaque sous-US
+> renvoie ici.
+
+### 🔴 Bloquants / CRITICAL
+1. **Provenance = enum `ProposalSource` (`ALGORITHM|PATIENT|NURSE|DOCTOR`)**, pas `Role`.
+   `proposedByUserId` **nullable** + `CHECK` DB (`ALGORITHM → userId IS NULL` ; sinon NOT NULL).
+   **Toujours dérivé serveur** (`session.user.id/role`), jamais lu du body (anti-usurpation).
+   Backfill des lignes existantes → `ALGORITHM`. *(US-2646)*
+2. **Union taguée sur `AdjustmentProposal`** (pas de sous-typage) : rendre `supportingEvents`,
+   `confidence`, `analysisPeriod`, `dataQuality`, `averageObservedValue` **nullable** +
+   `CHECK` conditionnel `source=ALGORITHM → supportingEvents & confidence NOT NULL`. *(US-2646)*
+3. **`fixedDose` atomique en US-2646** : enum `AdjustableParameter.fixedDose` **+** bornes
+   `CLINICAL_BOUNDS` (min/max/cap absolus U) **+** branche `validateProposedValue` **+** test,
+   livrés **ensemble**. **Ne PAS** ajouter `glucoseTarget` à l'enum (la cible = **édition directe
+   DOCTOR** sur `GlucoseTarget`/`CgmObjective`, jamais une proposition). *(US-2646)*
+4. **Table dédiée `FixedDoseSlot`** (`patientInsulinId`, `moment`, `valueU`…) — **pas**
+   `BasalConfiguration` (basal-only, 2 moments, 1:1 settings). **Pas de backfill auto** du texte
+   libre `PatientInsulin.dosage` (fourchettes non parsables) → **structuration opt-in par un PS**. *(US-2646)*
+5. **Objet distinct mode (c)** : nouveau `ClinicalReviewFlag` (`patientId`, `type`, `status`,
+   `createdBy` nullable, `resolvedBy`) — **défini en US-2646**. Le mode (c) ne crée **jamais**
+   d'`AdjustmentProposal` de dose. *(US-2646 + US-2651)*
+6. **Transport d'ÉCRITURE injecté** symétrique à `fetchAnalytics` (`mutate(endpoint, body)`),
+   identité résolue par l'adaptateur (jamais l'URL construite par le composant → anti-énumération).
+   **Éditeur `variant="page"` uniquement** : un `x-consultation-token` de **lecture** (drawer) ne doit
+   **jamais** autoriser une écriture insuline (escalade de privilège) → fail-closed. Capability
+   descriptor serveur `{ mode, canEditDirect, canPropose }`. *(US-2648)*
+7. **RBAC écriture directe** (CRITICAL HDS) : les routes `POST/PATCH /api/insulin-therapy/*` sont
+   aujourd'hui `requireRole(NURSE)` (hiérarchique → NURSE écrit en direct). Les passer à **DOCTOR
+   exact** ; NURSE → **403** et doit passer par l'endpoint de proposition. Re-routage **serveur**,
+   pas UI. Test E2E : `NURSE PATCH insulin-therapy/*` → 403. *(US-2648)*
+8. **Validation = DOCTOR exact + `canAccessPatient`** (MEDIUM HDS) : `requireRole(DOCTOR)` laisse
+   passer **ADMIN** → exclure. `accept/reject` : rôle exact DOCTOR, jamais l'UI. *(US-2649b)*
+
+### 🟠 À intégrer
+- **`treatmentMode` dérivé = source de vérité** ; le gate d'écriture **re-dérive dans la même
+  transaction** (Prisma 7 sans `$use()` → pas de recalcul middleware fiable). `Patient.treatmentMode`
+  persisté = **cache d'affichage** recalculé en transaction, **jamais** l'autorité (fail-**closed**).
+  Migration : **pas** de défaut global `basalBolus` ; backfill via détection (DT1 jamais `nonInsulin`). *(US-2646/2647)*
+- **Scinder US-2649** : **2649a** (primitive `createProposal` : provenance serveur, bornes-à-la-création,
+  anti-spam, `validateProposedValue` étendu) livrée **avant US-2648** ; **2649b** (notifications + UI
+  `/adjustment-proposals` + accept/reject mode-aware) après 2648/2651. Corriger les `dépend de` (2649 dépend
+  aussi de 2647 et 2651). *(dépendances)*
+- **`accept()` sûr** : `updateMany` silencieux → vérifier `count === 1` (sinon rollback + « slot introuvable »).
+  **Re-lire la valeur courante** au moment de l'accept, revalider le delta vs `currentValue` figée ; drift →
+  refus d'auto-application, re-saisie médecin. `applyImmediately` **forcé `false`** pour `source != DOCTOR`.
+  `validateProposedValue` **à la création ET à l'accept** (double gate). *(US-2649)*
+- **Justification patient = champ dédié chiffré** `AdjustmentProposal.proposerComment` (AES-256-GCM),
+  **pas** `AdjustmentProposalAck.comment` (qui est la réponse patient post-décision, 1:1). *(US-2646/2650)*
+- **Self-service patient own-id strict** : résolution **exclusive** `getOwnPatientId(user.id)` ; **aucun**
+  `?patientId`, **aucun** `x-consultation-token` sur les routes patient ; Zod **sans** `patientId`. Re-scoper
+  `/api/patient/insulin-settings`. Test : VIEWER visant un autre id / avec token → toujours son dossier. *(US-2650)*
+
+### 🟡 Nits (à ne pas perdre)
+- **Audit sans PHI** : `resourceId=proposalId` + `metadata={patientId, proposedByRole}` ; **jamais** de
+  dose/valeur en clair dans log/notif/URL. Notif push = corps générique + `data={type, proposalId}`,
+  détails via API auth. *(US-2649b)*
+- **Anti-spam serveur** : index unique partiel PG « 1 `pending` max par (patientId, parameterType, slot)
+  `WHERE status='pending'` » + cooldown 72 h. *(US-2649a)*
+- **Redirect `/insulin-therapy` role-branché** (DOCTOR/NURSE → fiche ; VIEWER → route patient). *(US-2648/2650)*
+- **Réutiliser le mapper pur `treatment-view.ts`** pour la détection (ratios complets, gap/overlap). *(US-2647)*
+- **`MAX_CHANGE_PERCENT=20`** en dur → remonter dans `CLINICAL_BOUNDS`. *(US-2651)*
+- **`InsulinSummary`** : vérifier absence de fuite import client/serveur avant montage `(patient)`. *(US-2650)*
+- **ADR #21** devient « 1 composant présentational, **N transports** » (ajout own-id patient) ; **DPIA** :
+  documenter les doses numériques en clair (calculabilité → at-rest pgcrypto + RBAC). *(US-2652)*
+
 ---
 
-*Source de la synthèse clinique : agent `medical-domain-validator` (fichiers cités : `prisma/schema.prisma`,
-`src/lib/clinical-bounds.ts`, `src/lib/proposal-algorithm.ts`, `src/lib/services/adjustment.service.ts`,
-`src/lib/services/insulin.service.ts`, `src/app/(dashboard)/patients/[id]/treatment-view.ts`).*
+*Sources : agents `medical-domain-validator`, `architect-reviewer`, `healthcare-security-auditor`
+(fichiers cités : `prisma/schema.prisma`, `src/lib/clinical-bounds.ts`, `src/lib/proposal-algorithm.ts`,
+`src/lib/services/adjustment.service.ts`, `src/lib/auth/{rbac,query-helpers}.ts`, `src/lib/access-control.ts`,
+`src/app/api/insulin-therapy/*`, `src/app/api/adjustment-proposals/[id]/{accept,reject}/route.ts`,
+`src/components/diabeo/patient/PatientRecordContext.tsx`, `treatment-view.ts`).*

--- a/docs/UserStory/insulinotherapie-edition/US-2646-socle-donnees-provenance-dose-fixe.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2646-socle-donnees-provenance-dose-fixe.md
@@ -41,4 +41,7 @@ et `PatientInsulin.dosage` est du texte libre non calculable.
 - **`ClinicalReviewFlag`** (mode c) défini ici (§12.5).
 - **`Patient.treatmentMode`** = cache d'affichage, source de vérité = dérivée ; migration **sans** défaut `basalBolus`, backfill fail-closed (DT1 jamais `nonInsulin`).
 - **`proposerComment`** chiffré AES-256-GCM sur `AdjustmentProposal` (justification patient) ; FK `proposedByUserId` onDelete documenté.
-- ⚠️ **Arbitrage clinique ouvert** : `FixedDoseSlot.valueU` = **valeur unique** ou **min/max** (fourchette « 6-8U ») ? À trancher avec `medical-domain-validator` avant migration.
+- ✅ **Arbitrage clinique tranché (utilisateur)** : `FixedDoseSlot.valueU` = **valeur numérique unique**
+  par moment (matin/midi/soir/nuit). Le soignant fixe une valeur lors de la structuration (ex. « 6-8U »
+  → 7U) ; le texte libre `PatientInsulin.dosage` d'origine est **conservé en note d'affichage**. Base
+  claire pour l'ajustement mode (b) (proposer ± 1–2 U bornés). Pas de fourchette min/max.

--- a/docs/UserStory/insulinotherapie-edition/US-2646-socle-donnees-provenance-dose-fixe.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2646-socle-donnees-provenance-dose-fixe.md
@@ -30,3 +30,15 @@ et `PatientInsulin.dosage` est du texte libre non calculable.
 - Valider avec `prisma-specialist` + `architect-reviewer` (réutiliser `AdjustmentProposal` vs objet dédié
   pour le mode non-insuliné — cf. US-2651, le mode (c) ne porte **pas** de posologie).
 - Alignement iOS si le modèle bouge (`swift-expert`).
+
+## Révision post-revue (archi + HDS) — voir épic §12
+
+**Impacts majeurs (bloquants) :**
+- Provenance = enum **`ProposalSource` (`ALGORITHM|PATIENT|NURSE|DOCTOR`)**, `proposedByUserId` **nullable** + `CHECK` (`ALGORITHM→null`) ; **dérivé serveur**, jamais du body ; backfill lignes existantes → `ALGORITHM` (§12.1).
+- **Union taguée** : rendre `supportingEvents`/`confidence`/`analysisPeriod`/`dataQuality`/`averageObservedValue` **nullable** + `CHECK` `source=ALGORITHM → supportingEvents & confidence NOT NULL` (§12.2).
+- **`fixedDose` atomique** : enum + bornes `CLINICAL_BOUNDS` + branche `validateProposedValue` + test **dans cette US** ; **ne pas** ajouter `glucoseTarget` (cible = édition directe DOCTOR) (§12.3).
+- **Table `FixedDoseSlot`** dédiée (pas `BasalConfiguration`) ; **pas de backfill auto** du texte libre → structuration **opt-in PS** (§12.4). AC-3 reformulé.
+- **`ClinicalReviewFlag`** (mode c) défini ici (§12.5).
+- **`Patient.treatmentMode`** = cache d'affichage, source de vérité = dérivée ; migration **sans** défaut `basalBolus`, backfill fail-closed (DT1 jamais `nonInsulin`).
+- **`proposerComment`** chiffré AES-256-GCM sur `AdjustmentProposal` (justification patient) ; FK `proposedByUserId` onDelete documenté.
+- ⚠️ **Arbitrage clinique ouvert** : `FixedDoseSlot.valueU` = **valeur unique** ou **min/max** (fourchette « 6-8U ») ? À trancher avec `medical-domain-validator` avant migration.

--- a/docs/UserStory/insulinotherapie-edition/US-2647-detection-mode-traitement.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2647-detection-mode-traitement.md
@@ -24,3 +24,7 @@ insuline ni d'ajustement de dose).
 
 ## Notes
 - Les patients oraux/GLP-1 (module médicaments, Phase 10) relèvent du mode (c).
+
+## Révision post-revue (archi) — voir épic §12
+- `treatmentMode` **dérivé = source de vérité** ; le **gate d'écriture re-dérive dans la même transaction** (fail-closed), jamais la colonne persistée (§12 « à intégrer »).
+- **Réutiliser le mapper pur `treatment-view.ts`** (ratios complets, `hasGap`/`hasOverlap`) pour une définition unique de « ratios complets » (§12 nit).

--- a/docs/UserStory/insulinotherapie-edition/US-2648-onglet-traitements-editable.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2648-onglet-traitements-editable.md
@@ -32,3 +32,9 @@ l'onglet devient l'éditeur (une seule vérité, cohérent US-2630/US-2604).
 
 ## Notes
 - Bornes cliniques appliquées serveur (inchangé) ; l'UI n'assouplit jamais les bornes.
+
+## Révision post-revue (archi + HDS) — voir épic §12
+- **Transport d'ÉCRITURE injecté** (`mutate`) symétrique à `fetchAnalytics` ; identité résolue par l'adaptateur (anti-énumération) (§12.6).
+- **Éditeur `variant="page"` uniquement** — jamais en contexte drawer/`x-consultation-token` (escalade de privilège), fail-closed. Capability descriptor serveur `{mode, canEditDirect, canPropose}` (§12.6).
+- 🔴 **CRITICAL HDS** : passer les routes `POST/PATCH /api/insulin-therapy/*` de `requireRole(NURSE)` à **DOCTOR exact** ; NURSE → **403** + endpoint de proposition. Re-routage **serveur**. Test E2E `NURSE PATCH → 403` (§12.7).
+- Redirect `/insulin-therapy` **role-branché** (DOCTOR/NURSE → fiche ; VIEWER → route patient) (§12 nit).

--- a/docs/UserStory/insulinotherapie-edition/US-2649-flux-proposition-validation.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2649-flux-proposition-validation.md
@@ -30,3 +30,12 @@ explicitement. L'écran de validation existe déjà (`/adjustment-proposals`) ma
 
 ## Notes
 - Réutiliser `AdjustmentProposalActualization` (US-2066) pour le suivi d'effet si pertinent.
+
+## Révision post-revue (archi + HDS) — SCINDÉE, voir épic §12
+**US-2649 est scindée** (le cycle 2648⇄2649 doit être cassé) :
+- **US-2649a (socle create)** — primitive `createProposal` : provenance **dérivée serveur**, **bornes vérifiées à la création**, `validateProposedValue` étendu (`fixedDose`), **anti-spam** (index unique partiel PG `WHERE status='pending'` + cooldown 72 h). Livrée **avant US-2648**.
+- **US-2649b (surface)** — notifications push **sans PHI** (`data={type, proposalId}`, corps générique) + UI `/adjustment-proposals` (surfacée) + **accept/reject mode-aware**. Après 2648/2651.
+- **`accept()` sûr** : `count === 1` obligatoire (TOCTOU `updateMany`), **re-lecture valeur courante** + revalidation delta vs `currentValue` figée (drift → refus auto), double gate `validateProposedValue` (create + accept), `applyImmediately=false` si `source != DOCTOR` (§12).
+- **Validation = DOCTOR exact + `canAccessPatient`** (ADMIN exclu) (§12.8).
+- **Audit sans PHI** : `resourceId=proposalId`, `metadata={patientId, proposedByRole}` ; jamais la dose (§12 nit).
+- Dépendances corrigées : dépend aussi de **2647** et **2651**.

--- a/docs/UserStory/insulinotherapie-edition/US-2650-self-service-patient.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2650-self-service-patient.md
@@ -30,3 +30,8 @@ Paramètres ; les API `/api/insulin-therapy/*` **bloquent VIEWER** ; `/insulin-t
 ## Notes
 - Réutiliser le composant orphelin `InsulinSummary` (mis en conformité design-system) pour la vue de synthèse.
 - L'endpoint `/api/patient/insulin-settings` existant (lecture) est à **re-scoper own-id** ou remplacer.
+
+## Révision post-revue (HDS + archi) — voir épic §12
+- **Own-id strict** : résolution **exclusive** `getOwnPatientId(user.id)` ; **aucun** `?patientId`, **aucun** `x-consultation-token` sur les routes patient ; Zod **sans** `patientId`. Re-scoper `/api/patient/insulin-settings` (§12 « à intégrer », HIGH IDOR). Test VIEWER visant un autre id/token → son dossier.
+- Justification patient → champ **`proposerComment`** chiffré (pas `Ack.comment`) (§12).
+- `InsulinSummary` : vérifier **absence de fuite import client/serveur** avant montage `(patient)` (§12 nit).

--- a/docs/UserStory/insulinotherapie-edition/US-2651-algorithme-ajustement-multimode.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2651-algorithme-ajustement-multimode.md
@@ -31,3 +31,8 @@ doses fixes (b) et non-insuliné (c) — **sans jamais franchir la ligne du dosa
 
 ## Notes
 - Le mode (c) **ne réutilise pas** `AdjustmentProposal` pour porter une dose — objet flag/tâche distinct.
+
+## Révision post-revue (archi + HDS) — voir épic §12
+- **Refus serveur** de toute `AdjustmentProposal` de dose si `treatmentMode=nonInsulin` ; mode (c) → `ClinicalReviewFlag` (défini US-2646), jamais une proposition de dose (§12.5, MDR).
+- Remonter **`MAX_CHANGE_PERCENT=20`** (en dur) dans `CLINICAL_BOUNDS` (source unique testée) (§12 nit).
+- Application `fixedDose` mode-aware côté `accept` (dépendance vers US-2649b).

--- a/docs/UserStory/insulinotherapie-edition/US-2652-gardefous-cliniques-i18n-tests.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2652-gardefous-cliniques-i18n-tests.md
@@ -34,3 +34,10 @@ et garantir conformité (clinique, HDS, a11y, i18n, design-system).
 
 ## Notes
 - Réviser l'inventaire orphelins : `InsulinSummary` et `/insulin-therapy` (redirigée) sortent du statut orphelin.
+
+## Révision post-revue — RECENTRÉE hardening (voir épic §12)
+Les bornes `fixedDose` **naissent en US-2646** (atomique). Cette US = **vérification/durcissement** :
+- Cas limites (grossesse/DG, pédiatrie cap **absolu U** + co-signature, DT1 jamais mode c, rénal/âgé, config incohérente) + **sens interdit patient appliqué serveur**.
+- **Chiffrement** effectif de `proposerComment`/notes (test AES-256-GCM, jamais en clair log/notif/URL).
+- **DPIA** : documenter les doses numériques en clair (calculabilité → at-rest pgcrypto + RBAC).
+- **ADR** : #21 → « 1 composant présentational, **N transports** » (ajout own-id patient) ; nouvel ADR provenance `AdjustmentProposal` (union taguée + `ProposalSource`).


### PR DESCRIPTION
Intègre à la spéc US-2645 les findings des revues **architect-reviewer** + **healthcare-security-auditor** (4 bloquants archi + 1 CRITICAL HDS + HIGH). Verrouille le validateur = **DOCTOR exact** (ADMIN exclu).

Épic §12 = source unique des changements imposés ; chaque sous-US renvoie aux points applicables. US-2649 scindée (2649a socle / 2649b surface). Un arbitrage clinique reste ouvert (FixedDoseSlot valeur unique vs fourchette) — noté dans US-2646.

Docs-only. Aucun code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)