### PR TITLE
US-2648a — Socle backend édition insuline : RBAC DOCTOR-direct + route de proposition

### DIFF
--- a/docs/UserStory/insulinotherapie-edition/US-2648-onglet-traitements-editable.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2648-onglet-traitements-editable.md
@@ -38,3 +38,11 @@ l'onglet devient l'éditeur (une seule vérité, cohérent US-2630/US-2604).
 - **Éditeur `variant="page"` uniquement** — jamais en contexte drawer/`x-consultation-token` (escalade de privilège), fail-closed. Capability descriptor serveur `{mode, canEditDirect, canPropose}` (§12.6).
 - 🔴 **CRITICAL HDS** : passer les routes `POST/PATCH /api/insulin-therapy/*` de `requireRole(NURSE)` à **DOCTOR exact** ; NURSE → **403** + endpoint de proposition. Re-routage **serveur**. Test E2E `NURSE PATCH → 403` (§12.7).
 - Redirect `/insulin-therapy` **role-branché** (DOCTOR/NURSE → fiche ; VIEWER → route patient) (§12 nit).
+
+## US-2648a (livré) — socle backend RBAC + route de proposition
+Tranche backend (débloque le front US-2648b) :
+- 🔴 **CRITICAL HDS résolu** : `POST/PUT/DELETE /api/insulin-therapy/*` (settings, sensitivity-factors, carb-ratios, basal-config, pump-slots) passés de `requireRole(NURSE)` à **`requireRole(DOCTOR)`** — NURSE en écriture directe → **403**.
+- **`POST /api/adjustment-proposals`** (route de proposition NURSE/patient/DOCTOR) : ferme les obligations route de US-2649a — accès via `resolvePatientId` (VIEWER→son dossier / pro→`canAccessPatient`), rôle proposeur **dérivé session** (ADMIN→403), réponse **sans `proposerComment`**, mapping erreurs métier→HTTP (422/400/404/409). `fixedDose` exclu du schéma.
+- Tests : 8 (route POST) + RBAC. Catalogue diabète §6 mis à jour.
+
+**Reste US-2648b (front)** : onglet Traitements éditable dans `<PatientRecord>` (transport `mutate` injecté, `variant="page"` only), capability descriptor serveur `{mode, canEditDirect, canPropose}`, redirect `/insulin-therapy` role-branché, `refreshTreatmentMode(tx)` writer, E2E `NURSE→403` + `NURSE save→proposition`.

--- a/docs/UserStory/insulinotherapie-edition/US-2652-gardefous-cliniques-i18n-tests.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2652-gardefous-cliniques-i18n-tests.md
@@ -51,3 +51,7 @@ Les bornes `fixedDose` **naissent en US-2646** (atomique). Cette US = **vérific
 - **Flag `riskDirection` (hypo/hyper)** : ne PAS « cap-and-hide » la direction hypo (baisse ISF/ICR, hausse basale/dose) — la calculer et la **surfacer au médecin** dans l'UI de validation (US-2649b).
 - **Dose fixe basal vs bolus** : bloquer *toute* baisse est trop rigide — une baisse de **bolus** fixe pour hypo est légitime ; distinguer basal (no-decrease) / bolus (baisse capée).
 - **Gate pathologie** : bloquer/assouplir les propositions **patient** en GD/grossesse et pédiatrie (cibles plus strictes, clinicien requis) — la primitive est pathology-blind par design.
