### PR TITLE
US-2649b (slice 3) — Notification du médecin référent à la création d'une proposition

### DIFF
--- a/docs/UserStory/insulinotherapie-edition/US-2649-flux-proposition-validation.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2649-flux-proposition-validation.md
@@ -82,3 +82,9 @@ Enrichit `/adjustment-proposals` (file de revue) avec des findings différés :
 ##### Corrections revue slice 2 (PR #653)
 - **Garde fail-closed uniformisé** sur les **3 paramètres** à l'accept : helper `assertRowApplied(count, code)` → ISF/ICR (comme le basal) lèvent `isfSlotNotFound`/`icrSlotNotFound` si le créneau a disparu/bougé entre proposition et accept → **plus de « accepté + appliqué » fantôme** (le rollback annule le statut). Ferme le finding HDS de cohérence (pré-existant, rendu visible par contraste).
 - Tests : +1 (ISF phantom-accept).
+
+#### US-2649b slice 3 : notification du médecin référent à la création
+- `createProposal` notifie le **médecin référent** du patient (push FCM) qu'une proposition est à revoir. **Best-effort et HORS transaction** : un échec push n'annule jamais la création (déjà commitée). Ne se notifie pas soi-même (référent qui propose). **Aucun PHI/dose** dans le message ; `data.type = proposal_review`. Symétrique à `notifyPatient` (accept/reject).
+- Tests : +4 (push référent, no-self-notify, pas de référent, best-effort sur échec push).
+
+**Reste US-2649b** : confiance basée sur `source` (UI) ; valeur LIVE affichée à l'accept.

