### PR TITLE
US-2651 (slice 3) — Surface UI des flags d'orientation (dashboard soignant)

### DIFF
--- a/docs/UserStory/insulinotherapie-edition/US-2651-algorithme-ajustement-multimode.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2651-algorithme-ajustement-multimode.md
@@ -93,3 +93,9 @@ Ferme le **caveat opérationnel** de la revue medical de #662 (le flag était é
 
 **Reste US-2651** : router `generateProposals` par mode · mode (b) `analyzeFixedDose*`. **Suivi** :
 `parameterType` intent (non-dosant) dans le flag ; résolution du flag (marquer `resolved`).
+
+##### Corrections revue slice 3 (PR #663)
+- **A (Low)** : commentaire « Grille 2×2 » de `medecin/page.tsx` corrigé (5 cartes désormais).
+- **Suivi B (Low, transverse)** : cap 10 silencieux (comme toute la famille dashboard : propositions
+  cap 5, etc.) → amélioration éventuelle d'un indice « 10+ »/compteur total **transverse** à toutes
+  les cartes (pas propre à celle-ci). Revues code+HDS : surface **scope-safe, PHI minimal, posology-free**.

--- a/docs/UserStory/insulinotherapie-edition/US-2651-algorithme-ajustement-multimode.md
+++ b/docs/UserStory/insulinotherapie-edition/US-2651-algorithme-ajustement-multimode.md
@@ -81,3 +81,15 @@ couches), **PHI-free**, **own-scoped** (IDOR impossible), RGPD gaté.
 **Suivis tracés** : (1) **intention spécifique** — capturer le `parameterType` visé en métadonnée
 **non-dosante** (schema change, medical Medium) ; (2) **surface UI des flags** (dashboard soignant —
 sans elle le « dead-end » n'est fermé qu'à moitié) ; (3) TOCTOU (index partiel unique) + rate-limit POST (LOW).
+
+### Slice 3 — surface UI des flags d'orientation (dashboard soignant)
+Ferme le **caveat opérationnel** de la revue medical de #662 (le flag était écrit mais invisible).
+- **`reviewFlagsQuery.forCaller`** (doctor-dashboard.service) : liste les `ClinicalReviewFlag` **ouverts**
+  du portefeuille (scope RBAC `getAccessiblePatientIds`, cap 10, prénom déchiffré, audit READ). Jamais de posologie.
+- **`GET /api/dashboard/medecin/review-flags`** (minRole NURSE, no-store) — miroir de `pending-proposals`.
+- **`ReviewFlagsCard`** (dashboard médecin « Ma journée ») : carte read-only, polling 60 s, renvoie vers
+  `/patients/[id]/review`. i18n `reviewFlags` (fr/en/ar) — `HbA1c`/`TIR` explicités.
+- Tests : +2 (scope RBAC + audit ; portefeuille vide → []).
+
+**Reste US-2651** : router `generateProposals` par mode · mode (b) `analyzeFixedDose*`. **Suivi** :
+`parameterType` intent (non-dosant) dans le flag ; résolution du flag (marquer `resolved`).

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -2020,6 +2020,21 @@
     "securityBadge": "مُستضيف بيانات صحية (HDS) · AES-256-GCM",
     "inlineDefaultLabel": "جارٍ التحميل…"
   },
+  "reviewFlags": {
+    "title": "للمراجعة في الاستشارة",
+    "stale": "بيانات غير محدّثة",
+    "loading": "جارٍ التحميل…",
+    "loadError": "تعذّر تحميل عناصر المراجعة.",
+    "emptyTitle": "لا شيء للمراجعة",
+    "emptyMessage": "لا يوجد مريض للمراجعة في الاستشارة حالياً.",
+    "patientFallback": "مريض",
+    "review": "فتح",
+    "reviewAria": "فتح ملف {name}",
+    "flagReviewInConsultation": "مراجعة في الاستشارة",
+    "flagHba1cStale": "الهيموغلوبين السكري (HbA1c) للتحديث",
+    "flagTirBelowTarget": "الوقت ضمن النطاق (TIR) تحت الهدف",
+    "flagObservance": "التحقق من الالتزام"
+  },
   "review": {
     "title": "وضع مراجعة الاستشارة",
     "subtitle": "تحليل منظَّم خطوة بخطوة — دون ذكاء اصطناعي.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2020,6 +2020,21 @@
     "securityBadge": "Health Data Host (HDS) · AES-256-GCM",
     "inlineDefaultLabel": "Loading…"
   },
