### PR TITLE
US-2650 (slice 1) — Lecture self-service patient (own-id strict, anti-IDOR)

### DIFF
--- a/docs/UserStory/insulinotherapie-edition/US-2650-self-service-patient.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2650-self-service-patient.md
@@ -38,3 +38,20 @@ Paramètres ; les API `/api/insulin-therapy/*` **bloquent VIEWER** ; `/insulin-t
 
 ## Reports de la revue code+migration (PR #638 / US-2646) — à fermer ici
 - **Chiffrement `proposer_comment`** (**CRITIQUE dès la 1ʳᵉ écriture patient**) : la justification patient (texte libre) est un `TEXT` en clair au socle → `encrypt()` AES-256-GCM à l'écriture, `decrypt()` en lecture autorisée uniquement ; **jamais** en clair (log/notif/URL). Test asserttant le format ciphertext (IV‖TAG‖CT base64). *(HDS)*
+
+---
+## Journal d'implémentation
+
+### Slice 1 — endpoint lecture own-id strict (back, sécurité)
+- `GET /api/patient/insulin-settings` **re-scopé own-id STRICT** : résolution exclusive
+  `getOwnPatientId(user.id)` — **plus** de `resolvePatientIdFromQuery` (donc plus de `?patientId`
+  ni de `x-consultation-token`). Ferme le HIGH IDOR §12 (AC-1). Endpoint sans caller (orphelin
+  US-2018b) → re-scope sûr. Un pro (pas de dossier patient) → `getOwnPatientId` null → 404 neutre ;
+  le workspace pro lit l'insuline via la fiche `/patients/[id]`.
+- Tests : +4 (own-id + audit, **anti-IDOR `?patientId` ignoré**, non-patient → 404, RGPD → 403).
+- **`proposerComment` déjà chiffré** (AES-256-GCM, `encryptField`) + omis des réponses `list` →
+  le CRITICAL « chiffrement proposer_comment » de §Reports est **déjà fermé** (US-2649a).
+
+**Reste US-2650** : endpoint PROPOSE own-id strict (bornes patient) · route `(patient)` + nav +
+UI lecture/proposer mode-aware · `InsulinSummary` (conformité DS + fuite client/serveur) · redirect
+`/insulin-therapy` VIEWER → route patient.

--- a/src/app/api/patient/insulin-settings/route.ts
+++ b/src/app/api/patient/insulin-settings/route.ts
@@ -27,6 +27,9 @@ export async function GET(req: NextRequest) {
     if (!hasConsent) return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
 
     // Own-id strict : jamais depuis l'URL/token. `null` (pas de dossier patient) → 404 neutre.
+    // Frontière d'autorisation = `getOwnPatientId` seul (pas de garde de rôle). Invariant dont
+    // dépend l'anti-IDOR : `Patient.userId @unique` → un `user.id` mappe AU PLUS un dossier (le
+    // sien). Si cette cardinalité change un jour, ré-introduire un garde de rôle explicite ici.
     const patientId = await getOwnPatientId(user.id)
     if (!patientId) return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
 

--- a/src/app/api/patient/insulin-settings/route.ts
+++ b/src/app/api/patient/insulin-settings/route.ts
@@ -1,15 +1,20 @@
 /**
- * US-2018b — GET /api/patient/insulin-settings
+ * GET /api/patient/insulin-settings — lecture SELF-SERVICE PATIENT (US-2650).
  *
- * Expose les paramètres d'insulinothérapie d'un patient (schéma basal, ISF/ICR
- * par créneau, config pompe, IOB) pour l'onglet « Traitements » du workspace.
- * Patient résolu via jeton de consultation (`x-consultation-token`) ou
- * `?patientId=` (cf. `resolvePatientIdFromQuery`). Lecture santé → auditée.
+ * Expose les paramètres d'insulinothérapie (schéma basal, ISF/ICR par créneau,
+ * config pompe, IOB) du patient connecté, pour son espace patient.
+ *
+ * **Own-id STRICT (anti-IDOR / anti-énumération)** : le patient est résolu
+ * EXCLUSIVEMENT depuis `user.id` via `getOwnPatientId` — **aucun** `?patientId`,
+ * **aucun** `x-consultation-token`. Un utilisateur sans dossier patient (pro) →
+ * `getOwnPatientId` renvoie `null` → 404 neutre. Le workspace PRO lit l'insuline
+ * via la fiche `/patients/[id]` (onglet Traitements), pas cette route.
+ * Lecture santé → auditée.
  */
 
 import { NextResponse, type NextRequest } from "next/server"
 import { requireAuth, AuthError } from "@/lib/auth"
-import { resolvePatientIdFromQuery } from "@/lib/auth/query-helpers"
+import { getOwnPatientId } from "@/lib/access-control"
 import { requireGdprConsent } from "@/lib/gdpr"
 import { insulinService } from "@/lib/services/insulin.service"
 import { auditService, extractRequestContext } from "@/lib/services/audit.service"
@@ -21,22 +26,21 @@ export async function GET(req: NextRequest) {
     const hasConsent = await requireGdprConsent(user.id)
     if (!hasConsent) return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
 
-    const res = await resolvePatientIdFromQuery(req, user.id, user.role)
-    if (res.error) {
-      return NextResponse.json({ error: res.error }, { status: res.error === "invalidPatientId" ? 400 : 404 })
-    }
+    // Own-id strict : jamais depuis l'URL/token. `null` (pas de dossier patient) → 404 neutre.
+    const patientId = await getOwnPatientId(user.id)
+    if (!patientId) return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
 
     const ctx = extractRequestContext(req)
-    const settings = await insulinService.getSettings(res.patientId)
+    const settings = await insulinService.getSettings(patientId)
 
     await auditService.log({
       userId: user.id,
       action: "READ",
       resource: "PATIENT",
-      resourceId: String(res.patientId),
+      resourceId: String(patientId),
       ipAddress: ctx.ipAddress,
       userAgent: ctx.userAgent,
-      metadata: { patientId: res.patientId, kind: "insulin_settings" },
+      metadata: { patientId, kind: "insulin_settings" },
     })
 
     return NextResponse.json(settings)

--- a/tests/unit/patient-insulin-settings-route.test.ts
+++ b/tests/unit/patient-insulin-settings-route.test.ts
@@ -1,0 +1,84 @@
+/**
+ * US-2650 — Route GET /api/patient/insulin-settings (self-service patient).
+ *
+ * Comportement clinique/sécurité testé :
+ * - Own-id STRICT : le patient est résolu depuis `user.id` (`getOwnPatientId`),
+ *   jamais depuis `?patientId` ni un jeton → anti-IDOR / anti-énumération (AC-1).
+ * - Un utilisateur sans dossier patient (pro) → 404 neutre.
+ * - Garde consentement RGPD.
+ * Risque couvert : un patient ne doit JAMAIS lire la thérapie d'un autre.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import type { NextRequest } from "next/server"
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    requireAuth: vi.fn(),
+    requireGdprConsent: vi.fn(),
+    getOwnPatientId: vi.fn(),
+    getSettings: vi.fn(),
+    auditLog: vi.fn(),
+  },
+}))
+vi.mock("@/lib/auth", () => {
+  class AuthError extends Error {
+    status = 401
+  }
+  return { requireAuth: mocks.requireAuth, AuthError }
+})
+vi.mock("@/lib/gdpr", () => ({ requireGdprConsent: mocks.requireGdprConsent }))
+vi.mock("@/lib/access-control", () => ({ getOwnPatientId: mocks.getOwnPatientId }))
+vi.mock("@/lib/services/insulin.service", () => ({ insulinService: { getSettings: mocks.getSettings } }))
+vi.mock("@/lib/services/audit.service", () => ({
+  auditService: { log: mocks.auditLog },
+  extractRequestContext: () => ({ ipAddress: "1.1.1.1", userAgent: "test", requestId: "r1" }),
+}))
+
+import { GET } from "@/app/api/patient/insulin-settings/route"
+
+// Requête avec un éventuel `?patientId` — qui DOIT être ignoré (own-id strict).
+const reqWith = (patientId?: string) =>
+  ({ nextUrl: { searchParams: new URLSearchParams(patientId ? { patientId } : {}) } }) as unknown as NextRequest
+
+beforeEach(() => {
+  Object.values(mocks).forEach((m) => m.mockReset())
+  mocks.requireAuth.mockReturnValue({ id: 20, role: "VIEWER" })
+  mocks.requireGdprConsent.mockResolvedValue(true)
+  mocks.getOwnPatientId.mockResolvedValue(7)
+  mocks.getSettings.mockResolvedValue({ id: 1, basalConfig: null })
+})
+
+describe("GET /api/patient/insulin-settings (self-service patient)", () => {
+  it("200 : lit la thérapie du patient connecté (own-id) + audit READ", async () => {
+    const res = await GET(reqWith())
+    expect(res.status).toBe(200)
+    expect(mocks.getOwnPatientId).toHaveBeenCalledWith(20)
+    expect(mocks.getSettings).toHaveBeenCalledWith(7)
+    expect(mocks.auditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "READ", resource: "PATIENT", resourceId: "7", metadata: { patientId: 7, kind: "insulin_settings" } }),
+    )
+  })
+
+  it("anti-IDOR : `?patientId=999` est IGNORÉ — renvoie toujours SON dossier (AC-1)", async () => {
+    const res = await GET(reqWith("999"))
+    expect(res.status).toBe(200)
+    // Résolu depuis user.id (7), jamais depuis l'URL (999).
+    expect(mocks.getSettings).toHaveBeenCalledWith(7)
+    expect(mocks.getSettings).not.toHaveBeenCalledWith(999)
+  })
+
+  it("utilisateur sans dossier patient (pro) → 404 neutre, pas de lecture", async () => {
+    mocks.getOwnPatientId.mockResolvedValue(null)
+    const res = await GET(reqWith())
+    expect(res.status).toBe(404)
+    expect(mocks.getSettings).not.toHaveBeenCalled()
+    expect(mocks.auditLog).not.toHaveBeenCalled()
+  })
+
+  it("consentement RGPD absent → 403", async () => {
+    mocks.requireGdprConsent.mockResolvedValue(false)
+    const res = await GET(reqWith())
+    expect(res.status).toBe(403)
+    expect(mocks.getOwnPatientId).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Premier jalon de US-2650 (self-service patient) : la **lecture** de l'insulinothérapie du patient connecté, en **own-id strict**.

## Contenu
- `GET /api/patient/insulin-settings` **re-scopé own-id STRICT** : résolution exclusive `getOwnPatientId(user.id)` — supprime `resolvePatientIdFromQuery` (donc **plus de `?patientId` ni de `x-consultation-token`**). Ferme le **HIGH IDOR** (§12) : un patient ne lit QUE son dossier (**AC-1**).
- Endpoint **sans caller** (orphelin US-2018b) → re-scope sûr, aucun pro cassé (le workspace pro lit l'insuline via la fiche `/patients/[id]`). Un utilisateur sans dossier patient → `getOwnPatientId` null → **404 neutre**.
- Tests : **+4** (own-id + audit READ · **anti-IDOR : `?patientId=999` ignoré** · non-patient → 404 · RGPD → 403).

## Déjà fermé
`proposerComment` est **déjà chiffré** (AES-256-GCM `encryptField`, US-2649a) + omis des réponses `list` → le CRITICAL « chiffrement proposer_comment » de §Reports n'a rien à faire ici.

## Reste US-2650
Endpoint PROPOSE own-id strict (bornes patient) · route `(patient)` + nav + UI mode-aware · `InsulinSummary` (conformité DS + fuite client/serveur) · redirect `/insulin-therapy` VIEWER.

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3668 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)