### PR TITLE
US-2651 — Garde HYPO sur les 4 analyseurs (prérequis générateur, validé medical)

### DIFF
--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -191,9 +191,10 @@ dans son document dédié : **[`algorithme-propositions-ajustement.md`](./algori
 `FIXED_DOSE_MIN` (0,5 U). Direction = dose **directe** (haut → hausse). Détail : `algorithme-propositions-ajustement.md` §4-5.
 
 **Garde-fous `analyzeFixedDose` (validés medical US-2651)** :
-- **Garde hypo** : aucune proposition de **HAUSSE** si un relevé du moment est en **hypo sévère**
-  (< `GLYCEMIA_THRESHOLDS_MGDL.SEVERE_HYPO` = 0,54 g/L) — la moyenne peut masquer une hypo
-  intermittente. La **baisse** reste permise (sens sûr).
+- **Garde hypo** : aucune proposition de **HAUSSE** en présence d'hypo contre-indiquante ; la **baisse**
+  reste permise (sens sûr). Depuis US-2651, cette garde est **commune aux 4 analyseurs** via
+  `hypoBlocksProposal` et couvre **le sévère (1 relevé) ET le niveau-1 récurrent (≥ 2)** — voir la
+  section « Garde HYPO des analyseurs » ci-dessous (la description sévère-only ici est historique).
 - **Garde entrée** : dose courante `null`/non finie/< `FIXED_DOSE_MIN` → aucune proposition (fail-closed).
 - **Blind spot connu** : une dose ≤ ~5 U est structurellement non ajustable (10 % < 0,5 U d'incrément) →
   le moteur reste silencieux (le médecin ajuste manuellement). Fail-safe, non bloquant.

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -200,8 +200,21 @@ dans son document dédié : **[`algorithme-propositions-ajustement.md`](./algori
 - **Contrat d'entrée** : `postGlucoseGl` = glycémie d'évaluation du moment (PPG 2 h pour un moment
   prandial ; à jeun/pré-repas pour une dose de type basal) — à câbler correctement dans le générateur.
 
-> **Suivi PRIORITAIRE (validé medical, à faire AVANT de câbler le générateur mode a)** — Garde HYPO
-> manquante sur `analyzeBasalTrend`/`analyzeIsfSlot`/`analyzeIcrSlot` : seul `analyzeFixedDose` refuse
-> une **hausse** si un relevé est en hypo sévère. Une hypo nocturne masquée par la moyenne pourrait
-> produire une **hausse basale** dangereuse. Mirrorer la garde hypo (< 0,54 g/L) sur ces analyseurs
-> avant de les relier à `createEngineProposal`.
+### Garde HYPO des analyseurs (US-2651, validé medical)
+
+Les **4 analyseurs** (`analyzeIsfSlot`/`analyzeIcrSlot`/`analyzeBasalTrend`/`analyzeFixedDose`) refusent
+toute proposition en **direction « plus d'insuline effective »** (risque hypo) si un relevé de la
+fenêtre est en **hypo SÉVÈRE** (< `GLYCEMIA_THRESHOLDS_MGDL.SEVERE_HYPO` = 0,54 g/L) — la moyenne peut
+masquer une hypo intermittente. Helper commun `hypoBlocksProposal`, direction dérivée de
+`deriveRiskDirection` (hausse basale/dose fixe **ou** baisse ISF/ICR = « hypo »). Le sens sûr (moins
+d'insuline) reste permis. Ferme le prérequis avant câblage du générateur mode a.
+
+**Déclencheurs (validé medical)** :
+- **Hypo sévère (niveau 2, < 0,54 g/L)** : **un seul** relevé suffit (urgence clinique).
+- **Hypo légère (niveau 1, < 0,70 g/L)** : freine aussi mais seulement si **récurrente** —
+  ≥ `HYPO_LEVEL1_RECURRENCE_MIN` (= 2) relevés dans la fenêtre (évite la sur-suppression sur un
+  événement isolé, très courant). Choix délibéré : le niveau 2 seul sur-protégerait moins mais
+  raterait des hypos légères répétées ; le comptage niveau-1 les capture sans bruit.
+- **Contrat basal (Somogyi)** : `analyzeBasalTrend` ne capte l'hypo nocturne masquée que si
+  `fastingValues` inclut le **nadir CGM nocturne** (pas seulement le pré-petit-déj) — précondition
+  JSDoc à respecter par le générateur au câblage.

--- a/src/lib/clinical-bounds.ts
+++ b/src/lib/clinical-bounds.ts
@@ -96,6 +96,14 @@ export const CLINICAL_BOUNDS = {
    * (pas d'index DB : course à faible enjeu, tout reste gaté médecin).
    */
   PATIENT_PROPOSAL_COOLDOWN_HOURS: 24,
+  /**
+   * US-2651 — garde HYPO des analyseurs. Une hypo **sévère** (niveau 2, < 0,54 g/L / 54 mg/dL)
+   * suffit (un seul relevé) à supprimer une proposition « plus d'insuline ». Une hypo **légère**
+   * (niveau 1, 0,54–0,70 g/L) freine aussi, mais seulement si **récurrente** : ≥ ce nombre de
+   * relevés niveau-1 dans la fenêtre (évite la sur-suppression sur un événement isolé courant).
+   * Seuils : `GLYCEMIA_THRESHOLDS_MGDL.SEVERE_HYPO` (54) / `.TARGET_LOW` (70).
+   */
+  HYPO_LEVEL1_RECURRENCE_MIN: 2,
 } as const
 
 export type ClinicalBounds = typeof CLINICAL_BOUNDS

--- a/src/lib/proposal-algorithm.ts
+++ b/src/lib/proposal-algorithm.ts
@@ -10,9 +10,35 @@
 import type { AdjustableParameter, AdjustmentReason, ConfidenceLevel, DoseMoment } from "@prisma/client"
 import { CLINICAL_BOUNDS, BGM_CARNET } from "@/lib/clinical-bounds"
 import { GLYCEMIA_THRESHOLDS_MGDL } from "@/lib/glycemia-thresholds"
+import { deriveRiskDirection } from "@/lib/insulin/risk-direction"
 
-/** Seuil d'hypo SÉVÈRE en g/L (source unique mg/dL ÷ 100). */
+/** Seuils d'hypo en g/L (source unique mg/dL ÷ 100). Sévère = niveau 2 ; bas = niveau 1. */
 const SEVERE_HYPO_GL = GLYCEMIA_THRESHOLDS_MGDL.SEVERE_HYPO / 100
+const LEVEL1_HYPO_GL = GLYCEMIA_THRESHOLDS_MGDL.TARGET_LOW / 100
+
+/**
+ * Garde HYPO commune (US-2651, validé medical) : une proposition en direction « plus d'insuline
+ * effective » (risque hypo) est **supprimée** si la fenêtre contient une hypo qui contre-indique
+ * d'augmenter l'insuline. La direction dangereuse par paramètre vient de `deriveRiskDirection`
+ * (hausse basale/dose fixe OU baisse ISF/ICR = « hypo »). La direction sûre (moins d'insuline) reste
+ * toujours permise.
+ *
+ * Déclencheurs (la moyenne peut masquer une hypo intermittente) :
+ *  - **sévère** (niveau 2, < `SEVERE_HYPO_GL`) : **un seul** relevé suffit (urgence clinique) ;
+ *  - **légère** (niveau 1, < `LEVEL1_HYPO_GL`) : seulement si **récurrente** (≥
+ *    `HYPO_LEVEL1_RECURRENCE_MIN` relevés) — évite la sur-suppression sur un événement isolé courant.
+ */
+function hypoBlocksProposal(
+  parameterType: AdjustableParameter,
+  currentValue: number,
+  proposedValue: number,
+  glucosesGl: number[],
+): boolean {
+  if (deriveRiskDirection(parameterType, currentValue, proposedValue) !== "hypo") return false
+  const hasSevere = glucosesGl.some((g) => g < SEVERE_HYPO_GL)
+  const level1Count = glucosesGl.filter((g) => g < LEVEL1_HYPO_GL).length
+  return hasSevere || level1Count >= CLINICAL_BOUNDS.HYPO_LEVEL1_RECURRENCE_MIN
+}
 
 /**
  * Adjustment proposal candidate — suggested parameter change with confidence.
@@ -109,13 +135,20 @@ export function analyzeIsfSlot(
   // Only propose if change is meaningful (> 2%)
   if (Math.abs(clampedChange) < 2) return null
 
+  const proposedValue = computeProposedValue(slot.sensitivityFactorGl, clampedChange)
+  // Garde HYPO : baisser l'ISF = corrections plus fortes (plus d'insuline) → supprimé si une
+  // glycémie post-correction de la fenêtre est en hypo sévère (une correction a sur-shooté).
+  if (hypoBlocksProposal("insulinSensitivityFactor", slot.sensitivityFactorGl, proposedValue, corrections.map((c) => c.postGlucoseGl))) {
+    return null
+  }
+
   const reason: AdjustmentReason = clampedChange > 0 ? "isfTooLow" : "isfTooHigh"
 
   return {
     parameterType: "insulinSensitivityFactor",
     reason,
     currentValue: slot.sensitivityFactorGl,
-    proposedValue: computeProposedValue(slot.sensitivityFactorGl, clampedChange),
+    proposedValue,
     changePercent: Math.round(clampedChange * 100) / 100,
     confidence: getConfidenceLevel(corrections.length),
     supportingEvents: corrections.length,
@@ -156,13 +189,20 @@ export function analyzeIcrSlot(
   // Post-repas AU-DESSUS de la cible → bolus trop faible → ICR trop HAUT → BAISSE (icrTooHigh) ;
   // EN DESSOUS → ICR trop BAS → HAUSSE (icrTooLow). (Correction validée medical US-2651 : les
   // libellés étaient inversés — la DIRECTION était correcte, seul le `reason` affiché était faux.)
+  const proposedValue = computeProposedValue(slot.gramsPerUnit, clampedChange)
+  // Garde HYPO : baisser l'ICR = plus d'insuline/gramme → supprimé si un post-repas de la fenêtre
+  // est en hypo sévère (un bolus repas a sur-shooté).
+  if (hypoBlocksProposal("insulinToCarbRatio", slot.gramsPerUnit, proposedValue, meals.map((m) => m.postGlucoseGl))) {
+    return null
+  }
+
   const reason: AdjustmentReason = clampedChange < 0 ? "icrTooHigh" : "icrTooLow"
 
   return {
     parameterType: "insulinToCarbRatio",
     reason,
     currentValue: slot.gramsPerUnit,
-    proposedValue: computeProposedValue(slot.gramsPerUnit, clampedChange),
+    proposedValue,
     changePercent: Math.round(clampedChange * 100) / 100,
     confidence: getConfidenceLevel(meals.length),
     supportingEvents: meals.length,
@@ -177,6 +217,12 @@ export function analyzeIcrSlot(
  * Analyze basal rate effectiveness from fasting glucose trends.
  * Detects systematic overnight drift (rising = too low, falling = too high).
  * Only proposes if 3+ fasting values AND change is meaningful (> 2%).
+ *
+ * ⚠️ **Contrat garde-hypo (US-2651, validé medical)** : `fastingValues` DOIT inclure le **nadir
+ * glycémique nocturne** (relevé CGM le plus bas de la nuit), pas seulement le pré-petit-déjeuner.
+ * Sinon une hypo nocturne à 3 h qui **rebondit** en hyperglycémie au réveil (effet Somogyi) reste
+ * invisible et la garde hypo n'empêchera pas une hausse basale dangereuse. À respecter par
+ * l'appelant (générateur) lors du câblage.
  * @param {number[]} fastingValues - Pre-breakfast glucose readings (g/L)
  * @param {number} targetGl - Fasting glucose target (g/L)
  * @param {number} currentRate - Current basal rate (U/h)
@@ -197,13 +243,18 @@ export function analyzeBasalTrend(
 
   if (Math.abs(clampedChange) < 2) return null
 
+  const proposedValue = computeProposedValue(currentRate, clampedChange)
+  // Garde HYPO : hausser la basale = plus d'insuline → supprimé si une glycémie à jeun de la fenêtre
+  // est en hypo sévère (hypo nocturne masquée par la moyenne du dawn phenomenon).
+  if (hypoBlocksProposal("basalRate", currentRate, proposedValue, fastingValues)) return null
+
   const reason: AdjustmentReason = clampedChange > 0 ? "basalTooLow" : "basalTooHigh"
 
   return {
     parameterType: "basalRate",
     reason,
     currentValue: currentRate,
-    proposedValue: computeProposedValue(currentRate, clampedChange),
+    proposedValue,
     changePercent: Math.round(clampedChange * 100) / 100,
     confidence: getConfidenceLevel(fastingValues.length),
     supportingEvents: fastingValues.length,
@@ -265,11 +316,10 @@ export function analyzeFixedDose(
   // Pas arrondi nul (< incrément délivrable) → non actionnable.
   if (Math.abs(effectiveDelta) < inc) return null
 
-  // Garde HYPO (validé medical US-2651) : ne JAMAIS proposer une HAUSSE si un relevé du moment
-  // est en hypo SÉVÈRE — la moyenne peut masquer une hypo intermittente, et hausser une dose fixe
-  // (sans logique de correction pour rattraper) serait la direction dangereuse. La BAISSE reste
-  // permise (sens sûr).
-  if (effectiveDelta > 0 && readings.some((r) => r.postGlucoseGl < SEVERE_HYPO_GL)) return null
+  // Garde HYPO (validé medical US-2651) : hausser la dose fixe = plus d'insuline (sans logique de
+  // correction pour rattraper) → supprimé si un relevé du moment est en hypo sévère (la moyenne peut
+  // masquer une hypo intermittente). La BAISSE reste permise. Helper commun aux 4 analyseurs.
+  if (hypoBlocksProposal("fixedDose", slot.valueU, proposedValue, readings.map((r) => r.postGlucoseGl))) return null
 
   const reason: AdjustmentReason = effectiveDelta > 0 ? "fixedDoseTooLow" : "fixedDoseTooHigh"
 

--- a/tests/unit/clinical-bounds.test.ts
+++ b/tests/unit/clinical-bounds.test.ts
@@ -62,6 +62,7 @@ describe("CLINICAL_BOUNDS — anti-drift (A3)", () => {
       MAX_CHANGE_PERCENT: 20,
       PATIENT_MAX_CHANGE_PERCENT: 10,
       PATIENT_PROPOSAL_COOLDOWN_HOURS: 24,
+      HYPO_LEVEL1_RECURRENCE_MIN: 2,
     })
   })
 

--- a/tests/unit/proposal-algorithm.test.ts
+++ b/tests/unit/proposal-algorithm.test.ts
@@ -110,6 +110,39 @@ describe("proposal-algorithm", () => {
       }))
       expect(analyzeIsfSlot(slot, corrections)).toBeNull()
     })
+
+    it("garde HYPO : baisse ISF supprimée si un post-correction est en hypo sévère (US-2651)", () => {
+      const corrections = [
+        ...Array.from({ length: 5 }, () => ({ postGlucoseGl: 1.80, targetGl: 1.20 })),
+        { postGlucoseGl: 0.40, targetGl: 1.20 }, // hypo sévère < 0,54 g/L
+      ]
+      // Moyenne haute → isfTooHigh (baisser l'ISF = corrections plus fortes = plus d'insuline) → supprimé.
+      expect(analyzeIsfSlot(slot, corrections)).toBeNull()
+    })
+
+    it("garde HYPO : hausse ISF (sens sûr, moins d'insuline) permise malgré des hypos", () => {
+      const corrections = Array.from({ length: 5 }, () => ({ postGlucoseGl: 0.40, targetGl: 1.20 }))
+      const r = analyzeIsfSlot(slot, corrections) // sur-correction → isfTooLow (hausse ISF)
+      expect(r!.reason).toBe("isfTooLow")
+    })
+
+    it("garde HYPO : UN seul relevé niveau-1 (0,54) ne supprime pas la baisse ISF (borne)", () => {
+      const corrections = [
+        ...Array.from({ length: 5 }, () => ({ postGlucoseGl: 1.80, targetGl: 1.20 })),
+        { postGlucoseGl: 0.54, targetGl: 1.20 }, // niveau 1, non sévère, isolé
+      ]
+      const r = analyzeIsfSlot(slot, corrections)
+      expect(r!.reason).toBe("isfTooHigh") // non supprimé
+    })
+
+    it("garde HYPO : DEUX relevés niveau-1 (< 0,70) récurrents suppriment la baisse ISF", () => {
+      const corrections = [
+        ...Array.from({ length: 4 }, () => ({ postGlucoseGl: 1.80, targetGl: 1.20 })),
+        { postGlucoseGl: 0.60, targetGl: 1.20 },
+        { postGlucoseGl: 0.65, targetGl: 1.20 },
+      ]
+      expect(analyzeIsfSlot(slot, corrections)).toBeNull()
+    })
   })
 
   describe("analyzeIcrSlot", () => {
@@ -138,6 +171,15 @@ describe("proposal-algorithm", () => {
     it("returns null with insufficient data", () => {
       expect(analyzeIcrSlot(slot, [])).toBeNull()
     })
+
+    it("garde HYPO : baisse ICR supprimée si un post-repas est en hypo sévère (US-2651)", () => {
+      const meals = [
+        ...Array.from({ length: 5 }, () => ({ postGlucoseGl: 2.00, targetGl: 1.20 })),
+        { postGlucoseGl: 0.40, targetGl: 1.20 },
+      ]
+      // Moyenne haute → icrTooHigh (baisser l'ICR = plus d'insuline/gramme) → supprimé par la garde hypo.
+      expect(analyzeIcrSlot(slot, meals)).toBeNull()
+    })
   })
 
   describe("analyzeBasalTrend", () => {
@@ -158,6 +200,12 @@ describe("proposal-algorithm", () => {
 
     it("returns null with < 3 values", () => {
       expect(analyzeBasalTrend([1.5], 1.2, 0.8)).toBeNull()
+    })
+
+    it("garde HYPO : hausse basale supprimée si une glycémie à jeun est en hypo sévère (US-2651)", () => {
+      // Moyenne élevée (dawn phenomenon) mais une hypo nocturne masquée → hausse basale supprimée.
+      const fasting = [1.60, 1.55, 1.58, 0.40]
+      expect(analyzeBasalTrend(fasting, 1.20, 0.80)).toBeNull()
     })
   })
 

--- a/tests/unit/proposal-algorithm.test.ts
+++ b/tests/unit/proposal-algorithm.test.ts
@@ -180,6 +180,12 @@ describe("proposal-algorithm", () => {
       // Moyenne haute → icrTooHigh (baisser l'ICR = plus d'insuline/gramme) → supprimé par la garde hypo.
       expect(analyzeIcrSlot(slot, meals)).toBeNull()
     })
+
+    it("garde HYPO : hausse ICR (sens sûr, moins d'insuline) permise malgré des hypos", () => {
+      const meals = Array.from({ length: 5 }, () => ({ postGlucoseGl: 0.40, targetGl: 1.20 }))
+      const r = analyzeIcrSlot(slot, meals) // moyenne basse → icrTooLow (hausse ICR)
+      expect(r!.reason).toBe("icrTooLow")
+    })
   })
 
   describe("analyzeBasalTrend", () => {
@@ -206,6 +212,12 @@ describe("proposal-algorithm", () => {
       // Moyenne élevée (dawn phenomenon) mais une hypo nocturne masquée → hausse basale supprimée.
       const fasting = [1.60, 1.55, 1.58, 0.40]
       expect(analyzeBasalTrend(fasting, 1.20, 0.80)).toBeNull()
+    })
+
+    it("garde HYPO : baisse basale (sens sûr, moins d'insuline) permise malgré des hypos", () => {
+      const fasting = [0.50, 0.55, 0.48, 0.52] // moyenne basse → basalTooHigh (baisse)
+      const r = analyzeBasalTrend(fasting, 1.20, 0.80)
+      expect(r!.reason).toBe("basalTooHigh")
     })
   })
 


### PR DESCRIPTION
Ferme le **prérequis prioritaire** flagué par la revue medical de #666 : seul `analyzeFixedDose` refusait une proposition « plus d'insuline » en présence d'hypo → une **hypo nocturne masquée** par la moyenne pouvait produire une **hausse basale dangereuse**. Généralisé aux **4 analyseurs**.

## Contenu
- **Helper commun `hypoBlocksProposal`** : supprime la proposition si sa direction est « plus d'insuline effective » (**`deriveRiskDirection === "hypo"`** — hausse basale/dose fixe **ou** baisse ISF/ICR) **ET** la fenêtre contient une hypo contre-indiquante. Direction **indépendante du libellé `reason`** (robuste). Le sens sûr (moins d'insuline) reste **toujours permis**.
- **Déclencheurs (validé medical)** : hypo **sévère** (niveau 2, < 0,54 g/L) → **1 relevé** suffit ; hypo **légère** (niveau 1, < 0,70 g/L) → seulement si **récurrente** (≥ `HYPO_LEVEL1_RECURRENCE_MIN` = 2). Constante cataloguée + anti-drift ; seuils réutilisent `GLYCEMIA_THRESHOLDS_MGDL`.
- **Contrat JSDoc `analyzeBasalTrend`** : `fastingValues` DOIT inclure le **nadir nocturne** (sinon Somogyi invisible) — précondition pour le générateur.
- `analyzeFixedDose` refactoré sur le helper commun (DRY). Tests : **+6**.

## Verdict medical
Direction **CORRECTE sur les 4** (supprime le dangereux, permet le sûr), aucun CRITICAL/HIGH. Différé (contrat câblage) : nadir nocturne.

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3706 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)