### PR TITLE
US-2649b (slice 2) — Durcissement de l'apply basal à l'accept (anti-IDOR)

### DIFF
--- a/docs/UserStory/insulinotherapie-edition/US-2649-flux-proposition-validation.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2649-flux-proposition-validation.md
@@ -72,3 +72,9 @@ Enrichit `/adjustment-proposals` (file de revue) avec des findings différés :
 - **HDS (fermé)** : `proposerComment` (ciphertext) n'est plus émis dans la réponse GET `list` — strippé au **service** (`omit`), donc tout consommateur est protégé (pas seulement la route). Décryptage pour le médecin = tranche future.
 - **fail-closed** : `deriveRiskDirection` renvoie `none` sur un `parameterType` inconnu (pas de verdict deviné) + test.
 - Confirmé clinique : les 4 directions correctes ; magnitude déjà affichée à côté du badge (anti alarm-fatigue).
+
+#### US-2649b slice 2 : durcissement de l'apply à l'accept
+- L'application d'une proposition **basale** acceptée est désormais **re-scopée au patient** (`updateMany` sur `id` + `basalConfig.settings.patientId`) comme ISF/ICR — un `pumpBasalSlotId` hors patient ne matche pas (**anti-IDOR défense en profondeur**), `count 0 → pumpSlotNotFound` (fail-closed). Avant : `update` par id seul.
+- Tests : +2 (apply basal scopé + pumpSlotNotFound).
+
+**Reste US-2649b** : confiance basée sur `source` dans l'UI ; valeur LIVE affichée à l'accept ; notifications push.

--- a/docs/UserStory/insulinotherapie-edition/US-2649-flux-proposition-validation.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2649-flux-proposition-validation.md
@@ -78,3 +78,7 @@ Enrichit `/adjustment-proposals` (file de revue) avec des findings différés :
 - Tests : +2 (apply basal scopé + pumpSlotNotFound).
 
 **Reste US-2649b** : confiance basée sur `source` dans l'UI ; valeur LIVE affichée à l'accept ; notifications push.
+
+##### Corrections revue slice 2 (PR #653)
+- **Garde fail-closed uniformisé** sur les **3 paramètres** à l'accept : helper `assertRowApplied(count, code)` → ISF/ICR (comme le basal) lèvent `isfSlotNotFound`/`icrSlotNotFound` si le créneau a disparu/bougé entre proposition et accept → **plus de « accepté + appliqué » fantôme** (le rollback annule le statut). Ferme le finding HDS de cohérence (pré-existant, rendu visible par contraste).
+- Tests : +1 (ISF phantom-accept).

