### PR TITLE
docs(US): reporter les findings différés de la revue US-2646 dans les US consommatrices

### DIFF
--- a/docs/UserStory/insulinotherapie-edition/US-2649-flux-proposition-validation.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2649-flux-proposition-validation.md
@@ -39,3 +39,12 @@ explicitement. L'écran de validation existe déjà (`/adjustment-proposals`) ma
 - **Validation = DOCTOR exact + `canAccessPatient`** (ADMIN exclu) (§12.8).
 - **Audit sans PHI** : `resourceId=proposalId`, `metadata={patientId, proposedByRole}` ; jamais la dose (§12 nit).
 - Dépendances corrigées : dépend aussi de **2647** et **2651**.
+
+## Reports de la revue code+migration (PR #638 / US-2646) — à fermer ici
+Invariants laissés volontairement « ouverts » par le socle, à fermer côté service :
+- **Provenance dérivée serveur** (2649a) : `source` + `proposedByUserId` depuis la **session**, jamais du body (anti-usurpation). **Nuller** `confidence`/`supportingEvents` quand `source != algorithm` (le CHECK DB ne l'impose pas). *(HDS MEDIUM, prisma)*
+- **Audit à la création** (2649b, **bloquant**) : enregistrer l'auteur (`metadata={patientId, proposedByRole}`) **dès la création** — sinon la suppression RGPD (FK SetNull) perd le lien forensique. *(HDS HIGH-dépendance)*
+- **Affichage basé sur `source`, pas `confidence`** (2649b) : ne jamais rendre une proposition non-`algorithm` comme « moteur » (une `confidence` bidon ne doit pas tromper le médecin qui valide). *(HDS LOW — sécurité clinique)*
+- **Notif sans PHI** : `data={type, proposalId}`, corps générique (déjà prévu).
+- **Index unique partiel** : `clinical_review_flags(patient_id, type) WHERE status='open'` (précédent `emergency_alerts_one_live_per_type`) pour éviter le spam de flags. *(prisma)*
+- **Écriture `fixedDose` dans `accept()`** : aujourd'hui **fail-closed** (throw `fixedDoseApplyNotImplemented`) → câbler l'écriture réelle dans `fixed_dose_slots` ; **activer les caps delta** (`FIXED_DOSE_MAX_DELTA_U` / `FIXED_DOSE_PATIENT_MAX_DELTA_U`, inertes au socle) ; **router les seuils d'avertissement** (`FIXED_BOLUS_WARN_U` / `FIXED_BASAL_WARN_U`) selon `PatientInsulin.usage` (basal vs bolus). *(code-review + medical)*

--- a/docs/UserStory/insulinotherapie-edition/US-2650-self-service-patient.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2650-self-service-patient.md
@@ -35,3 +35,6 @@ Paramètres ; les API `/api/insulin-therapy/*` **bloquent VIEWER** ; `/insulin-t
 - **Own-id strict** : résolution **exclusive** `getOwnPatientId(user.id)` ; **aucun** `?patientId`, **aucun** `x-consultation-token` sur les routes patient ; Zod **sans** `patientId`. Re-scoper `/api/patient/insulin-settings` (§12 « à intégrer », HIGH IDOR). Test VIEWER visant un autre id/token → son dossier.
 - Justification patient → champ **`proposerComment`** chiffré (pas `Ack.comment`) (§12).
 - `InsulinSummary` : vérifier **absence de fuite import client/serveur** avant montage `(patient)` (§12 nit).
+
+## Reports de la revue code+migration (PR #638 / US-2646) — à fermer ici
+- **Chiffrement `proposer_comment`** (**CRITIQUE dès la 1ʳᵉ écriture patient**) : la justification patient (texte libre) est un `TEXT` en clair au socle → `encrypt()` AES-256-GCM à l'écriture, `decrypt()` en lecture autorisée uniquement ; **jamais** en clair (log/notif/URL). Test asserttant le format ciphertext (IV‖TAG‖CT base64). *(HDS)*

--- a/docs/UserStory/insulinotherapie-edition/US-2652-gardefous-cliniques-i18n-tests.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2652-gardefous-cliniques-i18n-tests.md
@@ -41,3 +41,7 @@ Les bornes `fixedDose` **naissent en US-2646** (atomique). Cette US = **vérific
 - **Chiffrement** effectif de `proposerComment`/notes (test AES-256-GCM, jamais en clair log/notif/URL).
 - **DPIA** : documenter les doses numériques en clair (calculabilité → at-rest pgcrypto + RBAC).
 - **ADR** : #21 → « 1 composant présentational, **N transports** » (ajout own-id patient) ; nouvel ADR provenance `AdjustmentProposal` (union taguée + `ProposalSource`).
+
+## Reports de la revue code+migration (PR #638 / US-2646) — à fermer ici
+- **DPIA** : documenter que `fixed_dose_slots.value_u` **et** `clinical_review_flags.type` (health-adjacent : un flag `tirBelowTarget`/`hba1cStale` implique une préoccupation clinique) reposent sur le chiffrement **at-rest (pgcrypto) + RBAC**, pas sur l'AES-GCM applicatif (contrainte de calculabilité). Étendre la note DPIA au-delà des seules doses. *(HDS LOW)*
+- **Vérifier** que les caps delta dose fixe + les seuils d'avertissement par type (routés basal/bolus) sont bien enforced (implémentés en US-2649) et couverts par des tests de cas limites. *(medical)*


### PR DESCRIPTION
Trace les findings **différés** de la revue multi-agents de la PR #638 (US-2646 socle) dans les US qui doivent les fermer, pour ne pas les perdre :

- **US-2649** — provenance dérivée serveur + null métriques ; audit à la création (bloquant RGPD/forensique) ; affichage basé sur `source` pas `confidence` ; index unique partiel `clinical_review_flags ... WHERE status='open'` ; écriture `fixedDose` dans `accept()` (aujourd'hui fail-closed) + caps delta actifs + routage seuils warn basal/bolus.
- **US-2650** — chiffrement AES-256-GCM de `proposer_comment` (critique dès la 1ʳᵉ écriture patient).
- **US-2652** — DPIA (`value_u` + `clinical_review_flags.type` at-rest) + vérif enforcement bornes.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)