### PR TITLE
US-2646 — Socle données édition insulinothérapie (provenance + dose fixe + mode)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,6 +386,10 @@ const CLINICAL_BOUNDS = {
   INSULIN_ACTION_MIN: 3.5,       // heures (durée d'action analogues rapides)
   INSULIN_ACTION_MAX: 5.0,       // heures
   PUMP_BASAL_INCREMENT: 0.05,    // U/h
+  FIXED_DOSE_MIN: 0.5,           // U — dose fixe par moment (mode doses simples, US-2646)
+  FIXED_DOSE_MAX: 25.0,          // U — plafond dose fixe (≤ MAX_SINGLE_BOLUS)
+  FIXED_DOSE_MAX_DELTA_U: 2.0,   // U — variation max par ajustement (titration lente)
+  FIXED_DOSE_PATIENT_MAX_DELTA_U: 1.0, // U — cap patient resserré (< moteur)
 }
 
 // Formule : findSlotForHour(settings.sensitivityFactors, hour)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,8 +386,9 @@ const CLINICAL_BOUNDS = {
   INSULIN_ACTION_MIN: 3.5,       // heures (durée d'action analogues rapides)
   INSULIN_ACTION_MAX: 5.0,       // heures
   PUMP_BASAL_INCREMENT: 0.05,    // U/h
-  FIXED_DOSE_MIN: 0.5,           // U — dose fixe par moment (mode doses simples, US-2646)
-  FIXED_DOSE_MAX: 25.0,          // U — plafond dose fixe (≤ MAX_SINGLE_BOLUS)
+  FIXED_DOSE_MIN: 0.5,           // U — plancher bloquant dose fixe (mode doses simples, US-2646)
+  FIXED_BOLUS_WARN_U: 25.0,      // U — seuil d'AVERTISSEMENT bolus fixe (non bloquant)
+  FIXED_BASAL_WARN_U: 80.0,      // U — seuil d'AVERTISSEMENT basale fixe (non bloquant)
   FIXED_DOSE_MAX_DELTA_U: 2.0,   // U — variation max par ajustement (titration lente)
   FIXED_DOSE_PATIENT_MAX_DELTA_U: 1.0, // U — cap patient resserré (< moteur)
 }

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1483,7 +1483,8 @@
       "stale": "البيانات قديمة — في انتظار التحديث.",
       "deterministic": "حتمي",
       "review": "مراجعة",
