### PR TITLE
docs: règle doc/JSDoc par tâche + catalogue des règles & constantes diabète

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -578,11 +578,41 @@ au prochain `--update` tant que les fichiers source n'ont pas bougé.
 - **Supprimer le dossier `graphify-out/`** (knowledge graph local, gitignoré).
   - Il est coûteux à régénérer (~plusieurs M tokens d'extraction sémantique) et sert de carte du code pour les requêtes `/graphify`.
   - Ne jamais le `rm -rf` même pour "faire de la place" ou "nettoyer" : seuls les fichiers temporaires `graphify-out/.graphify_*` (intermédiaires de pipeline) peuvent être nettoyés ; `graph.json`, `graph.html`, `GRAPH_REPORT.md` et `cache/` doivent être préservés.
+- **Livrer une tâche sans sa documentation / sa JSDoc** (voir section « 📚 Documentation & règles métier »).
+- **Ajouter/modifier une constante, un intervalle, un seuil ou une règle métier DIABÈTE sans l'inscrire** dans `docs/clinical-logic/regles-et-constantes-diabete.md` (catalogue de référence unique).
 
 ---
 
+## 📚 Documentation & règles métier — OBLIGATOIRE
+
+**Non négociable, à chaque tâche réalisée** (feature, fix, refacto — pas seulement les « grosses ») :
+
+1. **Documentation + JSDoc à jour dans la MÊME PR.** Tout code ajouté/modifié doit être
+   documenté : **JSDoc** sur chaque composant, hook, service, fonction utilitaire (rôle,
+   params, retours, erreurs, comportements critiques) ; et la **documentation** impactée
+   (`docs/`, `README`, runbooks, ADR, `CLAUDE.md`) mise à jour. Une tâche n'est **pas
+   terminée** tant que sa doc/JSDoc ne l'est pas. Exclusion : on n'internationalise ni ne
+   documente les *logs* comme s'ils étaient de la doc utilisateur (cf. règle i18n/logs).
+
+2. **Toute règle métier DIABÈTE est répertoriée dans le document de référence
+   technico-fonctionnel** : **`docs/clinical-logic/regles-et-constantes-diabete.md`**.
+   - **Toutes les constantes, tous les intervalles, tous les seuils cliniques** (bornes
+     insuline, zones glycémiques, plages de suffisance, fenêtres temporelles, caps, etc.)
+     doivent y figurer — valeur + sens clinique + fichier source — **dans la même PR** que
+     leur ajout/modification.
+     - La **source de vérité reste le code** (ex. `src/lib/clinical-bounds.ts`) ; ce document
+       est le **catalogue fonctionnel** unique, gardé synchrone (verrou anti-drift :
+       `tests/unit/clinical-bounds.test.ts`).
+   - Toute **règle de décision clinique** (calcul de bolus, sélection de créneau,
+     détection de mode, garde-fous de proposition, invariants fail-closed, frontière
+     dispositif médical…) doit y être décrite ou y renvoyer.
+   - Ne **jamais** disséminer une constante/règle clinique sans l'inscrire au catalogue :
+     un futur soignant/dev doit trouver **toutes** les règles diabète à un seul endroit.
+
 ## ✅ Checklist avant chaque PR
 
+- [ ] **Documentation + JSDoc à jour** (composants/hooks/services/fonctions) dans la même PR
+- [ ] **Règles/constantes/intervalles diabète** répertoriés dans `docs/clinical-logic/regles-et-constantes-diabete.md`
 - [ ] Authentification + autorisation par rôle sur toutes les nouvelles API Routes
 - [ ] Données patients chiffrées avant insertion, déchiffrées uniquement à la lecture
 - [ ] `auditService.log()` appelé pour chaque accès à une donnée de santé

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -1,0 +1,126 @@
+# Règles & constantes métier — Diabète (référence technico-fonctionnelle)
+
+> **Document de référence UNIQUE** recensant **toutes** les règles métier diabète et
+> **toutes** les constantes / intervalles / seuils cliniques du backoffice.
+>
+> ⚠️ **Source de vérité = le code** (fichiers cités en regard). Ce document est le
+> **catalogue fonctionnel** : il décrit le *sens clinique*, la *valeur* et son *emplacement*.
+> Il est **tenu à jour à chaque tâche** touchant une règle/constante diabète
+> (règle `CLAUDE.md` § « Documentation & règles métier »). Les valeurs sont verrouillées
+> par `tests/unit/clinical-bounds.test.ts` (anti-drift).
+
+**Comment contribuer** : toute nouvelle constante clinique, tout intervalle, tout seuil,
+toute règle métier diabète ajouté au code **doit** apparaître ici (ligne dans le tableau
+du domaine concerné) dans la **même PR**, avec sa valeur et son fichier source.
+
+---
+
+## 1. Bornes de sécurité de l'insulinothérapie — `CLINICAL_BOUNDS`
+
+Source : `src/lib/clinical-bounds.ts` · Réfs : ADA Standards of Care 2025, règle 1800/ISF,
+consensus cap bolus 25 U.
+
+| Constante | Valeur | Unité | Sens clinique |
+|---|---|---|---|
+| `ISF_GL_MIN` / `ISF_GL_MAX` | 0.10 / 1.00 | g/L·U | Facteur de sensibilité (élargi DT2 insulino-résistant) |
+| `ISF_MGDL_MIN` / `ISF_MGDL_MAX` | 10 / 100 | mg/dL·U | ISF (règle 1800) |
+| `ICR_MIN` / `ICR_MAX` | 3.0 / 30.0 | g/U | Ratio insuline/glucides (élargi pédiatrie + résistant) |
+| `BASAL_MIN` / `BASAL_MAX` | 0.05 / 5.0 | U/h | Débit basal (>5 U/h = 240 U/j, dangereux) |
+| `TARGET_MIN_MGDL` / `TARGET_MAX_MGDL` | 60 / 250 | mg/dL | Bornes de la cible glycémique |
+| `MAX_SINGLE_BOLUS` | 25.0 | U | Plafond bolus unique (jamais dépasser) |
+| `INSULIN_ACTION_MIN` / `MAX` | 3.5 / 5.0 | h | Durée d'action analogues rapides |
+| `PUMP_BASAL_INCREMENT` | 0.05 | U/h | Pas d'incrément basal pompe |
+| `FIXED_DOSE_MIN` | 0.5 | U | Plancher **bloquant** dose fixe (mode doses simples, US-2646) |
+| `FIXED_BOLUS_WARN_U` | 25.0 | U | Seuil d'**avertissement** (non bloquant) bolus fixe |
+| `FIXED_BASAL_WARN_U` | 80.0 | U | Seuil d'**avertissement** (non bloquant) basale fixe |
+| `FIXED_DOSE_MAX_DELTA_U` | 2.0 | U | Variation max par ajustement (titration lente) |
+| `FIXED_DOSE_PATIENT_MAX_DELTA_U` | 1.0 | U | Cap variation **patient** dose fixe (< moteur) |
+| `PATIENT_MAX_CHANGE_PERCENT` | 10 | % | Cap variation **patient** sur ratios (proposition, US-2649) |
+
+**Règle dose fixe (US-2646)** : pas de plafond bloquant (une basale fixe peut dépasser 25 U) ;
+les `*_WARN_U` déclenchent un **avertissement** au service, jamais un rejet. Seul `FIXED_DOSE_MIN`
+bloque (dose ≤ 0 / < pas demi-unité).
+
+## 2. Zones glycémiques (seuils de coloration / alerte clinique)
+
+Source : `getGlycemiaZone` (`src/components/diabeo/GlycemiaValue.tsx`) · Design system : palette « glycémie ».
+
+| Zone | Intervalle (mg/dL) | Sémantique |
+|---|---|---|
+| very-low | < 54 | Hypoglycémie sévère (`role="alert"`) |
+| low | 54 – 69 | Hypoglycémie |
+| normal | 70 – 180 | Cible |
+| high | 181 – 250 | Hyperglycémie |
+| very-high | > 250 | Hyperglycémie marquée |
+| critical | seuils patient (opt.) | Zone critique (`role="alert"`) |
+
+> Les **bornes de la cible** sont **pathology-aware** : GD/grossesse 0.63–1.40 g/L vs 0.70–1.80
+> (voir `getCgmDefaults(pathology)`), ce document ne fige que les zones par défaut.
+
+## 3. Plages de données valides & suffisance
+
+| Constante | Valeur | Source | Sens |
+|---|---|---|---|
+| `CGM_AGGREGATE_RANGE_GL` | 0.20 – 6.00 g/L | `clinical-bounds.ts` | Plage CGM physiologiquement valide pour les **agrégats** (TIR/GMI/AGP). Aligné CHECK base `cgm_partitioning.sql`. |
+| Plancher d'affichage série CGM | 0.40 – 5.00 g/L | `glycemia.service.getCgmEntries` | Plage d'**affichage** de la courbe (≠ agrégats). |
+| `AGP_SUFFICIENCY.MIN_DAYS` | 14 j | `clinical-bounds.ts` | AGP fiable (ATTD/Battelino 2019) |
+| `AGP_SUFFICIENCY.MIN_CAPTURE_RATE` | 70 % | idem | Capture minimale AGP |
+| `AGP_SUFFICIENCY.MIN_SLOT_READINGS` | 5 | idem | Relevés min/slot 15 min avant de tracer P10–P90 |
+| `DASHBOARD_TIR.TARGET_PERCENT` | 70 % | idem | Cible TIR (≥ 70 %) |
+| `DASHBOARD_TIR.LOW_PERCENT` | 50 % | idem | Sous 50 % = « TIR bas » |
+| `DASHBOARD_TIR.MIN_CAPTURE_RATE` | 30 % | idem | Plancher de suffisance pour publier le TIR |
+| `HBA1C_STALE_DAYS` | 180 j | idem | Péremption HbA1c labo (~6 mois) |
+| `BGM_CARNET.MIN_READINGS_PER_MOMENT` | 3 | idem | Relevés capillaires min/moment avant de publier une moyenne |
+
+## 4. Tendances de repas — `MEAL_TREND` (US-2637)
+
+Source : `src/lib/clinical-bounds.ts` (durées en minutes, relatives à `t0` = heure du repas).
+
+| Constante | Valeur | Sens |
+|---|---|---|
+| `PRE_WINDOW_MIN` | 30 | Pré-repas = dernier relevé dans `[t0−30, t0]` |
+| `EXCURSION_MAX_MIN` | 180 | Fenêtre d'excursion plafonnée à 3 h |
+| `EXCURSION_MIN_WINDOW_MIN` | 90 | Sous cette durée → pic « non évaluable » |
+| `POST_2H_CENTER_MIN` / `POST_2H_TOL_MIN` | 120 / 30 | PPG 2 h : relevé proche de `t0+120` dans `[t0+90, t0+150]` |
+| `MIN_PAIRED_MEALS` | 3 | Repas appariés min pour une tendance |
+| `BUCKET_SIZE_MIN` / `BUCKET_MIN_READINGS` | 15 / 3 | Buckets d'alignement des mini-courbes |
+| `ALIGN_START_MIN` / `ALIGN_END_MIN` | −60 / 180 | Fenêtre d'alignement des courbes repas |
+
+> Plafonds post-prandiaux absolus = `getCgmDefaults(pathology)` (pathology-aware), **pas ici**.
+
+## 5. Règles de calcul & de sélection (logique métier)
+
+| Règle | Description | Source |
+|---|---|---|
+| **Calcul de bolus** | `mealBolus = carbs/ICR` ; `correction = max(0,(bg−target)/ISF)` ; `total = meal + correction − IOB` ; cappé à `MAX_SINGLE_BOLUS`. Suggestion **jamais** auto-injectée (ADR #13). | `insulin.service.ts` · `docs/clinical-logic/bolus-calculation.md` |
+| **Sélection du créneau horaire** | `findSlotForHour` : intervalle **demi-ouvert** `[startHour, endHour)`, gestion passage minuit. **Fail-closed** : heure non couverte → `undefined` → l'appelant **lève** (pas de dose sur heure non couverte). | `insulin.service.ts` |
+| **GMI ≠ HbA1c** | Le GMI (dérivé CGM) n'est jamais présenté comme une HbA1c labo. | `docs/clinical-logic/gmi-vs-ehba1c-terminology.md` |
+| **Détection du mode de traitement** | `basalBolus` (ISF **et** ICR) / `fixedDose` (insuline simple) / `nonInsulin`. **Fail-closed** : un DT1 — ou tout patient ayant déjà eu de l'insuline (config vidée) — n'est **jamais** `nonInsulin`. Source de vérité = dérivée à la lecture. | `treatment-mode.service.ts` (US-2647) |
+| **Couverture 24 h** | `analyzeSlotCoverage` : détection trou/chevauchement des créneaux ISF/ICR/basal (config incohérente → édition bloquée). | `src/lib/insulin/slot-coverage.ts` |
+
+## 6. Propositions d'ajustement — garde-fous (US-2649a)
+
+Source : `adjustmentService.createProposal` (`src/lib/services/adjustment.service.ts`) · ADR #13.
+
+| Règle | Détail |
+|---|---|
+| **Jamais auto-appliqué** | Toute proposition naît `pending` → validée par un **DOCTOR** (`accept`), bornes re-vérifiées à l'application. |
+| **Provenance** | `source` (`algorithm`/`patient`/`nurse`/`doctor`) + auteur **dérivés serveur** (jamais du body). |
+| **`currentValue` de confiance** | Lu **serveur** depuis la config réelle (jamais du body) → garde-fous ininviolables. |
+| **Sens interdit patient** | Un patient ne peut **baisser** une basale (risque hyper/cétose). ISF/ICR : monter la valeur *réduit* la dose → borné en amplitude seulement. |
+| **Cap patient** | Ratios ≤ `PATIENT_MAX_CHANGE_PERCENT` (10 %) ; dose fixe ≤ `FIXED_DOSE_PATIENT_MAX_DELTA_U` (1 U). |
+| **Anti-spam** | 1 proposition `pending` max par (patient, paramètre, créneau) — index unique partiel `adjustment_proposals_one_pending_per_slot`. |
+| **Frontière dispositif médical** | Mode non-insuliné : **aucune posologie** médicamenteuse orale/GLP-1 proposée (`ClinicalReviewFlag` = orientation, jamais une dose). |
+
+## 7. Invariants transverses fail-closed
+
+- Aucune dose calculée sur une heure non couverte par la config (voir §5).
+- Un mode de traitement inconnu ne débloque **jamais** l'édition insuline.
+- Toute donnée insuffisante (AGP/TIR/BGM sous les planchers §3) → **non publiée** plutôt qu'affichée trompeuse.
+- Toute proposition hors `CLINICAL_BOUNDS` → **rejetée à la création** (pas seulement à l'application).
+
+---
+
+*Réviser ce document à chaque ajout/modification de constante, intervalle, seuil ou règle
+métier diabète (obligation `CLAUDE.md`). Source de vérité = code ; valeurs verrouillées par
+`tests/unit/clinical-bounds.test.ts`.*


### PR DESCRIPTION
Ajoute une **règle de gouvernance** dans CLAUDE.md et le **document de référence technico-fonctionnel** demandé.

## CLAUDE.md — section « 📚 Documentation & règles métier — OBLIGATOIRE »
1. **Doc + JSDoc à jour dans la même PR** pour **chaque tâche** (feature/fix/refacto) — une tâche n'est pas terminée sans sa doc/JSDoc.
2. **Toute règle métier diabète + toutes les constantes/intervalles/seuils** répertoriés dans un document de référence unique. Source de vérité = code ; le doc est le **catalogue fonctionnel** synchrone.
+ 2 items de checklist PR + 2 garde-fous « JAMAIS ».

## Nouveau doc : `docs/clinical-logic/regles-et-constantes-diabete.md`
Catalogue unique (tableaux valeur + sens + source) : `CLINICAL_BOUNDS`, zones glycémiques, plages de validité/suffisance (CGM/AGP/TIR/HbA1c/BGM), `MEAL_TREND`, règles de calcul (bolus, findSlotForHour), détection du mode, garde-fous des propositions (US-2649a), invariants fail-closed.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)