--- a/src/lib/services/adjustment.service.ts
+++ b/src/lib/services/adjustment.service.ts
@@ -414,10 +414,17 @@ export const adjustmentService = {
             data: { gramsPerUnit: proposed },
           })
         } else if (proposal.parameterType === "basalRate" && proposal.pumpBasalSlotId) {
-          await tx.pumpBasalSlot.update({
-            where: { id: proposal.pumpBasalSlotId },
+          // Re-scopé au patient de la proposition (défense en profondeur, anti-IDOR) :
+          // un pumpBasalSlotId qui n'appartiendrait pas au patient ne matche pas → count 0
+          // → fail-closed (créneau introuvable), jamais d'écriture cross-patient.
+          const res = await tx.pumpBasalSlot.updateMany({
+            where: {
+              id: proposal.pumpBasalSlotId,
+              basalConfig: { settings: { patientId: proposal.patientId } },
+            },
             data: { rate: proposed },
           })
+          if (res.count === 0) throw new Error("pumpSlotNotFound")
         }
       }
 

--- a/src/lib/services/adjustment.service.ts
+++ b/src/lib/services/adjustment.service.ts
@@ -44,6 +44,16 @@ export type CreateProposalInput = {
  * @param {number} value - Proposed value
  * @returns {boolean} True if value is within bounds
  */
+/**
+ * Garde-fő fail-closed de l'application d'une proposition acceptée : si aucune ligne n'a
+ * été écrite (`count === 0` — créneau supprimé/déplacé ou hors patient entre la proposition
+ * et l'accept), lève `code` → rollback de la transaction, jamais d'« accepté + appliqué »
+ * fantôme. Partagé par les 3 paramètres (ISF/ICR/basal) pour éviter la dérive.
+ */
+function assertRowApplied(count: number, code: string): void {
+  if (count === 0) throw new Error(code)
+}
+
 function validateProposedValue(parameterType: string, value: number): boolean {
   switch (parameterType) {
     case "insulinSensitivityFactor":
@@ -395,7 +405,7 @@ export const adjustmentService = {
         }
 
         if (proposal.parameterType === "insulinSensitivityFactor" && proposal.timeSlotStartHour != null) {
-          await tx.insulinSensitivityFactor.updateMany({
+          const res = await tx.insulinSensitivityFactor.updateMany({
             where: {
               settings: { patientId: proposal.patientId },
               startHour: proposal.timeSlotStartHour,
@@ -405,14 +415,18 @@ export const adjustmentService = {
               sensitivityFactorMgdl: proposed * 100,
             },
           })
+          // Fail-closed : si le créneau a disparu/bougé entre proposition et accept, ne pas
+          // laisser un « accepté + appliqué » fantôme (le médecin croirait la valeur active).
+          assertRowApplied(res.count, "isfSlotNotFound")
         } else if (proposal.parameterType === "insulinToCarbRatio" && proposal.carbRatioSlotStart != null) {
-          await tx.carbRatio.updateMany({
+          const res = await tx.carbRatio.updateMany({
             where: {
               settings: { patientId: proposal.patientId },
               startHour: proposal.carbRatioSlotStart,
             },
             data: { gramsPerUnit: proposed },
           })
+          assertRowApplied(res.count, "icrSlotNotFound")
         } else if (proposal.parameterType === "basalRate" && proposal.pumpBasalSlotId) {
           // Re-scopé au patient de la proposition (défense en profondeur, anti-IDOR) :
           // un pumpBasalSlotId qui n'appartiendrait pas au patient ne matche pas → count 0
@@ -424,7 +438,7 @@ export const adjustmentService = {
             },
             data: { rate: proposed },
           })
-          if (res.count === 0) throw new Error("pumpSlotNotFound")
+          assertRowApplied(res.count, "pumpSlotNotFound")
         }
       }
 

--- a/tests/unit/adjustment.service.test.ts
+++ b/tests/unit/adjustment.service.test.ts
@@ -113,6 +113,46 @@ describe("adjustmentService", () => {
       // Le paramètre insuline n'est JAMAIS appliqué (validation avant updateMany).
       expect(mockTx.insulinSensitivityFactor.updateMany).not.toHaveBeenCalled()
     })
+
+    it("applies a basal proposal via a pump slot SCOPED to the patient (anti-IDOR)", async () => {
+      const mockTx = {
+        adjustmentProposal: {
+          findUnique: vi.fn().mockResolvedValue({
+            id: "p1", patientId: 1, status: "pending",
+            parameterType: "basalRate", proposedValue: 0.95, pumpBasalSlotId: "slot1",
+          }),
+          update: vi.fn().mockResolvedValue({}),
+        },
+        pumpBasalSlot: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+        auditLog: { create: vi.fn().mockResolvedValue({}) },
+      }
+      prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+
+      const result = await adjustmentService.accept("p1", 2, true)
+      expect(result.applied).toBe(true)
+      expect(mockTx.pumpBasalSlot.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ id: "slot1", basalConfig: { settings: { patientId: 1 } } }),
+        }),
+      )
+    })
+
+    it("throws 'pumpSlotNotFound' when the scoped basal slot matches nothing (fail-closed)", async () => {
+      const mockTx = {
+        adjustmentProposal: {
+          findUnique: vi.fn().mockResolvedValue({
+            id: "p1", patientId: 1, status: "pending",
+            parameterType: "basalRate", proposedValue: 0.95, pumpBasalSlotId: "slotX",
+          }),
+          update: vi.fn().mockResolvedValue({}),
+        },
+        pumpBasalSlot: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+        auditLog: { create: vi.fn().mockResolvedValue({}) },
+      }
+      prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+
+      await expect(adjustmentService.accept("p1", 2, true)).rejects.toThrow("pumpSlotNotFound")
+    })
   })
 
   describe("reject", () => {
@@ -210,14 +250,14 @@ describe("adjustmentService", () => {
           }),
           update: vi.fn().mockResolvedValue({}),
         },
-        pumpBasalSlot: { update: vi.fn().mockResolvedValue({}) },
+        pumpBasalSlot: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
         auditLog: { create: vi.fn().mockResolvedValue({}) },
       }
       prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
 
       const result = await adjustmentService.accept("p3", 2, true)
       expect(result.applied).toBe(true)
-      expect(mockTx.pumpBasalSlot.update).toHaveBeenCalled()
+      expect(mockTx.pumpBasalSlot.updateMany).toHaveBeenCalled()
     })
   })
 

--- a/tests/unit/adjustment.service.test.ts
+++ b/tests/unit/adjustment.service.test.ts
@@ -137,6 +137,23 @@ describe("adjustmentService", () => {
       )
     })
 
+    it("throws 'isfSlotNotFound' when the ISF slot vanished between propose and accept (no phantom accept)", async () => {
+      const mockTx = {
+        adjustmentProposal: {
+          findUnique: vi.fn().mockResolvedValue({
+            id: "p1", patientId: 1, status: "pending",
+            parameterType: "insulinSensitivityFactor", proposedValue: 0.55, timeSlotStartHour: 8,
+          }),
+          update: vi.fn().mockResolvedValue({}),
+        },
+        insulinSensitivityFactor: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+        auditLog: { create: vi.fn().mockResolvedValue({}) },
+      }
+      prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+
+      await expect(adjustmentService.accept("p1", 2, true)).rejects.toThrow("isfSlotNotFound")
+    })
+
     it("throws 'pumpSlotNotFound' when the scoped basal slot matches nothing (fail-closed)", async () => {
       const mockTx = {
         adjustmentProposal: {


### PR DESCRIPTION
Ferme le finding défense-en-profondeur relevé à la revue de #649/#650 : l'`accept()` appliquait une proposition **basale** via `pumpBasalSlot.update({where:{id}})` — **non re-scopé au patient**, contrairement à ISF/ICR.

## Contenu
- Apply basal → `updateMany({where:{ id, basalConfig:{settings:{patientId}} }})` : un `pumpBasalSlotId` hors patient **ne matche pas** (anti-IDOR, défense en profondeur) ; `count 0 → pumpSlotNotFound` (fail-closed — plus de faux `applied:true` sur un créneau absent). Symétrique à l'apply ISF/ICR.
- Tests : **+2** (apply basal scopé patient + `pumpSlotNotFound`) ; test pré-existant aligné (`update`→`updateMany`).

## Reste US-2649b
Confiance basée sur `source` (UI) · valeur LIVE affichée à l'accept · notifications push.

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3654 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)