### PR TITLE
US-2651 (build b, slice 1b) — Assemblage meal-trends : heure locale + nadir post-prandial

### DIFF
--- a/docs/clinical-logic/algorithme-propositions-ajustement.md
+++ b/docs/clinical-logic/algorithme-propositions-ajustement.md
@@ -208,6 +208,16 @@ accepte un champ **`nadirGl` optionnel** par repas, fourni **uniquement** à la 
 bornés à ≥ 0,20 g/L par `loadContext`, **aucun zéro-artefact** n'atteint l'analyseur (suivi LOW #669 clos).
 **Reste (slice 2)** : le générateur consomme `localHour` (→ `findSlotForHour`) et `nadirMgdl/100` (→ `nadirGl`).
 
+> **⚠️ Caveat clinique — troncature par resucrage (MEDIUM, validé medical).** La fenêtre nadir se termine
+> au **prochain apport glucidique** (anti mis-attribution : la glycémie post-collation ne doit pas être
+> imputée au bolus de ce repas). Mais si le patient **resucre** une hypo naissante (ex. glucide à t0+100),
+> le **vrai creux** (~t0+120) tombe **après** et est **exclu** → la garde hypo peut sous-protéger (elle
+> autorise alors une baisse d'ICR = plus d'insuline, la direction dangereuse). **Atténuation** : en CGM
+> 5 min, les relevés **pré-resucrage** (déjà sur la pente descendante) restent captés → la garde voit
+> souvent une valeur proche/sous le seuil, juste pas le point le plus bas (d'où MEDIUM, pas HIGH).
+> **Suivi tracé** : traiter un glucide **inférable comme resucrage** (petit glucide, sans bolus, glycémie
+> précédente basse) comme un **signal d'hypo** plutôt qu'une simple borne de troncature.
+
 **Bucketing meal → créneau ICR (MEDIUM/HIGH)** — bucketer à l'**heure réelle** du repas
 (`findSlotForHour(carbRatios, heureLocale)`), **jamais** au midpoint du moment (une frontière de créneau
 peut tomber au milieu d'un moment → mauvaise attribution). Fallback si contraint au moment : **fail-closed

--- a/docs/clinical-logic/algorithme-propositions-ajustement.md
+++ b/docs/clinical-logic/algorithme-propositions-ajustement.md
@@ -201,10 +201,12 @@ population la plus à risque). Répliquer exactement la règle de `meal-trends`.
 rapide tombe à ~3-4 h. Fournir à `hypoBlocksProposal` le **nadir** glycémique sur
 `[t0, min(prochain glucide, t0 + POSTMEAL_NADIR_WINDOW_MIN=300 min)]`, **pas** seulement la PPG 2 h
 (la *moyenne* qui pilote la direction reste sur la PPG 2 h). ✅ **Signature en place** : `analyzeIcrSlot`
-accepte désormais un champ **`nadirGl` optionnel** par repas, fourni **uniquement** à la garde hypo
-(repli sur `postGlucoseGl` si absent) — la moyenne/direction reste sur `postGlucoseGl`. **Reste (prérequis
-assemblage)** : `JournalMeal` n'expose ni l'heure réelle ni le nadir → augmenter `meal-trends`/`DiabetesEvent`
-pour **peupler** `nadirGl` (creux CGM sur `[t0, min(prochain glucide, t0+300 min)]`) et l'heure locale.
+accepte un champ **`nadirGl` optionnel** par repas, fourni **uniquement** à la garde hypo (repli sur
+`postGlucoseGl` si absent) — la moyenne/direction reste sur `postGlucoseGl`. ✅ **Assemblage en place** :
+`JournalMeal` expose désormais **`localHour`** (heure locale réelle, pour le bucketing) et **`nadirMgdl`**
+= creux CGM sur `[t0, min(prochain glucide, t0+`POSTMEAL_NADIR_WINDOW_MIN`)]`. Les relevés étant déjà
+bornés à ≥ 0,20 g/L par `loadContext`, **aucun zéro-artefact** n'atteint l'analyseur (suivi LOW #669 clos).
+**Reste (slice 2)** : le générateur consomme `localHour` (→ `findSlotForHour`) et `nadirMgdl/100` (→ `nadirGl`).
 
 **Bucketing meal → créneau ICR (MEDIUM/HIGH)** — bucketer à l'**heure réelle** du repas
 (`findSlotForHour(carbRatios, heureLocale)`), **jamais** au midpoint du moment (une frontière de créneau

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -261,3 +261,10 @@ fois l'emballement et l'érosion du bon contrôle.
 >   dans `nadirGl` supprimerait une proposition légitime (fail-safe mais érosion qualité). La **slice
 >   assemblage** (qui peuplera `nadirGl`) doit **filtrer** les valeurs non physiologiques AVANT
 >   `analyzeIcrSlot` — pas dans l'analyseur (qui traite `0` comme une hypo réelle, à raison).
+
+> **Suivi build — détection resucrage (US-2651, tracé depuis la revue medical #670)** : la fenêtre nadir
+> (`nadirWindowEnd`) se termine au prochain apport glucidique. Un **resucrage** d'hypo (glucide pris à
+> cause d'une hypo) peut donc **tronquer la fenêtre AVANT le vrai creux** → la garde hypo sous-protège
+> (autorise une baisse d'ICR = plus d'insuline). Atténué par la pente descendante captée en CGM 5 min.
+> **À faire** : inférer un resucrage (petit glucide, sans bolus, glycémie précédente basse) et le traiter
+> comme un **signal d'hypo** (pas une simple borne). Détail : `algorithme-propositions-ajustement.md` §5ter.

--- a/src/lib/services/meal-trends.service.ts
+++ b/src/lib/services/meal-trends.service.ts
@@ -27,7 +27,7 @@ import { prisma } from "@/lib/db/client"
 import { decimalToNumber } from "@/lib/db/decimal"
 import { auditService, type AuditContext } from "@/lib/services/audit.service"
 import { getCgmDefaults } from "@/lib/services/objectives.service"
-import { CGM_AGGREGATE_RANGE_GL, MEAL_TREND } from "@/lib/clinical-bounds"
+import { CGM_AGGREGATE_RANGE_GL, MEAL_TREND, CLINICAL_BOUNDS } from "@/lib/clinical-bounds"
 import { DAY_MOMENTS, momentForHour, momentBoundsFrom, type DayMoment } from "@/lib/day-moments"
 
 const CLINICAL_TZ = "Europe/Paris"
@@ -74,10 +74,17 @@ export interface JournalMeal {
   mealId: string
   /** Jour calendaire Europe/Paris, `YYYY-MM-DD`. */
   dayIso: string
+  /** Heure locale (0–23, Europe/Paris) de l'instant réel du repas — pour bucketer à l'heure
+   *  exacte sur les créneaux ICR (`findSlotForHour`), pas au moment (US-2651). */
+  localHour: number
   moment: MealMoment
   preMgdl: number | null
   /** Après = PPG 2 h. */
   postMgdl: number | null
+  /** Creux (nadir) glycémique post-prandial en mg/dL sur `[t0, min(prochain glucide, t0+300 min)]`
+   *  — fourni à la garde hypo de `analyzeIcrSlot` (creux à ~3-4 h invisible à la PPG 2 h, US-2651).
+   *  `null` si aucun relevé dans la fenêtre. Déjà borné physiologiquement (≥ 0,20 g/L) par `loadContext`. */
+  nadirMgdl: number | null
   carbs: number | null
   bolus: number | null
 }
@@ -379,12 +386,19 @@ function computeJournal(c: MealContext): JournalMeal[] {
       const post = (winEnd - t0) / MIN_MS >= MEAL_TREND.EXCURSION_MIN_WINDOW_MIN
         ? closestReading(c.readings, t0 + MEAL_TREND.POST_2H_CENTER_MIN * MIN_MS, MEAL_TREND.POST_2H_TOL_MIN * MIN_MS, winEnd)
         : null
+      const lh = localHour(realMs)
+      // Nadir post-prandial : plus bas relevé sur [t0, min(prochain glucide, t0+300 min)]. Fourni à
+      // la garde hypo de l'analyseur ICR (creux à ~3-4 h, après la PPG 2 h). Relevés déjà bornés
+      // physiologiquement (≥ 0,20 g/L) par loadContext → pas de zéro-artefact (suivi LOW #669 résolu).
+      const nadir = minReadingIn(c.readings, t0, nadirWindowEnd(t0, c.carbTimes))
       return {
         mealId: meal.id,
         dayIso: localDay(realMs),
-        moment: momentForHour(localHour(realMs), c.bounds),
+        localHour: lh,
+        moment: momentForHour(lh, c.bounds),
         preMgdl: pre,
         postMgdl: post,
+        nadirMgdl: nadir,
         carbs: meal.carbohydrates !== null ? decimalToNumber(meal.carbohydrates) : null,
         bolus: meal.bolusDose !== null ? decimalToNumber(meal.bolusDose) : null,
       }
@@ -399,6 +413,21 @@ function maxReadingIn(readings: Reading[], min: number, max: number): number | n
   let best: number | null = null
   for (const r of readings) if (r.t > min && r.t <= max && (best === null || r.mgdl > best)) best = r.mgdl
   return best
+}
+/** Plus bas relevé (nadir) dans `(min, max]`, ou `null` si aucun. Miroir de `maxReadingIn`. */
+function minReadingIn(readings: Reading[], min: number, max: number): number | null {
+  let best: number | null = null
+  for (const r of readings) if (r.t > min && r.t <= max && (best === null || r.mgdl < best)) best = r.mgdl
+  return best
+}
+/** Fin de la fenêtre de recherche du nadir post-prandial : `t0 + POSTMEAL_NADIR_WINDOW_MIN`,
+ *  bornée en amont par le prochain apport glucidique (le nadir ne doit pas déborder sur le repas
+ *  suivant). Miroir de `excursionWindowEnd` mais avec la fenêtre nadir (plus longue, ~5 h). */
+function nadirWindowEnd(t0: number, carbTimes: number[]): number {
+  const cap = t0 + CLINICAL_BOUNDS.POSTMEAL_NADIR_WINDOW_MIN * MIN_MS
+  let next = Infinity
+  for (const c of carbTimes) if (c > t0 && c < next) next = c
+  return Math.min(cap, next)
 }
 function mean(a: number[]): number {
   return a.reduce((s, x) => s + x, 0) / a.length

--- a/tests/unit/meal-trends.service.test.ts
+++ b/tests/unit/meal-trends.service.test.ts
@@ -119,6 +119,22 @@ describe("mealtimePattern.mealTrends", () => {
     expect(journal[0].nadirMgdl).toBe(180) // le creux à +210 (après le glucide) est exclu
   })
 
+  it("le glucide du repas lui-même (à t0) N'effondre PAS la fenêtre nadir (borne > t0 stricte)", async () => {
+    const meal = noonMeal(1)
+    const readings = [cgm(meal._t0, 60, 1.8), cgm(meal._t0, 210, 0.5)]
+    prismaMock.patient.findFirst.mockResolvedValue({ pathology: null, pregnancyMode: false } as any)
+    prismaMock.userDayMoment.findMany.mockResolvedValue([] as any)
+    prismaMock.diabetesEvent.findMany
+      .mockResolvedValueOnce([meal] as any)
+      .mockResolvedValueOnce([{ eventDate: meal.eventDate }] as any) // le glucide du repas, à t0
+    prismaMock.cgmEntry.findMany.mockResolvedValue(readings as any)
+    prismaMock.auditLog.create.mockResolvedValue({} as any)
+    const { journal } = await mealtimePattern.mealTrends(42, "14d", 1)
+    // Sans le « > t0 » strict, la fenêtre serait [t0, t0] → nadir null. Avec, le glucide à t0 est
+    // ignoré → fenêtre pleine (t0+300) → le creux à +210 est capté.
+    expect(journal[0].nadirMgdl).toBe(50)
+  })
+
   it("invalidates peak AND post when an intercurrent carb intake truncates the window (< 90 min) — M-1", async () => {
     const meals = [noonMeal(1), noonMeal(2), noonMeal(3)]
     prismaMock.patient.findFirst.mockResolvedValue({ pathology: null, pregnancyMode: false } as any)

--- a/tests/unit/meal-trends.service.test.ts
+++ b/tests/unit/meal-trends.service.test.ts
@@ -91,6 +91,34 @@ describe("mealtimePattern.mealTrends", () => {
     expect(journal[2].mealId).toBe("m3")
   })
 
+  it("journal expose l'heure locale et le NADIR post-prandial (creux tardif ≠ PPG 2 h, US-2651)", async () => {
+    const meals = [noonMeal(1), noonMeal(2), noonMeal(3)]
+    // pré, pic, PPG 2 h (150), + creux tardif à 3 h 30 (0,50 g/L = 50 mg/dL) — invisible à la PPG 2 h.
+    const readings = meals.flatMap((m) => [
+      cgm(m._t0, -10, 1.0), cgm(m._t0, 60, 1.8), cgm(m._t0, 120, 1.5), cgm(m._t0, 210, 0.5),
+    ])
+    setup(meals, readings)
+    const { journal } = await mealtimePattern.mealTrends(42, "14d", 1)
+    expect([13, 14]).toContain(journal[0].localHour) // 12:00 UTC → 13/14 h Paris selon l'heure d'été
+    expect(journal[0].postMgdl).toBe(150) // PPG 2 h inchangée
+    expect(journal[0].nadirMgdl).toBe(50) // le creux tardif est capté
+  })
+
+  it("le NADIR est borné par le prochain apport glucidique (pas de débordement sur le repas suivant)", async () => {
+    const meal = noonMeal(1)
+    // pic à +60 (180), creux à +210 (50) — MAIS un glucide à +90 tronque la fenêtre nadir à [t0, +90].
+    const readings = [cgm(meal._t0, 60, 1.8), cgm(meal._t0, 210, 0.5)]
+    prismaMock.patient.findFirst.mockResolvedValue({ pathology: null, pregnancyMode: false } as any)
+    prismaMock.userDayMoment.findMany.mockResolvedValue([] as any)
+    prismaMock.diabetesEvent.findMany
+      .mockResolvedValueOnce([meal] as any)
+      .mockResolvedValueOnce([{ eventDate: new Date(meal._t0 + 90 * MIN) }] as any) // glucide à +90
+    prismaMock.cgmEntry.findMany.mockResolvedValue(readings as any)
+    prismaMock.auditLog.create.mockResolvedValue({} as any)
+    const { journal } = await mealtimePattern.mealTrends(42, "14d", 1)
+    expect(journal[0].nadirMgdl).toBe(180) // le creux à +210 (après le glucide) est exclu
+  })
+
   it("invalidates peak AND post when an intercurrent carb intake truncates the window (< 90 min) — M-1", async () => {
     const meals = [noonMeal(1), noonMeal(2), noonMeal(3)]
     prismaMock.patient.findFirst.mockResolvedValue({ pathology: null, pregnancyMode: false } as any)


### PR DESCRIPTION
Peuple ce que l'analyseur ICR attend (la slice 1a #669 a posé la signature `nadirGl`).

## Contenu
- **`JournalMeal` expose 2 champs** :
  - **`localHour`** — heure locale réelle du repas → bucketing à l'**heure exacte** (`findSlotForHour`), pas au moment (corrige le finding bucketing du design #668).
  - **`nadirMgdl`** — creux CGM sur `[t0, min(prochain glucide, t0+POSTMEAL_NADIR_WINDOW_MIN=300 min)]` → nourrira la garde hypo (`nadirGl = nadirMgdl/100`). Helpers `minReadingIn` + `nadirWindowEnd` (miroirs de `maxReadingIn`/`excursionWindowEnd`).
- **Zéro-artefact CLOS** : les relevés sont déjà bornés **≥ 0,20 g/L** par `loadContext` → aucun `0` n'atteint l'analyseur (**suivi LOW #669 résolu sans code supplémentaire**).
- **Tests +2** : (1) le nadir capte un **creux tardif** (3 h 30, 50 mg/dL) **invisible à la PPG 2 h** (150) + `localHour` exposé ; (2) le nadir est **borné par le prochain apport glucidique** (pas de débordement).
- **Doc §5ter** : assemblage « en place ».

## Suite
**Slice 2** — le vertical `generateForPatient` (deadband post-prandial pathology/grossesse-aware, bucketing via `localHour`, portes qualité) → `createEngineProposal`, puis le **cron** nocturne.

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3714 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)