### PR TITLE
US-2649b (slice 4) — Provenance + direction de risque sur le VRAI écran de revue

### DIFF
--- a/docs/UserStory/insulinotherapie-edition/US-2649-flux-proposition-validation.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2649-flux-proposition-validation.md
@@ -88,3 +88,17 @@ Enrichit `/adjustment-proposals` (file de revue) avec des findings différés :
 - Tests : +4 (push référent, no-self-notify, pas de référent, best-effort sur échec push).
 
 **Reste US-2649b** : confiance basée sur `source` (UI) ; valeur LIVE affichée à l'accept.
+
+#### US-2649b slice 4 : provenance + risque sur le VRAI écran de revue (ReviewClient)
+Diagnostic : la page `/adjustment-proposals` enrichie en #652 est **orpheline** (aucun lien
+de navigation, 404 pour un médecin car fetch sans `patientId` — vestige US-2047). Le **vrai
+écran de revue** est `/patients/[id]/review` (`ReviewClient`, per-patient, câblé depuis
+`PendingProposalsCard`).
+- `ReviewProposalItem` += `source` ; `review/page.tsx` le fournit (`adjustmentService.list`).
+- `ReviewClient` (étape Décisions) : badge **provenance** (« demande patient » mis en avant) +
+  badge **direction de risque** (`deriveRiskDirection`, hypo ambre) à côté du %variation — ferme
+  le finding « fiabilité basée sur `source`, pas `confidence` » là où le médecin décide.
+- i18n `adjustments.source/risk` réutilisées (#652).
+
+**Suivi** : (1) supprimer la page orpheline `/adjustment-proposals` (dead code) — à confirmer ;
+(2) **valeur LIVE** du créneau à l'accept (re-lecture serveur, N requêtes) — non fait ici.

--- a/docs/inventory/composants-orphelins.md
+++ b/docs/inventory/composants-orphelins.md
@@ -53,7 +53,7 @@ bouton) ou à statuer comme abandonnées.
 
 | Route (UI) | Ce qu'elle fait (présumé) | Backend API | Statut |
 |---|---|---|---|
-| `/adjustment-proposals` | Liste des **propositions d'ajustement** de dose (accept/reject DOCTOR). | ✅ `api/adjustment-proposals/*` (GET, accept, reject, summary) | Page + API OK, **0 lien UI**. Sans doute destinée à devenir un onglet/section du dossier patient. |
+| `/adjustment-proposals` | Liste des **propositions d'ajustement** de dose (accept/reject DOCTOR). | ✅ `api/adjustment-proposals/*` (GET, accept, reject, summary) | **0 lien UI** + **404 pour un médecin** : la page fetch `?status=pending` **sans `patientId`** → `resolvePatientId` renvoie null (un pro doit préciser un patient). **Supplantée** par le vrai écran de revue **`/patients/[id]/review`** (`ReviewClient`, per-patient, câblé depuis `PendingProposalsCard`). Vestige US-2047 — candidate à suppression (diagnostic US-2649b, PR #655). |
 | `/analytics/radar` | Vue **radar** analytique (sous-page de `/analytics`). | — | **0 lien UI** — pas d'onglet depuis `/analytics`. |
 | `/events/new` | Création d'un **événement diabète** (`DiabetesEvent`). | — | **0 lien UI** — aucun bouton « nouvel événement » ne l'ouvre. |
 | `/devices/pair` | **Appairage** d'un appareil patient (`PatientDevice`). | — | **0 lien UI** depuis `/devices`. |

--- a/src/app/(dashboard)/patients/[id]/review/ReviewClient.tsx
+++ b/src/app/(dashboard)/patients/[id]/review/ReviewClient.tsx
@@ -16,7 +16,8 @@
 
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react"
 import { useLocale, useTranslations } from "next-intl"
-import type { AdjustableParameter } from "@prisma/client"
+import type { AdjustableParameter, ProposalSource } from "@prisma/client"
+import { deriveRiskDirection } from "@/lib/insulin/risk-direction"
 import { DashboardHeader } from "@/components/diabeo/DashboardHeader"
 import { PatientContextBar, type ContextFlags } from "@/components/diabeo/patient/PatientContextBar"
 import { GlycemiaValue, TirDonut, ClinicalBadge, StatCard } from "@/components/diabeo"