--- a/src/lib/services/adjustment.service.ts
+++ b/src/lib/services/adjustment.service.ts
@@ -162,6 +162,41 @@ function slotFieldsFor(parameterType: AdjustableParameter, input: CreateProposal
  * Adjustment proposal service — CRUD and review workflow.
  * @namespace adjustmentService
  */
+/**
+ * US-2649b — Notifie le médecin RÉFÉRENT du patient qu'une proposition d'ajustement est à
+ * revoir (push FCM). Best-effort et hors transaction (jamais bloquant pour la création). Ne
+ * se notifie pas soi-même (un référent qui propose). Aucun PHI/valeur de dose dans le message.
+ */
+async function notifyReviewers(
+  patientId: number,
+  proposal: { id: string; proposedByUserId: number | null },
+  ctx?: AuditContext,
+): Promise<{ notified: boolean }> {
+  const ref = await prisma.patientReferent.findFirst({
+    where: { patientId, patient: { deletedAt: null } },
+    select: { pro: { select: { userId: true } } },
+  })
+  const reviewerUserId = ref?.pro?.userId
+  if (!reviewerUserId || reviewerUserId === proposal.proposedByUserId) return { notified: false }
+
+  try {
+    const result = await fcmService.sendToUser(
+      {
+        userId: reviewerUserId,
+        senderId: proposal.proposedByUserId ?? reviewerUserId,
+        title: "Nouvelle proposition d'ajustement",
+        body: "Une proposition d'ajustement de traitement est en attente de votre validation.",
+        data: { type: "proposal_review", proposalId: proposal.id },
+      },
+      ctx,
+    )
+    return { notified: result.sent > 0 }
+  } catch (err) {
+    logger.error("adjustment", "Reviewer push notification failed", { patientId }, err)
+    return { notified: false }
+  }
+}
+
 export const adjustmentService = {
   /**
    * List adjustment proposals for a patient with optional filters.
@@ -322,7 +357,7 @@ export const adjustmentService = {
     //    rôle de SESSION (jamais du body ; rejeter ADMIN/VIEWER) ; (4) politique `proposerComment`
     //    (le renvoyer/pas dans le DTO — c'est du ciphertext, à ne pas exposer au client).
     try {
-      return await prisma.$transaction(async (tx) => {
+      const created = await prisma.$transaction(async (tx) => {
         const proposal = await tx.adjustmentProposal.create({
           data: {
             patientId,
@@ -354,6 +389,12 @@ export const adjustmentService = {
 
         return proposal
       })
+
+      // US-2649b — notifier le médecin RÉFÉRENT qu'une proposition est à revoir. Best-effort
+      // et HORS transaction : un échec push ne doit jamais annuler la création (déjà commitée).
+      await notifyReviewers(patientId, created, ctx).catch(() => {})
+
+      return created
     } catch (e) {
       // Course TOCTOU rattrapée par l'index partiel `adjustment_proposals_one_pending_per_slot`.
       // On ne re-mappe QUE cette contrainte-là (pas n'importe quel P2002) pour ne pas masquer

--- a/src/lib/services/adjustment.service.ts
+++ b/src/lib/services/adjustment.service.ts
@@ -390,9 +390,13 @@ export const adjustmentService = {
         return proposal
       })
 
-      // US-2649b — notifier le médecin RÉFÉRENT qu'une proposition est à revoir. Best-effort
-      // et HORS transaction : un échec push ne doit jamais annuler la création (déjà commitée).
-      await notifyReviewers(patientId, created, ctx).catch(() => {})
+      // US-2649b — notifier le médecin RÉFÉRENT qu'une proposition est à revoir.
+      // FIRE-AND-FORGET : hors transaction ET hors chemin de réponse (le serveur est
+      // persistant, le `.catch` s'exécute) — la 201 ne dépend pas de FCM (retries jusqu'à
+      // ~3 s si dégradé). L'échec (y compris la résolution du référent) est LOGUÉ, pas avalé.
+      void notifyReviewers(patientId, created, ctx).catch((err) =>
+        logger.error("adjustment", "notifyReviewers failed", { patientId }, err),
+      )
 
       return created
     } catch (e) {

--- a/tests/unit/adjustment-create-proposal.test.ts
+++ b/tests/unit/adjustment-create-proposal.test.ts
@@ -19,6 +19,8 @@ const { prismaMock, mocks } = vi.hoisted(() => {
     basalFindFirst: vi.fn(),
     create: vi.fn((args: { data: Record<string, unknown> }) => ({ id: "p1", ...args.data })),
     logWithTx: vi.fn(),
+    referentFindFirst: vi.fn(),
+    sendToUser: vi.fn(),
   }
   return {
     mocks: m,
@@ -27,6 +29,7 @@ const { prismaMock, mocks } = vi.hoisted(() => {
       insulinSensitivityFactor: { findFirst: m.isfFindFirst },
       carbRatio: { findFirst: m.icrFindFirst },
       pumpBasalSlot: { findFirst: m.basalFindFirst },
+      patientReferent: { findFirst: m.referentFindFirst },
       $transaction: async (fn: (tx: unknown) => unknown) =>
         fn({ adjustmentProposal: { create: m.create } }),
     },
@@ -34,7 +37,7 @@ const { prismaMock, mocks } = vi.hoisted(() => {
 })
 vi.mock("@/lib/db/client", () => ({ prisma: prismaMock }))
 vi.mock("@/lib/services/audit.service", () => ({ auditService: { logWithTx: mocks.logWithTx } }))
-vi.mock("@/lib/services/fcm.service", () => ({ fcmService: {} }))
+vi.mock("@/lib/services/fcm.service", () => ({ fcmService: { sendToUser: mocks.sendToUser } }))
 vi.mock("@/lib/crypto/fields", () => ({
   encryptField: (s: string) => `enc(${s})`,
   safeDecryptField: (s: string) => s,
@@ -65,6 +68,8 @@ beforeEach(() => {
   mocks.adjFindFirst.mockResolvedValue(null) // pas de doublon
   mocks.isfFindFirst.mockResolvedValue({ sensitivityFactorGl: 0.5 }) // valeur courante de confiance
   mocks.basalFindFirst.mockResolvedValue({ rate: 1.0 })
+  mocks.referentFindFirst.mockResolvedValue({ pro: { userId: 99 } }) // médecin référent
+  mocks.sendToUser.mockResolvedValue({ sent: 1 })
 })
 
 describe("createProposal — provenance & currentValue serveur", () => {
@@ -216,5 +221,33 @@ describe("createProposal — dérivation ICR/basal & normalisation créneau", ()
     const data = mocks.create.mock.calls[0]![0].data
     expect(data.pumpBasalSlotId).toBeNull()
     expect(data.timeSlotStartHour).toBe(8)
+  })
+})
+
+describe("createProposal — notification du médecin référent (US-2649b)", () => {
+  it("NURSE : push au référent (sans PHi/dose), type proposal_review", async () => {
+    await adjustmentService.createProposal(isf(0.52), nurse)
+    expect(mocks.sendToUser).toHaveBeenCalledTimes(1)
+    const arg = mocks.sendToUser.mock.calls[0]![0]
+    expect(arg).toMatchObject({ userId: 99, data: { type: "proposal_review", proposalId: "p1" } })
+    // pas de valeur de dose dans le message
+    expect(`${arg.title} ${arg.body}`).not.toContain("0.52")
+  })
+
+  it("ne se notifie pas soi-même (proposeur = référent)", async () => {
+    // Référent userId 99 ; un DOCTOR proposeur userId 99 → pas de push.
+    await adjustmentService.createProposal(isf(0.52), { userId: 99, role: "doctor" })
+    expect(mocks.sendToUser).not.toHaveBeenCalled()
+  })
+
+  it("pas de référent → pas de push, création OK", async () => {
+    mocks.referentFindFirst.mockResolvedValue(null)
+    await expect(adjustmentService.createProposal(isf(0.52), nurse)).resolves.toMatchObject({ id: "p1" })
+    expect(mocks.sendToUser).not.toHaveBeenCalled()
+  })
+
+  it("best-effort : un échec push ne casse pas la création", async () => {
+    mocks.sendToUser.mockRejectedValue(new Error("fcm down"))
+    await expect(adjustmentService.createProposal(isf(0.52), nurse)).resolves.toMatchObject({ id: "p1" })
   })
 })

--- a/tests/unit/adjustment-create-proposal.test.ts
+++ b/tests/unit/adjustment-create-proposal.test.ts
@@ -225,29 +225,35 @@ describe("createProposal — dérivation ICR/basal & normalisation créneau", ()
 })
 
 describe("createProposal — notification du médecin référent (US-2649b)", () => {
-  it("NURSE : push au référent (sans PHi/dose), type proposal_review", async () => {
+  // Notif en fire-and-forget → assertion après drain des microtasks.
+  const tick = () => new Promise((r) => setTimeout(r, 0))
+
+  it("NURSE : push au référent, type proposal_review, AUCUNE dose dans tout le payload", async () => {
     await adjustmentService.createProposal(isf(0.52), nurse)
-    expect(mocks.sendToUser).toHaveBeenCalledTimes(1)
+    await vi.waitFor(() => expect(mocks.sendToUser).toHaveBeenCalledTimes(1))
     const arg = mocks.sendToUser.mock.calls[0]![0]
     expect(arg).toMatchObject({ userId: 99, data: { type: "proposal_review", proposalId: "p1" } })
-    // pas de valeur de dose dans le message
-    expect(`${arg.title} ${arg.body}`).not.toContain("0.52")
+    // Payload COMPLET (title/body/data) sans valeur de dose (0.52) ni currentValue (0.5).
+    expect(JSON.stringify(arg)).not.toContain("0.52")
+    expect(JSON.stringify(arg.data)).not.toContain("0.5")
   })
 
   it("ne se notifie pas soi-même (proposeur = référent)", async () => {
-    // Référent userId 99 ; un DOCTOR proposeur userId 99 → pas de push.
     await adjustmentService.createProposal(isf(0.52), { userId: 99, role: "doctor" })
+    await tick()
     expect(mocks.sendToUser).not.toHaveBeenCalled()
   })
 
   it("pas de référent → pas de push, création OK", async () => {
     mocks.referentFindFirst.mockResolvedValue(null)
     await expect(adjustmentService.createProposal(isf(0.52), nurse)).resolves.toMatchObject({ id: "p1" })
+    await tick()
     expect(mocks.sendToUser).not.toHaveBeenCalled()
   })
 
   it("best-effort : un échec push ne casse pas la création", async () => {
     mocks.sendToUser.mockRejectedValue(new Error("fcm down"))
     await expect(adjustmentService.createProposal(isf(0.52), nurse)).resolves.toMatchObject({ id: "p1" })
+    await tick()
   })
 })


### PR DESCRIPTION
Le pendant « création » de `notifyPatient` : quand un patient/nurse (ou un autre médecin) crée une proposition, le **médecin référent** du patient reçoit un push FCM « à revoir ».

## Contenu
- **`notifyReviewers(patientId, proposal, ctx)`** : résout le référent (`PatientReferent.pro.userId`) → `fcmService.sendToUser`. Déclenché par `createProposal` **après commit**, **best-effort et HORS transaction** (un échec push n'annule jamais la création déjà commitée). **Ne se notifie pas soi-même** (référent = proposeur). **Aucun PHI/valeur de dose** ; `data.type = proposal_review`.
- Tests : **+4** (push référent, no-self-notify, pas de référent → no-op, best-effort sur échec push).

Note : titres/corps en FR en dur — **mirror du pattern existant `notifyPatient`** (l'i18n des push est un chantier transverse, hors scope).

## Reste US-2649b
Confiance basée sur `source` (UI) · valeur LIVE affichée à l'accept.

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3659 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)