+  "reviewFlags": {
+    "title": "To review in consultation",
+    "stale": "Data not refreshed",
+    "loading": "Loading…",
+    "loadError": "Could not load review items.",
+    "emptyTitle": "Nothing to review",
+    "emptyMessage": "No patient to review in consultation right now.",
+    "patientFallback": "Patient",
+    "review": "Open",
+    "reviewAria": "Open {name}'s record",
+    "flagReviewInConsultation": "Review in consultation",
+    "flagHba1cStale": "Glycated haemoglobin (HbA1c) to refresh",
+    "flagTirBelowTarget": "Time in range (TIR) below target",
+    "flagObservance": "Adherence to check"
+  },
   "review": {
     "title": "Consultation review mode",
     "subtitle": "Structured, step-by-step analysis — no artificial intelligence.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -2020,6 +2020,21 @@
     "securityBadge": "Hébergeur de données de santé (HDS) · AES-256-GCM",
     "inlineDefaultLabel": "Chargement…"
   },
+  "reviewFlags": {
+    "title": "À revoir en consultation",
+    "stale": "Données non rafraîchies",
+    "loading": "Chargement…",
+    "loadError": "Impossible de charger les orientations.",
+    "emptyTitle": "Aucune orientation",
+    "emptyMessage": "Aucun patient à revoir en consultation pour le moment.",
+    "patientFallback": "Patient",
+    "review": "Ouvrir",
+    "reviewAria": "Ouvrir la fiche de {name}",
+    "flagReviewInConsultation": "À revoir en consultation",
+    "flagHba1cStale": "Hémoglobine glyquée (HbA1c) à actualiser",
+    "flagTirBelowTarget": "Temps dans la cible (TIR) sous l'objectif",
+    "flagObservance": "Observance à vérifier"
+  },
   "review": {
     "title": "Mode revue de consultation",
     "subtitle": "Analyse structurée, étape par étape — sans intelligence artificielle.",

--- a/src/app/(dashboard)/medecin/page.tsx
+++ b/src/app/(dashboard)/medecin/page.tsx
@@ -33,6 +33,7 @@ import { KpiSection } from "@/components/diabeo/dashboard/medecin/KpiSection"
 import { RecallListCard } from "@/components/diabeo/dashboard/infirmier/RecallListCard"
 // US-2602 (Ma journée) incr. 2 — Propositions d'ajustement en attente.
 import { PendingProposalsCard } from "@/components/diabeo/dashboard/medecin/PendingProposalsCard"
+import { ReviewFlagsCard } from "@/components/diabeo/dashboard/medecin/ReviewFlagsCard"
 // US-2602 (Ma journée) incr. 3 — Messages non lus (liste).
 import { UnreadMessagesCard } from "@/components/diabeo/dashboard/medecin/UnreadMessagesCard"
 
@@ -86,6 +87,7 @@ export default async function MedecinDashboardPage() {
       {/* Grille 2×2 : Propositions · Rendez-vous / Relances · Messages. */}
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <PendingProposalsCard />
+        <ReviewFlagsCard />
         <AppointmentCard />
         <RecallListCard />
         <UnreadMessagesCard />

--- a/src/app/(dashboard)/medecin/page.tsx
+++ b/src/app/(dashboard)/medecin/page.tsx
@@ -84,7 +84,8 @@ export default async function MedecinDashboardPage() {
       />
       {/* Carte de triage en tête, pleine largeur (mockup §médecin). */}
       <EmergencyCard />
-      {/* Grille 2×2 : Propositions · Rendez-vous / Relances · Messages. */}
+      {/* Grille 2 colonnes (5 cartes) : Propositions · Flags d'orientation ·
+          Rendez-vous · Relances · Messages. */}
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <PendingProposalsCard />
         <ReviewFlagsCard />

--- a/src/app/api/dashboard/medecin/review-flags/route.ts
+++ b/src/app/api/dashboard/medecin/review-flags/route.ts
@@ -1,0 +1,24 @@
+/**
+ * US-2651 (mode c) — Flags d'orientation clinique OUVERTS (médecin).
+ * GET — `ClinicalReviewFlag` `open` du portefeuille du caller, scope RBAC.
+ * minRole NURSE (DOCTOR/ADMIN éligibles). Objet d'orientation : JAMAIS de posologie.
+ * Déterministe (aucun calcul front). PHI (prénom déchiffré) → pas de cache proxy.
+ */
+
+import { NextResponse, type NextRequest } from "next/server"
+import { AuthError } from "@/lib/auth"
+import { reviewFlagsQuery } from "@/lib/services/doctor-dashboard.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+import { auditedRequireRole, mapErrorToResponse } from "@/lib/team-route-helpers"
+
+export async function GET(req: NextRequest) {
+  const ctx = extractRequestContext(req)
+  try {
+    const user = await auditedRequireRole(req, "NURSE", ctx, "CLINICAL_REVIEW_FLAG", "0")
+    const items = await reviewFlagsQuery.forCaller(user.id, user.role, user.id, ctx)
+    return NextResponse.json({ items }, { headers: { "Cache-Control": "no-store, private" } })
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status })
+    return mapErrorToResponse(e, "dashboard/medecin/review-flags GET", ctx.requestId)
+  }
+}

--- a/src/components/diabeo/dashboard/medecin/ReviewFlagsCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/ReviewFlagsCard.tsx
@@ -1,0 +1,88 @@
+/**
+ * US-2651 (mode c) — Flags d'orientation clinique OUVERTS (médecin, « Ma journée »).
+ *
+ * Liste read-only, déterministe : `ClinicalReviewFlag` produits côté backend (ex. tentative
+ * d'un patient NON INSULINÉ). Objet d'ORIENTATION distinct d'`AdjustmentProposal` : n'affiche
+ * **JAMAIS** de posologie (frontière dispositif médical). Renvoie vers la fiche patient pour
+ * revue en consultation. Polling 60 s.
+ */
+
+"use client"
+
+import { useTranslations } from "next-intl"
+import { DiabeoCard } from "@/components/diabeo/DiabeoCard"
+import { DiabeoEmptyState } from "@/components/diabeo/DiabeoEmptyState"
+import { StaleBanner } from "@/components/diabeo/dashboard/medecin/StaleBanner"
+import { DashboardCardHeader } from "@/components/diabeo/dashboard/DashboardCardHeader"
+import { DashboardRow, DashboardAvatar, DashboardRowAction } from "@/components/diabeo/dashboard/DashboardRow"
+import { PathologyPill } from "@/components/diabeo/dashboard/DashboardPill"
+import { usePollingFetch } from "@/hooks/usePollingFetch"
+import type { ReviewFlagItem } from "@/lib/services/doctor-dashboard.service"
+
+type ApiResponse = { items: ReviewFlagItem[] }
+
+/** type de flag → clé i18n (namespace `reviewFlags`). Aucun libellé n'implique de dose. */
+const FLAG_TYPE_KEY: Record<ReviewFlagItem["type"], string> = {
+  reviewInConsultation: "flagReviewInConsultation",
+  hba1cStale: "flagHba1cStale",
+  tirBelowTarget: "flagTirBelowTarget",
+  observance: "flagObservance",
+}
+
+export function ReviewFlagsCard() {
+  const t = useTranslations("reviewFlags")
+  const { data, error, loading, isStale } = usePollingFetch<ApiResponse>(
+    "/api/dashboard/medecin/review-flags",
+    60_000,
+  )
+  const items = Array.isArray(data?.items) ? data!.items : []
+  const hasError = error !== null && data === null
+
+  return (
+    <DiabeoCard role="region" aria-labelledby="card-review-flags-title">
+      <DashboardCardHeader
+        titleId="card-review-flags-title"
+        title={t("title")}
+        dot="warning"
+        count={items.length}
+      />
+      {isStale && <StaleBanner message={t("stale")} />}
+      <div className="px-4 pb-4 pt-2">
+        {loading && items.length === 0 && <p className="text-sm text-muted-foreground">{t("loading")}</p>}
+        {hasError && <p className="text-sm text-glycemia-critical">{t("loadError")}</p>}
+        {!loading && !hasError && items.length === 0 && (
+          <DiabeoEmptyState variant="noData" title={t("emptyTitle")} message={t("emptyMessage")} />
+        )}
+        {items.length > 0 && (
+          <ul className="space-y-2">
+            {items.map((f, index) => {
+              const name = f.patientFirstName || t("patientFallback")
+              return (
+                <DashboardRow
+                  key={f.id}
+                  leading={<DashboardAvatar initials={name.charAt(0).toUpperCase()} tint="warning" />}
+                  title={
+                    <span className="flex items-center gap-2">
+                      {name}
+                      <PathologyPill pathology={f.pathology} />
+                    </span>
+                  }
+                  sub={<span>{t(FLAG_TYPE_KEY[f.type])}</span>}
+                  trailing={
+                    <DashboardRowAction
+                      href={`/patients/${f.patientId}/review`}
+                      variant={index === 0 ? "primary" : "default"}
+                      aria-label={t("reviewAria", { name })}
+                    >
+                      {t("review")}
+                    </DashboardRowAction>
+                  }
+                />
+              )
+            })}
+          </ul>
+        )}
+      </div>
+    </DiabeoCard>
+  )
+}

--- a/src/lib/services/doctor-dashboard.service.ts
+++ b/src/lib/services/doctor-dashboard.service.ts
@@ -23,6 +23,8 @@ import {
   EmergencyAlertSeverity,
   AppointmentStatus,
   ProposalStatus,
+  ClinicalReviewFlagStatus,
+  type ClinicalReviewFlagType,
   type AdjustableParameter,
   type Prisma,
 } from "@prisma/client"
@@ -939,6 +941,73 @@ export const pendingProposalsQuery = {
       changePercent: Number(r.changePercent),
       createdAt: r.createdAt,
       glucoseUnit,
+    }))
+  },
+}
+
+// ─────────────────────────────────────────────────────────────
+// US-2651 (mode c) — Flags d'orientation clinique OUVERTS (médecin)
+// ─────────────────────────────────────────────────────────────
+
+export type ReviewFlagItem = {
+  id: string
+  patientId: number
+  patientFirstName: string
+  pathology: string | null
+  type: ClinicalReviewFlagType
+  createdAt: Date
+}
+
+const REVIEW_FLAGS_LIMIT = 10
+
+/**
+ * Liste les `ClinicalReviewFlag` **ouverts** du portefeuille du caller (scope RBAC via
+ * `getAccessiblePatientIds`). Objet d'ORIENTATION distinct d'`AdjustmentProposal` : ne porte
+ * JAMAIS de posologie (frontière dispositif médical). Surface la carte « à revoir » du
+ * dashboard soignant (US-2651). Déterministe ; lecture santé auditée (prénom déchiffré).
+ */
+export const reviewFlagsQuery = {
+  async forCaller(
+    userId: number, role: Role,
+    auditUserId: number, ctx?: AuditContext,
+  ): Promise<ReviewFlagItem[]> {
+    const ids = await getAccessiblePatientIds(userId, role)
+    const scope = patientScopeWhere(ids)
+    if (scope === null) return []
+    const rows = await prisma.clinicalReviewFlag.findMany({
+      where: { ...scope, status: ClinicalReviewFlagStatus.open },
+      include: {
+        patient: {
+          select: { id: true, pathology: true, user: { select: { firstname: true } } },
+        },
+      },
+      orderBy: [{ createdAt: "desc" }],
+      take: REVIEW_FLAGS_LIMIT,
+    })
+
+    // Audit : résumé + pivot par patient (PHI : prénom déchiffré exposé). Jamais de posologie.
+    await auditService.log({
+      userId: auditUserId, action: "READ", resource: "CLINICAL_REVIEW_FLAG",
+      resourceId: "0",
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: { kind: "dashboard.medecin.reviewFlags", count: rows.length },
+    })
+    await Promise.allSettled(rows.map((r) =>
+      auditService.log({
+        userId: auditUserId, action: "READ", resource: "CLINICAL_REVIEW_FLAG",
+        resourceId: r.id,
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: { patientId: r.patientId, kind: "dashboard.medecin.reviewFlags" },
+      }),
+    ))
+
+    return rows.map((r) => ({
+      id: r.id,
+      patientId: r.patientId,
+      patientFirstName: safeDecryptField(r.patient.user.firstname ?? "") ?? "",
+      pathology: r.patient.pathology,
+      type: r.type,
+      createdAt: r.createdAt,
     }))
   },
 }

