### PR TITLE
US-2651 — Doc de l'algorithme de propositions + corrections libellés (validées medical)

### DIFF
--- a/docs/clinical-logic/algorithme-propositions-ajustement.md
+++ b/docs/clinical-logic/algorithme-propositions-ajustement.md
@@ -100,12 +100,12 @@ Deux incohérences **clinique↔code** relevées en documentant, **validées et 
 (directions appliquées toutes correctes → **aucun CRITICAL** ; grep confirmé : **aucun consommateur ne
 dérive la direction/dose depuis `reason`** → le libellé n'impacte que l'explication affichée) :
 
-1. **Commentaire ISF (l.98-99) — CORRIGÉ.** L'ancien commentaire était **inversé** ; le **code était
-   correct** (au-dessus de la cible → ISF trop haut → baisse). Commentaire réécrit pour matcher le code.
-2. **Libellés `reason` ICR (l.149) — CORRIGÉ.** La **direction** était correcte mais les **libellés étaient
-   inversés** (`icrTooLow`↔`icrTooHigh`) — ils contredisaient le commentaire correct (l.142-143) et
-   affichaient une mauvaise explication au médecin. Ternaire corrigé + test de verrou ajouté. Sévérité
-   MEDIUM (aucun impact dose ; aucun consommateur ne lit la direction depuis `reason`).
+1. **Commentaire ISF (`analyzeIsfSlot`) — CORRIGÉ.** L'ancien commentaire était **inversé** ; le **code
+   était correct** (au-dessus de la cible → ISF trop haut → baisse). Commentaire réécrit pour matcher le code.
+2. **Libellés `reason` ICR (`analyzeIcrSlot`) — CORRIGÉ.** La **direction** était correcte mais les
+   **libellés étaient inversés** (`icrTooLow`↔`icrTooHigh`) — ils contredisaient le commentaire (correct)
+   de la fonction et affichaient une mauvaise explication au médecin. Ternaire corrigé + test de verrou
+   ajouté. Sévérité MEDIUM (aucun impact dose ; aucun consommateur ne lit la direction depuis `reason`).
 3. **Basal — aucun défaut** (direction + libellé corrects). Seuils (`±20 %`, `≥3 événements`, `≥2 %`, cap
    patient 10 %, cooldown 24 h) **cliniquement défendables** (jamais auto-appliqué, confiance graduée).
 