+
+## Reports de la revue US-2648a (PR #644)
+- **Rate-limit création patient-originated** (`POST /api/adjustment-proposals`) : l'index partiel borne le *pending*/slot mais pas le débit create→reject→recreate ni le volume multi-slots. Ajouter un rate-limit via `src/lib/auth/api-rate-limit.ts` sur le POST patient. (Résiduel, non bloquant PR #644.)
+- **Audit des accès refusés** : `resolvePatientId` n'audite pas les 403/404 (cohérent avec le GET voisin). Router les tentatives hors-portefeuille vers l'audit (`accessDenied`) pour la détection d'énumération (US-2265 burst detection).

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -111,6 +111,7 @@ Source : `adjustmentService.createProposal` (`src/lib/services/adjustment.servic
 | **Cap patient** | Ratios ≤ `PATIENT_MAX_CHANGE_PERCENT` (10 %) ; dose fixe ≤ `FIXED_DOSE_PATIENT_MAX_DELTA_U` (1 U). |
 | **Anti-spam** | 1 proposition `pending` max par (patient, paramètre, créneau) — index unique partiel `adjustment_proposals_one_pending_per_slot`. |
 | **Frontière dispositif médical** | Mode non-insuliné : **aucune posologie** médicamenteuse orale/GLP-1 proposée (`ClinicalReviewFlag` = orientation, jamais une dose). |
+| **RBAC édition / proposition (US-2648a)** | Écriture **directe** de la config insuline = **DOCTOR** (autorité clinique). NURSE / patient → **proposition** `POST /api/adjustment-proposals` (validée par un médecin). ADMIN rejeté. Rôle proposeur dérivé de la **session** ; accès via `resolvePatientId` (VIEWER→son dossier / pro→`canAccessPatient`) ; réponse sans `proposerComment`. Routes : `src/app/api/insulin-therapy/*` (DOCTOR) + `src/app/api/adjustment-proposals` (POST). |
 
 ## 7. Invariants transverses fail-closed
 

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -111,7 +111,7 @@ Source : `adjustmentService.createProposal` (`src/lib/services/adjustment.servic
 | **Cap patient** | Ratios ≤ `PATIENT_MAX_CHANGE_PERCENT` (10 %) ; dose fixe ≤ `FIXED_DOSE_PATIENT_MAX_DELTA_U` (1 U). |
 | **Anti-spam** | 1 proposition `pending` max par (patient, paramètre, créneau) — index unique partiel `adjustment_proposals_one_pending_per_slot`. |
 | **Frontière dispositif médical** | Mode non-insuliné : **aucune posologie** médicamenteuse orale/GLP-1 proposée (`ClinicalReviewFlag` = orientation, jamais une dose). |
-| **RBAC édition / proposition (US-2648a)** | Écriture **directe** de la config insuline = **DOCTOR** (autorité clinique). NURSE / patient → **proposition** `POST /api/adjustment-proposals` (validée par un médecin). ADMIN rejeté. Rôle proposeur dérivé de la **session** ; accès via `resolvePatientId` (VIEWER→son dossier / pro→`canAccessPatient`) ; réponse sans `proposerComment`. Routes : `src/app/api/insulin-therapy/*` (DOCTOR) + `src/app/api/adjustment-proposals` (POST). |
+| **RBAC édition / proposition (US-2648a)** | Écriture **directe** de la config insuline = **DOCTOR** (autorité clinique). NURSE / patient → **proposition** `POST /api/adjustment-proposals` (validée par un médecin). ADMIN rejeté. Rôle proposeur dérivé de la **session** ; accès via `resolvePatientId` (VIEWER→son dossier / pro→`canAccessPatient`) ; réponse sans `proposerComment`. Routes : `src/app/api/insulin-therapy/*` (DOCTOR) + `src/app/api/adjustment-proposals` (POST). **ADMIN** : rejeté à la *proposition* (pas d'identité clinique) mais conserve l'*écriture directe* — bypass PHI V1 assumé (`access-control.ts`, levé V4/F1). |
 
 ## 7. Invariants transverses fail-closed
 

--- a/src/app/api/adjustment-proposals/route.ts
+++ b/src/app/api/adjustment-proposals/route.ts
@@ -82,7 +82,10 @@ export async function POST(req: NextRequest) {
     const hasConsent = await requireGdprConsent(user.id)
     if (!hasConsent) return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
 
-    // ADMIN = rôle technique, non clinicien → ne propose pas.
+    // ADMIN = rôle technique, non clinicien → ne PROPOSE pas (une proposition émane
+    // d'une identité clinique patient/nurse/doctor). NB : l'écriture DIRECTE de config
+    // insuline reste ouverte à ADMIN via requireRole(DOCTOR, hiérarchique) — c'est le
+    // bypass PHI V1 ASSUMÉ (cf. access-control.ts, levé en V4/F1), pas une incohérence.
     if (user.role === "ADMIN") return NextResponse.json({ error: "forbidden" }, { status: 403 })
 
     const body: unknown = await req.json().catch(() => null)

--- a/src/app/api/adjustment-proposals/route.ts
+++ b/src/app/api/adjustment-proposals/route.ts
@@ -39,3 +39,82 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "serverError" }, { status: 500 })
   }
 }
+
+// US-2648a — création d'une PROPOSITION humaine (NURSE / patient / DOCTOR).
+// `fixedDose` volontairement absent (non câblé, cf. createProposal). `patientId`
+// ignoré pour un VIEWER (résolu sur son propre dossier).
+const createSchema = z.object({
+  patientId: z.number().int().positive().optional(),
+  parameterType: z.enum(["insulinSensitivityFactor", "insulinToCarbRatio", "basalRate"]),
+  proposedValue: z.number().finite(),
+  reason: z.enum(["patientRequested", "manualAdjustment"]),
+  timeSlotStartHour: z.number().int().min(0).max(23).optional(),
+  timeSlotEndHour: z.number().int().min(0).max(24).optional(),
+  carbRatioSlotStart: z.number().int().min(0).max(23).optional(),
+  carbRatioSlotEnd: z.number().int().min(0).max(24).optional(),
+  pumpBasalSlotId: z.string().uuid().optional(),
+  proposerComment: z.string().max(1000).optional(),
+})
+
+/** Erreurs métier de `createProposal` → statut HTTP (codes stables, sans PHI). */
+const ERROR_STATUS: Record<string, number> = {
+  valueOutOfBounds: 422,
+  patientDecreaseForbidden: 422,
+  patientDeltaTooLarge: 422,
+  slotRequired: 400,
+  fixedDoseNotWired: 400,
+  currentValueNotFound: 404,
+  duplicatePendingProposal: 409,
+}
+
+/**
+ * POST /api/adjustment-proposals — créer une proposition d'ajustement (US-2648a).
+ *
+ * Sécurité (obligations route de US-2649a) : accès résolu par `resolvePatientId`
+ * (VIEWER → SON dossier en ignorant `patientId` ; pro → `canAccessPatient`) ;
+ * rôle proposeur dérivé de la SESSION (jamais du body ; ADMIN rejeté) ; la réponse
+ * n'expose JAMAIS `proposerComment` (ciphertext). La primitive `createProposal`
+ * dérive `currentValue` serveur, borne, anti-spam et n'applique jamais.
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const user = requireAuth(req)
+    const hasConsent = await requireGdprConsent(user.id)
+    if (!hasConsent) return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
+
+    // ADMIN = rôle technique, non clinicien → ne propose pas.
+    if (user.role === "ADMIN") return NextResponse.json({ error: "forbidden" }, { status: 403 })
+
+    const body: unknown = await req.json().catch(() => null)
+    const parsed = createSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: "validationFailed", details: parsed.error.flatten().fieldErrors }, { status: 400 })
+    }
+
+    // Accès : VIEWER → son propre dossier (ignore body.patientId) ; pro → canAccessPatient.
+    const patientId = await resolvePatientId(user.id, user.role, parsed.data.patientId)
+    if (!patientId) return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+
+    // Rôle proposeur dérivé de la session (anti-usurpation) — jamais du body.
+    const proposerRole = user.role === "DOCTOR" ? "doctor" : user.role === "NURSE" ? "nurse" : "patient"
+    const ctx = extractRequestContext(req)
+
+    const { patientId: _pid, ...input } = parsed.data
+    const proposal = await adjustmentService.createProposal(
+      { patientId, ...input },
+      { userId: user.id, role: proposerRole },
+      ctx,
+    )
+
+    // Ne JAMAIS renvoyer le ciphertext `proposerComment` au client (CLAUDE.md).
+    const { proposerComment: _c, ...dto } = proposal
+    return NextResponse.json(dto, { status: 201 })
+  } catch (error) {
+    if (error instanceof AuthError) return NextResponse.json({ error: error.message }, { status: error.status })
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    const status = ERROR_STATUS[msg]
+    if (status) return NextResponse.json({ error: msg }, { status })
+    console.error("[adjustment-proposals POST]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/app/api/insulin-therapy/basal-config/pump-slots/route.ts
+++ b/src/app/api/insulin-therapy/basal-config/pump-slots/route.ts
@@ -72,11 +72,11 @@ export async function GET(req: NextRequest) {
 
 /**
  * POST /api/insulin-therapy/basal-config/pump-slots
- * Create a new pump basal slot. Requires NURSE+ role.
+ * Create a new pump basal slot. DOCTOR only (US-2648a) — NURSE/patient via proposition.
  */
 export async function POST(req: NextRequest) {
   try {
-    const user = requireRole(req, "NURSE")
+    const user = requireRole(req, "DOCTOR")
     const hasConsent = await requireGdprConsent(user.id)
     if (!hasConsent) {
       return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
@@ -126,11 +126,11 @@ export async function POST(req: NextRequest) {
 
 /**
  * DELETE /api/insulin-therapy/basal-config/pump-slots?id=
- * Delete a pump basal slot by UUID. Requires NURSE+ role.
+ * Delete a pump basal slot by UUID. DOCTOR only (US-2648a).
  */
 export async function DELETE(req: NextRequest) {
   try {
-    const user = requireRole(req, "NURSE")
+    const user = requireRole(req, "DOCTOR")
     const hasConsent = await requireGdprConsent(user.id)
     if (!hasConsent) {
       return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })

--- a/src/app/api/insulin-therapy/basal-config/route.ts
+++ b/src/app/api/insulin-therapy/basal-config/route.ts
@@ -72,7 +72,7 @@ export async function GET(req: NextRequest) {
  */
 export async function PUT(req: NextRequest) {
   try {
-    const user = requireRole(req, "NURSE")
+    const user = requireRole(req, "DOCTOR")
     const hasConsent = await requireGdprConsent(user.id)
     if (!hasConsent) {
       return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })

--- a/src/app/api/insulin-therapy/calculate-bolus/route.ts
+++ b/src/app/api/insulin-therapy/calculate-bolus/route.ts
@@ -20,8 +20,9 @@ export async function POST(req: NextRequest) {
     // calculation is a pure read-model simulation — it produces a
     // recommendation that ADR #13 forbids from being auto-injected;
     // the patient must explicitly accept before any insulin delivery.
-    // The dose-driving parameters (ISF/ICR/settings) are NURSE+ guarded
-    // separately in /sensitivity-factors, /carb-ratios, /settings.
+    // The dose-driving parameters (ISF/ICR/settings) are DOCTOR-guarded (direct
+    // write) separately in /sensitivity-factors, /carb-ratios, /settings ; NURSE/
+    // patient proposent via /api/adjustment-proposals (US-2648a).
     const user = requireAuth(req)
     const hasConsent = await requireGdprConsent(user.id)
     if (!hasConsent) return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })

--- a/src/app/api/insulin-therapy/carb-ratios/route.ts
+++ b/src/app/api/insulin-therapy/carb-ratios/route.ts
@@ -37,9 +37,9 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    // US-SEC-001 (HIGH): NURSE+ required. ICR values feed calculateBolus —
-    // VIEWER (the patient) cannot self-modify dose-driving parameters.
-    const user = requireRole(req, "NURSE")
+    // US-2648a — écriture DIRECTE réservée au DOCTOR. ICR pilote calculateBolus ;
+    // NURSE/patient passent par une proposition validée (POST /api/adjustment-proposals).
+    const user = requireRole(req, "DOCTOR")
     const hasConsent = await requireGdprConsent(user.id)
     if (!hasConsent) return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
 

--- a/src/app/api/insulin-therapy/sensitivity-factors/route.ts
+++ b/src/app/api/insulin-therapy/sensitivity-factors/route.ts
@@ -36,9 +36,9 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    // US-SEC-001 (HIGH): NURSE+ required. ISF values feed calculateBolus —
-    // VIEWER (the patient) cannot self-modify dose-driving parameters.
-    const user = requireRole(req, "NURSE")
+    // US-2648a — écriture DIRECTE réservée au DOCTOR. ISF pilote calculateBolus ;
+    // NURSE/patient passent par une proposition validée (POST /api/adjustment-proposals).
+    const user = requireRole(req, "DOCTOR")
     const hasConsent = await requireGdprConsent(user.id)
     if (!hasConsent) return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
 

--- a/src/app/api/insulin-therapy/settings/route.ts
+++ b/src/app/api/insulin-therapy/settings/route.ts
@@ -39,10 +39,10 @@ export async function GET(req: NextRequest) {
 
 export async function PUT(req: NextRequest) {
   try {
-    // US-SEC-001 (HIGH): NURSE+ required. VIEWER (the patient themselves)
-    // must NOT mutate parameters consumed by calculateBolus — see CLAUDE.md
-    // RBAC table and docs/security/audit-2026-04-15.md.
-    const user = requireRole(req, "NURSE")
+    // US-2648a — écriture DIRECTE réservée au DOCTOR (autorité clinique). Un NURSE
+    // ou un patient passe désormais par une PROPOSITION (POST /api/adjustment-proposals,
+    // validée par un médecin). VIEWER/NURSE en écriture directe → 403. (Anc. US-SEC-001.)
+    const user = requireRole(req, "DOCTOR")
     const hasConsent = await requireGdprConsent(user.id)
     if (!hasConsent) return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
 

--- a/tests/integration/api-insulin-therapy-rbac.test.ts
+++ b/tests/integration/api-insulin-therapy-rbac.test.ts
@@ -1,19 +1,20 @@
 /**
- * Test suite: US-SEC-001 — RBAC on insulin-therapy mutation routes
+ * Test suite: RBAC on insulin-therapy mutation routes (US-2648a, supersedes US-SEC-001)
  *
  * Clinical / security behavior tested:
- * - PUT /api/insulin-therapy/settings, POST /api/insulin-therapy/sensitivity-
- *   factors, and POST /api/insulin-therapy/carb-ratios MUST reject role
- *   VIEWER (the patient themselves) with HTTP 403 forbidden.
- * - NURSE and DOCTOR continue to write successfully.
- * - These parameters feed `insulinService.calculateBolus` — a patient
- *   self-mutating their ISF/ICR could bias dose suggestions toward
- *   hypoglycemia. RBAC is the only guard.
+ * - PUT /api/insulin-therapy/settings, POST /sensitivity-factors, POST /carb-ratios
+ *   and POST/DELETE /basal-config/pump-slots MUST reject role VIEWER (the patient)
+ *   AND role NURSE with HTTP 403 forbidden.
+ * - **US-2648a**: direct writes of dose-driving config are now **DOCTOR only**. A
+ *   NURSE (and a patient) no longer writes directly — they go through a validated
+ *   proposal (POST /api/adjustment-proposals). Only DOCTOR writes directly.
+ * - These parameters feed `insulinService.calculateBolus` — an unqualified self-
+ *   mutation of ISF/ICR could bias dose suggestions toward hypoglycemia.
  *
  * Associated risks:
- * - A regression replacing `requireRole(req, "NURSE")` with `requireAuth(req)`
- *   would re-open the privilege escalation. These tests are the regression
- *   guard for the audit fix landed 2026-04-15.
+ * - A regression relaxing `requireRole(req, "DOCTOR")` back to NURSE (or to
+ *   `requireAuth`) would re-open the privilege escalation. These tests are the
+ *   regression guard (US-SEC-001 audit 2026-04-15, durci par US-2648a).
  */
 
 import { describe, expect, it, vi } from "vitest"
@@ -111,9 +112,9 @@ describe("US-SEC-001 — insulin-therapy mutation routes RBAC", () => {
       expect(res.status).toBe(403)
     })
 
-    it("accepts NURSE", async () => {
+    it("REJECTS NURSE with 403 (US-2648a — proposition, pas écriture directe)", async () => {
       const res = await settingsPut(req("http://localhost/api/insulin-therapy/settings", validSettingsBody, "NURSE"))
-      expect(res.status).toBe(200)
+      expect(res.status).toBe(403)
     })
 
     it("accepts DOCTOR", async () => {
@@ -128,8 +129,13 @@ describe("US-SEC-001 — insulin-therapy mutation routes RBAC", () => {
       expect(res.status).toBe(403)
     })
 
-    it("accepts NURSE", async () => {
+    it("REJECTS NURSE with 403 (US-2648a)", async () => {
       const res = await isfPost(req("http://localhost/api/insulin-therapy/sensitivity-factors", validIsfBody, "NURSE"))
+      expect(res.status).toBe(403)
+    })
+
+    it("accepts DOCTOR", async () => {
+      const res = await isfPost(req("http://localhost/api/insulin-therapy/sensitivity-factors", validIsfBody, "DOCTOR"))
       expect(res.status).toBe(201)
     })
   })
@@ -140,8 +146,13 @@ describe("US-SEC-001 — insulin-therapy mutation routes RBAC", () => {
       expect(res.status).toBe(403)
     })
 
-    it("accepts NURSE", async () => {
+    it("REJECTS NURSE with 403 (US-2648a)", async () => {
       const res = await icrPost(req("http://localhost/api/insulin-therapy/carb-ratios", validIcrBody, "NURSE"))
+      expect(res.status).toBe(403)
+    })
+
+    it("accepts DOCTOR", async () => {
+      const res = await icrPost(req("http://localhost/api/insulin-therapy/carb-ratios", validIcrBody, "DOCTOR"))
       expect(res.status).toBe(201)
     })
   })
@@ -172,7 +183,7 @@ describe("US-SEC-001 — insulin-therapy mutation routes RBAC", () => {
     })
   })
 
-  describe("POST + DELETE /api/insulin-therapy/basal-config/pump-slots (NURSE+)", () => {
+  describe("POST + DELETE /api/insulin-therapy/basal-config/pump-slots (DOCTOR only)", () => {
     const validSlot = { startTime: "06:00", endTime: "12:00", rate: 0.95 }
 
     it("POST REJECTS VIEWER with 403", async () => {
@@ -180,8 +191,13 @@ describe("US-SEC-001 — insulin-therapy mutation routes RBAC", () => {
       expect(res.status).toBe(403)
     })
 
-    it("POST accepts NURSE", async () => {
+    it("POST REJECTS NURSE with 403 (US-2648a)", async () => {
       const res = await pumpSlotPost(req("http://localhost/api/insulin-therapy/basal-config/pump-slots", validSlot, "NURSE"))
+      expect(res.status).toBe(403)
+    })
+
+    it("POST accepts DOCTOR", async () => {
+      const res = await pumpSlotPost(req("http://localhost/api/insulin-therapy/basal-config/pump-slots", validSlot, "DOCTOR"))
       // 201 (created) or 404 (no settings configured for patientId 42 in mock chain) — either way NOT 403
       expect([201, 404]).toContain(res.status)
     })
@@ -192,12 +208,17 @@ describe("US-SEC-001 — insulin-therapy mutation routes RBAC", () => {
       expect(res.status).toBe(403)
     })
 
-    it("DELETE accepts NURSE", async () => {
+    it("DELETE REJECTS NURSE with 403 (US-2648a)", async () => {
       const url = "http://localhost/api/insulin-therapy/basal-config/pump-slots?id=123e4567-e89b-42d3-a456-426614174000&patientId=42"
       const res = await pumpSlotDelete(reqMethod(url, "DELETE", "NURSE"))
+      expect(res.status).toBe(403)
+    })
+
+    it("DELETE accepts DOCTOR", async () => {
+      const url = "http://localhost/api/insulin-therapy/basal-config/pump-slots?id=123e4567-e89b-42d3-a456-426614174000&patientId=42"
+      const res = await pumpSlotDelete(reqMethod(url, "DELETE", "DOCTOR"))
       // Not 403 — the role guard let the request through. 404 acceptable
-      // because mock chain doesn't surface a matching slot. Goal here is
-      // only to assert the role guard does NOT reject NURSE.
+      // because mock chain doesn't surface a matching slot.
       expect([200, 404]).toContain(res.status)
     })
   })

--- a/tests/unit/adjustment-proposals-post.test.ts
+++ b/tests/unit/adjustment-proposals-post.test.ts
@@ -1,0 +1,124 @@
+/**
+ * US-2648a — Route POST /api/adjustment-proposals (création de proposition).
+ *
+ * Sécurité testée (obligations route de US-2649a) : accès via resolvePatientId
+ * (VIEWER → SON dossier / pro → canAccessPatient), rôle proposeur dérivé de la
+ * SESSION (jamais du body ; ADMIN rejeté), réponse SANS proposerComment (ciphertext),
+ * mapping des erreurs métier → statuts HTTP stables.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import type { NextRequest } from "next/server"
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    requireAuth: vi.fn(),
+    requireGdprConsent: vi.fn(),
+    resolvePatientId: vi.fn(),
+    createProposal: vi.fn(),
+  },
+}))
+vi.mock("@/lib/auth", () => {
+  class AuthError extends Error {
+    status = 401
+  }
+  return { requireAuth: mocks.requireAuth, AuthError }
+})
+vi.mock("@/lib/gdpr", () => ({ requireGdprConsent: mocks.requireGdprConsent }))
+vi.mock("@/lib/access-control", () => ({ resolvePatientId: mocks.resolvePatientId }))
+vi.mock("@/lib/services/adjustment.service", () => ({
+  adjustmentService: { createProposal: mocks.createProposal, list: vi.fn() },
+}))
+vi.mock("@/lib/services/audit.service", () => ({
+  extractRequestContext: () => ({ ipAddress: "1.1.1.1", userAgent: "test" }),
+}))
+
+import { POST } from "@/app/api/adjustment-proposals/route"
+
+const isfBody = {
+  parameterType: "insulinSensitivityFactor",
+  proposedValue: 0.52,
+  reason: "manualAdjustment",
+  timeSlotStartHour: 8,
+  timeSlotEndHour: 12,
+}
+const reqWith = (body: unknown) => ({ json: async () => body }) as unknown as NextRequest
+
+beforeEach(() => {
+  Object.values(mocks).forEach((m) => m.mockReset())
+  mocks.requireAuth.mockReturnValue({ id: 20, role: "NURSE" })
+  mocks.requireGdprConsent.mockResolvedValue(true)
+  mocks.resolvePatientId.mockResolvedValue(5)
+  mocks.createProposal.mockResolvedValue({
+    id: "p1",
+    proposerComment: "enc(secret)",
+    currentValue: 0.5,
+    proposedValue: 0.52,
+    source: "nurse",
+  })
+})
+
+describe("POST /api/adjustment-proposals", () => {
+  it("NURSE : 201, rôle proposeur 'nurse' dérivé session, proposerComment NON exposé", async () => {
+    const res = await POST(reqWith(isfBody))
+    expect(res.status).toBe(201)
+    const json = await res.json()
+    expect(json.id).toBe("p1")
+    expect(json).not.toHaveProperty("proposerComment")
+    expect(mocks.createProposal).toHaveBeenCalledWith(
+      expect.objectContaining({ patientId: 5, parameterType: "insulinSensitivityFactor" }),
+      { userId: 20, role: "nurse" },
+      expect.anything(),
+    )
+  })
+
+  it("VIEWER : rôle 'patient', patientId résolu sur SON dossier (body ignoré)", async () => {
+    mocks.requireAuth.mockReturnValue({ id: 42, role: "VIEWER" })
+    mocks.resolvePatientId.mockResolvedValue(7)
+    const res = await POST(reqWith({ ...isfBody, patientId: 999 }))
+    expect(res.status).toBe(201)
+    // resolvePatientId reçoit le rôle réel ; c'est LUI qui ignore le patientId pour un VIEWER.
+    expect(mocks.resolvePatientId).toHaveBeenCalledWith(42, "VIEWER", 999)
+    expect(mocks.createProposal).toHaveBeenCalledWith(
+      expect.objectContaining({ patientId: 7 }),
+      { userId: 42, role: "patient" },
+      expect.anything(),
+    )
+  })
+
+  it("ADMIN : 403 (rôle technique, non clinicien)", async () => {
+    mocks.requireAuth.mockReturnValue({ id: 1, role: "ADMIN" })
+    const res = await POST(reqWith(isfBody))
+    expect(res.status).toBe(403)
+    expect(mocks.createProposal).not.toHaveBeenCalled()
+  })
+
+  it("corps invalide (parameterType manquant) → 400", async () => {
+    const res = await POST(reqWith({ proposedValue: 0.52, reason: "manualAdjustment" }))
+    expect(res.status).toBe(400)
+    expect(mocks.createProposal).not.toHaveBeenCalled()
+  })
+
+  it("fixedDose refusé par le schéma → 400", async () => {
+    const res = await POST(reqWith({ parameterType: "fixedDose", proposedValue: 10, reason: "manualAdjustment" }))
+    expect(res.status).toBe(400)
+  })
+
+  it("accès refusé (resolvePatientId null) → 404", async () => {
+    mocks.resolvePatientId.mockResolvedValue(null)
+    const res = await POST(reqWith(isfBody))
+    expect(res.status).toBe(404)
+    expect(mocks.createProposal).not.toHaveBeenCalled()
+  })
+
+  it("doublon pending → 409", async () => {
+    mocks.createProposal.mockRejectedValue(new Error("duplicatePendingProposal"))
+    const res = await POST(reqWith(isfBody))
+    expect(res.status).toBe(409)
+  })
+
+  it("garde-fou clinique (patientDecreaseForbidden) → 422", async () => {
+    mocks.createProposal.mockRejectedValue(new Error("patientDecreaseForbidden"))
+    const res = await POST(reqWith(isfBody))
+    expect(res.status).toBe(422)
+  })
+})

--- a/tests/unit/adjustment-proposals-post.test.ts
+++ b/tests/unit/adjustment-proposals-post.test.ts
@@ -92,6 +92,24 @@ describe("POST /api/adjustment-proposals", () => {
     expect(mocks.createProposal).not.toHaveBeenCalled()
   })
 
+  it("DOCTOR : rôle proposeur 'doctor' (les caps patient ne doivent PAS s'appliquer)", async () => {
+    mocks.requireAuth.mockReturnValue({ id: 30, role: "DOCTOR" })
+    const res = await POST(reqWith(isfBody))
+    expect(res.status).toBe(201)
+    expect(mocks.createProposal).toHaveBeenCalledWith(
+      expect.objectContaining({ patientId: 5 }),
+      { userId: 30, role: "doctor" },
+      expect.anything(),
+    )
+  })
+
+  it("consentement RGPD absent → 403, aucune création", async () => {
+    mocks.requireGdprConsent.mockResolvedValue(false)
+    const res = await POST(reqWith(isfBody))
+    expect(res.status).toBe(403)
+    expect(mocks.createProposal).not.toHaveBeenCalled()
+  })
+
   it("corps invalide (parameterType manquant) → 400", async () => {
     const res = await POST(reqWith({ proposedValue: 0.52, reason: "manualAdjustment" }))
     expect(res.status).toBe(400)


### PR DESCRIPTION
Tranche **backend** de US-2648 (issue #631) — débloque le front US-2648b. Ferme le **CRITICAL HDS** et les obligations route différées de US-2649a.

## 🔴 RBAC durci (CRITICAL HDS)
Écritures directes de la config insuline passées de `requireRole(NURSE)` → **`requireRole(DOCTOR)`** : `settings` PUT, `sensitivity-factors` POST, `carb-ratios` POST, `basal-config` PUT, `pump-slots` POST/DELETE. **NURSE en écriture directe → 403** (il passe désormais par une proposition).

## `POST /api/adjustment-proposals` (route de proposition)
Ferme les obligations route de US-2649a :
- **Accès** via `resolvePatientId` (VIEWER → **son** dossier en ignorant `patientId` ; pro → `canAccessPatient`).
- **Rôle proposeur dérivé de la SESSION** (jamais du body) ; **ADMIN → 403**.
- **Réponse sans `proposerComment`** (ciphertext non exposé).
- **Mapping erreurs métier → HTTP** : 422 (bornes/garde-fous patient), 400 (slot/fixedDose), 404 (currentValueNotFound), 409 (duplicate). `fixedDose` exclu du schéma.

## Docs (règle CLAUDE.md)
Catalogue `docs/clinical-logic/regles-et-constantes-diabete.md` §6 (RBAC édition/proposition) + doc US-2648 (section 2648a livré / 2648b restant).

## Différé US-2648b (front)
Onglet Traitements éditable dans `<PatientRecord>` (transport `mutate` injecté, `variant=page` only), capability descriptor `{mode, canEditDirect, canPropose}`, redirect `/insulin-therapy` role-branché, `refreshTreatmentMode(tx)`, E2E `NURSE→403`.

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **2732 tests** (+8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)