--- a/tests/unit/doctor-dashboard.service.test.ts
+++ b/tests/unit/doctor-dashboard.service.test.ts
@@ -27,7 +27,7 @@ vi.mock("@/lib/services/messaging.service", () => ({
 import {
   urgenciesQuery, appointmentsQuery,
   patientsAtRiskQuery, kpisQuery, pendingProposalsQuery,
-  unreadThreadsQuery, getPatientFlags, triageSummaryQuery,
+  unreadThreadsQuery, getPatientFlags, triageSummaryQuery, reviewFlagsQuery,
 } from "@/lib/services/doctor-dashboard.service"
 import { getAccessiblePatientIds } from "@/lib/access-control"
 import { messagingService } from "@/lib/services/messaging.service"
@@ -624,5 +624,33 @@ describe("getPatientFlags (US-2603)", () => {
     pmf.cgmEntry.aggregate.mockResolvedValue({ _max: { timestamp: new Date() } })
     const f = await getPatientFlags(42)
     expect(f.openUrgency).toBe(true)
+  })
+})
+
+describe("reviewFlagsQuery (US-2651 mode c)", () => {
+  it("portefeuille vide → [] (aucune requête)", async () => {
+    mockedAccessible.mockResolvedValue([])
+    const res = await reviewFlagsQuery.forCaller(10, "DOCTOR", 10)
+    expect(res).toEqual([])
+    expect(prismaMock.clinicalReviewFlag.findMany).not.toHaveBeenCalled()
+  })
+
+  it("liste les flags OUVERTS scopés + audit READ (sans posologie)", async () => {
+    mockedAccessible.mockResolvedValue([1, 2])
+    prismaMock.clinicalReviewFlag.findMany.mockResolvedValue([
+      { id: "f1", patientId: 1, type: "reviewInConsultation", createdAt: new Date("2026-07-05T00:00:00Z"),
+        patient: { id: 1, pathology: "DT2", user: { firstname: null } } },
+    ] as never)
+
+    const res = await reviewFlagsQuery.forCaller(10, "DOCTOR", 10)
+
+    expect(res).toHaveLength(1)
+    expect(res[0]).toMatchObject({ id: "f1", patientId: 1, type: "reviewInConsultation", pathology: "DT2" })
+    // Scope RBAC : findMany filtré sur status open + patients accessibles.
+    const where = (prismaMock.clinicalReviewFlag.findMany.mock.calls[0]![0] as any).where
+    expect(where.status).toBe("open")
+    expect(where.patientId).toEqual({ in: [1, 2] })
+    // Audit READ émis (résumé). Jamais de dose dans un flag.
+    expect(prismaMock.auditLog.create).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Ferme le **caveat opérationnel** de la revue medical de #662 : le `ClinicalReviewFlag` était persisté mais **sans surface soignant** → l'intention du patient restait invisible.

## Contenu
- **`reviewFlagsQuery.forCaller`** (`doctor-dashboard.service`) : liste les flags **ouverts** du portefeuille du caller (scope RBAC `getAccessiblePatientIds`, cap 10, prénom déchiffré, **audit READ** résumé + par patient). **Jamais de posologie** (objet d'orientation).
- **`GET /api/dashboard/medecin/review-flags`** (minRole NURSE, `Cache-Control: no-store`) — miroir exact de `pending-proposals`.
- **`ReviewFlagsCard`** (dashboard médecin « Ma journée ») : carte read-only, polling 60 s, renvoie vers `/patients/[id]/review`. Montée dans la grille du dashboard.
- i18n `reviewFlags` (fr/en/ar) — `HbA1c`/`TIR` explicités (le garde anti-acronyme a d'ailleurs rattrapé `HbA1c` nu).
- Tests : **+2** (scope RBAC + audit ; portefeuille vide → `[]`).

## Reste US-2651
Router `generateProposals` par mode · mode (b) `analyzeFixedDose*`. **Suivi** : `parameterType` intent (non-dosant) dans le flag ; résolution de flag (`resolved`).

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ i18n parité · ✅ **3686 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)