### PR TITLE
US-2648b (slice 2c) — Proposition d'ajustement BASAL (créneau pompe)

### DIFF
--- a/docs/UserStory/insulinotherapie-edition/US-2648-onglet-traitements-editable.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2648-onglet-traitements-editable.md
@@ -88,3 +88,11 @@ Tranche backend (débloque le front US-2648b) :
 - Clinique : **plage autorisée** affichée en indice (`min–max unité` depuis `CLINICAL_BOUNDS`) — évite les typos ; serveur reste l'autorité.
 - Robustesse : signal d'`abort` transmis au `mutate` + annulation à la fermeture (anti-course) ; `maxLength=1000` sur le commentaire.
 - Différé (LOW, tracé) : delta live « vs valeur actuelle » ; affichage « patient requested » côté review médecin (US-2649b).
+
+### US-2648b (en cours) — slice 2c : proposition BASAL (créneau pompe)
+- `BasalSlot` porte `pumpBasalSlotId` (exposé via `getSettings`/`treatment-view`) → créneau pompe adressable.
+- `ProposalTarget` discriminé (`timeSlot` ISF/ICR | `pumpSlot` basal) ; `buildProposalBody` construit `pumpBasalSlotId` pour le basal. `ProposableParameter` = ISF/ICR/basal.
+- `InsulinProposalDialog` généralisé (slot d'affichage + `target`) ; bornes basal (`BASAL_MIN/MAX`) dans l'indice.
+- SlotList basal : bouton « Proposer » (gated `capability.canPropose` + `basalRate` éditable). i18n `proposalParamBasal`. Tests +1 (corps basal).
+
+**Reste 2648b** : édition directe DOCTOR (PUT), `refreshTreatmentMode(tx)`, redirect role-branché, transport drawer, E2E.

--- a/docs/UserStory/insulinotherapie-edition/US-2648-onglet-traitements-editable.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2648-onglet-traitements-editable.md
@@ -96,3 +96,8 @@ Tranche backend (débloque le front US-2648b) :
 - SlotList basal : bouton « Proposer » (gated `capability.canPropose` + `basalRate` éditable). i18n `proposalParamBasal`. Tests +1 (corps basal).
 
 **Reste 2648b** : édition directe DOCTOR (PUT), `refreshTreatmentMode(tx)`, redirect role-branché, transport drawer, E2E.
+
+#### Corrections revue slice 2c (PR #649)
+- **Incrément basal (MEDIUM)** : un débit basal proposé doit être multiple de `PUMP_BASAL_INCREMENT` (0,05 U/h) — validé au service (`validateProposedValue` → `valueOutOfBounds`) + `step="0.05"` au form. Catalogue §6 mis à jour. Test ajouté.
+- **Message « baisse interdite »** enrichi (route vers soignant / déclaration hypo) — fr/en/ar.
+- Différés (tracés) : test de rendu du gating basal (mock lourd, non bloquant) ; warning médecin sur gros écart mono-créneau basal (US-2649b) ; hint personnalisé `current ±10%` (nécessite le rôle client) ; débit live à l'accept + re-scoping patient de `pumpBasalSlot.update` (US-2649b).

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -109,6 +109,7 @@ Source : `adjustmentService.createProposal` (`src/lib/services/adjustment.servic
 | **`currentValue` de confiance** | Lu **serveur** depuis la config réelle (jamais du body) → garde-fous ininviolables. |
 | **Sens interdit patient** | Un patient ne peut **baisser** une basale (risque hyper/cétose). ISF/ICR : monter la valeur *réduit* la dose → borné en amplitude seulement. |
 | **Cap patient** | Ratios ≤ `PATIENT_MAX_CHANGE_PERCENT` (10 %) ; dose fixe ≤ `FIXED_DOSE_PATIENT_MAX_DELTA_U` (1 U). |
+| **Incrément basal (US-2648b)** | Un débit basal proposé doit être un **multiple de `PUMP_BASAL_INCREMENT`** (0,05 U/h) — sinon non programmable sur la pompe → rejeté à la création (`validateProposedValue`). Miroir UI : `step="0.05"`. |
 | **Anti-spam** | 1 proposition `pending` max par (patient, paramètre, créneau) — index unique partiel `adjustment_proposals_one_pending_per_slot`. |
 | **Éditabilité par mode (US-2648b)** | Capability `deriveEditCapability(role, {mode,coherent})` : `canEditDirect` (DOCTOR/ADMIN), `canPropose` (DOCTOR/NURSE/patient, ADMIN exclu) ; `editableParameters` = ISF/ICR/basal **si** `basalBolus` **ET** `coherent`, sinon **vide** (`fixedDose`/`nonInsulin`/incohérent → non éditable, fail-closed). Pilote l'UI ; n'autorise rien (RBAC = routes). Source : `src/lib/insulin/edit-capability.ts`. |
 | **Frontière dispositif médical** | Mode non-insuliné : **aucune posologie** médicamenteuse orale/GLP-1 proposée (`ClinicalReviewFlag` = orientation, jamais une dose). |

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1582,7 +1582,7 @@
     "proposalSuccess": "تم إرسال الاقتراح إلى الطبيب للتحقق.",
     "proposalErrorDuplicate": "يوجد اقتراح قيد الانتظار لهذه الفترة بالفعل.",
     "proposalErrorOutOfBounds": "القيمة خارج الحدود السريرية المسموح بها.",
-    "proposalErrorDecreaseForbidden": "لا يُسمح بالتخفيض عبر هذه القناة.",
+    "proposalErrorDecreaseForbidden": "لا يمكن اقتراح تخفيض هنا؛ أبلغ فريق الرعاية (أو سجّل نقص سكر الدم).",
     "proposalErrorDeltaTooLarge": "التغيير كبير جدًا للاقتراح.",
     "proposalErrorValidation": "قيمة غير صالحة.",
     "proposalErrorConsent": "الموافقة مطلوبة.",

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1589,6 +1589,7 @@
     "proposalErrorGeneric": "فشل الإرسال. حاول مرة أخرى.",
     "proposalParamIsf": "عامل حساسية الأنسولين (ISF)",
     "proposalParamIcr": "نسبة الأنسولين إلى الكربوهيدرات (ICR)",
+    "proposalParamBasal": "المعدل القاعدي",
     "tabDocuments": "المستندات",
     "subtitle": "{pathology} — {age} سنة — متابعة من {referent}",
     "kpiCurrentGlucose": "سكر الدم الحالي",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1589,6 +1589,7 @@
     "proposalErrorGeneric": "Sending failed. Please try again.",
     "proposalParamIsf": "Insulin sensitivity factor (ISF)",
     "proposalParamIcr": "Insulin-to-carb ratio (ICR)",
+    "proposalParamBasal": "Basal rate",
     "tabDocuments": "Documents",
     "subtitle": "{pathology} — {age} y.o. — Followed by {referent}",
     "kpiCurrentGlucose": "Current glucose",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1582,7 +1582,7 @@
     "proposalSuccess": "Proposal sent to the doctor for validation.",
     "proposalErrorDuplicate": "A proposal is already pending for this slot.",
     "proposalErrorOutOfBounds": "Value outside the allowed clinical bounds.",
-    "proposalErrorDecreaseForbidden": "A decrease is not allowed through this channel.",
+    "proposalErrorDecreaseForbidden": "A decrease can't be proposed here; tell your care team (or report a hypoglycemia).",
     "proposalErrorDeltaTooLarge": "Change too large for a proposal.",
     "proposalErrorValidation": "Invalid value.",
     "proposalErrorConsent": "Consent required.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1582,7 +1582,7 @@
     "proposalSuccess": "Proposition envoyée au médecin pour validation.",
     "proposalErrorDuplicate": "Une proposition est déjà en attente pour ce créneau.",
     "proposalErrorOutOfBounds": "Valeur hors des bornes cliniques autorisées.",
-    "proposalErrorDecreaseForbidden": "Une baisse n'est pas autorisée par ce canal.",
+    "proposalErrorDecreaseForbidden": "Une baisse ne peut pas être proposée ici ; signalez-la à votre soignant (ou déclarez une hypoglycémie).",
     "proposalErrorDeltaTooLarge": "Variation trop importante pour une proposition.",
     "proposalErrorValidation": "Valeur invalide.",
     "proposalErrorConsent": "Consentement requis.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1589,6 +1589,7 @@
     "proposalErrorGeneric": "Échec de l'envoi. Réessayez.",
     "proposalParamIsf": "Facteur de sensibilité (ISF)",
     "proposalParamIcr": "Ratio insuline/glucides (ICR)",
+    "proposalParamBasal": "Débit basal",
     "tabDocuments": "Documents",
     "subtitle": "{pathology} — {age} ans — Suivi par {referent}",
     "kpiCurrentGlucose": "Glycémie actuelle",

--- a/src/app/(dashboard)/patients/[id]/treatment-view.ts
+++ b/src/app/(dashboard)/patients/[id]/treatment-view.ts
@@ -46,7 +46,7 @@ type SettingsInput = {
   deliveryMethod: InsulinDelivery
   sensitivityFactors: { startHour: number; endHour: number; sensitivityFactorGl: DecimalLike }[]
   carbRatios: { startHour: number; endHour: number; gramsPerUnit: DecimalLike }[]
-  basalConfiguration: { pumpSlots: { startTime: Date | string; endTime: Date | string; rate: DecimalLike }[] } | null
+  basalConfiguration: { pumpSlots: { id: string; startTime: Date | string; endTime: Date | string; rate: DecimalLike }[] } | null
   bolusInsulin?: {
     usage?: string | null
     isActive?: boolean | null
@@ -150,6 +150,7 @@ export function buildTreatmentView(
       icr.map((c) => ({ start: c.startHour * 60, end: c.endHour * 60 })),
     ),
     basalSlots: basal.map((p) => ({
+      pumpBasalSlotId: p.id,
       range: `${hhmm(p.startTime)}–${hhmm(p.endTime)}`,
       rate: num(p.rate),
     })),

--- a/src/components/diabeo/patient/InsulinProposalDialog.tsx
+++ b/src/components/diabeo/patient/InsulinProposalDialog.tsx
@@ -27,7 +27,12 @@ import {
 import { Button } from "@/components/ui/button"
 import { DiabeoTextField } from "@/components/diabeo/DiabeoTextField"
 import { usePatientRecordContext } from "@/components/diabeo/patient/PatientRecordContext"
-import { buildProposalBody, mapProposalOutcome, type ProposableParameter } from "@/components/diabeo/patient/insulin-proposal"
+import {
+  buildProposalBody,
+  mapProposalOutcome,
+  type ProposableParameter,
+  type ProposalTarget,
+} from "@/components/diabeo/patient/insulin-proposal"
 
 type Feedback = { kind: "error" | "success"; text: string } | null
 
@@ -36,19 +41,24 @@ type Feedback = { kind: "error" | "success"; text: string } | null
 const PARAM_BOUNDS: Record<ProposableParameter, { min: number; max: number }> = {
   insulinSensitivityFactor: { min: CLINICAL_BOUNDS.ISF_GL_MIN, max: CLINICAL_BOUNDS.ISF_GL_MAX },
   insulinToCarbRatio: { min: CLINICAL_BOUNDS.ICR_MIN, max: CLINICAL_BOUNDS.ICR_MAX },
+  basalRate: { min: CLINICAL_BOUNDS.BASAL_MIN, max: CLINICAL_BOUNDS.BASAL_MAX },
 }
 
 export function InsulinProposalDialog({
   parameterType,
   paramLabel,
   slot,
+  target,
   unit,
   onSubmitted,
 }: {
   parameterType: ProposableParameter
   /** Libellé traduit du paramètre (ex. « Facteur de sensibilité (ISF) »). */
   paramLabel: string
-  slot: { range: string; value: number; startHour: number; endHour: number }
+  /** Créneau à afficher (plage + valeur courante). */
+  slot: { range: string; value: number }
+  /** Cible adressable de la proposition (créneau horaire ISF/ICR ou créneau pompe basal). */
+  target: ProposalTarget
   unit: string
   /** Appelé après une proposition acceptée (ex. rafraîchir une liste). */
   onSubmitted?: () => void
@@ -94,8 +104,7 @@ export function InsulinProposalDialog({
         buildProposalBody({
           parameterType,
           proposedValue: proposed,
-          startHour: slot.startHour,
-          endHour: slot.endHour,
+          target,
           comment: comment.trim() || undefined,
         }),
         { signal: ctrl.signal },

--- a/src/components/diabeo/patient/InsulinProposalDialog.tsx
+++ b/src/components/diabeo/patient/InsulinProposalDialog.tsx
@@ -156,7 +156,8 @@ export function InsulinProposalDialog({
             label={t("proposalNewValue")}
             type="number"
             inputMode="decimal"
-            step="any"
+            // Basal : incrément pompe (0,05 U/h) → snapping natif + garde ; ISF/ICR : libre.
+            step={parameterType === "basalRate" ? String(CLINICAL_BOUNDS.PUMP_BASAL_INCREMENT) : "any"}
             required
             value={value}
             onChange={(e) => setValue(e.target.value)}

--- a/src/components/diabeo/patient/PatientRecord.tsx
+++ b/src/components/diabeo/patient/PatientRecord.tsx
@@ -711,9 +711,19 @@ export function PatientRecord({
                       <SlotList
                         label={t("basalLabel")}
                         unit={tUnits("basal")}
-                        slots={data.treatment.basalSlots.map((b) => ({ range: b.range, value: b.rate }))}
+                        slots={data.treatment.basalSlots.map((b) => ({
+                          range: b.range,
+                          value: b.rate,
+                          pumpBasalSlotId: b.pumpBasalSlotId,
+                        }))}
                         coverage={data.treatment.basalCoverage}
                         family="basal"
+                        propose={
+                          insulinCapability.capability?.canPropose &&
+                          insulinCapability.capability.editableParameters.includes("basalRate")
+                            ? { parameterType: "basalRate", paramLabel: t("proposalParamBasal") }
+                            : undefined
+                        }
                       />
                     )}
                   </div>
@@ -815,7 +825,7 @@ function SlotList({
 }: {
   label: ReactNode
   unit: string
-  slots: { range: string; value: number; startHour?: number; endHour?: number }[]
+  slots: { range: string; value: number; startHour?: number; endHour?: number; pumpBasalSlotId?: string }[]
   coverage?: SlotCoverage
   /** "ratio" = ISF/ICR (trou = config à vérifier) ; "basal" = pompe (24 h requis). */
   family?: "ratio" | "basal"
@@ -834,14 +844,28 @@ function SlotList({
               <span className="font-medium">
                 {s.value} {unit}
               </span>
-              {propose && s.startHour !== undefined && s.endHour !== undefined && (
-                <InsulinProposalDialog
-                  parameterType={propose.parameterType}
-                  paramLabel={propose.paramLabel}
-                  slot={{ range: s.range, value: s.value, startHour: s.startHour, endHour: s.endHour }}
-                  unit={unit}
-                />
-              )}
+              {(() => {
+                if (!propose) return null
+                // Cible adressable selon le paramètre : basal → créneau pompe (id) ;
+                // ISF/ICR → créneau horaire. Rien si le discriminateur manque (fail-closed).
+                const target =
+                  propose.parameterType === "basalRate"
+                    ? s.pumpBasalSlotId
+                      ? ({ kind: "pumpSlot", pumpBasalSlotId: s.pumpBasalSlotId } as const)
+                      : null
+                    : s.startHour !== undefined && s.endHour !== undefined
+                      ? ({ kind: "timeSlot", startHour: s.startHour, endHour: s.endHour } as const)
+                      : null
+                return target ? (
+                  <InsulinProposalDialog
+                    parameterType={propose.parameterType}
+                    paramLabel={propose.paramLabel}
+                    slot={{ range: s.range, value: s.value }}
+                    target={target}
+                    unit={unit}
+                  />
+                ) : null
+              })()}
             </div>
           </li>
         ))}

--- a/src/components/diabeo/patient/insulin-proposal.ts
+++ b/src/components/diabeo/patient/insulin-proposal.ts
@@ -7,8 +7,17 @@
  */
 import type { EditableParameter } from "@/lib/insulin/edit-capability"
 
-/** Paramètres proposables via l'UI de ce slice (basal différé — nécessite pumpBasalSlotId). */
-export type ProposableParameter = Extract<EditableParameter, "insulinSensitivityFactor" | "insulinToCarbRatio">
+/** Paramètres proposables via l'UI : ISF/ICR (créneau horaire) + basal (créneau pompe). */
+export type ProposableParameter = EditableParameter
+
+/**
+ * Cible d'une proposition : créneau HORAIRE (ISF/ICR, adressé par heure) ou créneau
+ * POMPE (basal, adressé par `pumpBasalSlotId`). Discriminée pour construire le bon
+ * champ de créneau attendu par la route.
+ */
+export type ProposalTarget =
+  | { kind: "timeSlot"; startHour: number; endHour: number }
+  | { kind: "pumpSlot"; pumpBasalSlotId: string }
 
 export type ProposalOutcome = { kind: "success" } | { kind: "error"; messageKey: string }
 
@@ -36,26 +45,31 @@ export function mapProposalOutcome(status: number, code: string | undefined): Pr
 export const PARAM_LABEL_KEY: Record<ProposableParameter, string> = {
   insulinSensitivityFactor: "proposalParamIsf",
   insulinToCarbRatio: "proposalParamIcr",
+  basalRate: "proposalParamBasal",
 }
 
 /**
- * Construit le corps de la proposition pour un créneau ISF/ICR (le champ de créneau
- * dépend du paramètre). `patientId` est ajouté par le transport de mutation (adaptateur).
- * `reason` fixé à `manualAdjustment` : la vraie provenance (patient/nurse/doctor) est
- * dérivée SERVEUR du rôle de session (`source`), pas de ce champ.
+ * Construit le corps de la proposition. Le champ de créneau dépend de la cible :
+ * ISF → `timeSlot*`, ICR → `carbRatioSlot*`, basal → `pumpBasalSlotId`. `patientId` est
+ * ajouté par le transport de mutation (adaptateur). `reason` fixé à `manualAdjustment` :
+ * la vraie provenance (patient/nurse/doctor) est dérivée SERVEUR du rôle de session
+ * (`source`), pas de ce champ.
  */
 export function buildProposalBody(args: {
   parameterType: ProposableParameter
   proposedValue: number
-  startHour: number
-  endHour: number
+  target: ProposalTarget
   comment?: string
 }): Record<string, unknown> {
-  const { parameterType, proposedValue, startHour, endHour, comment } = args
-  const slot =
-    parameterType === "insulinSensitivityFactor"
-      ? { timeSlotStartHour: startHour, timeSlotEndHour: endHour }
-      : { carbRatioSlotStart: startHour, carbRatioSlotEnd: endHour }
+  const { parameterType, proposedValue, target, comment } = args
+  let slot: Record<string, unknown>
+  if (target.kind === "pumpSlot") {
+    slot = { pumpBasalSlotId: target.pumpBasalSlotId }
+  } else if (parameterType === "insulinSensitivityFactor") {
+    slot = { timeSlotStartHour: target.startHour, timeSlotEndHour: target.endHour }
+  } else {
+    slot = { carbRatioSlotStart: target.startHour, carbRatioSlotEnd: target.endHour }
+  }
   return {
     parameterType,
     proposedValue,

--- a/src/components/diabeo/patient/patient-record-views.ts
+++ b/src/components/diabeo/patient/patient-record-views.ts
@@ -71,7 +71,8 @@ export type { SlotCoverage }
  * le libellé d'affichage.
  */
 export type Slot = { range: string; value: number; startHour: number; endHour: number }
-export type BasalSlot = { range: string; rate: number }
+/** Créneau basal pompe. `pumpBasalSlotId` exposé (US-2648b) pour la proposition ciblée. */
+export type BasalSlot = { range: string; rate: number; pumpBasalSlotId: string }
 export type TreatmentItem = { id: number; name: string | null; posology: string | null }
 /** Insuline bolus active (nom commercial du catalogue + DCI + posologie). */
 export type BolusInsulin = { name: string; genericName: string; dosage: string | null }

--- a/src/lib/services/adjustment.service.ts
+++ b/src/lib/services/adjustment.service.ts
@@ -43,14 +43,25 @@ export type CreateProposalInput = {
  * @param {number} value - Proposed value
  * @returns {boolean} True if value is within bounds
  */
+/** Vrai si `value` est un multiple de `step` (tolérance flottante). */
+const isOnIncrement = (value: number, step: number): boolean =>
+  Math.abs(value / step - Math.round(value / step)) < 1e-9
+
 function validateProposedValue(parameterType: string, value: number): boolean {
   switch (parameterType) {
     case "insulinSensitivityFactor":
       return value >= INSULIN_BOUNDS.ISF_GL_MIN && value <= INSULIN_BOUNDS.ISF_GL_MAX
     case "insulinToCarbRatio":
       return value >= INSULIN_BOUNDS.ICR_MIN && value <= INSULIN_BOUNDS.ICR_MAX
+    // US-2648b — un débit basal doit être PROGRAMMABLE sur la pompe : multiple de
+    // `PUMP_BASAL_INCREMENT` (0,05 U/h). Sinon la valeur passe les bornes mais n'est pas
+    // délivrable (arrondi silencieux / profil rejeté à l'application). Rejet à la création.
     case "basalRate":
-      return value >= INSULIN_BOUNDS.BASAL_MIN && value <= INSULIN_BOUNDS.BASAL_MAX
+      return (
+        value >= INSULIN_BOUNDS.BASAL_MIN &&
+        value <= INSULIN_BOUNDS.BASAL_MAX &&
+        isOnIncrement(value, INSULIN_BOUNDS.PUMP_BASAL_INCREMENT)
+      )
     // US-2646 — dose fixe (mode « doses simples »). SEUL le plancher de sanité bloque
     // (dose ≤ 0 / < 0,5 U invalide). PAS de plafond bloquant : une basale fixe peut
     // dépasser 25 U ; le dépassement des seuils théoriques (FIXED_BOLUS/BASAL_WARN_U)

--- a/tests/components/patient-record.test.tsx
+++ b/tests/components/patient-record.test.tsx
@@ -128,7 +128,7 @@ const baseData: PatientDetailData = {
     isfCoverage: { hasGap: false, hasOverlap: false },
     icrSlots: [{ range: "00h–06h", value: 10, startHour: 0, endHour: 6 }],
     icrCoverage: { hasGap: false, hasOverlap: false },
-    basalSlots: [{ range: "00:00–06:00", rate: 0.8 }],
+    basalSlots: [{ range: "00:00–06:00", rate: 0.8, pumpBasalSlotId: "b1" }],
     basalCoverage: { hasGap: false, hasOverlap: false },
     treatments: [{ id: 1, name: "Metformine", posology: "850 mg x2/j" }],
   },

--- a/tests/unit/adjustment-create-proposal.test.ts
+++ b/tests/unit/adjustment-create-proposal.test.ts
@@ -103,6 +103,16 @@ describe("createProposal — provenance & currentValue serveur", () => {
 })
 
 describe("createProposal — bornes, overflow, garde-fous patient", () => {
+  it("basal hors incrément pompe (0,37 U/h) → valueOutOfBounds (non délivrable)", async () => {
+    await expect(
+      adjustmentService.createProposal(
+        { patientId: 5, parameterType: "basalRate", proposedValue: 0.37, reason: "manualAdjustment", pumpBasalSlotId: "slot1" },
+        nurse,
+      ),
+    ).rejects.toThrow("valueOutOfBounds")
+    expect(mocks.create).not.toHaveBeenCalled()
+  })
+
   it("hors bornes → valueOutOfBounds, aucune création", async () => {
     await expect(adjustmentService.createProposal(isf(0.05), nurse)).rejects.toThrow("valueOutOfBounds")
     expect(mocks.create).not.toHaveBeenCalled()

--- a/tests/unit/insulin-proposal.test.ts
+++ b/tests/unit/insulin-proposal.test.ts
@@ -33,7 +33,11 @@ describe("mapProposalOutcome", () => {
 describe("buildProposalBody", () => {
   it("ISF → champs timeSlot + reason manualAdjustment (provenance serveur)", () => {
     expect(
-      buildProposalBody({ parameterType: "insulinSensitivityFactor", proposedValue: 0.55, startHour: 8, endHour: 12 }),
+      buildProposalBody({
+        parameterType: "insulinSensitivityFactor",
+        proposedValue: 0.55,
+        target: { kind: "timeSlot", startHour: 8, endHour: 12 },
+      }),
     ).toEqual({
       parameterType: "insulinSensitivityFactor",
       proposedValue: 0.55,
@@ -45,7 +49,12 @@ describe("buildProposalBody", () => {
 
   it("ICR → champs carbRatio + commentaire chiffré côté serveur", () => {
     expect(
-      buildProposalBody({ parameterType: "insulinToCarbRatio", proposedValue: 10, startHour: 8, endHour: 12, comment: "hypos matin" }),
+      buildProposalBody({
+        parameterType: "insulinToCarbRatio",
+        proposedValue: 10,
+        target: { kind: "timeSlot", startHour: 8, endHour: 12 },
+        comment: "hypos matin",
+      }),
     ).toEqual({
       parameterType: "insulinToCarbRatio",
       proposedValue: 10,
@@ -56,8 +65,27 @@ describe("buildProposalBody", () => {
     })
   })
 
+  it("basal → pumpBasalSlotId (créneau pompe adressé par id)", () => {
+    expect(
+      buildProposalBody({
+        parameterType: "basalRate",
+        proposedValue: 0.95,
+        target: { kind: "pumpSlot", pumpBasalSlotId: "slot-uuid" },
+      }),
+    ).toEqual({
+      parameterType: "basalRate",
+      proposedValue: 0.95,
+      reason: "manualAdjustment",
+      pumpBasalSlotId: "slot-uuid",
+    })
+  })
+
   it("sans commentaire → pas de clé proposerComment", () => {
-    const body = buildProposalBody({ parameterType: "insulinSensitivityFactor", proposedValue: 0.5, startHour: 0, endHour: 6 })
+    const body = buildProposalBody({
+      parameterType: "insulinSensitivityFactor",
+      proposedValue: 0.5,
+      target: { kind: "timeSlot", startHour: 0, endHour: 6 },
+    })
     expect(body).not.toHaveProperty("proposerComment")
   })
 })

--- a/tests/unit/treatment-view.test.ts
+++ b/tests/unit/treatment-view.test.ts
@@ -16,7 +16,7 @@ describe("buildTreatmentView", () => {
         sensitivityFactors: [{ startHour: 0, endHour: 6, sensitivityFactorGl: "0.30" }],
         carbRatios: [{ startHour: 0, endHour: 6, gramsPerUnit: "10.0" }],
         basalConfiguration: {
-          pumpSlots: [{ startTime: "1970-01-01T00:00:00.000Z", endTime: "1970-01-01T06:00:00.000Z", rate: "0.800" }],
+          pumpSlots: [{ id: "b1", startTime: "1970-01-01T00:00:00.000Z", endTime: "1970-01-01T06:00:00.000Z", rate: "0.800" }],
         },
       },
       [],
@@ -25,7 +25,7 @@ describe("buildTreatmentView", () => {
     expect(v.deliveryMethod).toBe("pump")
     expect(v.isfSlots).toEqual([{ range: "00h–06h", value: 0.3, startHour: 0, endHour: 6 }])
     expect(v.icrSlots).toEqual([{ range: "00h–06h", value: 10, startHour: 0, endHour: 6 }])
-    expect(v.basalSlots).toEqual([{ range: "00:00–06:00", rate: 0.8 }])
+    expect(v.basalSlots).toEqual([{ range: "00:00–06:00", rate: 0.8, pumpBasalSlotId: "b1" }])
     // Un seul créneau 00–06 → trou sur le reste de la journée (garde-fou).
     expect(v.isfCoverage).toEqual({ hasGap: true, hasOverlap: false })
     expect(v.basalCoverage).toEqual({ hasGap: true, hasOverlap: false })


### PR DESCRIPTION
Complète le flux « Proposer » aux **3 paramètres** (ISF/ICR/**basal**), en réutilisant la route US-2648a (qui accepte déjà `basalRate` + `pumpBasalSlotId`).

## Contenu
- **`BasalSlot` += `pumpBasalSlotId`** (exposé via `getSettings` include → `treatment-view`) → créneau pompe **adressable**.
- **`ProposalTarget` discriminé** (`timeSlot` ISF/ICR | `pumpSlot` basal) ; `buildProposalBody` construit `pumpBasalSlotId` pour le basal. `ProposableParameter` = ISF/ICR/basal.
- **`InsulinProposalDialog` généralisé** (slot d'affichage + `target`) ; bornes basal (`BASAL_MIN/MAX`) en indice.
- **SlotList basal** : bouton « Proposer » gated (`canPropose` + `basalRate` éditable), **fail-closed** si `pumpBasalSlotId` absent. i18n `proposalParamBasal`.

## Reste US-2648b
Édition directe DOCTOR (PUT), `refreshTreatmentMode(tx)`, redirect role-branché, transport drawer, E2E.

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3625 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)