@@ -40,6 +41,8 @@ import {
 export type ReviewProposalItem = {
   id: string
   parameterType: AdjustableParameter
+  /** Provenance dérivée serveur (US-2649b) — pilote l'affichage de fiabilité (≠ confidence moteur). */
+  source: ProposalSource
   currentValue: number
   proposedValue: number
   changePercent: number
@@ -406,6 +409,7 @@ function SlotBlock({ label, unit, slots }: { label: ReactNode; unit: string; slo
 function DecisionsStep({ data }: { data: ReviewData }) {
   const t = useTranslations("review")
   const tUnits = useTranslations("insulinUnits")
+  const tAdj = useTranslations("adjustments")
   const locale = useLocale()
   const fmt = (n: number) => n.toLocaleString(bcp47(locale), { maximumFractionDigits: 2 })
 
@@ -463,6 +467,20 @@ function DecisionsStep({ data }: { data: ReviewData }) {
                 <Badge variant={Math.abs(p.changePercent) >= PROPOSAL_MAJOR_CHANGE_PCT ? "destructive" : "secondary"}>
                   {p.changePercent > 0 ? `+${Math.round(p.changePercent)}` : Math.round(p.changePercent)}&nbsp;%
                 </Badge>
+                {/* US-2649b — provenance (fiabilité ≠ confidence moteur) : « demande patient » mise en avant. */}
+                <Badge variant={p.source === "patient" ? "default" : "outline"}>{tAdj(`source.${p.source}`)}</Badge>
+                {/* Direction de risque : l'hypo (plus d'insuline) signalée en ambre. */}
+                {(() => {
+                  const risk = deriveRiskDirection(p.parameterType, p.currentValue, p.proposedValue)
+                  return risk === "none" ? null : (
+                    <Badge
+                      variant="outline"
+                      className={risk === "hypo" ? "border-feedback-warning text-feedback-warning" : "text-muted-foreground"}
+                    >
+                      {tAdj(`risk.${risk}`)}
+                    </Badge>
+                  )
+                })()}
                 {data.canDecide && (
                   <span className="flex gap-2">
                     <Button size="sm" variant="default" disabled={busyId === p.id} onClick={() => decide(p.id, "accept")}>

--- a/src/app/(dashboard)/patients/[id]/review/page.tsx
+++ b/src/app/(dashboard)/patients/[id]/review/page.tsx
@@ -132,6 +132,7 @@ export default async function PatientReviewPage({
   const proposals: ReviewProposalItem[] = pending.map((p) => ({
     id: p.id,
     parameterType: p.parameterType,
+    source: p.source,
     currentValue: Number(p.currentValue),
     proposedValue: Number(p.proposedValue),
     changePercent: Number(p.changePercent),

--- a/tests/components/review-client.test.tsx
+++ b/tests/components/review-client.test.tsx
@@ -101,6 +101,13 @@ describe("ReviewClient", () => {
     expect(screen.getAllByTestId("stat").some((n) => n.textContent?.includes("142"))).toBe(true)
   })
 
+  it("affiche les badges provenance et direction de risque (US-2649b)", () => {
+    render(<ReviewClient data={BASE} />)
+    // source=patient → « Demande patient » ; basal 1.0→1.2 (plus d'insuline) → « Risque hypo ».
+    expect(screen.getByText("Demande patient")).toBeTruthy()
+    expect(screen.getByText("Risque hypo")).toBeTruthy()
+  })
+
   it("médecin : accepter une proposition appelle la route et la retire de la liste", async () => {
     render(<ReviewClient data={BASE} />)
     const accept = screen.getByRole("button", { name: "Accepter" })

--- a/tests/components/review-client.test.tsx
+++ b/tests/components/review-client.test.tsx
@@ -82,7 +82,7 @@ const BASE: ReviewData = {
   },
   proposals: [
     {
-      id: "p1", parameterType: "basalRate", currentValue: 1.0, proposedValue: 1.2,
+      id: "p1", parameterType: "basalRate", source: "patient", currentValue: 1.0, proposedValue: 1.2,
       changePercent: 20, reason: "trend", confidence: "high",
       timeSlotStartHour: null, timeSlotEndHour: null, createdAt: "2026-06-15T00:00:00.000Z",
     },


### PR DESCRIPTION
## Diagnostic (option « a » : réparer l'écran de revue)
La page `/adjustment-proposals` que j'avais enrichie en **#652 est ORPHELINE** : aucun lien de navigation, et elle **404 pour un médecin** (fetch `?status=pending` sans `patientId` → `resolvePatientId` renvoie null). C'est un vestige (US-2047). Le **vrai** écran de revue médecin est **`/patients/[id]/review`** (`ReviewClient`, per-patient, câblé depuis `PendingProposalsCard → /patients/{id}/review`) — il fonctionne.

→ Je porte donc les badges (source + risque) **sur le vrai écran**, là où le médecin accepte/refuse.

## Contenu
- `ReviewProposalItem` += `source` ; `review/page.tsx` le fournit (`adjustmentService.list`).
- `ReviewClient` (étape Décisions) : **badge provenance** (« demande patient » mis en avant) + **badge direction de risque** (`deriveRiskDirection`, hypo en ambre) à côté du %variation → **ferme le finding « fiabilité basée sur `source`, pas `confidence` »** (le vrai écran portait `confidence`, null pour les humains).
- i18n `adjustments.source/risk` réutilisées (#652). Fixture alignée.

## Suivi (tracé)
1. **Supprimer la page orpheline** `/adjustment-proposals` (dead code — à confirmer avec toi).
2. **Valeur LIVE** du créneau à l'accept (re-lecture serveur, N requêtes) — non fait ici.

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3659 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)