-      "reviewAria": "مراجعة اقتراح {name}"
+      "reviewAria": "مراجعة اقتراح {name}",
+      "paramFixedDose": "جرعة ثابتة"
     },
     "medecinMessages": {
       "title": "رسائل غير مقروءة",
@@ -1532,7 +1533,8 @@
     "isfMgdl": "mg/dL/U",
     "isfMmol": "mmol/L/U",
     "icr": "g/U",
-    "basal": "U/h"
+    "basal": "U/h",
+    "u": "U"
   },
   "patientContextBar": {
     "backToWorklist": "العودة إلى يومي",
@@ -2015,7 +2017,8 @@
     "finalize": "إنهاء التقرير",
     "finalizeError": "فشل الإنهاء. أعد المحاولة.",
     "finalizedTitle": "تم إنهاء التقرير",
-    "finalizedNote": "هذا التقرير نهائي وغير قابل للتعديل (لا يمكن تغييره بعد الآن)."
+    "finalizedNote": "هذا التقرير نهائي وغير قابل للتعديل (لا يمكن تغييره بعد الآن).",
+    "paramFixedDose": "جرعة ثابتة"
   },
   "cabinetMembers": {
     "title": "أعضاء العيادة والصلاحيات",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1483,7 +1483,8 @@
       "stale": "Data is stale — refresh pending.",
       "deterministic": "deterministic",
       "review": "Review",
-      "reviewAria": "Review {name}'s proposal"
+      "reviewAria": "Review {name}'s proposal",
+      "paramFixedDose": "Fixed dose"
     },
     "medecinMessages": {
       "title": "Unread messages",
@@ -1532,7 +1533,8 @@
     "isfMgdl": "mg/dL/U",
     "isfMmol": "mmol/L/U",
     "icr": "g/U",
-    "basal": "U/h"
+    "basal": "U/h",
+    "u": "U"
   },
   "patientContextBar": {
     "backToWorklist": "Back to My day",
@@ -2015,7 +2017,8 @@
     "finalize": "Finalize report",
     "finalizeError": "Finalization failed. Please retry.",
     "finalizedTitle": "Report finalized",
-    "finalizedNote": "This report is finalized and immutable (it can no longer be edited)."
+    "finalizedNote": "This report is finalized and immutable (it can no longer be edited).",
+    "paramFixedDose": "Fixed dose"
   },
   "cabinetMembers": {
     "title": "Cabinet personnel & rights",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1483,7 +1483,8 @@
       "stale": "Données obsolètes — rafraîchissement en attente.",
       "deterministic": "déterministe",
       "review": "Revoir",
-      "reviewAria": "Revoir la proposition de {name}"
+      "reviewAria": "Revoir la proposition de {name}",
+      "paramFixedDose": "Dose fixe"
     },
     "medecinMessages": {
       "title": "Messages non lus",
@@ -1532,7 +1533,8 @@
     "isfMgdl": "mg/dL/U",
     "isfMmol": "mmol/L/U",
     "icr": "g/U",
-    "basal": "U/h"
+    "basal": "U/h",
+    "u": "U"
   },
   "patientContextBar": {
     "backToWorklist": "Retour à Ma journée",
@@ -2015,7 +2017,8 @@
     "finalize": "Finaliser le compte rendu",
     "finalizeError": "La finalisation a échoué. Réessayez.",
     "finalizedTitle": "Compte rendu finalisé",
-    "finalizedNote": "Ce compte rendu est finalisé et immuable (il ne peut plus être modifié)."
+    "finalizedNote": "Ce compte rendu est finalisé et immuable (il ne peut plus être modifié).",
+    "paramFixedDose": "Dose fixe"
   },
   "cabinetMembers": {
     "title": "Personnel & droits du cabinet",

--- a/prisma/migrations/20260704120000_us2646_socle_insulino_provenance_fixeddose/migration.sql
+++ b/prisma/migrations/20260704120000_us2646_socle_insulino_provenance_fixeddose/migration.sql
@@ -1,0 +1,119 @@
+-- ═══════════════════════════════════════════════════════════════
+-- US-2646 — Socle données édition insulinothérapie (épic US-2645)
+-- ═══════════════════════════════════════════════════════════════
+-- - Provenance AdjustmentProposal : enum ProposalSource + proposed_by_user_id
+--   (nullable, FK SetNull) + proposer_comment (chiffré AES-256-GCM applicatif).
+--   confidence / supporting_events rendus nullable (union taguée : une proposition
+--   humaine n'a pas de métriques moteur). Backfill implicite des lignes existantes
+--   via DEFAULT 'algorithm'.
+-- - AdjustableParameter += fixedDose ; AdjustmentReason += patientRequested/manualAdjustment.
+-- - Tables : fixed_dose_slots (dose fixe structurée, mode b), clinical_review_flags
+--   (orientation mode non-insuliné — JAMAIS de posologie, D7).
+-- - patients.treatment_mode (cache d'affichage ; source de vérité = dérivée US-2647).
+--
+-- ⚠️ CHECK de provenance : n'impose QUE l'invariant `algorithm` (userId NULL +
+-- métriques présentes). Le « userId NOT NULL pour une proposition humaine » est
+-- imposé côté SERVICE (à la création), PAS en base, car la suppression RGPD
+-- (FK SetNull) peut annuler l'auteur — le rôle reste porté par `source`.
+-- CreateEnum
+CREATE TYPE "ProposalSource" AS ENUM ('algorithm', 'patient', 'nurse', 'doctor');
+
+-- CreateEnum
+CREATE TYPE "TreatmentMode" AS ENUM ('basalBolus', 'fixedDose', 'nonInsulin');
+
+-- CreateEnum
+CREATE TYPE "DoseMoment" AS ENUM ('morning', 'noon', 'evening', 'night');
+
+-- CreateEnum
+CREATE TYPE "ClinicalReviewFlagType" AS ENUM ('reviewInConsultation', 'hba1cStale', 'tirBelowTarget', 'observance');
+
+-- CreateEnum
+CREATE TYPE "ClinicalReviewFlagStatus" AS ENUM ('open', 'resolved');
+
+-- AlterEnum
+ALTER TYPE "AdjustableParameter" ADD VALUE 'fixedDose';
+
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "AdjustmentReason" ADD VALUE 'patientRequested';
+ALTER TYPE "AdjustmentReason" ADD VALUE 'manualAdjustment';
+
+-- AlterTable
+ALTER TABLE "adjustment_proposals" ADD COLUMN     "proposed_by_user_id" INTEGER,
+ADD COLUMN     "proposer_comment" TEXT,
+ADD COLUMN     "source" "ProposalSource" NOT NULL DEFAULT 'algorithm',
+ALTER COLUMN "confidence" DROP NOT NULL,
+ALTER COLUMN "supporting_events" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "patients" ADD COLUMN     "treatment_mode" "TreatmentMode";
+
+-- CreateTable
+CREATE TABLE "fixed_dose_slots" (
+    "id" TEXT NOT NULL,
+    "patient_insulin_id" INTEGER NOT NULL,
+    "moment" "DoseMoment" NOT NULL,
+    "value_u" DECIMAL(5,2) NOT NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL,
+
+    CONSTRAINT "fixed_dose_slots_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "clinical_review_flags" (
+    "id" TEXT NOT NULL,
+    "patient_id" INTEGER NOT NULL,
+    "type" "ClinicalReviewFlagType" NOT NULL,
+    "status" "ClinicalReviewFlagStatus" NOT NULL DEFAULT 'open',
+    "created_by" INTEGER,
+    "resolved_by" INTEGER,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "resolved_at" TIMESTAMPTZ,
+
+    CONSTRAINT "clinical_review_flags_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "fixed_dose_slots_patient_insulin_id_idx" ON "fixed_dose_slots"("patient_insulin_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "fixed_dose_slots_patient_insulin_id_moment_key" ON "fixed_dose_slots"("patient_insulin_id", "moment");
+
+-- CreateIndex
+CREATE INDEX "clinical_review_flags_patient_id_status_idx" ON "clinical_review_flags"("patient_id", "status");
+
+-- AddForeignKey
+ALTER TABLE "adjustment_proposals" ADD CONSTRAINT "adjustment_proposals_proposed_by_user_id_fkey" FOREIGN KEY ("proposed_by_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "fixed_dose_slots" ADD CONSTRAINT "fixed_dose_slots_patient_insulin_id_fkey" FOREIGN KEY ("patient_insulin_id") REFERENCES "patient_insulins"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "clinical_review_flags" ADD CONSTRAINT "clinical_review_flags_patient_id_fkey" FOREIGN KEY ("patient_id") REFERENCES "patients"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "clinical_review_flags" ADD CONSTRAINT "clinical_review_flags_created_by_fkey" FOREIGN KEY ("created_by") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "clinical_review_flags" ADD CONSTRAINT "clinical_review_flags_resolved_by_fkey" FOREIGN KEY ("resolved_by") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+
+-- US-2646 — invariant de provenance (union taguée). Prisma ne modélise pas les
+-- CHECK ; ajouté ici en DDL (appliqué par migrate deploy, présent en CI/E2E).
+ALTER TABLE "adjustment_proposals"
+  ADD CONSTRAINT "adjustment_proposals_algorithm_provenance_check"
+  CHECK (
+    "source" <> 'algorithm'
+    OR (
+      "proposed_by_user_id" IS NULL
+      AND "supporting_events" IS NOT NULL
+      AND "confidence" IS NOT NULL
+    )
+  );

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -96,6 +96,44 @@ enum AdjustableParameter {
   basalRate
   insulinSensitivityFactor
   insulinToCarbRatio
+  // US-2646 — dose fixe par moment (mode « doses simples »). Borne dans CLINICAL_BOUNDS + validateProposedValue.
+  fixedDose
+}
+
+// US-2646 — provenance d'une AdjustmentProposal (union taguée).
+enum ProposalSource {
+  algorithm
+  patient
+  nurse
+  doctor
+}
+
+// US-2646 — mode de traitement (cache d'affichage ; source de vérité = dérivée US-2647).
+enum TreatmentMode {
+  basalBolus
+  fixedDose
+  nonInsulin
+}
+
+// US-2646 — moment d'une dose fixe (mode b).
+enum DoseMoment {
+  morning
+  noon
+  evening
+  night
+}
+
+// US-2646 — type de flag d'orientation (mode non-insuliné ; jamais une posologie).
+enum ClinicalReviewFlagType {
+  reviewInConsultation
+  hba1cStale
+  tirBelowTarget
+  observance
+}
+
+enum ClinicalReviewFlagStatus {
+  open
+  resolved
 }
 
 enum AdjustmentReason {
@@ -109,6 +147,9 @@ enum AdjustmentReason {
   icrTooHigh
   icrCorrect
   insufficientData
+  // US-2646 — propositions humaines (non issues du moteur diagnostique).
+  patientRequested
+  manualAdjustment
 }
 
 enum ConfidenceLevel {
@@ -394,6 +435,9 @@ model User {
   pushScheduled                     PushScheduledNotification[]
   auditLogs                         AuditLog[]
   reviewedProposals                 AdjustmentProposal[]              @relation("ReviewedBy")
+  proposedAdjustments               AdjustmentProposal[]              @relation("ProposedBy")
+  reviewFlagsCreated                ClinicalReviewFlag[]              @relation("ReviewFlagCreatedBy")
+  reviewFlagsResolved               ClinicalReviewFlag[]              @relation("ReviewFlagResolvedBy")
   prescribedInsulins                PatientInsulin[]                  @relation("PrescribedInsulins")
   mydiabbyCredential                MyDiabbyCredential?
   acknowledgedAlerts                EmergencyAlert[]                  @relation("AlertAcknowledger")
@@ -626,6 +670,12 @@ model Patient {
   /// pour permettre activation rapide sans saisir DPA, puis synchronisation
   /// par la couche service vers PatientPregnancy lorsque les détails sont saisis.
   pregnancyMode Boolean   @default(false) @map("pregnancy_mode")
+  /// US-2646 — mode de traitement (basalBolus / fixedDose / nonInsulin). CACHE
+  /// d'affichage : la source de vérité reste la config (settings/insulines),
+  /// re-dérivée en transaction au gate d'écriture (US-2647). NULL = non encore
+  /// résolu → dériver à la lecture (fail-closed : jamais d'édition insuline sur
+  /// un mode inconnu).
+  treatmentMode TreatmentMode? @map("treatment_mode")
   /// US-2076bis-V2 (Issue #442) — UUID v4 opaque pour anonymisation UI
   /// (ThreadList messagerie + future Patient list). Élimine timing oracle
   /// énumération `patient.id` séquentiel (ANSSI / RGPD Art. 5.1.f). Le
@@ -651,6 +701,7 @@ model Patient {
   insulinTherapySettings InsulinTherapySettings?
   bolusCalculationLogs   BolusCalculationLog[]
   adjustmentProposals    AdjustmentProposal[]
+  clinicalReviewFlags    ClinicalReviewFlag[]
   cgmEntries             CgmEntry[]
   glycemiaEntries        GlycemiaEntry[]
   diabetesEvents         DiabetesEvent[]
@@ -1095,6 +1146,7 @@ model PatientInsulin {
   prescriber     User?                    @relation("PrescribedInsulins", fields: [prescribedBy], references: [id], onDelete: SetNull)
   bolusSettings  InsulinTherapySettings[] @relation("BolusInsulinSettings")
   basalSettings  InsulinTherapySettings[] @relation("BasalInsulinSettings")
+  fixedDoseSlots FixedDoseSlot[]
 
   @@index([patientId, isActive])
   @@index([patientId, insulinCatalogId])
@@ -1265,9 +1317,18 @@ model AdjustmentProposal {
   currentValue          Decimal             @map("current_value") @db.Decimal(8, 4)
   proposedValue         Decimal             @map("proposed_value") @db.Decimal(8, 4)
   changePercent         Decimal             @map("change_percent") @db.Decimal(5, 2)
-  confidence            ConfidenceLevel
+  // US-2646 — provenance de la proposition (union taguée sur une seule table).
+  // `algorithm` = généré par le moteur (proposedByUserId NULL) ; patient/nurse/doctor
+  // = proposition humaine (proposedByUserId NOT NULL). Dérivé serveur, jamais du body.
+  // Contrainte CHECK (migration) : algorithm ⇔ userId NULL & supportingEvents/confidence NOT NULL.
+  source                ProposalSource      @default(algorithm)
+  proposedByUserId      Int?                @map("proposed_by_user_id")
+  // Justification texte libre d'une proposition patient — chiffrée AES-256-GCM (base64). Jamais en clair (log/notif/URL).
+  proposerComment       String?             @map("proposer_comment")
+  // Nullable depuis US-2646 : une proposition humaine n'a ni confidence ni supportingEvents (métriques moteur).
+  confidence            ConfidenceLevel?
   reason                AdjustmentReason
-  supportingEvents      Int                 @map("supporting_events")
+  supportingEvents      Int?                @map("supporting_events")
   totalEventsConsidered Int?                @map("total_events_considered")
   excludedEvents        Int?                @map("excluded_events")
   averageObservedValue  Decimal?            @map("average_observed_value") @db.Decimal(8, 4)
@@ -1285,6 +1346,9 @@ model AdjustmentProposal {
 
   patient       Patient                          @relation(fields: [patientId], references: [id], onDelete: Cascade)
   reviewer      User?                            @relation("ReviewedBy", fields: [reviewedBy], references: [id])
+  // US-2646 — auteur de la proposition (patient/nurse/doctor). onDelete: SetNull pour
+  // préserver la ligne (traçabilité) après suppression RGPD de l'auteur ; le rôle reste porté par `source`.
+  proposer      User?                            @relation("ProposedBy", fields: [proposedByUserId], references: [id], onDelete: SetNull)
   pumpBasalSlot PumpBasalSlot?                   @relation(fields: [pumpBasalSlotId], references: [id])
   /// US-2065 — accusé patient (1:1).
   ack           AdjustmentProposalAck?
@@ -1293,6 +1357,46 @@ model AdjustmentProposal {
 
   @@index([patientId, status, createdAt])
   @@map("adjustment_proposals")
+}
+
+// US-2646 — dose fixe structurée par moment (mode « doses simples »). Base
+// NUMÉRIQUE de l'ajustement mode (b). `valueU` = valeur unique par moment
+// (arbitrage clinique : pas de fourchette). Le texte libre `PatientInsulin.dosage`
+// reste l'affichage d'origine ; cette table est la valeur calculable.
+model FixedDoseSlot {
+  id               String     @id @default(uuid())
+  patientInsulinId Int        @map("patient_insulin_id")
+  moment           DoseMoment
+  valueU           Decimal    @map("value_u") @db.Decimal(5, 2)
+  createdAt        DateTime   @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt        DateTime   @updatedAt @map("updated_at") @db.Timestamptz()
+
+  patientInsulin PatientInsulin @relation(fields: [patientInsulinId], references: [id], onDelete: Cascade)
+
+  @@unique([patientInsulinId, moment])
+  @@index([patientInsulinId])
+  @@map("fixed_dose_slots")
+}
+
+// US-2646 — flag d'orientation clinique (mode non-insuliné). Objet DISTINCT
+// d'AdjustmentProposal : ne porte JAMAIS de posologie (frontière dispositif
+// médical, D7). `createdBy` NULL = généré par algorithme.
+model ClinicalReviewFlag {
+  id         String                   @id @default(uuid())
+  patientId  Int                      @map("patient_id")
+  type       ClinicalReviewFlagType
+  status     ClinicalReviewFlagStatus @default(open)
+  createdBy  Int?                     @map("created_by")
+  resolvedBy Int?                     @map("resolved_by")
+  createdAt  DateTime                 @default(now()) @map("created_at") @db.Timestamptz()
+  resolvedAt DateTime?                @map("resolved_at") @db.Timestamptz()
+
+  patient  Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  creator  User?   @relation("ReviewFlagCreatedBy", fields: [createdBy], references: [id], onDelete: SetNull)
+  resolver User?   @relation("ReviewFlagResolvedBy", fields: [resolvedBy], references: [id], onDelete: SetNull)
+
+  @@index([patientId, status])
+  @@map("clinical_review_flags")
 }
 
 // ═══════════════════════════════════════════════════════════════

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -115,7 +115,9 @@ enum TreatmentMode {
   nonInsulin
 }
 
-// US-2646 — moment d'une dose fixe (mode b).
+// US-2646 — moment d'une dose fixe (mode b). Enum distinct de `DayMomentType`
+// (qui porte un `custom` sans objet pour une dose fixe) : une dose fixe se répartit
+// sur 4 moments fixes (matin/midi/soir/nuit), jamais sur un moment personnalisé.
 enum DoseMoment {
   morning
   noon

--- a/src/app/(dashboard)/patients/[id]/review/ReviewClient.tsx
+++ b/src/app/(dashboard)/patients/[id]/review/ReviewClient.tsx
@@ -44,7 +44,8 @@ export type ReviewProposalItem = {
   proposedValue: number
   changePercent: number
   reason: string
-  confidence: string
+  // US-2646 — nullable : une proposition humaine (patient/infirmier) n'a pas de confiance moteur.
+  confidence: string | null
   timeSlotStartHour: number | null
   timeSlotEndHour: number | null
   createdAt: string
@@ -94,13 +95,15 @@ const PARAM_LABEL_KEY: Record<AdjustableParameter, string> = {
   basalRate: "paramBasalRate",
   insulinSensitivityFactor: "paramInsulinSensitivityFactor",
   insulinToCarbRatio: "paramInsulinToCarbRatio",
+  fixedDose: "paramFixedDose",
 }
 
 /** parameterType → clé d'unité (namespace `insulinUnits`). ISF stocké en g/L. */
-const PARAM_UNIT_KEY: Record<AdjustableParameter, "isfGl" | "icr" | "basal"> = {
+const PARAM_UNIT_KEY: Record<AdjustableParameter, "isfGl" | "icr" | "basal" | "u"> = {
   insulinSensitivityFactor: "isfGl",
   insulinToCarbRatio: "icr",
   basalRate: "basal",
+  fixedDose: "u",
 }
 
 const STEPS = [

--- a/src/components/diabeo/dashboard/medecin/PendingProposalsCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/PendingProposalsCard.tsx
@@ -36,6 +36,7 @@ const PARAM_LABEL_KEY: Record<PendingProposalItem["parameterType"], string> = {
   basalRate: "paramBasalRate",
   insulinSensitivityFactor: "paramInsulinSensitivityFactor",
   insulinToCarbRatio: "paramInsulinToCarbRatio",
+  fixedDose: "paramFixedDose",
 }
 
 /** Clés du namespace i18n `insulinUnits` (source unique des libellés d'unités). */

--- a/src/components/diabeo/dashboard/medecin/PendingProposalsCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/PendingProposalsCard.tsx
@@ -40,7 +40,7 @@ const PARAM_LABEL_KEY: Record<PendingProposalItem["parameterType"], string> = {
 }
 
 /** Clés du namespace i18n `insulinUnits` (source unique des libellés d'unités). */
-type InsulinUnitKey = "isfGl" | "isfMgdl" | "isfMmol" | "icr" | "basal"
+type InsulinUnitKey = "isfGl" | "isfMgdl" | "isfMmol" | "icr" | "basal" | "u"
 
 /**
  * Unité d'affichage de l'ISF selon l'unité de glycémie de l'appelant.
@@ -68,7 +68,12 @@ function displayFor(p: PendingProposalItem): { from: number; to: number; unitKey
   return {
     from: p.currentValue,
     to: p.proposedValue,
-    unitKey: p.parameterType === "basalRate" ? "basal" : "icr",
+    unitKey:
+      p.parameterType === "basalRate"
+        ? "basal"
+        : p.parameterType === "fixedDose"
+          ? "u" // US-2646 — dose fixe exprimée en unités (jamais g/U)
+          : "icr",
   }
 }
 

--- a/src/lib/clinical-bounds.ts
+++ b/src/lib/clinical-bounds.ts
@@ -37,13 +37,19 @@ export const CLINICAL_BOUNDS = {
   PUMP_BASAL_INCREMENT: 0.05,
   /**
    * US-2646 — Dose fixe par moment (mode « doses simples »), en unités.
-   * `FIXED_DOSE_MIN`/`MAX` = bornes absolues d'une dose fixe unitaire (plancher > 0
-   * pour éviter une dose nulle qui casserait la couverture ; plafond = `MAX_SINGLE_BOLUS`).
-   * `FIXED_DOSE_MAX_DELTA_U` = variation absolue maximale par ajustement (titration lente).
+   * `FIXED_DOSE_MIN` = plancher absolu de sanité (bloquant : pas de dose ≤ 0 ; pas
+   * < 0,5 U = pas des stylos demi-unité). PAS de plafond BLOQUANT : une basale fixe
+   * peut légitimement dépasser 25 U (DT2 insulino-résistant, dégludec/glargine U-300
+   * jusqu'à ~80 U). À la place, seuils d'AVERTISSEMENT théoriques par type — ils
+   * déclenchent un warning (au service), jamais un rejet :
+   *   - `FIXED_BOLUS_WARN_U` : dose fixe prandiale au-delà de laquelle on alerte.
+   *   - `FIXED_BASAL_WARN_U`  : dose fixe basale au-delà de laquelle on alerte.
+   * `FIXED_DOSE_MAX_DELTA_U` = variation max par ajustement (titration lente) ;
    * `FIXED_DOSE_PATIENT_MAX_DELTA_U` = cap PATIENT resserré (une demande, pas une titration).
    */
   FIXED_DOSE_MIN: 0.5,
-  FIXED_DOSE_MAX: 25.0,
+  FIXED_BOLUS_WARN_U: 25.0,
+  FIXED_BASAL_WARN_U: 80.0,
   FIXED_DOSE_MAX_DELTA_U: 2.0,
   FIXED_DOSE_PATIENT_MAX_DELTA_U: 1.0,
 } as const

--- a/src/lib/clinical-bounds.ts
+++ b/src/lib/clinical-bounds.ts
@@ -35,6 +35,17 @@ export const CLINICAL_BOUNDS = {
   INSULIN_ACTION_MAX: 5.0,
   /** Pump basal increment in U/h */
   PUMP_BASAL_INCREMENT: 0.05,
+  /**
+   * US-2646 — Dose fixe par moment (mode « doses simples »), en unités.
+   * `FIXED_DOSE_MIN`/`MAX` = bornes absolues d'une dose fixe unitaire (plancher > 0
+   * pour éviter une dose nulle qui casserait la couverture ; plafond = `MAX_SINGLE_BOLUS`).
+   * `FIXED_DOSE_MAX_DELTA_U` = variation absolue maximale par ajustement (titration lente).
+   * `FIXED_DOSE_PATIENT_MAX_DELTA_U` = cap PATIENT resserré (une demande, pas une titration).
+   */
+  FIXED_DOSE_MIN: 0.5,
+  FIXED_DOSE_MAX: 25.0,
+  FIXED_DOSE_MAX_DELTA_U: 2.0,
+  FIXED_DOSE_PATIENT_MAX_DELTA_U: 1.0,
 } as const
 
 export type ClinicalBounds = typeof CLINICAL_BOUNDS

--- a/src/lib/services/adjustment.service.ts
+++ b/src/lib/services/adjustment.service.ts
@@ -29,6 +29,11 @@ function validateProposedValue(parameterType: string, value: number): boolean {
       return value >= INSULIN_BOUNDS.ICR_MIN && value <= INSULIN_BOUNDS.ICR_MAX
     case "basalRate":
       return value >= INSULIN_BOUNDS.BASAL_MIN && value <= INSULIN_BOUNDS.BASAL_MAX
+    // US-2646 — dose fixe (mode « doses simples »). Bornes absolues ; le cap de
+    // variation (delta) et le sens interdit patient sont vérifiés à la création
+    // (service), pas ici (borne de valeur uniquement).
+    case "fixedDose":
+      return value >= INSULIN_BOUNDS.FIXED_DOSE_MIN && value <= INSULIN_BOUNDS.FIXED_DOSE_MAX
     default:
       return false
   }

--- a/src/lib/services/adjustment.service.ts
+++ b/src/lib/services/adjustment.service.ts
@@ -29,11 +29,13 @@ function validateProposedValue(parameterType: string, value: number): boolean {
       return value >= INSULIN_BOUNDS.ICR_MIN && value <= INSULIN_BOUNDS.ICR_MAX
     case "basalRate":
       return value >= INSULIN_BOUNDS.BASAL_MIN && value <= INSULIN_BOUNDS.BASAL_MAX
-    // US-2646 — dose fixe (mode « doses simples »). Bornes absolues ; le cap de
-    // variation (delta) et le sens interdit patient sont vérifiés à la création
-    // (service), pas ici (borne de valeur uniquement).
+    // US-2646 — dose fixe (mode « doses simples »). SEUL le plancher de sanité bloque
+    // (dose ≤ 0 / < 0,5 U invalide). PAS de plafond bloquant : une basale fixe peut
+    // dépasser 25 U ; le dépassement des seuils théoriques (FIXED_BOLUS/BASAL_WARN_U)
+    // déclenche un AVERTISSEMENT au service, pas un rejet. Delta/sens interdit patient
+    // vérifiés à la création (service), pas ici.
     case "fixedDose":
-      return value >= INSULIN_BOUNDS.FIXED_DOSE_MIN && value <= INSULIN_BOUNDS.FIXED_DOSE_MAX
+      return value >= INSULIN_BOUNDS.FIXED_DOSE_MIN
     default:
       return false
   }
@@ -152,6 +154,13 @@ export const adjustmentService = {
 
         if (!validateProposedValue(proposal.parameterType, proposed)) {
           throw new Error("valueOutOfBounds")
+        }
+
+        // US-2646 — l'écriture d'une dose fixe (fixed_dose_slots) est câblée en
+        // US-2647/2649. Tant qu'elle ne l'est pas, on REFUSE l'application immédiate
+        // (fail-closed) plutôt que de renvoyer un faux `applied: true` sur un no-op.
+        if (proposal.parameterType === "fixedDose") {
+          throw new Error("fixedDoseApplyNotImplemented")
         }
 
         if (proposal.parameterType === "insulinSensitivityFactor" && proposal.timeSlotStartHour != null) {

--- a/tests/unit/access-control.test.ts
+++ b/tests/unit/access-control.test.ts
@@ -57,7 +57,7 @@ describe("canAccessPatient", () => {
 
   it("ADMIN can access any non-deleted patient", async () => {
     prismaMock.patient.findFirst.mockResolvedValue({
-      id: 99, userId: 50, pathology: "DT1", pregnancyMode: false,
+      id: 99, userId: 50, pathology: "DT1", pregnancyMode: false, treatmentMode: null,
       // US-2076bis-V2 (Issue #442) — publicRef requis dans le shape Patient.
       publicRef: "99000000-0000-4000-8000-000000000000",
       createdAt: new Date(), deletedAt: null,
@@ -74,7 +74,7 @@ describe("canAccessPatient", () => {
 
   it("VIEWER can access own patient record", async () => {
     prismaMock.patient.findFirst.mockResolvedValue({
-      id: 5, userId: 42, pathology: "DT1", pregnancyMode: false,
+      id: 5, userId: 42, pathology: "DT1", pregnancyMode: false, treatmentMode: null,
       // US-2076bis-V2 (Issue #442) — publicRef requis dans le shape Patient.
       publicRef: "05000000-0000-4000-8000-000000000000",
       createdAt: new Date(), deletedAt: null,

--- a/tests/unit/clinical-bounds.test.ts
+++ b/tests/unit/clinical-bounds.test.ts
@@ -36,9 +36,10 @@ describe("CLINICAL_BOUNDS — anti-drift (A3)", () => {
       INSULIN_ACTION_MIN: 3.5,
       INSULIN_ACTION_MAX: 5.0,
       PUMP_BASAL_INCREMENT: 0.05,
-      // US-2646 — dose fixe (mode « doses simples »)
+      // US-2646 — dose fixe (mode « doses simples ») : plancher bloquant + seuils warn
       FIXED_DOSE_MIN: 0.5,
-      FIXED_DOSE_MAX: 25.0,
+      FIXED_BOLUS_WARN_U: 25.0,
+      FIXED_BASAL_WARN_U: 80.0,
       FIXED_DOSE_MAX_DELTA_U: 2.0,
       FIXED_DOSE_PATIENT_MAX_DELTA_U: 1.0,
     })
@@ -53,11 +54,11 @@ describe("CLINICAL_BOUNDS — anti-drift (A3)", () => {
     expect(CLINICAL_BOUNDS.INSULIN_ACTION_MIN).toBeLessThan(CLINICAL_BOUNDS.INSULIN_ACTION_MAX)
   })
 
-  it("US-2646 — dose fixe : bornes cohérentes et cap patient ≤ cap moteur", () => {
+  it("US-2646 — dose fixe : plancher > 0, seuils warn bolus < basal, cap patient < moteur", () => {
     expect(CLINICAL_BOUNDS.FIXED_DOSE_MIN).toBeGreaterThan(0)
-    expect(CLINICAL_BOUNDS.FIXED_DOSE_MIN).toBeLessThan(CLINICAL_BOUNDS.FIXED_DOSE_MAX)
-    // le plafond d'une dose fixe ne dépasse jamais le cap bolus unique
-    expect(CLINICAL_BOUNDS.FIXED_DOSE_MAX).toBeLessThanOrEqual(CLINICAL_BOUNDS.MAX_SINGLE_BOLUS)
+    // seuils d'AVERTISSEMENT (non bloquants) : le bolus fixe alerte plus tôt que la basale
+    expect(CLINICAL_BOUNDS.FIXED_DOSE_MIN).toBeLessThan(CLINICAL_BOUNDS.FIXED_BOLUS_WARN_U)
+    expect(CLINICAL_BOUNDS.FIXED_BOLUS_WARN_U).toBeLessThan(CLINICAL_BOUNDS.FIXED_BASAL_WARN_U)
     // cap de variation patient strictement plus strict que le cap moteur
     expect(CLINICAL_BOUNDS.FIXED_DOSE_PATIENT_MAX_DELTA_U).toBeLessThan(CLINICAL_BOUNDS.FIXED_DOSE_MAX_DELTA_U)
   })

--- a/tests/unit/clinical-bounds.test.ts
+++ b/tests/unit/clinical-bounds.test.ts
@@ -36,6 +36,11 @@ describe("CLINICAL_BOUNDS — anti-drift (A3)", () => {
       INSULIN_ACTION_MIN: 3.5,
       INSULIN_ACTION_MAX: 5.0,
       PUMP_BASAL_INCREMENT: 0.05,
+      // US-2646 — dose fixe (mode « doses simples »)
+      FIXED_DOSE_MIN: 0.5,
+      FIXED_DOSE_MAX: 25.0,
+      FIXED_DOSE_MAX_DELTA_U: 2.0,
+      FIXED_DOSE_PATIENT_MAX_DELTA_U: 1.0,
     })
   })
 
@@ -46,6 +51,15 @@ describe("CLINICAL_BOUNDS — anti-drift (A3)", () => {
     expect(CLINICAL_BOUNDS.BASAL_MIN).toBeLessThan(CLINICAL_BOUNDS.BASAL_MAX)
     expect(CLINICAL_BOUNDS.TARGET_MIN_MGDL).toBeLessThan(CLINICAL_BOUNDS.TARGET_MAX_MGDL)
     expect(CLINICAL_BOUNDS.INSULIN_ACTION_MIN).toBeLessThan(CLINICAL_BOUNDS.INSULIN_ACTION_MAX)
+  })
+
+  it("US-2646 — dose fixe : bornes cohérentes et cap patient ≤ cap moteur", () => {
+    expect(CLINICAL_BOUNDS.FIXED_DOSE_MIN).toBeGreaterThan(0)
+    expect(CLINICAL_BOUNDS.FIXED_DOSE_MIN).toBeLessThan(CLINICAL_BOUNDS.FIXED_DOSE_MAX)
+    // le plafond d'une dose fixe ne dépasse jamais le cap bolus unique
+    expect(CLINICAL_BOUNDS.FIXED_DOSE_MAX).toBeLessThanOrEqual(CLINICAL_BOUNDS.MAX_SINGLE_BOLUS)
+    // cap de variation patient strictement plus strict que le cap moteur
+    expect(CLINICAL_BOUNDS.FIXED_DOSE_PATIENT_MAX_DELTA_U).toBeLessThan(CLINICAL_BOUNDS.FIXED_DOSE_MAX_DELTA_U)
   })
 })
 


### PR DESCRIPTION
Première brique de l'épic **US-2645** (socle données, **aucune logique métier/UI**). Ferme #629.

## Migration `20260704120000_us2646_socle_insulino_provenance_fixeddose`
- **AdjustmentProposal — provenance** : enum `ProposalSource` (`algorithm|patient|nurse|doctor`), `proposed_by_user_id` nullable (FK SetNull, RGPD-compatible), `proposer_comment` (chiffré AES-256-GCM applicatif). `confidence`/`supporting_events` → **nullable** (union taguée). **CHECK** invariant `algorithm` (userId NULL + métriques présentes) ; le userId requis pour une proposition humaine est imposé **côté service** (compatible SetNull).
- **Enums** : `AdjustableParameter += fixedDose` ; `AdjustmentReason += patientRequested/manualAdjustment`.
- **Tables** : `fixed_dose_slots` (dose fixe = **valeur unique** par moment) ; `clinical_review_flags` (orientation mode non-insuliné — **jamais de posologie**, D7).
- **`patients.treatment_mode`** (cache ; source de vérité = dérivée en US-2647).

## Bornes & retombées
- `CLINICAL_BOUNDS += FIXED_DOSE_*` + branche `validateProposedValue(fixedDose)` + test anti-drift ; sync copie CLAUDE.md.
- `Record<AdjustableParameter>` rendus exhaustifs (+ i18n `paramFixedDose`, `insulinUnits.u` fr/en/ar) ; `ReviewProposalItem.confidence` nullable.

## Vérifs locales (Postgres 16)
✅ `migrate deploy` · ✅ **drift-gate exit 0** · ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **2688 tests unitaires**.

Conforme aux revues archi + HDS (épic §12). Prochaine brique : US-2647 (détection du mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)