### PR TITLE
US-2651 (générateur, slice a) — Socle constantes + spec ICR validée medical (deadband post-prandial)

### DIFF
--- a/docs/clinical-logic/algorithme-propositions-ajustement.md
+++ b/docs/clinical-logic/algorithme-propositions-ajustement.md
@@ -210,6 +210,17 @@ containment** (bucketer seulement si le moment entier tient dans un seul crénea
 (`bolus`), ou pré-repas hors bande cible (`preMgdl` — la PPG refléterait une correction, pas l'ICR).
 Les repas avec glucide intercurrent avant t0+90 sont déjà nullés en amont (`computeJournal`).
 
+> **⚠️ Limite connue — régime HYBRIDE (pompe + compléments bolus au stylo).** `InsulinDeliveryMethod`
+> (`pump`/`manual`) est un **flag patient unique** sur `InsulinTherapySettings` : le modèle traite un
+> patient comme pompe **ou** stylo, **pas hybride**. Le journal repas lit `DiabetesEvent.bolusDose`
+> **sans** méthode de délivrance → un **complément stylo** n'est pas distinguable d'un bolus pompe (et
+> n'est vu que s'il a été loggué). Conséquences (surtout **sous-détection = fail-safe**, pas de
+> sur-dosage) : (1) **ICR masqué** — un complément stylo qui ramène la PPG à la cible cache une
+> déficience réelle du ratio pompe → proposition manquée ; (2) **ISF** — une **correction au stylo**
+> hors calculateur n'est pas dans `BolusCalculationLog` → chute glycémique non appariée. Le risque de
+> sur-proposition reste faible (≥ 3 repas + moyenne + garde hypo). **À gérer** quand le régime hybride
+> sera modélisé en première classe (méthode de délivrance **par bolus**, pas par patient) → suivi build.
+
 **Minimum de preuve** — **≥ 3 repas/créneau** (aligné `analyzeIcrSlot` + `BGM_CARNET.MIN_READINGS_PER_MOMENT`),
 sinon fail-closed (aucune proposition).
 

--- a/docs/clinical-logic/algorithme-propositions-ajustement.md
+++ b/docs/clinical-logic/algorithme-propositions-ajustement.md
@@ -135,6 +135,20 @@ Base d'erreur relative = écart moyen à la cible. `confidence` = `getConfidence
     3 h vaut `0,45` g/L → **supprimé** (une hausse basale aggraverait l'hypo). ⚠️ N'est capté que si le
     nadir figure dans `fastingValues` (contrat JSDoc `analyzeBasalTrend`).
 
+> **⚠️ Portée : basale POMPE uniquement — le stylo/MDI n'est PAS géré (limite connue).**
+> `analyzeBasalTrend` raisonne sur un **débit U/h** et cible un `pumpBasalSlotId`
+> (`AdjustableParameter = basalRate`) → il ne couvre que `BasalConfigType = pump`. Les patients
+> **stylo/MDI** — `single_injection` (dose journalière, type Lantus, dans `dailyDose`) ou
+> `split_injection` (matin/soir, type Levemir, dans `morningDose`/`eveningDose`), basale exprimée en
+> **U** et non en U/h — ne reçoivent donc **aucune** proposition basale aujourd'hui (leurs **ISF/ICR
+> restent** proposés). C'est le **même type de trou que `fixedDose`**. Combler ce cas exige :
+> (1) un paramètre/discriminateur dédié (ex. `basalDose` matin/soir/journalier) ; (2) une **variante
+> d'analyseur** titrant en **U/jour** (à jeun → dose lente) et non en U/h ; (3) des **bornes dédiées**
+> (une basale stylo se compte en dizaines d'U — cf. `FIXED_BASAL_WARN_U` = 80 U — pas 0,05–5 U/h) ;
+> (4) le ciblage de persistance (`resolveCurrentValue` lit aujourd'hui `PumpBasalSlot.rate`). La
+> titration d'une basale lente au stylo par la glycémie à jeun étant une pratique standard → **slice
+> dédiée du build (b)**, après le socle ICR.
+
 > Sortie de chaque analyseur : `ProposalCandidate` (`parameterType, reason, currentValue,
 > proposedValue, changePercent, confidence, supportingEvents, totalEventsConsidered,
 > timeSlotStartHour?/EndHour?, averageObservedValue?`).

--- a/docs/clinical-logic/algorithme-propositions-ajustement.md
+++ b/docs/clinical-logic/algorithme-propositions-ajustement.md
@@ -97,6 +97,14 @@ Base d'erreur relative = écart moyen à la cible. `confidence` = `getConfidence
   - Glycémie post-correction **au-dessus** de la cible → correction trop faible → **ISF trop haut** →
     proposition de **baisse** de l'ISF (`reason = isfTooHigh`).
   - **En dessous** de la cible (sur-correction) → **ISF trop bas** → **hausse** (`reason = isfTooLow`).
+- **Exemples** (ISF courant `0,50` g/L/U, cible `1,00` g/L) :
+  - *Baisse* : 5 post-corrections à `1,60` g/L → `errorPercent = ((1,60−1,00)/1,00)×−100 = −60 %` →
+    clampé `−20 %` → ISF `0,50 → 0,40` (`isfTooHigh`, corrections plus fortes).
+  - *Hausse* : post-corrections moyennes à `0,70` g/L (sur-correction) → `+30 %` → clampé `+20 %` →
+    ISF `0,50 → 0,60` (`isfTooLow`, corrections plus douces).
+  - *Aucune proposition* : moyenne `1,01` g/L → `−1 %` → `|1 %| < 2 %` → `null`.
+  - *Garde hypo* : moyenne `1,60` (⇒ baisse) **mais** un relevé à `0,50` g/L (hypo sévère) → **supprimé**
+    (baisser l'ISF = corriger plus fort = plus d'insuline, direction dangereuse).
 
 ### 4.2 `analyzeIcrSlot(slot, meals[])` — ratio insuline/glucides (ICR)
 - Entrée : glycémies **post-repas** vs cible, pour un créneau horaire.
@@ -105,6 +113,12 @@ Base d'erreur relative = écart moyen à la cible. `confidence` = `getConfidence
   - Post-repas **au-dessus** de la cible → bolus trop faible → **baisse** de l'ICR (plus d'insuline/gramme),
     `reason = icrTooHigh` (l'ICR courant est trop haut).
   - **En dessous** → **hausse** de l'ICR, `reason = icrTooLow`.
+- **Exemples** (ICR courant `10` g/U, cible post-prandiale `1,40` g/L — cf. §5ter pour son choix) :
+  - *Baisse* : PPG 2 h moyenne `1,80` g/L → `((1,80−1,40)/1,40)×−100 = −28,6 %` → clampé `−20 %` →
+    ICR `10 → 8` (`icrTooHigh`, plus d'insuline/gramme).
+  - *Hausse* : PPG moyenne `1,10` g/L → `+21,4 %` → clampé `+20 %` → ICR `10 → 12` (`icrTooLow`).
+  - *Garde hypo* : PPG moyenne `1,80` (⇒ baisse) **mais** deux post-repas à `0,60` et `0,65` g/L
+    (niveau 1 récurrent) → **supprimé** (baisser l'ICR = plus d'insuline).
 
 ### 4.3 `analyzeBasalTrend(fastingValues[], targetGl, currentRate)` — débit basal
 - Entrée : glycémies **à jeun** (pré-petit-déjeuner) vs cible, débit basal courant.
@@ -113,6 +127,13 @@ Base d'erreur relative = écart moyen à la cible. `confidence` = `getConfidence
   - Glycémie à jeun **au-dessus** de la cible (montée nocturne) → basale **trop basse** → **hausse**
     (`reason = basalTooLow`).
   - **En dessous** (chute nocturne) → basale **trop haute** → **baisse** (`reason = basalTooHigh`).
+- **Exemples** (débit courant `0,80` U/h, cible `1,10` g/L) :
+  - *Hausse* : glycémies à jeun moyennes `1,40` g/L → `((1,40−1,10)/1,10)×100 = +27 %` → clampé
+    `+20 %` → `0,80 → 0,96` U/h (`basalTooLow`).
+  - *Baisse* : à jeun moyennes `0,80` g/L → `−27 %` → clampé `−20 %` → `0,80 → 0,64` U/h (`basalTooHigh`).
+  - *Effet Somogyi (garde hypo)* : à jeun moyennes `1,40` (⇒ hausse) **mais** le **nadir** nocturne à
+    3 h vaut `0,45` g/L → **supprimé** (une hausse basale aggraverait l'hypo). ⚠️ N'est capté que si le
+    nadir figure dans `fastingValues` (contrat JSDoc `analyzeBasalTrend`).
 
 > Sortie de chaque analyseur : `ProposalCandidate` (`parameterType, reason, currentValue,
 > proposedValue, changePercent, confidence, supportingEvents, totalEventsConsidered,
@@ -127,6 +148,15 @@ Le mode est **dérivé serveur** (`resolveTreatmentMode`, fail-closed : un DT1 n
 | **(a) basalBolus** | Analyseurs ISF/ICR/basal du §4 (existant). |
 | **(b) fixedDose** | **`analyzeFixedDose(slot, readings)` (livré, pur)** : dose **directe** par **moment** (carnet BGM). Au-dessus de la cible → dose trop basse → hausse (`fixedDoseTooLow`) ; en dessous → baisse (`fixedDoseTooHigh`). Bornée : **plus petit** de ± `FIXED_DOSE_MAX_CHANGE_PERCENT` (10 %) et ± `FIXED_DOSE_MAX_DELTA_U` (2 U) ; plancher `FIXED_DOSE_MIN` (0,5 U) ; arrondi à l'incrément délivrable (0,5 U) — pas nul → aucune proposition. **Cooldown 72 h/moment** (`FIXED_DOSE_COOLDOWN_HOURS`) au câblage du générateur (pas dans l'analyseur pur). **Jamais** : convertir doses fixes → basal-bolus, ni créer ISF/ICR ex nihilo. |
 | **(c) nonInsulin** | **Aucune proposition de dose** (frontière MDR). Uniquement des `ClinicalReviewFlag` d'orientation (« à revoir en consultation », HbA1c périmée, TIR sous cible, observance). La **cible** glycémique reste ajustable **par le médecin** (bornée, plus stricte en `pregnancyMode`). |
+
+- **Exemples mode (b) dose fixe** (dose matin `10` U, cible `1,40` g/L) :
+  - *Hausse* : glycémies du moment moyennes `2,00` g/L → dose trop basse → cap `min(10 % de 10 U ; 2 U) = 1 U`
+    → `10 → 11` U (`fixedDoseTooLow`).
+  - *Baisse* : moyennes `1,00` g/L → `10 → 9` U (`fixedDoseTooHigh`).
+  - *Non ajustable* : dose `3` U → 10 % = `0,3 U` < incrément délivrable `0,5 U` → arrondi nul → `null`
+    (blind spot documenté).
+  - *Mode (c)* : patient sous metformine seule → **aucune** proposition de dose ; un
+    `ClinicalReviewFlag` « à revoir en consultation » peut être levé (jamais une posologie).
 
 ## 5ter. Générateur ICR nocturne (mode a) — spec d'implémentation (validée medical, US-2651)
 
@@ -173,6 +203,18 @@ sinon fail-closed (aucune proposition).
 carbRatioSlotStart, carbRatioSlotEnd })` : re-dérive `currentValue`, re-borne, garde hypo (déjà dans
 l'analyseur), anti-spam, frontière nonInsulin. Cooldown moteur au niveau générateur.
 
+**Cas illustrés** (adulte, créneau ICR `10` g/U, plafond `1,80` / borne basse `1,00` g/L) :
+
+| Cas | PPG 2 h moy. | Décision | Détail |
+|---|---|---|---|
+| **Baisse ICR** (> plafond) | `2,00` g/L | ICR `10 → 8,9` (`icrTooHigh`) | analyseur avec cible = plafond `1,80` → `−11 %`. Plus d'insuline/gramme. |
+| **Hausse ICR** (< borne basse) | `0,85` g/L | ICR `10 → 11,5` (`icrTooLow`) | analyseur avec cible = borne basse `1,00` → `+15 %`. Moins d'insuline. |
+| **Zone morte** (bon contrôle) | `1,40` g/L | **aucune proposition** | entre `1,00` et `1,80` → rien (n'érode pas un bon contrôle). |
+| **Grossesse** (DT1 enceinte) | `1,55` g/L | ICR `10 → …` (baisse) | plafond **`1,40`** (pas 1,80) car `isPregnancy`. **Sans** cette règle, `1,55 < 1,80` aurait donné une **hausse** — dangereux. |
+| **Nadir tardif** (garde hypo) | `1,90` g/L | candidat baisse **supprimé** | un repas a un nadir à 3 h 30 de `0,50` g/L (hypo sévère) → la baisse d'ICR (plus d'insuline) est refusée. Invisible si on ne regarde que la PPG 2 h (`1,70`). |
+| **Bucketing** (mal attribué) | — | mauvais créneau titré | créneaux ICR `[12,18)` et `[18,24)`, moment « soir » `[16,22)` : un repas à **16 h 30** (créneau `[12,18)`) mappé par midpoint `19 h` → titrerait le **mauvais** créneau `[18,24)`. → bucketing à l'**heure réelle**. |
+| **Porte qualité** (exclu) | — | repas écarté | repas sans glucides enregistrés, ou pré-repas `2,20` g/L (le bolus incluait une correction) → la PPG ne reflète pas l'ICR → **exclu** de l'analyse. |
+
 ## 6. Chaîne complète (génération → application)
 
 1. **Génération** (`proposal-algorithm`, pur) → `ProposalCandidate` (déjà clampé ± 20 %, ≥ 3 événements, ≥ 2 %).
@@ -199,6 +241,17 @@ créneau** selon le slot analysé (ISF/ICR → `timeSlot*`/`carbRatio*` ; basal 
 **REJETTE** (`baselineMovedAtPersist`) au lieu de persister une magnitude hors-cap ou un sens inversé
 (le `baselineMoved` de l'accept ne couvre que persist→accept). En défense en profondeur, la cohérence
 `reason` ↔ signe du delta est asservie (`reasonDirectionMismatch`), et `supportingEvents > 0` exigé.
+
+**Exemples de rejet** :
+- *Dérive (`baselineMovedAtPersist`)* : candidat ISF calculé sur snapshot `0,50` → `proposedValue 0,60`
+  (`+20 %`). Entre l'analyse et la persistance, le médecin abaisse l'ISF live à `0,45`. `createEngineProposal`
+  re-dérive `0,45 ≠ 0,50` → **rejeté** (sinon on stockerait `+33 %`, hors cap). Le run suivant ré-analyse
+  sur `0,45`.
+- *Incohérence (`reasonDirectionMismatch`)* : candidat `reason = isfTooLow` (hausse attendue) mais
+  `proposedValue 0,45 < currentValue live 0,50` (baisse) → **rejeté** (l'explication affichée serait fausse
+  et l'application défairait le réglage du médecin).
+- *`supportingEvents = 0`* → **rejeté** (`invalidSupportingEvents`) : une proposition sans événement n'a
+  aucun sens.
 
 ## 7. Validation `medical-domain-validator` (US-2651) — verdicts
 

--- a/docs/clinical-logic/algorithme-propositions-ajustement.md
+++ b/docs/clinical-logic/algorithme-propositions-ajustement.md
@@ -30,7 +30,7 @@
 | **Fail-closed containment** | Variante du bucketing : ne rattacher un moment à un créneau **que s'il y tient entièrement**, sinon on **skip** (pas de mauvaise attribution). |
 | **Snapshot → persist** | Le candidat est calculé sur un **instantané** (snapshot) de la config ; s'il a **dérivé** avant l'enregistrement, on rejette (`baselineMovedAtPersist`). |
 | **Compare-and-swap** (`baselineMoved`) | Vérifier que la **valeur de base n'a pas changé** entre lecture et écriture avant d'appliquer ; sinon on annule. |
-| **Hypo sévère / légère** | Hypoglycémie **niveau 2** (< 0,54 g/L, urgence clinique) / **niveau 1** (0,54–0,70 g/L, à traiter mais moins critique). |
+| **Hypo sévère / légère** | Ici : hypoglycémie **niveau 2** (< 0,54 g/L / 54 mg/dL, cliniquement significative) / **niveau 1** (0,54–0,70 g/L, à traiter mais moins critique). *Précision* : l'ADA réserve le terme « **severe** » au **niveau 3** (atteinte cognitive nécessitant l'aide d'un tiers, sans seuil chiffré) ; le raccourci « < 54 = sévère » employé ici est la convention usuelle en CGM. |
 | **Bolus / basal** | **Bolus** = insuline ponctuelle (repas ou correction). **Basale** = insuline de fond, continue (débit U/h). |
 
 ### Abréviations & sigles
@@ -202,6 +202,10 @@ rapide tombe à ~3-4 h. Fournir à `hypoBlocksProposal` le **nadir** glycémique
 `[t0, min(prochain glucide, t0 + POSTMEAL_NADIR_WINDOW_MIN=300 min)]`, **pas** seulement la PPG 2 h
 (la *moyenne* qui pilote la direction reste sur la PPG 2 h). `JournalMeal` n'expose ni l'heure ni le
 nadir → **prérequis build** : augmenter l'assemblage (au niveau `DiabetesEvent`/`meal-trends`).
+⚠️ **Changement de signature** : `analyzeIcrSlot` prend aujourd'hui **un seul** tableau `postGlucoseGl`
+servant **à la fois** à la moyenne (direction) **et** à la garde hypo. Fournir le nadir exige un **champ
+distinct** (ex. `nadirGl` par repas) — sinon injecter le nadir dans `postGlucoseGl` **corromprait** la
+moyenne qui pilote la direction. À faire dans la même slice que l'assemblage.
 
 **Bucketing meal → créneau ICR (MEDIUM/HIGH)** — bucketer à l'**heure réelle** du repas
 (`findSlotForHour(carbRatios, heureLocale)`), **jamais** au midpoint du moment (une frontière de créneau
@@ -237,7 +241,7 @@ l'analyseur), anti-spam, frontière nonInsulin. Cooldown moteur au niveau géné
 | **Baisse ICR** (> plafond) | `2,00` g/L | ICR `10 → 8,9` (`icrTooHigh`) | analyseur avec cible = plafond `1,80` → `−11 %`. Plus d'insuline/gramme. |
 | **Hausse ICR** (< borne basse) | `0,85` g/L | ICR `10 → 11,5` (`icrTooLow`) | analyseur avec cible = borne basse `1,00` → `+15 %`. Moins d'insuline. |
 | **Zone morte** (bon contrôle) | `1,40` g/L | **aucune proposition** | entre `1,00` et `1,80` → rien (n'érode pas un bon contrôle). |
-| **Grossesse** (DT1 enceinte) | `1,55` g/L | ICR `10 → …` (baisse) | plafond **`1,40`** (pas 1,80) car `isPregnancy`. **Sans** cette règle, `1,55 < 1,80` aurait donné une **hausse** — dangereux. |
+| **Grossesse** (DT1 enceinte) | `1,55` g/L | ICR `10 → …` (baisse) | plafond **`1,40`** (pas 1,80) car `isPregnancy` → `1,55 > 1,40` → **baisse** (plus d'insuline), correct. **Sans** la règle, les bornes seraient `[1,00 ; 1,80]` → `1,55` tomberait dans la **zone morte → aucune proposition** : on **manquerait** le resserrement nécessaire chez la population la plus à risque (**sous-traitement silencieux**, pas un sur-dosage). |
 | **Nadir tardif** (garde hypo) | `1,90` g/L | candidat baisse **supprimé** | un repas a un nadir à 3 h 30 de `0,50` g/L (hypo sévère) → la baisse d'ICR (plus d'insuline) est refusée. Invisible si on ne regarde que la PPG 2 h (`1,70`). |
 | **Bucketing** (mal attribué) | — | mauvais créneau titré | créneaux ICR `[12,18)` et `[18,24)`, moment « soir » `[16,22)` : un repas à **16 h 30** (créneau `[12,18)`) mappé par midpoint `19 h` → titrerait le **mauvais** créneau `[18,24)`. → bucketing à l'**heure réelle**. |
 | **Porte qualité** (exclu) | — | repas écarté | repas sans glucides enregistrés, ou pré-repas `2,20` g/L (le bolus incluait une correction) → la PPG ne reflète pas l'ICR → **exclu** de l'analyse. |

--- a/docs/clinical-logic/algorithme-propositions-ajustement.md
+++ b/docs/clinical-logic/algorithme-propositions-ajustement.md
@@ -5,6 +5,8 @@
 > **Source de vérité = le code** (`src/lib/proposal-algorithm.ts`, `src/lib/clinical-bounds.ts`,
 > `src/lib/services/adjustment.service.ts`) ; ce document en est le catalogue fonctionnel.
 > **⚠️ US-2651 exige la validation `medical-domain-validator`** (voir §7 « Points à valider »).
+> **📊 Vue d'ensemble visuelle** : [`organigramme-propositions.html`](./organigramme-propositions.html)
+> (organigramme complet mode → analyseurs → gardes → persistance → validation médecin).
 
 ---
 

--- a/docs/clinical-logic/algorithme-propositions-ajustement.md
+++ b/docs/clinical-logic/algorithme-propositions-ajustement.md
@@ -84,6 +84,51 @@ Le mode est **dérivé serveur** (`resolveTreatmentMode`, fail-closed : un DT1 n
 | **(b) fixedDose** | **`analyzeFixedDose(slot, readings)` (livré, pur)** : dose **directe** par **moment** (carnet BGM). Au-dessus de la cible → dose trop basse → hausse (`fixedDoseTooLow`) ; en dessous → baisse (`fixedDoseTooHigh`). Bornée : **plus petit** de ± `FIXED_DOSE_MAX_CHANGE_PERCENT` (10 %) et ± `FIXED_DOSE_MAX_DELTA_U` (2 U) ; plancher `FIXED_DOSE_MIN` (0,5 U) ; arrondi à l'incrément délivrable (0,5 U) — pas nul → aucune proposition. **Cooldown 72 h/moment** (`FIXED_DOSE_COOLDOWN_HOURS`) au câblage du générateur (pas dans l'analyseur pur). **Jamais** : convertir doses fixes → basal-bolus, ni créer ISF/ICR ex nihilo. |
 | **(c) nonInsulin** | **Aucune proposition de dose** (frontière MDR). Uniquement des `ClinicalReviewFlag` d'orientation (« à revoir en consultation », HbA1c périmée, TIR sous cible, observance). La **cible** glycémique reste ajustable **par le médecin** (bornée, plus stricte en `pregnancyMode`). |
 
+## 5ter. Générateur ICR nocturne (mode a) — spec d'implémentation (validée medical, US-2651)
+
+> **Statut** : spec **validée** avant build (`proposalGeneratorService.generateForPatient`, chemin ICR).
+> Les analyseurs sont purs et prêts ; ce qui suit est le **contrat d'assemblage** des données qui les
+> nourrit, corrigé des 6 points relevés par `medical-domain-validator`. **Le générateur qui persiste
+> ne sera câblé qu'une fois ces contrats tenus** — sinon risque d'emballement hypo.
+
+**Source & fenêtre** — `mealtimePattern.dailyJournal(patientId, "14d", …, {source:"cgm"})`. CGM (pas BGM :
+un BGM n'a quasi jamais un relevé pile à +2 h). PPG 2 h en mg/dL → **÷ 100** en g/L. Filtrer `postMgdl null`.
+
+**Cible = post-prandiale, JAMAIS à jeun (CRITICAL)** — nourrir l'analyseur avec la cible à jeun (~1,0 g/L)
+proposerait des **baisses d'ICR systématiques** (plus d'insuline) chez des patients bien contrôlés →
+**emballement vers l'hypo**. Utiliser un **deadband asymétrique** :
+- PPG moyenne **> plafond** `getCgmDefaults(isPregnancy ? "GD" : pathologie).ok` (**1,80** adulte /
+  **1,40** GD-grossesse) → **baisse** d'ICR (plus d'insuline).
+- PPG moyenne **< borne basse** (`POSTPRANDIAL_TITRATION_LOW_GL` = **1,0** ; grossesse
+  `…_PREGNANCY_GL` = **0,9**) → **hausse** d'ICR (moins d'insuline).
+- **Entre les deux → aucune proposition** (bon contrôle préservé).
+
+**Grossesse (HIGH)** — `isPregnancy = patient.pregnancyMode === true || pathologie === "GD"`. Un DT1
+**enceinte** a `pathologie = DT1` → `getCgmDefaults("DT1")` renverrait 1,80 (trop lâche pour la
+population la plus à risque). Répliquer exactement la règle de `meal-trends`.
+
+**Nadir post-prandial tardif (HIGH)** — la garde hypo ne voit que le point +2 h ; le nadir d'un analogue
+rapide tombe à ~3-4 h. Fournir à `hypoBlocksProposal` le **nadir** glycémique sur
+`[t0, min(prochain glucide, t0 + POSTMEAL_NADIR_WINDOW_MIN=300 min)]`, **pas** seulement la PPG 2 h
+(la *moyenne* qui pilote la direction reste sur la PPG 2 h). `JournalMeal` n'expose ni l'heure ni le
+nadir → **prérequis build** : augmenter l'assemblage (au niveau `DiabetesEvent`/`meal-trends`).
+
+**Bucketing meal → créneau ICR (MEDIUM/HIGH)** — bucketer à l'**heure réelle** du repas
+(`findSlotForHour(carbRatios, heureLocale)`), **jamais** au midpoint du moment (une frontière de créneau
+peut tomber au milieu d'un moment → mauvaise attribution). Fallback si contraint au moment : **fail-closed
+containment** (bucketer seulement si le moment entier tient dans un seul créneau, sinon skip).
+
+**Portes qualité (MEDIUM/HIGH)** — exclure un repas si : glucides absents/0 (`carbs`), bolus absent
+(`bolus`), ou pré-repas hors bande cible (`preMgdl` — la PPG refléterait une correction, pas l'ICR).
+Les repas avec glucide intercurrent avant t0+90 sont déjà nullés en amont (`computeJournal`).
+
+**Minimum de preuve** — **≥ 3 repas/créneau** (aligné `analyzeIcrSlot` + `BGM_CARNET.MIN_READINGS_PER_MOMENT`),
+sinon fail-closed (aucune proposition).
+
+**Persistance** — chaque candidat → `createEngineProposal({ …, expectedCurrentValue: candidat.currentValue,
+carbRatioSlotStart, carbRatioSlotEnd })` : re-dérive `currentValue`, re-borne, garde hypo (déjà dans
+l'analyseur), anti-spam, frontière nonInsulin. Cooldown moteur au niveau générateur.
+
 ## 6. Chaîne complète (génération → application)
 
 1. **Génération** (`proposal-algorithm`, pur) → `ProposalCandidate` (déjà clampé ± 20 %, ≥ 3 événements, ≥ 2 %).

--- a/docs/clinical-logic/algorithme-propositions-ajustement.md
+++ b/docs/clinical-logic/algorithme-propositions-ajustement.md
@@ -8,6 +8,50 @@
 
 ---
 
+## 0. Glossaire (termes techniques & abréviations)
+
+> À lire d'abord — ce document emploie du vocabulaire clinique et technique. Aucun terme ci-dessous
+> n'est laissé sans définition dans le corps du document.
+
+### Termes techniques & cliniques
+
+| Terme | Définition |
+|---|---|
+| **Nadir** | Point le **plus bas** de la glycémie sur une fenêtre donnée (ici, le creux post-prandial ou nocturne). Une moyenne peut masquer un nadir dangereux → on le fournit explicitement à la garde hypo. |
+| **Bucketing** (repas → créneau) | Regroupement de chaque **repas dans le créneau horaire** (d'ICR) qui couvre son heure, afin d'analyser un ratio par créneau. « Bucket » = seau/panier. |
+| **Deadband** (zone morte) | Plage de glycémie autour de la cible où **aucune proposition** n'est émise (évite de titrer sur du bruit ou sur un patient déjà bien contrôlé). Ici **asymétrique** : bornes haute et basse distinctes. |
+| **Post-prandial** | **Après le repas** (par opposition à « à jeun »). La glycémie post-prandiale est physiologiquement plus haute qu'à jeun, même avec un dosage parfait. |
+| **Titration** | Ajustement **progressif et prudent** d'une dose, par petits pas, jusqu'à l'objectif (d'où les caps ± 20 % / ± 2 U). |
+| **Effet Somogyi** | **Hypo nocturne** suivie d'un **rebond hyperglycémique** au réveil. Piège : la glycémie à jeun est haute alors qu'il y a eu une hypo → augmenter la basale serait dangereux. |
+| **Dawn phenomenon** (phénomène de l'aube) | Montée **physiologique** de la glycémie en fin de nuit (sécrétion hormonale) qui peut élever la moyenne à jeun sans excès d'insuline manquant. |
+| **Fail-closed** | En cas de doute ou de donnée manquante, le système **refuse** (aucune proposition/aucune dose) plutôt que de risquer une valeur erronée. Sécurité par défaut. |
+| **Fail-closed containment** | Variante du bucketing : ne rattacher un moment à un créneau **que s'il y tient entièrement**, sinon on **skip** (pas de mauvaise attribution). |
+| **Snapshot → persist** | Le candidat est calculé sur un **instantané** (snapshot) de la config ; s'il a **dérivé** avant l'enregistrement, on rejette (`baselineMovedAtPersist`). |
+| **Compare-and-swap** (`baselineMoved`) | Vérifier que la **valeur de base n'a pas changé** entre lecture et écriture avant d'appliquer ; sinon on annule. |
+| **Hypo sévère / légère** | Hypoglycémie **niveau 2** (< 0,54 g/L, urgence clinique) / **niveau 1** (0,54–0,70 g/L, à traiter mais moins critique). |
+| **Bolus / basal** | **Bolus** = insuline ponctuelle (repas ou correction). **Basale** = insuline de fond, continue (débit U/h). |
+
+### Abréviations & sigles
+
+| Sigle | Développé | Sens |
+|---|---|---|
+| **ICR** | *Insulin-to-Carb Ratio* | Ratio insuline/glucides — grammes de glucides couverts par 1 unité d'insuline. |
+| **ISF** | *Insulin Sensitivity Factor* | Facteur de sensibilité — baisse de glycémie attendue pour 1 unité d'insuline. |
+| **PPG** | *PostPrandial Glucose* | Glycémie post-prandiale ; ici mesurée **à 2 h** (« PPG 2 h »). |
+| **CGM** | *Continuous Glucose Monitoring* | Mesure du glucose **en continu** (capteur interstitiel). |
+| **BGM** | *Blood Glucose Monitoring* | Glycémie **capillaire** (lecteur au bout du doigt). |
+| **TIR** | *Time In Range* | Temps passé dans la cible glycémique. |
+| **HbA1c** | Hémoglobine glyquée | Reflet de la glycémie moyenne des ~3 derniers mois. |
+| **MDR** | *Medical Device Regulation* | Règlement européen (UE) 2017/745 sur les dispositifs médicaux. |
+| **IEC 62304** | — | Norme du **cycle de vie du logiciel** de dispositif médical. |
+| **GD** | Diabète gestationnel | Diabète de la grossesse (cibles plus strictes). |
+| **DT1 / DT2** | Diabète de type 1 / type 2 | — |
+| **U** / **U/h** | Unité(s) d'insuline | Dose / débit (unités par heure pour la basale). |
+| **g/L** / **mg/dL** | — | Unités de glycémie. **1 g/L = 100 mg/dL**. |
+| **ADA** | *American Diabetes Association* | Source de plusieurs seuils (PPG < 180 mg/dL, etc.). |
+
+---
+
 ## 1. Principe & garde-fous fondamentaux
 
 - Une proposition est une **suggestion**, **JAMAIS** appliquée automatiquement (ADR #13). Format :

--- a/docs/clinical-logic/organigramme-propositions.html
+++ b/docs/clinical-logic/organigramme-propositions.html
@@ -1,0 +1,194 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Organigramme — Algorithme de propositions d'ajustement (Diabeo, US-2651)</title>
+<!--
+  Document technico-fonctionnel autonome (hors app React). Couleurs = palette Diabeo
+  « Sérénité Active » (miroir de src/design-system/tokens.ts) inlinées en variables CSS —
+  exception tolérée pour un fichier HTML de doc, au même titre que les templates email.
+  Source de vérité de l'algorithme : src/lib/proposal-algorithm.ts + adjustment.service.ts.
+  Spec : docs/clinical-logic/algorithme-propositions-ajustement.md
+-->
+<style>
+  :root {
+    --teal: #0D9488;        /* primaire — process/décision */
+    --teal-dark: #0f766e;
+    --coral: #F97316;       /* secondaire — flag/orientation */
+    --green: #10B981;       /* glycémie normale — succès/proposition */
+    --amber: #F59E0B;       /* glycémie haute — garde/avertissement */
+    --red: #EF4444;         /* glycémie critique — rejet/suppression */
+    --ink: #1F2937;
+    --muted: #6B7280;
+    --bg: #FAFAFA;
+    --bg2: #F3F4F6;
+    --border: #E5E7EB;
+    --card: #FFFFFF;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --ink: #F3F4F6; --muted: #9CA3AF; --bg: #111827; --bg2: #1F2937;
+      --border: #374151; --card: #1F2937;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 2rem 1rem 4rem;
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    background: var(--bg); color: var(--ink); line-height: 1.5;
+  }
+  .wrap { max-width: 980px; margin: 0 auto; }
+  h1 { font-size: 1.5rem; color: var(--teal); margin: 0 0 .25rem; }
+  .sub { color: var(--muted); margin: 0 0 1.5rem; font-size: .9rem; }
+  .legend {
+    display: flex; flex-wrap: wrap; gap: .75rem; margin: 0 0 2rem;
+    padding: 1rem; background: var(--bg2); border: 1px solid var(--border); border-radius: 12px;
+  }
+  .legend span { display: inline-flex; align-items: center; gap: .4rem; font-size: .82rem; }
+  .dot { width: 14px; height: 14px; border-radius: 4px; display: inline-block; }
+  .flow { display: flex; flex-direction: column; align-items: center; gap: 0; }
+  .node {
+    border-radius: 12px; padding: .7rem 1rem; text-align: center; max-width: 640px;
+    border: 2px solid var(--border); background: var(--card); box-shadow: 0 1px 3px rgba(0,0,0,.06);
+    font-size: .9rem;
+  }
+  .node b { display: block; }
+  .node small { color: var(--muted); font-size: .78rem; }
+  .node.start { border-color: var(--teal); background: color-mix(in srgb, var(--teal) 12%, var(--card)); }
+  .node.process { border-color: var(--teal); }
+  .node.decision { border-color: var(--amber); background: color-mix(in srgb, var(--amber) 12%, var(--card)); border-radius: 24px; }
+  .node.reject { border-color: var(--red); background: color-mix(in srgb, var(--red) 12%, var(--card)); color: var(--ink); }
+  .node.flag { border-color: var(--coral); background: color-mix(in srgb, var(--coral) 12%, var(--card)); }
+  .node.success { border-color: var(--green); background: color-mix(in srgb, var(--green) 14%, var(--card)); }
+  .node.doctor { border-color: var(--teal-dark); background: color-mix(in srgb, var(--teal) 8%, var(--card)); }
+  .arrow { width: 2px; height: 26px; background: var(--muted); position: relative; }
+  .arrow::after {
+    content: ""; position: absolute; bottom: 0; left: 50%; transform: translateX(-50%);
+    border-left: 5px solid transparent; border-right: 5px solid transparent; border-top: 7px solid var(--muted);
+  }
+  .arrow.short { height: 18px; }
+  .lbl { font-size: .72rem; color: var(--muted); background: var(--bg); padding: 0 .3rem; }
+  .branches { display: flex; flex-wrap: wrap; gap: 1rem; justify-content: center; align-items: flex-start; width: 100%; }
+  .col { display: flex; flex-direction: column; align-items: center; gap: 0; flex: 1 1 260px; min-width: 240px; }
+  .col > .node { width: 100%; }
+  .stage {
+    width: 100%; max-width: 720px; margin-top: 1.5rem; padding: 1rem 1rem .4rem;
+    border: 1px dashed var(--border); border-radius: 14px; background: color-mix(in srgb, var(--bg2) 60%, transparent);
+  }
+  .stage-title { font-size: .8rem; font-weight: 700; color: var(--teal); text-transform: uppercase; letter-spacing: .04em; margin: 0 0 .8rem; }
+  .stage .flow { gap: 0; }
+  .reject-row { display: flex; align-items: center; gap: .5rem; }
+  .reject-row .arrow-h { width: 30px; height: 2px; background: var(--red); position: relative; }
+  .reject-row .arrow-h::after { content:""; position:absolute; right:0; top:50%; transform:translateY(-50%); border-top:5px solid transparent; border-bottom:5px solid transparent; border-left:7px solid var(--red); }
+  .foot { margin-top: 2.5rem; font-size: .8rem; color: var(--muted); border-top: 1px solid var(--border); padding-top: 1rem; }
+  code { background: var(--bg2); padding: .05rem .3rem; border-radius: 4px; font-size: .82em; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Algorithme de propositions d'ajustement d'insulinothérapie</h1>
+  <p class="sub">Épic US-2645 / US-2651 · générateur nocturne · une proposition n'est <b>jamais</b> appliquée automatiquement (ADR&nbsp;#13). Source&nbsp;: <code>proposal-algorithm.ts</code> + <code>adjustment.service.ts</code>.</p>
+
+  <div class="legend">
+    <span><i class="dot" style="background:var(--teal)"></i> Processus / entrée</span>
+    <span><i class="dot" style="background:var(--amber)"></i> Décision (garde-fou)</span>
+    <span><i class="dot" style="background:var(--red)"></i> Rejet / suppression (fail-closed)</span>
+    <span><i class="dot" style="background:var(--coral)"></i> Flag d'orientation (pas de dose)</span>
+    <span><i class="dot" style="background:var(--green)"></i> Proposition créée (pending)</span>
+  </div>
+
+  <div class="flow">
+    <div class="node start"><b>Patient éligible</b><small>cron nocturne · portefeuille actif (deletedAt null)</small></div>
+    <div class="arrow"></div>
+    <div class="node decision"><b>resolveTreatmentMode()</b><small>dérivé serveur · fail-closed (un DT1 n'est jamais nonInsulin)</small></div>
+    <div class="arrow"><span class="lbl">selon le mode</span></div>
+
+    <div class="branches">
+      <!-- Mode c -->
+      <div class="col">
+        <div class="node flag"><b>(c) nonInsulin</b><small>frontière MDR / IEC&nbsp;62304</small></div>
+        <div class="arrow short"></div>
+        <div class="node reject"><b>Aucune proposition de dose</b></div>
+        <div class="arrow short"></div>
+        <div class="node flag"><b>ClinicalReviewFlag</b><small>« à revoir en consultation » · HbA1c périmée · TIR sous cible</small></div>
+      </div>
+
+      <!-- Mode b -->
+      <div class="col">
+        <div class="node process"><b>(b) fixedDose</b><small>doses simples · carnet BGM</small></div>
+        <div class="arrow short"></div>
+        <div class="node process"><b>analyzeFixedDose(moment)</b><small>dose directe par moment · cap min(10&nbsp;%, 2&nbsp;U) · plancher 0,5&nbsp;U</small></div>
+      </div>
+
+      <!-- Mode a -->
+      <div class="col">
+        <div class="node process"><b>(a) basalBolus</b><small>basal/bolus complet</small></div>
+        <div class="arrow short"></div>
+        <div class="node process"><b>analyzeIsfSlot · analyzeIcrSlot · analyzeBasalTrend</b><small>par créneau horaire · ICR : deadband post-prandial (§5ter)<br>basal : pompe uniquement (stylo/MDI non géré)</small></div>
+      </div>
+    </div>
+
+    <!-- Étape analyseur (commune a/b) -->
+    <div class="stage">
+      <p class="stage-title">Analyseur (pur) — garde-fous du candidat</p>
+      <div class="flow">
+        <div class="node decision"><b>≥ 3 événements ?</b></div>
+        <div class="reject-row"><span class="lbl">non</span><span class="arrow-h"></span><div class="node reject">null (bruit)</div></div>
+        <div class="arrow short"><span class="lbl">oui</span></div>
+        <div class="node decision"><b>|variation| ≥ 2 % ?</b></div>
+        <div class="reject-row"><span class="lbl">non</span><span class="arrow-h"></span><div class="node reject">null (non actionnable)</div></div>
+        <div class="arrow short"><span class="lbl">oui</span></div>
+        <div class="node process"><b>clamp ± 20 %</b> <small>(MAX_CHANGE_PERCENT)</small></div>
+        <div class="arrow short"></div>
+        <div class="node decision"><b>Garde HYPO</b><small>direction « plus d'insuline » ET hypo sévère (&lt;0,54) ou niveau-1 récurrente (&lt;0,70 ×≥2) ?</small></div>
+        <div class="reject-row"><span class="lbl">oui</span><span class="arrow-h"></span><div class="node reject">supprimé</div></div>
+        <div class="arrow short"><span class="lbl">non</span></div>
+        <div class="node success"><b>ProposalCandidate</b></div>
+      </div>
+    </div>
+
+    <div class="arrow"></div>
+
+    <!-- Étape persistance -->
+    <div class="stage">
+      <p class="stage-title">createEngineProposal — persistance moteur (re-validation serveur)</p>
+      <div class="flow">
+        <div class="node decision"><b>Frontière nonInsulin ?</b></div>
+        <div class="reject-row"><span class="lbl">oui</span><span class="arrow-h"></span><div class="node reject">throw nonInsulinNoDose</div></div>
+        <div class="arrow short"><span class="lbl">non</span></div>
+        <div class="node decision"><b>Bornes dures + supportingEvents &gt; 0 ?</b><small>validateProposedValue</small></div>
+        <div class="reject-row"><span class="lbl">hors bornes</span><span class="arrow-h"></span><div class="node reject">valueOutOfBounds</div></div>
+        <div class="arrow short"><span class="lbl">ok</span></div>
+        <div class="node process"><b>currentValue re-dérivé serveur</b><small>jamais celui du candidat · changePercent recalculé</small></div>
+        <div class="arrow short"></div>
+        <div class="node decision"><b>Config a dérivé depuis l'analyse ?</b><small>|live − expectedCurrentValue| &gt; 0</small></div>
+        <div class="reject-row"><span class="lbl">oui</span><span class="arrow-h"></span><div class="node reject">baselineMovedAtPersist</div></div>
+        <div class="arrow short"><span class="lbl">non</span></div>
+        <div class="node decision"><b>reason ↔ signe du delta cohérents ?</b></div>
+        <div class="reject-row"><span class="lbl">non</span><span class="arrow-h"></span><div class="node reject">reasonDirectionMismatch</div></div>
+        <div class="arrow short"><span class="lbl">oui</span></div>
+        <div class="node decision"><b>Déjà une proposition pending ?</b><small>index one_pending_per_slot</small></div>
+        <div class="reject-row"><span class="lbl">oui</span><span class="arrow-h"></span><div class="node reject">duplicatePendingProposal</div></div>
+        <div class="arrow short"><span class="lbl">non</span></div>
+        <div class="node success"><b>INSERT</b><small>source = algorithm · proposedByUserId = null · status = pending</small></div>
+      </div>
+    </div>
+
+    <div class="arrow"><span class="lbl">best-effort</span></div>
+    <div class="node process"><b>Notification du médecin référent</b></div>
+    <div class="arrow"></div>
+    <div class="node doctor"><b>Validation DOCTOR</b><small>accept / reject · compare-and-swap (baselineMoved) si la base a bougé</small></div>
+    <div class="arrow"><span class="lbl">accept</span></div>
+    <div class="node success"><b>Application scopée patient</b></div>
+  </div>
+
+  <p class="foot">
+    Fail-closed partout : au moindre doute (données manquantes, base dérivée, hors bornes, doublon), on
+    <b>refuse</b> plutôt que de risquer une dose erronée. Limites connues explicites : basale stylo/MDI et
+    régime hybride pompe+stylo (voir la spec). Détails, formules et exemples chiffrés&nbsp;:
+    <code>algorithme-propositions-ajustement.md</code>.
+  </p>
+</div>
+</body>
+</html>

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -243,3 +243,12 @@ fois l'emballement et l'érosion du bon contrôle.
 > proposition basale (leurs ISF/ICR restent proposés). Combler ce trou (paramètre `basalDose` dédié +
 > variante d'analyseur en U/jour + bornes stylo + ciblage de persistance) = **slice dédiée du build**.
 > Détail : `algorithme-propositions-ajustement.md` §4.3.
+
+> **Limite connue — régime hybride pompe + compléments bolus stylo** (validé avec l'utilisateur, US-2651).
+> `InsulinDeliveryMethod` (pump/manual) est un flag patient unique (`InsulinTherapySettings`) : pas de
+> modèle hybride. Le journal repas lit `DiabetesEvent.bolusDose` sans méthode de délivrance → un
+> complément stylo n'est pas distinguable (et vu seulement s'il est loggué). Effet = **sous-détection
+> fail-safe** : un complément stylo qui corrige la PPG masque une déficience du ratio pompe (ICR),
+> et une correction stylo hors calculateur échappe à l'analyse ISF (`BolusCalculationLog`). Risque de
+> sur-proposition faible (≥3 repas + moyenne + garde hypo). À gérer via une méthode de délivrance
+> **par bolus** (pas par patient). Détail : `algorithme-propositions-ajustement.md` §5ter.

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -219,3 +219,19 @@ d'insuline) reste permis. Ferme le prérequis avant câblage du générateur mod
 - **Contrat basal (Somogyi)** : `analyzeBasalTrend` ne capte l'hypo nocturne masquée que si
   `fastingValues` inclut le **nadir CGM nocturne** (pas seulement le pré-petit-déj) — précondition
   JSDoc à respecter par le générateur au câblage.
+
+### Générateur ICR nocturne — deadband post-prandial & nadir (US-2651, validé medical)
+
+Constantes d'assemblage du **générateur ICR** (spec : `docs/clinical-logic/algorithme-propositions-ajustement.md` §5ter) :
+
+| Constante | Valeur | Sens clinique |
+|---|---|---|
+| plafond post-prandial (réutilisé) | `getCgmDefaults(pathologie/grossesse).ok` = **1,80** g/L adulte / **1,40** GD-grossesse | PPG 2 h moyenne au-dessus → **baisse** d'ICR (plus d'insuline). |
+| `POSTPRANDIAL_TITRATION_LOW_GL` | **1,0** g/L | PPG 2 h moyenne en dessous → **hausse** d'ICR (moins d'insuline). Entre les deux → aucune proposition. |
+| `POSTPRANDIAL_TITRATION_LOW_PREGNANCY_GL` | **0,9** g/L | Borne basse resserrée en grossesse (`pregnancyMode` ou GD). |
+| `POSTMEAL_NADIR_WINDOW_MIN` | **300** min | Fenêtre de recherche du **nadir** post-prandial fourni à la garde hypo (le nadir d'un analogue rapide tombe après le point PPG 2 h). |
+
+**Pourquoi PAS la cible à jeun** : une PPG 2 h est physiologiquement au-dessus de la glycémie à jeun ;
+prendre la cible à jeun (~1,0 g/L) comme référence proposerait des baisses d'ICR systématiques (plus
+d'insuline) chez des patients bien contrôlés → **emballement hypo**. Le deadband asymétrique évite à la
+fois l'emballement et l'érosion du bon contrôle.

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -235,3 +235,11 @@ Constantes d'assemblage du **générateur ICR** (spec : `docs/clinical-logic/alg
 prendre la cible à jeun (~1,0 g/L) comme référence proposerait des baisses d'ICR systématiques (plus
 d'insuline) chez des patients bien contrôlés → **emballement hypo**. Le deadband asymétrique évite à la
 fois l'emballement et l'érosion du bon contrôle.
+
+> **Limite connue — basale STYLO/MDI non gérée par le générateur** (validé avec l'utilisateur, US-2651).
+> La titration basale automatique ne couvre que `BasalConfigType = pump` (débit U/h → `pumpBasalSlotId`,
+> `AdjustableParameter = basalRate`). Les patients en `single_injection` (dose journalière, type Lantus)
+> ou `split_injection` (matin/soir, type Levemir) — basale en **U**, pas U/h — ne reçoivent **aucune**
+> proposition basale (leurs ISF/ICR restent proposés). Combler ce trou (paramètre `basalDose` dédié +
+> variante d'analyseur en U/jour + bornes stylo + ciblage de persistance) = **slice dédiée du build**.
+> Détail : `algorithme-propositions-ajustement.md` §4.3.

--- a/src/lib/clinical-bounds.ts
+++ b/src/lib/clinical-bounds.ts
@@ -104,6 +104,23 @@ export const CLINICAL_BOUNDS = {
    * Seuils : `GLYCEMIA_THRESHOLDS_MGDL.SEVERE_HYPO` (54) / `.TARGET_LOW` (70).
    */
   HYPO_LEVEL1_RECURRENCE_MIN: 2,
+  /**
+   * US-2651 — générateur ICR (mode a), **deadband post-prandial asymétrique** (validé medical).
+   * L'analyse ICR compare la PPG 2 h moyenne à des bornes post-prandiales, PAS à la cible à jeun
+   * (sinon emballement hypo : une PPG est physiologiquement > à jeun). Borne HAUTE (plafond, déclenche
+   * une BAISSE d'ICR = plus d'insuline) = `getCgmDefaults(pathologie/grossesse).ok` (1,80 adulte /
+   * 1,40 GD-grossesse) — réutilisée, pas de constante ici. Bornes BASSES (déclenchent une HAUSSE d'ICR
+   * = moins d'insuline) ci-dessous ; entre les deux → aucune proposition (bon contrôle préservé).
+   */
+  POSTPRANDIAL_TITRATION_LOW_GL: 1.0,
+  POSTPRANDIAL_TITRATION_LOW_PREGNANCY_GL: 0.9,
+  /**
+   * US-2651 — fenêtre (minutes depuis le repas) sur laquelle chercher le **nadir** glycémique
+   * post-prandial à fournir à la garde hypo (le pic d'action d'un analogue rapide tombe à ~3-4 h,
+   * après le point PPG 2 h). Bornée en amont par le prochain apport glucidique. Sans ce nadir, une
+   * hypo tardive resterait invisible et le générateur pourrait baisser l'ICR à tort (hypo profonde).
+   */
+  POSTMEAL_NADIR_WINDOW_MIN: 300,
 } as const
 
 export type ClinicalBounds = typeof CLINICAL_BOUNDS

--- a/tests/unit/clinical-bounds.test.ts
+++ b/tests/unit/clinical-bounds.test.ts
@@ -63,6 +63,9 @@ describe("CLINICAL_BOUNDS — anti-drift (A3)", () => {
       PATIENT_MAX_CHANGE_PERCENT: 10,
       PATIENT_PROPOSAL_COOLDOWN_HOURS: 24,
       HYPO_LEVEL1_RECURRENCE_MIN: 2,
+      POSTPRANDIAL_TITRATION_LOW_GL: 1.0,
+      POSTPRANDIAL_TITRATION_LOW_PREGNANCY_GL: 0.9,
+      POSTMEAL_NADIR_WINDOW_MIN: 300,
     })
   })
 
@@ -82,6 +85,15 @@ describe("CLINICAL_BOUNDS — anti-drift (A3)", () => {
     expect(CLINICAL_BOUNDS.FIXED_BOLUS_WARN_U).toBeLessThan(CLINICAL_BOUNDS.FIXED_BASAL_WARN_U)
     // cap de variation patient strictement plus strict que le cap moteur
     expect(CLINICAL_BOUNDS.FIXED_DOSE_PATIENT_MAX_DELTA_U).toBeLessThan(CLINICAL_BOUNDS.FIXED_DOSE_MAX_DELTA_U)
+  })
+
+  it("US-2651 — deadband ICR : borne basse < plafond adulte (1,80), grossesse plus stricte", () => {
+    // borne basse post-prandiale strictement sous le plafond adulte → deadband non vide
+    expect(CLINICAL_BOUNDS.POSTPRANDIAL_TITRATION_LOW_GL).toBeLessThan(1.8)
+    // grossesse plus stricte que l'adulte (borne basse resserrée)
+    expect(CLINICAL_BOUNDS.POSTPRANDIAL_TITRATION_LOW_PREGNANCY_GL)
+      .toBeLessThan(CLINICAL_BOUNDS.POSTPRANDIAL_TITRATION_LOW_GL)
+    expect(CLINICAL_BOUNDS.POSTMEAL_NADIR_WINDOW_MIN).toBeGreaterThan(120) // > le point PPG 2 h
   })
 })
 


### PR DESCRIPTION
Étape **(a)** du plan « a puis b » : **valider le design de l'assemblage ICR AVANT de coder** (validate-first). La validation medical a évité un générateur **dangereux** — les 6 corrections sont capturées en spec + un socle de constantes.

## Pourquoi cette PR (et pas directement le build)
Le medical a relevé, sur le **design** :
| Sévérité | Finding | Correction (spec) |
|---|---|---|
| **CRITICAL** | Cible à jeun → **baisses d'ICR systématiques → emballement hypo** | Deadband **post-prandial** asymétrique (plafond `getCgmDefaults(...).ok` 1,80/1,40 → baisse ; borne basse 1,0 / grossesse 0,9 → hausse ; entre → rien). |
| **HIGH** | Grossesse : un DT1 enceinte aurait 1,80 (trop lâche) | `isPregnancy = pregnancyMode || pathology==="GD"`. |
| **HIGH** | Nadir tardif (3-4 h) invisible à la garde hypo | Nadir sur `[t0, min(prochain glucide, +300 min)]` (`POSTMEAL_NADIR_WINDOW_MIN`). |
| MEDIUM/HIGH | Bucketing midpoint mal attribué · portes qualité manquantes | Bucketing à l'**heure réelle** ; exclure glucides/bolus absents / pré-repas hors bande ; ≥3 repas/créneau. |

## Contenu
- `CLINICAL_BOUNDS` += `POSTPRANDIAL_TITRATION_LOW_GL` (1,0) / `…_PREGNANCY_GL` (0,9) / `POSTMEAL_NADIR_WINDOW_MIN` (300) — **anti-drift** `toEqual` + invariants.
- **Spec d'implémentation** : `algorithme-propositions-ajustement.md` **§5ter** (contrat d'assemblage complet, corrigé des 6 findings).
- **Catalogue** : constantes + rationale « pas la cible à jeun ».

## Prérequis build (b) — notés
`JournalMeal` n'expose **ni l'heure réelle ni le nadir** → il faudra augmenter l'assemblage (niveau `DiabetesEvent`/`meal-trends`) **avant** de câbler la persistance. C'est ce qui rend (b) délicat et justifie (a) d'abord.

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3709 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)