### PR TITLE
US-2651 (générateur, slice 1) — Primitive createEngineProposal (persistance moteur)

### DIFF
--- a/docs/clinical-logic/algorithme-propositions-ajustement.md
+++ b/docs/clinical-logic/algorithme-propositions-ajustement.md
@@ -105,6 +105,12 @@ re-vérif contre la config LIVE) + `changePercent` recalculé, **anti-spam** (`o
 Statut `pending` ; notifie le référent (best-effort). Le générateur fournit les **discriminateurs de
 créneau** selon le slot analysé (ISF/ICR → `timeSlot*`/`carbRatio*` ; basal → `pumpBasalSlotId`).
 
+**Fenêtre snapshot→persist (validé medical)** : le candidat est calculé sur `expectedCurrentValue`
+(snapshot). Si la config a **dérivé** entre l'analyse et la persistance, `createEngineProposal`
+**REJETTE** (`baselineMovedAtPersist`) au lieu de persister une magnitude hors-cap ou un sens inversé
+(le `baselineMoved` de l'accept ne couvre que persist→accept). En défense en profondeur, la cohérence
+`reason` ↔ signe du delta est asservie (`reasonDirectionMismatch`), et `supportingEvents > 0` exigé.
+
 ## 7. Validation `medical-domain-validator` (US-2651) — verdicts
 
 Deux incohérences **clinique↔code** relevées en documentant, **validées et corrigées** dans cette slice

--- a/docs/clinical-logic/algorithme-propositions-ajustement.md
+++ b/docs/clinical-logic/algorithme-propositions-ajustement.md
@@ -94,6 +94,17 @@ Le mode est **dérivé serveur** (`resolveTreatmentMode`, fail-closed : un DT1 n
 3. **Validation médecin** (`accept`) — re-vérifie les bornes + **compare-and-swap** (`baselineMoved`)
    si la base a bougé depuis la proposition. Application scopée patient.
 
+## 6bis. Persistance d'une proposition MOTEUR — `createEngineProposal` (US-2651)
+
+`createProposal` est **humain-only** (source patient/nurse/doctor ; viole la contrainte CHECK
+`algorithm`). Le générateur persiste via **`adjustmentService.createEngineProposal(input, ctx)`** :
+`source = algorithm`, `proposedByUserId = null`, métriques moteur (`confidence`/`supportingEvents`)
+**non nulles** (CHECK). Reprend les garde-fous serveur de `createProposal` : frontière **nonInsulin**
+(MDR), **bornes dures**, `currentValue` **re-dérivé serveur** (le candidat est calculé sur un snapshot →
+re-vérif contre la config LIVE) + `changePercent` recalculé, **anti-spam** (`one_pending_per_slot`).
+Statut `pending` ; notifie le référent (best-effort). Le générateur fournit les **discriminateurs de
+créneau** selon le slot analysé (ISF/ICR → `timeSlot*`/`carbRatio*` ; basal → `pumpBasalSlotId`).
+
 ## 7. Validation `medical-domain-validator` (US-2651) — verdicts
 
 Deux incohérences **clinique↔code** relevées en documentant, **validées et corrigées** dans cette slice

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -199,3 +199,9 @@ dans son document dédié : **[`algorithme-propositions-ajustement.md`](./algori
   le moteur reste silencieux (le médecin ajuste manuellement). Fail-safe, non bloquant.
 - **Contrat d'entrée** : `postGlucoseGl` = glycémie d'évaluation du moment (PPG 2 h pour un moment
   prandial ; à jeun/pré-repas pour une dose de type basal) — à câbler correctement dans le générateur.
+
+> **Suivi PRIORITAIRE (validé medical, à faire AVANT de câbler le générateur mode a)** — Garde HYPO
+> manquante sur `analyzeBasalTrend`/`analyzeIsfSlot`/`analyzeIcrSlot` : seul `analyzeFixedDose` refuse
+> une **hausse** si un relevé est en hypo sévère. Une hypo nocturne masquée par la moyenne pourrait
+> produire une **hausse basale** dangereuse. Mirrorer la garde hypo (< 0,54 g/L) sur ces analyseurs
+> avant de les relier à `createEngineProposal`.

--- a/src/lib/services/adjustment.service.ts
+++ b/src/lib/services/adjustment.service.ts
@@ -17,8 +17,30 @@ import { isDeliverableBasalRate } from "@/lib/clinical-bounds"
 import { encryptField } from "@/lib/crypto/fields"
 import type { AuditContext } from "./patient.service"
 import type {
-  ProposalStatus, Prisma, AdjustableParameter, AdjustmentReason, ProposalSource,
+  ProposalStatus, Prisma, AdjustableParameter, AdjustmentReason, ProposalSource, ConfidenceLevel,
 } from "@prisma/client"
+
+/**
+ * Entrée d'une proposition MOTEUR (US-2651) : candidat d'analyseur + discriminateurs de créneau.
+ * Métriques moteur (`confidence`/`supportingEvents`) OBLIGATOIRES (contrainte CHECK `algorithm`).
+ */
+export type CreateEngineProposalInput = {
+  patientId: number
+  parameterType: AdjustableParameter
+  proposedValue: number
+  reason: AdjustmentReason
+  confidence: ConfidenceLevel
+  supportingEvents: number
+  totalEventsConsidered?: number | null
+  averageObservedValue?: number | null
+  analysisPeriod?: string | null
+  dataQuality?: string | null
+  timeSlotStartHour?: number | null
+  timeSlotEndHour?: number | null
+  carbRatioSlotStart?: number | null
+  carbRatioSlotEnd?: number | null
+  pumpBasalSlotId?: string | null
+}
 
 /** Sources humaines d'une proposition (l'algorithme passe par le chemin `algorithm`). */
 type HumanProposerRole = Extract<ProposalSource, "patient" | "nurse" | "doctor">
@@ -506,6 +528,109 @@ export const adjustmentService = {
       // Course TOCTOU rattrapée par l'index partiel `adjustment_proposals_one_pending_per_slot`.
       // On ne re-mappe QUE cette contrainte-là (pas n'importe quel P2002) pour ne pas masquer
       // un futur conflit d'unicité sans rapport.
+      const err = e as { code?: string; meta?: { target?: unknown } }
+      const target = Array.isArray(err.meta?.target) ? err.meta!.target.join(",") : String(err.meta?.target ?? "")
+      if (err.code === "P2002" && target.includes("one_pending")) {
+        throw new Error("duplicatePendingProposal")
+      }
+      throw e
+    }
+  },
+
+  /**
+   * US-2651 — Créer une proposition MOTEUR (générateur nocturne). Distinct de `createProposal`
+   * (humain) : `source = algorithm`, `proposedByUserId = null`, métriques moteur NON nulles
+   * (contrainte CHECK). Reprend les mêmes garde-fous serveur : frontière **nonInsulin** (MDR),
+   * **bornes dures**, `currentValue` **re-dérivé serveur** (le candidat a été calculé sur un
+   * snapshot — on re-vérifie contre la config LIVE) et recompute `changePercent`, **anti-spam**
+   * (index `one_pending_per_slot`). Jamais appliqué (`pending`). Notifie le référent (best-effort).
+   *
+   * @param input Candidat + discriminateurs de créneau (fournis par le générateur selon le slot analysé).
+   * @param ctx Contexte requête (audit).
+   * @returns La proposition créée.
+   */
+  async createEngineProposal(input: CreateEngineProposalInput, ctx?: AuditContext) {
+    const { patientId, parameterType, proposedValue } = input
+
+    // 0. Frontière MDR : jamais de proposition de dose pour un patient non insuliné.
+    const { mode } = await treatmentModeService.resolveTreatmentMode(patientId)
+    if (mode === "nonInsulin") throw new Error("nonInsulinNoDose")
+
+    // 1. Bornes cliniques dures.
+    if (!validateProposedValue(parameterType, proposedValue)) throw new Error("valueOutOfBounds")
+
+    // 2. `currentValue` re-dérivé SERVEUR (jamais celui du candidat) + `changePercent` recalculé
+    //    (borné ± 999,99 pour la colonne Decimal(5,2)). Réutilise les helpers de `createProposal`.
+    const asInput: CreateProposalInput = {
+      patientId,
+      parameterType,
+      proposedValue,
+      reason: input.reason,
+      timeSlotStartHour: input.timeSlotStartHour,
+      timeSlotEndHour: input.timeSlotEndHour,
+      carbRatioSlotStart: input.carbRatioSlotStart,
+      carbRatioSlotEnd: input.carbRatioSlotEnd,
+      pumpBasalSlotId: input.pumpBasalSlotId,
+    }
+    const currentValue = await resolveCurrentValue(patientId, parameterType, asInput)
+    const rawPct = currentValue !== 0 ? ((proposedValue - currentValue) / currentValue) * 100 : 0
+    const changePercent = Math.max(-999.99, Math.min(999.99, rawPct))
+    const slot = slotFieldsFor(parameterType, asInput)
+
+    // 3. Anti-spam (pré-check + index partiel unique via P2002 ci-dessous). Pas de garde patient.
+    const existing = await prisma.adjustmentProposal.findFirst({
+      where: {
+        patientId,
+        parameterType,
+        status: "pending",
+        timeSlotStartHour: slot.timeSlotStartHour,
+        carbRatioSlotStart: slot.carbRatioSlotStart,
+        pumpBasalSlotId: slot.pumpBasalSlotId,
+      },
+      select: { id: true },
+    })
+    if (existing) throw new Error("duplicatePendingProposal")
+
+    try {
+      const created = await prisma.$transaction(async (tx) => {
+        const proposal = await tx.adjustmentProposal.create({
+          data: {
+            patientId,
+            parameterType,
+            currentValue,
+            proposedValue,
+            changePercent,
+            reason: input.reason,
+            source: "algorithm",
+            proposedByUserId: null,
+            confidence: input.confidence,
+            supportingEvents: input.supportingEvents,
+            totalEventsConsidered: input.totalEventsConsidered ?? null,
+            averageObservedValue: input.averageObservedValue ?? null,
+            analysisPeriod: input.analysisPeriod ?? null,
+            dataQuality: input.dataQuality ?? null,
+            status: "pending",
+            ...slot,
+          },
+        })
+        // Audit SANS PHI : provenance moteur + pivot patient, jamais la valeur de dose.
+        await auditService.logWithTx(tx, {
+          userId: null,
+          action: "CREATE",
+          resource: "ADJUSTMENT_PROPOSAL",
+          resourceId: proposal.id,
+          ipAddress: ctx?.ipAddress,
+          userAgent: ctx?.userAgent,
+          metadata: { patientId, proposedByRole: "algorithm" },
+        })
+        return proposal
+      })
+
+      void notifyReviewers(patientId, created, ctx).catch((err) =>
+        logger.error("adjustment", "notifyReviewers failed", { patientId }, err),
+      )
+      return created
+    } catch (e) {
       const err = e as { code?: string; meta?: { target?: unknown } }
       const target = Array.isArray(err.meta?.target) ? err.meta!.target.join(",") : String(err.meta?.target ?? "")
       if (err.code === "P2002" && target.includes("one_pending")) {

--- a/src/lib/services/adjustment.service.ts
+++ b/src/lib/services/adjustment.service.ts
@@ -28,6 +28,9 @@ export type CreateEngineProposalInput = {
   patientId: number
   parameterType: AdjustableParameter
   proposedValue: number
+  /** `currentValue` du SNAPSHOT sur lequel l'analyseur a calculé `proposedValue` (candidat).
+   *  Sert au compare-and-swap de persistance (rejet si la config a dérivé depuis l'analyse). */
+  expectedCurrentValue: number
   reason: AdjustmentReason
   confidence: ConfidenceLevel
   supportingEvents: number
@@ -76,6 +79,17 @@ export type CreateProposalInput = {
  */
 function assertRowApplied(count: number, code: string): void {
   if (count === 0) throw new Error(code)
+}
+
+/**
+ * Sens clinique impliqué par un `reason` de titration : `*TooLow` ⇒ HAUSSE, `*TooHigh` ⇒ BAISSE.
+ * `null` pour un motif non directionnel (`*Correct`, `insufficientData`, motifs humains). Sert à
+ * vérifier la cohérence `reason` ↔ signe du delta d'une proposition moteur (US-2651).
+ */
+function reasonImpliesIncrease(reason: AdjustmentReason): boolean | null {
+  if (reason.endsWith("TooLow")) return true
+  if (reason.endsWith("TooHigh")) return false
+  return null
 }
 
 function validateProposedValue(parameterType: string, value: number): boolean {
@@ -556,8 +570,11 @@ export const adjustmentService = {
     const { mode } = await treatmentModeService.resolveTreatmentMode(patientId)
     if (mode === "nonInsulin") throw new Error("nonInsulinNoDose")
 
-    // 1. Bornes cliniques dures.
+    // 1. Bornes cliniques dures + métriques moteur valides.
     if (!validateProposedValue(parameterType, proposedValue)) throw new Error("valueOutOfBounds")
+    if (!Number.isFinite(input.supportingEvents) || input.supportingEvents <= 0) {
+      throw new Error("invalidSupportingEvents") // une proposition à 0 événement n'a aucun sens
+    }
 
     // 2. `currentValue` re-dérivé SERVEUR (jamais celui du candidat) + `changePercent` recalculé
     //    (borné ± 999,99 pour la colonne Decimal(5,2)). Réutilise les helpers de `createProposal`.
@@ -573,8 +590,28 @@ export const adjustmentService = {
       pumpBasalSlotId: input.pumpBasalSlotId,
     }
     const currentValue = await resolveCurrentValue(patientId, parameterType, asInput)
+
+    // 2b. COMPARE-AND-SWAP de persistance (US-2651, validé medical) : le candidat a été calculé sur
+    //     `expectedCurrentValue` (snapshot). Si la config a DÉRIVÉ depuis l'analyse (médecin qui édite,
+    //     autre proposition acceptée), on REJETTE plutôt que de persister une magnitude hors-cap OU un
+    //     sens inversé (le `baselineMoved` de l'accept ne couvre que persist→accept). Le générateur
+    //     re-analysera sur la nouvelle base au prochain run. Tolérance : bruit float sous la résolution
+    //     Decimal(4). Rejeter, pas re-clamper (le re-clamp rebaserait une analyse périmée).
+    if (Math.abs(currentValue - input.expectedCurrentValue) > 1e-9) {
+      throw new Error("baselineMovedAtPersist")
+    }
+
     const rawPct = currentValue !== 0 ? ((proposedValue - currentValue) / currentValue) * 100 : 0
     const changePercent = Math.max(-999.99, Math.min(999.99, rawPct))
+
+    // 2c. Cohérence `reason` ↔ direction (défense en profondeur : garde aussi un candidat mal formé).
+    //     `*TooLow` doit HAUSSER, `*TooHigh` doit BAISSER — sinon l'explication affichée serait fausse.
+    const wantsIncrease = reasonImpliesIncrease(input.reason)
+    if (wantsIncrease !== null) {
+      const delta = proposedValue - currentValue
+      if (delta === 0 || delta > 0 !== wantsIncrease) throw new Error("reasonDirectionMismatch")
+    }
+
     const slot = slotFieldsFor(parameterType, asInput)
 
     // 3. Anti-spam (pré-check + index partiel unique via P2002 ci-dessous). Pas de garde patient.

--- a/tests/unit/adjustment.service.test.ts
+++ b/tests/unit/adjustment.service.test.ts
@@ -354,8 +354,8 @@ describe("adjustmentService", () => {
 
       const res = await adjustmentService.createEngineProposal({
         patientId: 1, parameterType: "insulinSensitivityFactor", proposedValue: 0.55,
-        reason: "isfTooLow", confidence: "high", supportingEvents: 12, totalEventsConsidered: 12,
-        timeSlotStartHour: 8, timeSlotEndHour: 12,
+        expectedCurrentValue: 0.5, reason: "isfTooLow", confidence: "high", supportingEvents: 12,
+        totalEventsConsidered: 12, timeSlotStartHour: 8, timeSlotEndHour: 12,
       })
 
       expect(res.id).toBe("e1")
@@ -376,9 +376,35 @@ describe("adjustmentService", () => {
       await expect(
         adjustmentService.createEngineProposal({
           patientId: 1, parameterType: "insulinSensitivityFactor", proposedValue: 0.55,
-          reason: "isfTooLow", confidence: "high", supportingEvents: 12, timeSlotStartHour: 8, timeSlotEndHour: 12,
+          expectedCurrentValue: 0.5, reason: "isfTooLow", confidence: "high", supportingEvents: 12,
+          timeSlotStartHour: 8, timeSlotEndHour: 12,
         }),
       ).rejects.toThrow("nonInsulinNoDose")
+    })
+
+    const isfInput = (over: Record<string, unknown>) => ({
+      patientId: 1, parameterType: "insulinSensitivityFactor" as const, proposedValue: 0.55,
+      expectedCurrentValue: 0.5, reason: "isfTooLow" as const, confidence: "high" as const,
+      supportingEvents: 12, timeSlotStartHour: 8, timeSlotEndHour: 12, ...over,
+    })
+
+    it("config dérivée depuis l'analyse (live ≠ expected) → baselineMovedAtPersist", async () => {
+      prismaMock.insulinSensitivityFactor.findFirst.mockResolvedValue({ sensitivityFactorGl: 0.5 } as never)
+      // candidat calculé sur 0.4, mais la config live est 0.5 → rejet (re-analyse au prochain run).
+      await expect(adjustmentService.createEngineProposal(isfInput({ expectedCurrentValue: 0.4 })))
+        .rejects.toThrow("baselineMovedAtPersist")
+    })
+
+    it("reason ↔ direction incohérents (isfTooLow mais baisse) → reasonDirectionMismatch", async () => {
+      prismaMock.insulinSensitivityFactor.findFirst.mockResolvedValue({ sensitivityFactorGl: 0.5 } as never)
+      // isfTooLow (hausse attendue) mais proposedValue 0.45 < 0.5 → mismatch.
+      await expect(adjustmentService.createEngineProposal(isfInput({ proposedValue: 0.45 })))
+        .rejects.toThrow("reasonDirectionMismatch")
+    })
+
+    it("supportingEvents ≤ 0 → invalidSupportingEvents", async () => {
+      await expect(adjustmentService.createEngineProposal(isfInput({ supportingEvents: 0 })))
+        .rejects.toThrow("invalidSupportingEvents")
     })
   })
 

--- a/tests/unit/adjustment.service.test.ts
+++ b/tests/unit/adjustment.service.test.ts
@@ -340,4 +340,46 @@ describe("adjustmentService", () => {
       expect(result.applied).toBe(false)
     })
   })
+
+  describe("createEngineProposal (US-2651 moteur)", () => {
+    it("crée une proposition ALGORITHM : source algorithm, userId null, métriques non nulles, currentValue re-dérivé", async () => {
+      // currentValue re-lu serveur (ISF 0.5) ≠ du candidat ; changePercent recalculé (0.55 vs 0.5 = +10 %).
+      prismaMock.insulinSensitivityFactor.findFirst.mockResolvedValue({ sensitivityFactorGl: 0.5 } as never)
+      prismaMock.adjustmentProposal.findFirst.mockResolvedValue(null) // pas de pending
+      const mockTx = {
+        adjustmentProposal: { create: vi.fn().mockResolvedValue({ id: "e1", status: "pending", proposedByUserId: null }) },
+        auditLog: { create: vi.fn().mockResolvedValue({}) },
+      }
+      prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+
+      const res = await adjustmentService.createEngineProposal({
+        patientId: 1, parameterType: "insulinSensitivityFactor", proposedValue: 0.55,
+        reason: "isfTooLow", confidence: "high", supportingEvents: 12, totalEventsConsidered: 12,
+        timeSlotStartHour: 8, timeSlotEndHour: 12,
+      })
+
+      expect(res.id).toBe("e1")
+      const data = mockTx.adjustmentProposal.create.mock.calls[0]![0].data
+      expect(data.source).toBe("algorithm")
+      expect(data.proposedByUserId).toBeNull()
+      expect(data.confidence).toBe("high")
+      expect(data.supportingEvents).toBe(12)
+      expect(Number(data.currentValue)).toBe(0.5) // serveur, pas le candidat
+      expect(Number(data.changePercent)).toBeCloseTo(10)
+      // Audit moteur sans PHI (userId null, pas de dose).
+      expect(mockTx.auditLog.create).toHaveBeenCalled()
+    })
+
+    it("patient nonInsulin → nonInsulinNoDose (frontière MDR)", async () => {
+      const { treatmentModeService } = await import("@/lib/services/treatment-mode.service")
+      vi.mocked(treatmentModeService.resolveTreatmentMode).mockResolvedValueOnce({ mode: "nonInsulin", coherent: true })
+      await expect(
+        adjustmentService.createEngineProposal({
+          patientId: 1, parameterType: "insulinSensitivityFactor", proposedValue: 0.55,
+          reason: "isfTooLow", confidence: "high", supportingEvents: 12, timeSlotStartHour: 8, timeSlotEndHour: 12,
+        }),
+      ).rejects.toThrow("nonInsulinNoDose")
+    })
+  })
+
 })


### PR DESCRIPTION
Pièce maîtresse du câblage du générateur nocturne (mode a/b). La cartographie a révélé que **`createProposal` n'est PAS utilisable pour le moteur** (human-only : rôle patient/nurse/doctor, métriques `null` → **viole la contrainte CHECK** `algorithm ⇔ userId NULL & confidence/supportingEvents NOT NULL`). D'où un primitive dédié.

## Contenu
- **`adjustmentService.createEngineProposal(input, ctx)`** : `source = algorithm`, `proposedByUserId = null`, métriques moteur **non nulles** (satisfait le CHECK). Reprend **les mêmes garde-fous serveur** que `createProposal` :
  - frontière **nonInsulin** (MDR) ; **bornes dures** ;
  - **`currentValue` re-dérivé serveur** (le candidat d'analyseur est calculé sur un snapshot → re-vérif contre la config **live**) + `changePercent` recalculé (borné ±999,99) ;
  - **anti-spam** (`one_pending_per_slot` + P2002) ; statut `pending` ; notifie le référent (best-effort).
  - Les **discriminateurs de créneau** (ISF/ICR → `timeSlot*`/`carbRatio*` ; basal → `pumpBasalSlotId`) sont fournis par l'appelant (le générateur, selon le slot analysé).
- Tests : **+2** (proposition `algorithm` bien formée + `currentValue` serveur ; `nonInsulin` → `nonInsulinNoDose`).

## Prochaines slices
Cron + générateur + **ICR** (le plus facile, via `meal-trends`), puis **basal**, **ISF** (dur), **fixedDose** (précédé d'une migration `moment` sur `AdjustmentProposal`).

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3697 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)