--- a/docs/clinical-logic/algorithme-propositions-ajustement.md
+++ b/docs/clinical-logic/algorithme-propositions-ajustement.md
@@ -1,0 +1,114 @@
+# Algorithme de calcul des propositions d'ajustement
+
+> **Portée** — Document technico-fonctionnel de référence de l'algorithme qui **génère** les
+> propositions d'ajustement d'insulinothérapie (`proposal-algorithm.ts`). Épic US-2645, US-2651.
+> **Source de vérité = le code** (`src/lib/proposal-algorithm.ts`, `src/lib/clinical-bounds.ts`,
+> `src/lib/services/adjustment.service.ts`) ; ce document en est le catalogue fonctionnel.
+> **⚠️ US-2651 exige la validation `medical-domain-validator`** (voir §7 « Points à valider »).
+
+---
+
+## 1. Principe & garde-fous fondamentaux
+
+- Une proposition est une **suggestion**, **JAMAIS** appliquée automatiquement (ADR #13). Format :
+  `AdjustmentProposal` (statut `pending`) → validation **DOCTOR** (accept/reject) → application.
+- **Frontière dispositif médical (MDR / IEC 62304)** : l'algorithme ne recommande **jamais** de
+  posologie orale/GLP-1. Un patient **non insuliné** (mode c) ne reçoit **aucune** proposition de
+  dose (voir §5) — refus serveur `nonInsulinNoDose` + `ClinicalReviewFlag` d'orientation.
+- **Fail-closed** : toute valeur hors bornes cliniques est refusée à la création
+  (`adjustmentService.createProposal`), pas seulement à l'accept.
+- **Séparation des responsabilités** :
+  - `proposal-algorithm.ts` = **pur** (aucune I/O) — calcule des *candidats* à partir de données déjà agrégées.
+  - `adjustmentService.createProposal` = persistance + **re-validation** des bornes + garde-fous
+    proposeur (cap patient, sens interdit, cooldown) + audit.
+
+## 2. Constantes (source : `CLINICAL_BOUNDS`)
+
+| Constante | Valeur | Rôle |
+|---|---|---|
+| `MAX_CHANGE_PERCENT` | **± 20 %** | Cap de variation **moteur** : toute proposition auto est clampée à ± ce %. |
+| Seuil « minimum d'événements » | **3** | En dessous → aucune proposition (bruit statistique). |
+| Seuil « variation significative » | **2 %** | `|changePercent| < 2 %` → aucune proposition (non actionnable). |
+| `PATIENT_MAX_CHANGE_PERCENT` | ± 10 % | Cap **patient** (proposition self-service) — plus strict que le moteur, appliqué au niveau service. |
+
+## 3. Primitives communes (`proposal-algorithm.ts`)
+
+- **`getConfidenceLevel(eventCount)`** — force de preuve par volume :
+  - `> 10` événements → `high`
+  - `6 – 10` → `medium`
+  - `< 6` → `low`
+- **`clampChangePercent(pct)`** — borne `pct` dans `[-20, +20]` (`MAX_CHANGE_PERCENT`).
+- **`computeProposedValue(current, changePercent)`** — `current × (1 + clamp(changePercent)/100)`,
+  arrondi à 4 décimales.
+
+## 4. Mode (a) — basal/bolus complet (existant)
+
+Trois analyseurs, chacun : **≥ 3 événements** requis, **|variation| ≥ 2 %** requise, sinon `null`.
+Base d'erreur relative = écart moyen à la cible. `confidence` = `getConfidenceLevel(nb événements)`.
+
+### 4.1 `analyzeIsfSlot(slot, corrections[])` — facteur de sensibilité (ISF)
+- Entrée : glycémies **post-correction** vs cible, pour un créneau horaire.
+- `errorPercent = ((avgPost − avgTarget) / avgTarget) × −100`, puis clampé.
+- **Sens (code, cliniquement correct)** :
+  - Glycémie post-correction **au-dessus** de la cible → correction trop faible → **ISF trop haut** →
+    proposition de **baisse** de l'ISF (`reason = isfTooHigh`).
+  - **En dessous** de la cible (sur-correction) → **ISF trop bas** → **hausse** (`reason = isfTooLow`).
+
+### 4.2 `analyzeIcrSlot(slot, meals[])` — ratio insuline/glucides (ICR)
+- Entrée : glycémies **post-repas** vs cible, pour un créneau horaire.
+- `errorPercent = ((avgPost − avgTarget) / avgTarget) × −100`, puis clampé.
+- **Sens (direction du changement, cliniquement correcte)** :
+  - Post-repas **au-dessus** de la cible → bolus trop faible → **baisse** de l'ICR (plus d'insuline/gramme),
+    `reason = icrTooHigh` (l'ICR courant est trop haut).
+  - **En dessous** → **hausse** de l'ICR, `reason = icrTooLow`.
+
+### 4.3 `analyzeBasalTrend(fastingValues[], targetGl, currentRate)` — débit basal
+- Entrée : glycémies **à jeun** (pré-petit-déjeuner) vs cible, débit basal courant.
+- `errorPercent = ((avgFasting − targetGl) / targetGl) × 100` (**pas** de ×−1 ici — dérive directe).
+- **Sens** :
+  - Glycémie à jeun **au-dessus** de la cible (montée nocturne) → basale **trop basse** → **hausse**
+    (`reason = basalTooLow`).
+  - **En dessous** (chute nocturne) → basale **trop haute** → **baisse** (`reason = basalTooHigh`).
+
+> Sortie de chaque analyseur : `ProposalCandidate` (`parameterType, reason, currentValue,
+> proposedValue, changePercent, confidence, supportingEvents, totalEventsConsidered,
+> timeSlotStartHour?/EndHour?, averageObservedValue?`).
+
+## 5. Multi-mode (US-2651) — routage par `treatmentMode`
+
+Le mode est **dérivé serveur** (`resolveTreatmentMode`, fail-closed : un DT1 n'est jamais `nonInsulin`).
+
+| Mode | Logique de proposition |
+|---|---|
+| **(a) basalBolus** | Analyseurs ISF/ICR/basal du §4 (existant). |
+| **(b) fixedDose** | **`analyzeFixedDose*` (à livrer)** : base = tendance glycémique **par moment** (carnet BGM). Proposition de dose fixe **bornée** : cap **absolu** ± 1–2 U ou ± 10 % (le plus petit), plancher/plafond absolu, **cooldown 72 h/moment**. **Jamais** : convertir doses fixes → basal-bolus, ni créer ISF/ICR ex nihilo. |
+| **(c) nonInsulin** | **Aucune proposition de dose** (frontière MDR). Uniquement des `ClinicalReviewFlag` d'orientation (« à revoir en consultation », HbA1c périmée, TIR sous cible, observance). La **cible** glycémique reste ajustable **par le médecin** (bornée, plus stricte en `pregnancyMode`). |
+
+## 6. Chaîne complète (génération → application)
+
+1. **Génération** (`proposal-algorithm`, pur) → `ProposalCandidate` (déjà clampé ± 20 %, ≥ 3 événements, ≥ 2 %).
+2. **Persistance** (`adjustmentService.createProposal`) — re-vérifie : frontière nonInsulin (refus),
+   **bornes dures** (`validateProposedValue`), `currentValue` **dérivé serveur** (jamais du body),
+   garde-fous **proposeur** (cap patient ± 10 %, basale patient jamais en baisse, **cooldown 24 h**
+   patient), anti-spam (index `one_pending_per_slot`). Statut `pending`.
+3. **Validation médecin** (`accept`) — re-vérifie les bornes + **compare-and-swap** (`baselineMoved`)
+   si la base a bougé depuis la proposition. Application scopée patient.
+
+## 7. Validation `medical-domain-validator` (US-2651) — verdicts
+
+Deux incohérences **clinique↔code** relevées en documentant, **validées et corrigées** dans cette slice
+(directions appliquées toutes correctes → **aucun CRITICAL** ; grep confirmé : **aucun consommateur ne
+dérive la direction/dose depuis `reason`** → le libellé n'impacte que l'explication affichée) :
+
+1. **Commentaire ISF (l.98-99) — CORRIGÉ.** L'ancien commentaire était **inversé** ; le **code était
+   correct** (au-dessus de la cible → ISF trop haut → baisse). Commentaire réécrit pour matcher le code.
+2. **Libellés `reason` ICR (l.149) — CORRIGÉ.** La **direction** était correcte mais les **libellés étaient
+   inversés** (`icrTooLow`↔`icrTooHigh`) — ils contredisaient le commentaire correct (l.142-143) et
+   affichaient une mauvaise explication au médecin. Ternaire corrigé + test de verrou ajouté. Sévérité
+   MEDIUM (aucun impact dose ; aucun consommateur ne lit la direction depuis `reason`).
+3. **Basal — aucun défaut** (direction + libellé corrects). Seuils (`±20 %`, `≥3 événements`, `≥2 %`, cap
+   patient 10 %, cooldown 24 h) **cliniquement défendables** (jamais auto-appliqué, confiance graduée).
+
+**Reste à livrer** — `proposal-algorithm.ts` n'est **relié à aucune persistance** (seulement testé). Le
+router multi-mode (§5), `analyzeFixedDose*` (mode b) et le câblage `→ createProposal` restent à faire ;
+toute sortie devra repasser par la frontière nonInsulin + les bornes (§6).

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -172,3 +172,9 @@ acceptée entre-temps), appliquer la valeur absolue **sur-corrige** (ex. base de
   (HTTP 422). Un patient non insuliné relève d'un **flag d'orientation** (« à revoir en consultation »),
   jamais d'une `AdjustmentProposal`. Fail-closed : le mode est **dérivé serveur** (`resolveTreatmentMode`,
   US-2647) et un DT1 n'est **jamais** classé `nonInsulin`.
+
+### Algorithme de génération des propositions
+
+Le fonctionnement de l'algorithme de **calcul des propositions d'ajustement** (analyseurs ISF/ICR/basal,
+constantes moteur, routage multi-mode a/b/c, frontière MDR, chaîne génération→validation) est décrit
+dans son document dédié : **[`algorithme-propositions-ajustement.md`](./algorithme-propositions-ajustement.md)**.

--- a/src/lib/proposal-algorithm.ts
+++ b/src/lib/proposal-algorithm.ts
@@ -95,8 +95,10 @@ export function analyzeIsfSlot(
 
   if (avgTarget === 0) return null
 
-  // If post-correction glucose is consistently above target → ISF too low (needs increase)
-  // If below target → ISF too high (needs decrease)
+  // ISF est un DÉNOMINATEUR (dose = (BG−cible)/ISF), d'où le sign-flip (×−100) :
+  // - post-correction AU-DESSUS de la cible → correction trop faible → ISF trop HAUT → BAISSE (isfTooHigh) ;
+  // - EN DESSOUS (sur-correction) → ISF trop BAS → HAUSSE (isfTooLow).
+  // (Validé medical US-2651 ; l'ancien commentaire était inversé.)
   const errorPercent = ((avgPost - avgTarget) / avgTarget) * -100
   const clampedChange = clampChangePercent(errorPercent)
 
@@ -146,7 +148,11 @@ export function analyzeIcrSlot(
 
   if (Math.abs(clampedChange) < 2) return null
 
-  const reason: AdjustmentReason = clampedChange < 0 ? "icrTooLow" : "icrTooHigh"
+  // ICR est un DÉNOMINATEUR (bolus = glucides/ICR) : baisser l'ICR = plus d'insuline/gramme.
+  // Post-repas AU-DESSUS de la cible → bolus trop faible → ICR trop HAUT → BAISSE (icrTooHigh) ;
+  // EN DESSOUS → ICR trop BAS → HAUSSE (icrTooLow). (Correction validée medical US-2651 : les
+  // libellés étaient inversés — la DIRECTION était correcte, seul le `reason` affiché était faux.)
+  const reason: AdjustmentReason = clampedChange < 0 ? "icrTooHigh" : "icrTooLow"
 
   return {
     parameterType: "insulinToCarbRatio",

--- a/tests/unit/proposal-algorithm.test.ts
+++ b/tests/unit/proposal-algorithm.test.ts
@@ -116,13 +116,24 @@ describe("proposal-algorithm", () => {
   describe("analyzeIcrSlot", () => {
     const slot = { startHour: 12, endHour: 14, gramsPerUnit: 10 }
 
-    it("detects high post-meal glucose (ICR too high)", () => {
+    it("post-repas au-dessus de la cible → ICR trop haut → baisse (reason icrTooHigh)", () => {
       const meals = Array.from({ length: 6 }, () => ({
         postGlucoseGl: 2.00, targetGl: 1.20,
       }))
       const result = analyzeIcrSlot(slot, meals)
       expect(result).not.toBeNull()
       expect(result!.parameterType).toBe("insulinToCarbRatio")
+      // Direction : baisse de l'ICR (plus d'insuline/gramme).
+      expect(result!.proposedValue).toBeLessThan(slot.gramsPerUnit)
+      // Libellé corrigé (US-2651, validé medical) : l'ICR courant est trop HAUT.
+      expect(result!.reason).toBe("icrTooHigh")
+    })
+
+    it("post-repas en dessous de la cible → ICR trop bas → hausse (reason icrTooLow)", () => {
+      const meals = Array.from({ length: 6 }, () => ({ postGlucoseGl: 0.80, targetGl: 1.20 }))
+      const result = analyzeIcrSlot(slot, meals)
+      expect(result!.proposedValue).toBeGreaterThan(slot.gramsPerUnit)
+      expect(result!.reason).toBe("icrTooLow")
     })
 
     it("returns null with insufficient data", () => {

--- a/tests/unit/proposal-algorithm.test.ts
+++ b/tests/unit/proposal-algorithm.test.ts
@@ -5,12 +5,11 @@
  * - Confidence level assignment based on the number of qualifying glucose
  *   events: 3–5 events = "low", 6–10 = "medium", >10 = "high"; proposals
  *   below "low" confidence are not generated (insufficient data)
- * - Change percent clamping: ISF and ICR adjustments are capped at ±20% per
- *   proposal cycle to prevent overcorrection; basal rate adjustments are
- *   capped at ±15% to stay within CLINICAL_BOUNDS
+ * - Change percent clamping: ISF, ICR AND basal adjustments are all capped at
+ *   ±20% per proposal cycle (CLINICAL_BOUNDS.MAX_CHANGE_PERCENT) via the shared
+ *   `clampChangePercent` — no per-parameter cap difference
  * - Proposed value computation: applies the clamped percentage change to the
- *   current parameter value and rounds to the appropriate clinical precision
- *   (ISF: 0.01 g/L/U; ICR: 0.5 g/U; basal: 0.05 U/h)
+ *   current value and rounds uniformly to 4 decimals (`computeProposedValue`)
  * - ISF slot analysis: compares post-meal correction outcomes within a time
  *   slot against the glucose target to infer whether the sensitivity factor
  *   should increase or decrease


### PR DESCRIPTION
Premier pas de US-2651 (approche doc-first) : **documenter l'algorithme de calcul des propositions**, et corriger au passage les incohérences que la rédaction a fait apparaître.

## Contenu
- **Nouveau document** `docs/clinical-logic/algorithme-propositions-ajustement.md` : garde-fous fondamentaux (jamais auto-appliqué, frontière MDR, fail-closed), constantes moteur (`CLINICAL_BOUNDS`), primitives (confiance/clamp/valeur proposée), analyseurs **ISF/ICR/basal** (formules + sens clinique), **routage multi-mode a/b/c**, chaîne **génération → persistance → validation**.
- **2 corrections validées `medical-domain-validator`** (US-2651 exige sa validation) :
  1. **ISF** — commentaire (l.98-99) **inversé** ; le **code était correct** → commentaire réécrit.
  2. **ICR** — libellés `reason` **inversés** (l.149, `icrTooLow`↔`icrTooHigh`) : **direction correcte**, seul le libellé affiché au médecin était faux → ternaire corrigé + **tests de verrou** (reason + direction, 2 sens).
  - **Aucun CRITICAL** : grep confirmé qu'**aucun consommateur ne dérive la direction/dose depuis `reason`** ; le générateur n'est pas encore câblé à la persistance. Basal : aucun défaut.
- Pointeur ajouté depuis le catalogue clinique.

## Reste US-2651
Router `generateProposals` par mode · mode (b) `analyzeFixedDose*` · câblage générateur → `createProposal`.

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3687 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)