### PR TITLE
US-2651 (build b, slice 1a) — analyzeIcrSlot : signature nadir (creux ≠ moyenne)

### DIFF
--- a/docs/clinical-logic/algorithme-propositions-ajustement.md
+++ b/docs/clinical-logic/algorithme-propositions-ajustement.md
@@ -200,12 +200,11 @@ population la plus à risque). Répliquer exactement la règle de `meal-trends`.
 **Nadir post-prandial tardif (HIGH)** — la garde hypo ne voit que le point +2 h ; le nadir d'un analogue
 rapide tombe à ~3-4 h. Fournir à `hypoBlocksProposal` le **nadir** glycémique sur
 `[t0, min(prochain glucide, t0 + POSTMEAL_NADIR_WINDOW_MIN=300 min)]`, **pas** seulement la PPG 2 h
-(la *moyenne* qui pilote la direction reste sur la PPG 2 h). `JournalMeal` n'expose ni l'heure ni le
-nadir → **prérequis build** : augmenter l'assemblage (au niveau `DiabetesEvent`/`meal-trends`).
-⚠️ **Changement de signature** : `analyzeIcrSlot` prend aujourd'hui **un seul** tableau `postGlucoseGl`
-servant **à la fois** à la moyenne (direction) **et** à la garde hypo. Fournir le nadir exige un **champ
-distinct** (ex. `nadirGl` par repas) — sinon injecter le nadir dans `postGlucoseGl` **corromprait** la
-moyenne qui pilote la direction. À faire dans la même slice que l'assemblage.
+(la *moyenne* qui pilote la direction reste sur la PPG 2 h). ✅ **Signature en place** : `analyzeIcrSlot`
+accepte désormais un champ **`nadirGl` optionnel** par repas, fourni **uniquement** à la garde hypo
+(repli sur `postGlucoseGl` si absent) — la moyenne/direction reste sur `postGlucoseGl`. **Reste (prérequis
+assemblage)** : `JournalMeal` n'expose ni l'heure réelle ni le nadir → augmenter `meal-trends`/`DiabetesEvent`
+pour **peupler** `nadirGl` (creux CGM sur `[t0, min(prochain glucide, t0+300 min)]`) et l'heure locale.
 
 **Bucketing meal → créneau ICR (MEDIUM/HIGH)** — bucketer à l'**heure réelle** du repas
 (`findSlotForHour(carbRatios, heureLocale)`), **jamais** au midpoint du moment (une frontière de créneau

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -252,3 +252,12 @@ fois l'emballement et l'érosion du bon contrôle.
 > et une correction stylo hors calculateur échappe à l'analyse ISF (`BolusCalculationLog`). Risque de
 > sur-proposition faible (≥3 repas + moyenne + garde hypo). À gérer via une méthode de délivrance
 > **par bolus** (pas par patient). Détail : `algorithme-propositions-ajustement.md` §5ter.
+
+> **Suivis build générateur (US-2651, tracés depuis les revues #669)** :
+> - **Nadir ISF** — `analyzeIsfSlot` a le même angle mort que l'ICR (une correction rapide fait son
+>   creux à ~3-4 h, après la glycémie post-correction ponctuelle). Contrat JSDoc ajouté ; le **champ
+>   `nadirGl`** par correction (symétrique de `analyzeIcrSlot`) reste à câbler dans la **slice ISF**.
+> - **Assainissement des zéros CGM** — un `0`/artefact sous le plancher capteur (`CRITICAL_LOW` 0,40 g/L)
+>   dans `nadirGl` supprimerait une proposition légitime (fail-safe mais érosion qualité). La **slice
+>   assemblage** (qui peuplera `nadirGl`) doit **filtrer** les valeurs non physiologiques AVANT
+>   `analyzeIcrSlot` — pas dans l'analyseur (qui traite `0` comme une hypo réelle, à raison).

--- a/src/lib/proposal-algorithm.ts
+++ b/src/lib/proposal-algorithm.ts
@@ -110,8 +110,15 @@ export function computeProposedValue(currentValue: number, changePercent: number
  * Analyze ISF (insulin sensitivity factor) effectiveness for a time slot.
  * Detects systematic over/under-correction from post-correction glucose patterns.
  * Only proposes if 3+ events AND change is meaningful (> 2%).
- * @param {Object} slot - ISF slot configuration (startHour, endHour, sensitivityFactorGl)
- * @param {Array<{postGlucoseGl: number, targetGl: number}>} corrections - Post-correction readings and targets
+ *
+ * ⚠️ **Contrat nadir à câbler (US-2651, suivi medical)** : comme l'ICR, une correction d'analogue
+ * rapide fait son creux à ~3-4 h, APRÈS la glycémie post-correction ponctuelle utilisée ici. La garde
+ * hypo ne voit donc pas un creux tardif → angle mort. Quand l'ISF sera relié au générateur, ajouter un
+ * champ `nadirGl` par correction (symétrique de `analyzeIcrSlot`), fourni UNIQUEMENT à la garde hypo,
+ * la moyenne/direction restant sur `postGlucoseGl`. En attendant, l'ISF n'est câblé à aucun générateur.
+ *
+ * @param slot - ISF slot configuration (startHour, endHour, sensitivityFactorGl)
+ * @param corrections - Post-correction readings and targets (postGlucoseGl, targetGl)
  * @returns {ProposalCandidate | null} Proposal if detected, null otherwise
  */
 export function analyzeIsfSlot(

--- a/src/lib/proposal-algorithm.ts
+++ b/src/lib/proposal-algorithm.ts
@@ -163,13 +163,18 @@ export function analyzeIsfSlot(
  * Analyze ICR (insulin-to-carb ratio) effectiveness for a time slot.
  * Detects systematic post-meal glucose over/under-coverage from carb ratio.
  * Only proposes if 3+ meals AND change is meaningful (> 2%).
- * @param {Object} slot - ICR slot configuration (startHour, endHour, gramsPerUnit)
- * @param {Array<{postGlucoseGl: number, targetGl: number}>} meals - Post-meal readings and targets
+ * Contrat nadir (US-2651, validé medical) : chaque repas porte `postGlucoseGl` (PPG 2 h, g/L) qui
+ * pilote la MOYENNE et la direction, et un `nadirGl` OPTIONNEL (creux post-prandial ~3-4 h) fourni
+ * UNIQUEMENT à la garde hypo (repli sur `postGlucoseGl` si absent). Ne jamais injecter le nadir dans
+ * `postGlucoseGl` : cela corromprait la moyenne. Voir spec section 5ter.
+ *
+ * @param slot - ICR slot configuration (startHour, endHour, gramsPerUnit)
+ * @param meals - Un élément par repas : postGlucoseGl (PPG 2 h), targetGl, et nadirGl optionnel.
  * @returns {ProposalCandidate | null} Proposal if detected, null otherwise
  */
 export function analyzeIcrSlot(
   slot: { startHour: number; endHour: number; gramsPerUnit: number },
-  meals: { postGlucoseGl: number; targetGl: number }[],
+  meals: { postGlucoseGl: number; targetGl: number; nadirGl?: number }[],
 ): ProposalCandidate | null {
   if (meals.length < 3) return null
 
@@ -190,9 +195,13 @@ export function analyzeIcrSlot(
   // EN DESSOUS → ICR trop BAS → HAUSSE (icrTooLow). (Correction validée medical US-2651 : les
   // libellés étaient inversés — la DIRECTION était correcte, seul le `reason` affiché était faux.)
   const proposedValue = computeProposedValue(slot.gramsPerUnit, clampedChange)
-  // Garde HYPO : baisser l'ICR = plus d'insuline/gramme → supprimé si un post-repas de la fenêtre
-  // est en hypo sévère (un bolus repas a sur-shooté).
-  if (hypoBlocksProposal("insulinToCarbRatio", slot.gramsPerUnit, proposedValue, meals.map((m) => m.postGlucoseGl))) {
+  // Garde HYPO : baisser l'ICR = plus d'insuline/gramme → supprimé si un creux de la fenêtre est en
+  // hypo (un bolus repas a sur-shooté). ⚠️ La garde regarde le **nadir** post-prandial (`nadirGl`,
+  // creux à ~3-4 h) quand il est fourni — le pic d'action d'un analogue rapide tombe APRÈS la PPG 2 h,
+  // et une moyenne à 2 h peut masquer une hypo tardive (US-2651, validé medical). Repli sur la PPG 2 h
+  // (`postGlucoseGl`) si le nadir n'est pas disponible. La MOYENNE qui pilote la direction reste, elle,
+  // toujours sur `postGlucoseGl` (ci-dessus) — ne JAMAIS injecter le nadir dans `avgPost`.
+  if (hypoBlocksProposal("insulinToCarbRatio", slot.gramsPerUnit, proposedValue, meals.map((m) => m.nadirGl ?? m.postGlucoseGl))) {
     return null
   }
 

--- a/tests/unit/proposal-algorithm.test.ts
+++ b/tests/unit/proposal-algorithm.test.ts
@@ -186,6 +186,34 @@ describe("proposal-algorithm", () => {
       const r = analyzeIcrSlot(slot, meals) // moyenne basse → icrTooLow (hausse ICR)
       expect(r!.reason).toBe("icrTooLow")
     })
+
+    it("garde HYPO : le NADIR supprime une baisse que la PPG 2 h seule laisserait passer (US-2651)", () => {
+      const meals = [
+        ...Array.from({ length: 5 }, () => ({ postGlucoseGl: 1.80, targetGl: 1.40 })),
+        { postGlucoseGl: 1.70, targetGl: 1.40, nadirGl: 0.50 }, // PPG 2 h saine, mais nadir 3-4 h en hypo sévère
+      ]
+      // avgPost ≈ 1,78 > cible → baisse (icrTooHigh) ; le nadir 0,50 déclenche la garde → supprimé.
+      expect(analyzeIcrSlot(slot, meals)).toBeNull()
+    })
+
+    it("garde HYPO : SANS nadir, la même fenêtre (PPG 2 h saines) n'est PAS supprimée (contrôle)", () => {
+      const meals = [
+        ...Array.from({ length: 5 }, () => ({ postGlucoseGl: 1.80, targetGl: 1.40 })),
+        { postGlucoseGl: 1.70, targetGl: 1.40 }, // pas de nadir → repli sur PPG 2 h (1,70, saine)
+      ]
+      expect(analyzeIcrSlot(slot, meals)!.reason).toBe("icrTooHigh")
+    })
+
+    it("le nadir ne corrompt PAS la moyenne/direction (% identique avec et sans nadir)", () => {
+      const base = Array.from({ length: 5 }, () => ({ postGlucoseGl: 0.80, targetGl: 1.40 }))
+      const withNadir = base.map((m) => ({ ...m, nadirGl: 0.60 }))
+      const r1 = analyzeIcrSlot(slot, base)
+      const r2 = analyzeIcrSlot(slot, withNadir)
+      // sens sûr (hausse icrTooLow) dans les deux cas ; le nadir n'affecte ni la direction ni le %.
+      expect(r1!.reason).toBe("icrTooLow")
+      expect(r2!.reason).toBe("icrTooLow")
+      expect(r2!.changePercent).toBe(r1!.changePercent)
+    })
   })
 
   describe("analyzeBasalTrend", () => {


### PR DESCRIPTION
Première brique du **build (b)**, issue de la **note LOW de la revue medical de #668**. Le contrat nadir exigeait un **changement de signature** : la garde hypo doit voir le **creux post-prandial** (~3-4 h, après le point PPG 2 h) **sans corrompre la moyenne** qui pilote la direction.

## Contenu
- **`analyzeIcrSlot`** : `meals` accepte un champ **`nadirGl` optionnel** par repas. La garde hypo utilise `(nadirGl ?? postGlucoseGl)` ; la **moyenne/direction reste sur `postGlucoseGl`**. Ne jamais injecter le nadir dans `postGlucoseGl` (corromprait `avgPost`).
- **Tests +3** : (1) le nadir **supprime** une baisse que la PPG 2 h seule laisserait passer ; (2) **contrôle** sans nadir → non supprimé ; (3) le nadir **ne change ni la direction ni le %** (moyenne intacte).
- **Doc §5ter** : signature « en place » ; reste l'**assemblage** (peupler `nadirGl` + heure réelle).
- **Fix JSDoc** : type inline retiré du `@param` (tsc parse les types JSDoc ; `nadirGl?: number` y est invalide) — la signature TS porte le type.

## Suite
Assemblage `meal-trends`/`DiabetesEvent` (heure locale + nadir CGM sur `[t0, min(prochain glucide, +300 min)]`), puis vertical **cron + ICR**.

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3712 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)