### PR TITLE
US-2651 (build b, slice 3) — Cron nocturne du générateur (generateForAllPatients + route)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -740,7 +740,7 @@ tous corrigés. Migration `20260513230000_groupe5_review_fixes` (FK + unique + p
 | US-2648 | Onglet Traitements éditable (fiche) : DOCTOR direct / NURSE→proposition | front/back | 2646, 2647 | L | ⏳ TODO (#631) |
 | US-2649 | Flux proposition → validation (provenance, notif, UI `/adjustment-proposals`) | front/back | 2646 | L | ⏳ TODO (#632) |
 | US-2650 | Self-service patient : route `(patient)` + nav + lecture + proposer | front/back | 2648, 2649 | L | ⏳ TODO (#633) |
-| US-2651 | Algorithme d'ajustement multi-mode (basal-bolus / doses fixes / non insuliné) | back | 2646, 2647 | L | ⏳ TODO (#634) |
+| US-2651 | Algorithme d'ajustement multi-mode (basal-bolus / doses fixes / non insuliné) | back | 2646, 2647 | L | 🟡 EN COURS — analyseurs + garde hypo + persistance moteur + **générateur ICR de bout en bout + cron** livrés (#666→#672) ; restent ISF/basal/fixedDose/nonInsulin (#634) |
 | US-2652 | Garde-fous cliniques + i18n/acronymes + design-system + tests + docs | transverse | 2646→2651 | M | ⏳ TODO (#635) |
 | US-2653 | Propositions de **dé-escalade sur hypos récurrentes** (nadir-trigger, moins d'insuline) transverse aux 4 analyseurs, indépendant du deadband sur la moyenne | back | 2651 | M/L | 🟡 SPEC |
 

--- a/docs/clinical-logic/algorithme-propositions-ajustement.md
+++ b/docs/clinical-logic/algorithme-propositions-ajustement.md
@@ -216,8 +216,11 @@ sont **logués et non fatals**. ✅ **Cron en place (slice 3)** : `generateForAl
 advisory session** (`withSessionAdvisoryLock`, anti double-run OVH+Vercel), boucle les patients actifs
 (`deletedAt null` + `user.status active`) avec **isolation per-patient** (une erreur infra n'arrête pas le
 portefeuille), lectures attribuées à l'**acteur système `null`**. Route `GET|POST /api/cron/generate-proposals`
-(Bearer `CRON_SECRET`, audit `cron.auth.failed`, headers ANSSI). Le chemin **ICR est complet** de bout en
-bout ; restent les autres paramètres (ISF/basal/fixedDose) et modes en slices ultérieures.
+(Bearer `CRON_SECRET`, audit `cron.auth.failed`, headers ANSSI). **Audit run-level immuable**
+(`proposal.generator.cron.run` + métriques ; `skipped_locked` sur skip concurrent) → traçabilité HDS.
+DPIA : [`dpia-us2651-proposal-generator.md`](../compliance/dpia-us2651-proposal-generator.md). Le chemin
+**ICR est complet** de bout en bout ; restent les autres paramètres (ISF/basal/fixedDose) et modes en
+slices ultérieures.
 
 La **porte qualité pré-repas** est **grossesse-aware** : borne haute resserrée à `ICR_PREMEAL_MAX_PREGNANCY_GL`
 (1,10 g/L) quand `isPregnancy` — sinon un pré-repas déjà élevé pour une enceinte contaminerait le signal ICR.

--- a/docs/clinical-logic/algorithme-propositions-ajustement.md
+++ b/docs/clinical-logic/algorithme-propositions-ajustement.md
@@ -212,7 +212,12 @@ bolus > 0, pré-repas dans `[ICR_PREMEAL_MIN_GL, ICR_PREMEAL_MAX_GL]`), **bucket
 (`findSlotForHour(carbRatios, localHour)`), calcule la cible par **deadband** (plafond `getCgmDefaults(...).ok`
 / borne basse, `isPregnancy`-aware), lance `analyzeIcrSlot` (avec `nadirGl = nadirMgdl/100`) et persiste via
 `createEngineProposal`. Les rejets fail-closed (baseline dérivée, doublon, sens incohérent, hors bornes)
-sont **logués et non fatals**. **Reste (slice 3)** : le **cron** nocturne (boucle portefeuille + verrou advisory).
+sont **logués et non fatals**. ✅ **Cron en place (slice 3)** : `generateForAllPatients(ctx)` sous **verrou
+advisory session** (`withSessionAdvisoryLock`, anti double-run OVH+Vercel), boucle les patients actifs
+(`deletedAt null` + `user.status active`) avec **isolation per-patient** (une erreur infra n'arrête pas le
+portefeuille), lectures attribuées à l'**acteur système `null`**. Route `GET|POST /api/cron/generate-proposals`
+(Bearer `CRON_SECRET`, audit `cron.auth.failed`, headers ANSSI). Le chemin **ICR est complet** de bout en
+bout ; restent les autres paramètres (ISF/basal/fixedDose) et modes en slices ultérieures.
 
 La **porte qualité pré-repas** est **grossesse-aware** : borne haute resserrée à `ICR_PREMEAL_MAX_PREGNANCY_GL`
 (1,10 g/L) quand `isPregnancy` — sinon un pré-repas déjà élevé pour une enceinte contaminerait le signal ICR.

--- a/docs/compliance/dpia-us2605-consultation-review.md
+++ b/docs/compliance/dpia-us2605-consultation-review.md
@@ -28,10 +28,16 @@ pivot `metadata.patientId` uniquement).
 
 - **PRO (NURSE/DOCTOR/ADMIN)** : RGPD Art. 9.2.h — prise en charge médicale par
   professionnel soumis au secret. Le mode revue est **réservé aux PRO**.
-- **Sans IA** : aucune logique de décision automatisée (Art. 22 non applicable). Le
-  Résumé est une **projection serveur déterministe** ; les décisions thérapeutiques
-  (étape 5) restent le workflow `AdjustmentProposal` existant (DOCTOR-only, jamais
-  auto-appliqué).
+- **Sans IA (périmètre US-2605)** : le mode revue lui-même n'a **aucune logique de décision
+  automatisée**. Le Résumé est une **projection serveur déterministe** ; les décisions
+  thérapeutiques (étape 5) restent le workflow `AdjustmentProposal` existant (DOCTOR-only,
+  jamais auto-appliqué).
+  > **⚠️ MAJ US-2651** : le **générateur nocturne** de propositions (`AdjustmentProposal` source
+  > `algorithm`) introduit une **génération automatisée systématique** — traitée dans sa propre DPIA
+  > [`dpia-us2651-proposal-generator.md`](./dpia-us2651-proposal-generator.md). Art. 22 **strict reste
+  > non applicable** : chaque proposition est **doctor-gated** (jamais auto-appliquée) → pas d'effet
+  > juridique/significatif sans intervention humaine. Ne pas lire la phrase ci-dessus comme un « pas
+  > d'automatisation » global au niveau plateforme.
 
 ## 3. Décisions de design à valider DPO
 

--- a/docs/compliance/dpia-us2651-proposal-generator.md
+++ b/docs/compliance/dpia-us2651-proposal-generator.md
@@ -1,0 +1,93 @@
+# DPIA — US-2651 Générateur automatisé de propositions d'ajustement (cron nocturne)
+
+> **Statut** : V1 — décision DPO requise sur les risques résiduels (§3).
+> **Traitement** : génération **automatisée systématique** de propositions d'ajustement
+> d'insulinothérapie (chemin **ICR** livré ; ISF/basal/fixedDose à venir), exécutée **chaque nuit**
+> sur l'ensemble du portefeuille patient actif. **Aucune proposition n'est appliquée automatiquement**
+> (ADR #13) : chaque proposition est `pending` et validée par un **DOCTOR**.
+
+---
+
+## 1. Périmètre du traitement
+
+- **Finalité** : proposer aux soignants des ajustements de ratio insuline/glucides (ICR) fondés sur les
+  tendances glycémiques post-prandiales, pour accélérer la titration. **Suggestion, jamais exécution.**
+- **Déclencheur** : cron `GET|POST /api/cron/generate-proposals` (OVH/Vercel/GitHub Action), schedule
+  recommandé `0 2 * * *`. Auth **Bearer `CRON_SECRET`** (pas de JWT user).
+- **Données lues** (Art. 9 — santé), par patient, sur **14 jours glissants** :
+  - configuration d'insulinothérapie (créneaux ICR) — `InsulinTherapySettings`/`CarbRatio` ;
+  - journal repas dérivé du CGM (PPG 2 h, nadir post-prandial, glucides, bolus, pré-repas) — agrégé,
+    **lecture seule** ;
+  - pathologie + `pregnancyMode` (pour la cible post-prandiale pathology/grossesse-aware).
+- **Données écrites** : `AdjustmentProposal` (`source = algorithm`, `proposedByUserId = null`, statut
+  `pending`). **Valeurs stockées = ratios ICR + agrégat `averageObservedValue`** (moyenne PPG), **pas**
+  de série glycémique brute nouvelle.
+- **Population** : patients **actifs et non supprimés** uniquement (`deletedAt: null` +
+  `user.status = 'active'`) → exclusion RGPD Art. 17 (droit à l'effacement) et comptes inactifs.
+
+## 2. Mesures techniques implémentées
+
+- **Frontière dispositif médical (MDR / IEC 62304)** : un patient **non insuliné** ne reçoit **aucune**
+  proposition de dose (refus serveur `nonInsulinNoDose`). Fail-closed sur config incohérente.
+- **Garde-fous cliniques** (source unique `CLINICAL_BOUNDS`) : bornes dures ICR `[3,0 ; 30,0]` g/U,
+  cap moteur ± 20 %, **garde hypo** (nadir post-prandial → suppression d'une baisse d'ICR si hypo
+  sévère/niveau-1 récurrent), **deadband post-prandial** asymétrique pathology/grossesse-aware,
+  portes qualité pré-repas. Détail : `docs/clinical-logic/algorithme-propositions-ajustement.md`.
+- **Anti-emballement** : `createEngineProposal` re-dérive `currentValue` serveur, rejette si la base a
+  dérivé (`baselineMovedAtPersist`), asservit `reason`↔direction, anti-spam `one_pending_per_slot`.
+- **Idempotence + anti double-run** : verrou **advisory session** (`withSessionAdvisoryLock`) — deux
+  runs concurrents (OVH + Vercel) → l'un skip (`skippedConcurrent`).
+- **Traçabilité HDS** : audit **run-level immuable** (`proposal.generator.cron.run` + métriques +
+  `durationMs` ; `skipped_locked` sur skip concurrent) ; **chaque lecture** de santé auditée
+  (`READ INSULIN_THERAPY`, `READ DIABETES_EVENT`) ; **chaque `CREATE`** de proposition audité — tous
+  attribués à l'**acteur système** (`userId: null`, sentinel FK-safe), avec `metadata.patientId` pivot
+  forensique et `requestId` de run partagé.
+- **Isolation** : erreur infra sur un patient → comptée (`errored`) sans arrêter le portefeuille.
+- **PHI** : réponse HTTP = **compteurs seuls** (`processed/created/errored/skippedConcurrent`) ;
+  logs sans valeur clinique (`patientId`/`bucket`/`failMode` codes) ; secret jamais logué.
+- **Auth durcie** : `constantTimeEqual` (timing-safe), 503 sans secret, 401 générique + audit
+  `cron.auth.failed` (burst SOC US-2265). `CRON_SECRET` validé au boot (≥ 64 hex + entropie).
+
+## 3. Risques résiduels V1 (décision DPO requise)
+
+### 3.1 MEDIUM — Acteur système `null` (vs compte de service dédié)
+Les lectures de masse Art. 9 sont attribuées à `userId: null` (convention repo, partagée avec les crons
+invoice/appointment). Le marqueur run-level (`proposal.generator.cron.run`) **ancre** le `requestId`
+partagé → traçabilité suffisante à ce stade. **Amélioration tracée** : compte de service **non-login
+identifiable** (`svc-proposal-generator`, sa propre ligne `User`) pour rendre les accès système
+auto-identifiants. Décision DPO : `null` + marqueur run acceptable en V1 ?
+
+### 3.2 MEDIUM — Art. 22 (décision automatisée)
+La génération est **automatisée et systématique**, mais chaque proposition est **doctor-gated** (jamais
+auto-appliquée) → **pas d'effet juridique ou significatif sans intervention humaine** → **Art. 22 strict
+non applicable** (même raisonnement que `dpia-us2108`). Le gate DOCTOR **est** la garantie d'intervention
+humaine. À confirmer DPO ; information patient (transparence Art. 13/14) sur l'aide algorithmique à revoir.
+
+### 3.3 LOW — Minimisation (lecture nocturne de 14 j pour tout le portefeuille)
+Lecture seule, agrégée, sans nouveau stockage brut, proportionnée à la finalité (titration ICR par
+créneau). Pas de sur-collecte. Fréquence nocturne = hors pics d'usage.
+
+### 3.4 LOW — Angles morts cliniques documentés
+Resucrage tronquant le nadir, mean-vs-nadir (US-2653), basale stylo/MDI, régime hybride — tous
+**fail-safe** (sous-action, jamais sur-dosage) et tracés dans le catalogue clinique.
+
+## 4. Procédures opérationnelles
+
+- **Configuration cron** : `0 2 * * *`, header `Authorization: Bearer $CRON_SECRET`.
+- **Désactivation en incident** : vider `CRON_SECRET` (route → 503) puis redéployer, **ou** feature-flag
+  de désactivation (à prévoir). Note : `assertRequiredEnv` crashe au boot si `CRON_SECRET` absent →
+  préférer un flag à la suppression du secret en prod.
+- **Observabilité** : métriques de réponse + audit run-level (`kind: proposal.generator.cron.run`).
+
+## 5. Validation
+
+- [ ] Revue DPO — risques 3.1 (acteur système) et 3.2 (Art. 22 / information patient).
+- [x] Revue sécurité (healthcare-security-auditor) — auth OK, filtre RGPD OK, audit run-level ajouté.
+- [x] Revue médicale (medical-domain-validator) — bornes, deadband, garde hypo validés.
+- [ ] Information patient (transparence aide algorithmique) — à intégrer aux CGU/politique.
+
+---
+
+*DPIA liée : [`dpia-us2605-consultation-review.md`](./dpia-us2605-consultation-review.md) (mode revue,
+sans automatisation — périmètre distinct). Source de vérité algorithme :
+`docs/clinical-logic/algorithme-propositions-ajustement.md`.*

--- a/src/app/api/cron/generate-proposals/route.ts
+++ b/src/app/api/cron/generate-proposals/route.ts
@@ -1,0 +1,96 @@
+/**
+ * @route GET|POST /api/cron/generate-proposals
+ * @description US-2651 — Cron entry du générateur de propositions d'ajustement (ICR).
+ *
+ * **Authentification** : Bearer `CRON_SECRET` (env var), pas de JWT user — cron externe
+ * (OVHcloud cron / Vercel cron / GitHub Action). `CRON_SECRET` validé par `assertRequiredEnv()`
+ * au boot. GET **et** POST acceptés (les crons basiques utilisent souvent GET).
+ *
+ * **Idempotent + anti double-run** : `generateForAllPatients` prend un verrou advisory session
+ * (`withSessionAdvisoryLock`) ; deux runs concurrents (OVH + Vercel) → l'un skip (`skippedConcurrent`).
+ * Chaque proposition est de toute façon dédupliquée par l'index `one_pending_per_slot`.
+ *
+ * **Auth failure audit** : un Bearer manquant/faux émet un audit `cron.auth.failed` (burst detection SOC).
+ *
+ * **Retour** : métriques JSON `{ processed, created, errored, skippedConcurrent }` (aucune PHI).
+ *
+ * **Cron schedule recommandé** : `0 2 * * *` (2 h locale — analyse nocturne, hors pics d'usage).
+ */
+import { NextResponse, type NextRequest } from "next/server"
+import { timingSafeEqual } from "crypto"
+import { auditService, extractRequestContext } from "@/lib/services/audit.service"
+import { mapErrorToResponse } from "@/lib/team-route-helpers"
+import { proposalGeneratorService } from "@/lib/services/proposal-generator.service"
+import { logger } from "@/lib/logger"
+
+/** Comparaison à temps constant (longueur du `CRON_SECRET` publique par convention). */
+function constantTimeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, "utf8")
+  const bufB = Buffer.from(b, "utf8")
+  if (bufA.length !== bufB.length) return false
+  return timingSafeEqual(bufA, bufB)
+}
+
+async function emitAuthFailedAudit(_req: NextRequest, ctx: ReturnType<typeof extractRequestContext>): Promise<void> {
+  // Audit auth failed (burst detection SOC). Caller anonyme (bypass JWT) → userId null (système).
+  await auditService.log({
+    userId: null,
+    action: "UNAUTHORIZED",
+    resource: "ADJUSTMENT_PROPOSAL",
+    resourceId: "cron",
+    ipAddress: ctx.ipAddress,
+    userAgent: ctx.userAgent,
+    requestId: ctx.requestId,
+    metadata: { kind: "cron.auth.failed" },
+  }).catch((err) => {
+    logger.error("cron-generate-proposals", "audit auth.failed write failed", { kind: "audit.write.failed" }, err)
+  })
+}
+
+const SECURITY_HEADERS = {
+  "Cache-Control": "no-store, private",
+  "Referrer-Policy": "no-referrer",
+  "X-Content-Type-Options": "nosniff",
+} as const
+
+function jsonResponse(body: unknown, status = 200): NextResponse {
+  return NextResponse.json(body, { status, headers: SECURITY_HEADERS })
+}
+
+async function handle(req: NextRequest): Promise<NextResponse> {
+  const ctx = extractRequestContext(req)
+  try {
+    const expectedSecret = process.env.CRON_SECRET
+    if (!expectedSecret) {
+      // Sans secret configuré, la route est neutralisée (defense-in-depth ; le boot aurait dû crash).
+      logger.error("cron-generate-proposals", "CRON_SECRET not configured — route disabled", { statusCode: 503 })
+      return jsonResponse({ error: "cronDisabled" }, 503)
+    }
+
+    const auth = req.headers.get("authorization") ?? ""
+    const match = auth.match(/^Bearer\s+(\S+)\s*$/)
+    const submittedSecret = match?.[1] ?? ""
+    if (!submittedSecret || !constantTimeEqual(submittedSecret, expectedSecret)) {
+      await emitAuthFailedAudit(req, ctx)
+      return jsonResponse({ error: "unauthorized" }, 401)
+    }
+
+    const t0 = Date.now()
+    const metrics = await proposalGeneratorService.generateForAllPatients(ctx)
+    const durationMs = Date.now() - t0
+
+    logger.info("cron-generate-proposals", "run completed", { resource: "ADJUSTMENT_PROPOSAL", durationMs })
+    return jsonResponse(metrics)
+  } catch (e) {
+    return mapErrorToResponse(e, "cron/generate-proposals", ctx.requestId)
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  return handle(req)
+}
+
+// GET accepté aussi (Vercel cron / OVH cron basic utilisent GET).
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  return handle(req)
+}

--- a/src/lib/services/insulin-therapy.service.ts
+++ b/src/lib/services/insulin-therapy.service.ts
@@ -44,7 +44,7 @@ export const insulinTherapyService = {
    * @param {AuditContext} [ctx] - Request context (IP, User-Agent)
    * @returns {Promise<Object | null>} InsulinTherapySettings with all relations or null
    */
-  async getSettings(patientId: number, auditUserId: number, ctx?: AuditContext) {
+  async getSettings(patientId: number, auditUserId: number | null, ctx?: AuditContext) {
     const settings = await prisma.insulinTherapySettings.findUnique({
       where: { patientId },
       include: {

--- a/src/lib/services/meal-trends.service.ts
+++ b/src/lib/services/meal-trends.service.ts
@@ -255,7 +255,7 @@ type MealContext = Awaited<ReturnType<typeof loadContext>>
 export const mealtimePattern = {
   /** Courbes glycémiques moyennes alignées sur l'heure du repas, par moment. */
   async alignedCurve(
-    patientId: number, period: string, auditUserId: number, ctx?: AuditContext,
+    patientId: number, period: string, auditUserId: number | null, ctx?: AuditContext,
     opts?: { source?: "cgm" | "bgm"; skipAudit?: boolean },
   ): Promise<AlignedCurveResult> {
     const source = opts?.source ?? "cgm"
@@ -267,7 +267,7 @@ export const mealtimePattern = {
 
   /** Journal repas : 1 entrée par repas (jour × moment), numérique. */
   async dailyJournal(
-    patientId: number, period: string, auditUserId: number, ctx?: AuditContext,
+    patientId: number, period: string, auditUserId: number | null, ctx?: AuditContext,
     opts?: { source?: "cgm" | "bgm"; skipAudit?: boolean },
   ): Promise<JournalMeal[]> {
     const source = opts?.source ?? "cgm"
@@ -439,7 +439,7 @@ function parsePeriodDays(period: string): number {
   return n
 }
 async function auditRead(
-  userId: number, patientId: number, period: string, windowDays: number,
+  userId: number | null, patientId: number, period: string, windowDays: number,
   source: string, kind: string, ctx?: AuditContext,
 ) {
   await auditService.log({

--- a/src/lib/services/proposal-generator.service.ts
+++ b/src/lib/services/proposal-generator.service.ts
@@ -23,6 +23,7 @@ import { insulinTherapyService } from "@/lib/services/insulin-therapy.service"
 import { mealtimePattern, type JournalMeal } from "@/lib/services/meal-trends.service"
 import { getCgmDefaults } from "@/lib/services/objectives.service"
 import { adjustmentService } from "@/lib/services/adjustment.service"
+import { auditService } from "@/lib/services/audit.service"
 import type { AuditContext } from "@/lib/services/patient.service"
 
 /** Fenêtre d'analyse (14 j — standard AGP, aligné `AGP_SUFFICIENCY.MIN_DAYS`). */
@@ -199,6 +200,7 @@ export const proposalGeneratorService = {
    * @returns Métriques agrégées ; `skippedConcurrent` si un autre run détient le verrou.
    */
   async generateForAllPatients(ctx?: AuditContext): Promise<GenerateAllResult> {
+    const t0 = Date.now()
     const run = await withSessionAdvisoryLock(CRON_LOCK_KEY, async () => {
       const patients = await prisma.patient.findMany({
         where: { deletedAt: null, user: { status: "active" } }, // RGPD : ni supprimés ni comptes inactifs
@@ -221,7 +223,29 @@ export const proposalGeneratorService = {
       }
       return { processed, created, errored, skippedConcurrent: false }
     })
-    // Verrou non acquis → un autre run est en cours : skip silencieux (cron retry-safe).
-    return run ?? { processed: 0, created: 0, errored: 0, skippedConcurrent: true }
+    const durationMs = Date.now() - t0
+
+    // Marqueur d'audit RUN-LEVEL immuable (piste HDS 5 ans, pas un simple log applicatif) — aligné sur
+    // les crons invoice/appointment. Ancre le `requestId` partagé des lectures per-patient (acteur null).
+    // Best-effort : un échec d'audit ne doit pas faire échouer le run.
+    if (run === null) {
+      // Verrou non acquis → un autre run est en cours : skip tracé (cron retry-safe).
+      await auditService.log({
+        userId: CRON_AUDIT_USER_ID, action: "CREATE", resource: "ADJUSTMENT_PROPOSAL", resourceId: "cron",
+        ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+        metadata: { kind: "proposal.generator.cron.skipped_locked", durationMs },
+      }).catch((err) => logger.error("proposal-generator", "cron audit (skipped) failed", { kind: "audit.write.failed" }, err))
+      return { processed: 0, created: 0, errored: 0, skippedConcurrent: true }
+    }
+
+    await auditService.log({
+      userId: CRON_AUDIT_USER_ID, action: "CREATE", resource: "ADJUSTMENT_PROPOSAL", resourceId: "cron",
+      ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
+      metadata: {
+        kind: "proposal.generator.cron.run",
+        processed: run.processed, created: run.created, errored: run.errored, durationMs,
+      },
+    }).catch((err) => logger.error("proposal-generator", "cron audit (run) failed", { kind: "audit.write.failed" }, err))
+    return run
   },
 }

--- a/src/lib/services/proposal-generator.service.ts
+++ b/src/lib/services/proposal-generator.service.ts
@@ -14,6 +14,7 @@
  */
 import { prisma } from "@/lib/db/client"
 import { logger } from "@/lib/logger"
+import { withSessionAdvisoryLock } from "@/lib/db/cron-lock"
 import { CLINICAL_BOUNDS } from "@/lib/clinical-bounds"
 import { findSlotForHour } from "@/lib/insulin-slots"
 import { analyzeIcrSlot } from "@/lib/proposal-algorithm"
@@ -36,6 +37,21 @@ export interface GenerateResult {
   mealsUsable: number
   skipped: string | null
 }
+
+/** Résultat d'un run PORTEFEUILLE (cron) — métriques agrégées, aucune valeur clinique. */
+export interface GenerateAllResult {
+  processed: number
+  created: number
+  errored: number
+  skippedConcurrent: boolean
+}
+
+/** Acteur d'audit du cron = acteur SYSTÈME (`null`, FK-safe) — cohérent avec `createEngineProposal`
+ *  (userId null) et les autres crons. Les lectures (`getSettings`/`dailyJournal`) sont donc attribuées
+ *  au système, pas à un soignant. */
+const CRON_AUDIT_USER_ID: number | null = null
+/** Clé du verrou advisory global (anti double-run OVH + Vercel). */
+const CRON_LOCK_KEY = "proposal-generator-cron"
 
 const EMPTY = (skipped: string): GenerateResult => ({ created: 0, slotsConsidered: 0, mealsUsable: 0, skipped })
 
@@ -79,7 +95,7 @@ export const proposalGeneratorService = {
    * @param ctx Contexte requête (audit).
    * @returns Métriques du run (sans PHI).
    */
-  async generateForPatient(patientId: number, auditUserId: number, ctx?: AuditContext): Promise<GenerateResult> {
+  async generateForPatient(patientId: number, auditUserId: number | null, ctx?: AuditContext): Promise<GenerateResult> {
     // 0. Mode — seul `basalBolus` a des ratios ICR par créneau à titrer.
     const { mode } = await treatmentModeService.resolveTreatmentMode(patientId)
     if (mode !== "basalBolus") return EMPTY("mode")
@@ -171,5 +187,41 @@ export const proposalGeneratorService = {
     }
 
     return { created, slotsConsidered, mealsUsable: usable.length, skipped: null }
+  },
+
+  /**
+   * Run PORTEFEUILLE (cron nocturne) : génère les propositions ICR pour tous les patients actifs.
+   * Sous **verrou advisory session** (`withSessionAdvisoryLock`) : anti double-run (OVH + Vercel).
+   * **Isolation per-patient** : une erreur infra sur un patient (`errored++`) n'arrête pas le portefeuille.
+   * Idempotent (anti-spam `one_pending_per_slot`) → sûr même en cas de course. Lectures attribuées à
+   * l'acteur système (`CRON_AUDIT_USER_ID = null`).
+   * @param ctx Contexte requête (audit).
+   * @returns Métriques agrégées ; `skippedConcurrent` si un autre run détient le verrou.
+   */
+  async generateForAllPatients(ctx?: AuditContext): Promise<GenerateAllResult> {
+    const run = await withSessionAdvisoryLock(CRON_LOCK_KEY, async () => {
+      const patients = await prisma.patient.findMany({
+        where: { deletedAt: null, user: { status: "active" } }, // RGPD : ni supprimés ni comptes inactifs
+        select: { id: true },
+      })
+      let processed = 0
+      let created = 0
+      let errored = 0
+      for (const { id } of patients) {
+        try {
+          const r = await proposalGeneratorService.generateForPatient(id, CRON_AUDIT_USER_ID, ctx)
+          created += r.created
+        } catch (err) {
+          // Isolation : erreur infra (DB/lecture) sur un patient → on compte et on continue.
+          errored++
+          logger.error("proposal-generator", "generateForPatient failed",
+            { patientId: id, failMode: "unexpected" }, err as Error)
+        }
+        processed++
+      }
+      return { processed, created, errored, skippedConcurrent: false }
+    })
+    // Verrou non acquis → un autre run est en cours : skip silencieux (cron retry-safe).
+    return run ?? { processed: 0, created: 0, errored: 0, skippedConcurrent: true }
   },
 }

--- a/tests/integration/api-cron-generate-proposals.test.ts
+++ b/tests/integration/api-cron-generate-proposals.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @description US-2651 — Cron route générateur de propositions : tests d'intégration.
+ *
+ * Couvre : auth Bearer CRON_SECRET (timing-safe), 503 sans secret, 401 sans/mauvais Bearer,
+ * 200 + métriques, GET accepté, audit `cron.auth.failed`, headers ANSSI, ctx audit propagé.
+ */
+import { beforeEach, describe, expect, it, vi, afterEach } from "vitest"
+import { NextRequest } from "next/server"
+
+vi.mock("@/lib/db/client", () => ({ prisma: {} }))
+
+vi.mock("@/lib/services/proposal-generator.service", () => ({
+  proposalGeneratorService: {
+    generateForAllPatients: vi.fn().mockResolvedValue({
+      processed: 3, created: 2, errored: 0, skippedConcurrent: false,
+    }),
+  },
+}))
+
+vi.mock("@/lib/services/audit.service", async (orig) => {
+  const actual = await orig<typeof import("@/lib/services/audit.service")>()
+  return {
+    ...actual,
+    auditService: { ...actual.auditService, log: vi.fn().mockResolvedValue(undefined) },
+  }
+})
+
+import { proposalGeneratorService } from "@/lib/services/proposal-generator.service"
+import { auditService } from "@/lib/services/audit.service"
+const { POST, GET } = await import("@/app/api/cron/generate-proposals/route")
+
+const VALID_SECRET = "test-cron-secret-32-bytes-long-aaa"
+
+function makeReq(bearer?: string): NextRequest {
+  const headers = new Headers()
+  if (bearer !== undefined) headers.set("authorization", `Bearer ${bearer}`)
+  return new NextRequest(new URL("/api/cron/generate-proposals", "http://test.local"), { method: "POST", headers })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  process.env.CRON_SECRET = VALID_SECRET
+})
+afterEach(() => { delete process.env.CRON_SECRET })
+
+describe("POST /api/cron/generate-proposals", () => {
+  it("200 + métriques si Bearer correct", async () => {
+    const res = await POST(makeReq(VALID_SECRET))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toMatchObject({ processed: 3, created: 2, errored: 0, skippedConcurrent: false })
+    expect(proposalGeneratorService.generateForAllPatients).toHaveBeenCalledTimes(1)
+  })
+
+  it("401 sans header authorization (générateur non appelé)", async () => {
+    const res = await POST(makeReq())
+    expect(res.status).toBe(401)
+    expect((await res.json()).error).toBe("unauthorized")
+    expect(proposalGeneratorService.generateForAllPatients).not.toHaveBeenCalled()
+  })
+
+  it("401 si Bearer incorrect + timing-safe (longueur différente ne crash pas)", async () => {
+    expect((await POST(makeReq("wrong-secret"))).status).toBe(401)
+    expect((await POST(makeReq("short"))).status).toBe(401)
+  })
+
+  it("503 si CRON_SECRET non configuré (defense-in-depth)", async () => {
+    delete process.env.CRON_SECRET
+    const res = await POST(makeReq(VALID_SECRET))
+    expect(res.status).toBe(503)
+    expect((await res.json()).error).toBe("cronDisabled")
+  })
+
+  it("GET accepté (200) avec Bearer correct", async () => {
+    expect((await GET(makeReq(VALID_SECRET))).status).toBe(200)
+  })
+
+  it("émet un audit cron.auth.failed (userId null) sur 401", async () => {
+    await POST(makeReq("wrong-secret"))
+    expect(auditService.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: null, action: "UNAUTHORIZED", resource: "ADJUSTMENT_PROPOSAL", resourceId: "cron",
+        metadata: expect.objectContaining({ kind: "cron.auth.failed" }),
+      }),
+    )
+  })
+
+  it("headers ANSSI (no-store, no-referrer, nosniff) sur la réponse", async () => {
+    const res = await POST(makeReq(VALID_SECRET))
+    expect(res.headers.get("Cache-Control")).toContain("no-store")
+    expect(res.headers.get("Referrer-Policy")).toBe("no-referrer")
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff")
+  })
+
+  it("le générateur reçoit le ctx audit (requestId)", async () => {
+    await POST(makeReq(VALID_SECRET))
+    const call = vi.mocked(proposalGeneratorService.generateForAllPatients).mock.calls[0]
+    expect(call![0]).toHaveProperty("requestId")
+  })
+})

--- a/tests/unit/proposal-generator.service.test.ts
+++ b/tests/unit/proposal-generator.service.test.ts
@@ -20,13 +20,19 @@ vi.mock("@/lib/services/meal-trends.service", () => ({
 vi.mock("@/lib/services/adjustment.service", () => ({
   adjustmentService: { createEngineProposal: vi.fn() },
 }))
+// Verrou advisory : par défaut « acquis » → exécute le travail. Surchargé pour le cas concurrent.
+vi.mock("@/lib/db/cron-lock", () => ({
+  withSessionAdvisoryLock: vi.fn((_key: string, fn: () => Promise<unknown>) => fn()),
+}))
 
 import { proposalGeneratorService } from "@/lib/services/proposal-generator.service"
 import { treatmentModeService } from "@/lib/services/treatment-mode.service"
 import { insulinTherapyService } from "@/lib/services/insulin-therapy.service"
 import { mealtimePattern } from "@/lib/services/meal-trends.service"
 import { adjustmentService } from "@/lib/services/adjustment.service"
+import { withSessionAdvisoryLock } from "@/lib/db/cron-lock"
 
+const lock = vi.mocked(withSessionAdvisoryLock)
 const mode = vi.mocked(treatmentModeService.resolveTreatmentMode)
 const getSettings = vi.mocked(insulinTherapyService.getSettings)
 const dailyJournal = vi.mocked(mealtimePattern.dailyJournal)
@@ -152,5 +158,40 @@ describe("proposalGeneratorService.generateForPatient", () => {
     expect(createEngine.mock.calls[0]![0]).toMatchObject({
       carbRatioSlotStart: 8, carbRatioSlotEnd: 12, expectedCurrentValue: 12,
     })
+  })
+})
+
+describe("proposalGeneratorService.generateForAllPatients (cron)", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("boucle le portefeuille actif (deletedAt null + user actif) → agrège created/processed", async () => {
+    setup() // par patient : basalBolus + 3 repas PPG 2,0 → 1 proposition
+    prismaMock.patient.findMany.mockResolvedValue([{ id: 1 }, { id: 2 }] as never)
+    const res = await proposalGeneratorService.generateForAllPatients()
+    expect(res.processed).toBe(2)
+    expect(res.created).toBe(2)
+    expect(res.errored).toBe(0)
+    expect(res.skippedConcurrent).toBe(false)
+    expect(prismaMock.patient.findMany.mock.calls[0]![0]!.where).toMatchObject({
+      deletedAt: null, user: { status: "active" },
+    })
+  })
+
+  it("verrou non acquis (run concurrent) → skippedConcurrent, aucun traitement", async () => {
+    lock.mockResolvedValueOnce(null) // withSessionAdvisoryLock renvoie null
+    const res = await proposalGeneratorService.generateForAllPatients()
+    expect(res.skippedConcurrent).toBe(true)
+    expect(res.processed).toBe(0)
+    expect(prismaMock.patient.findMany).not.toHaveBeenCalled()
+  })
+
+  it("isolation per-patient : une erreur infra sur un patient n'arrête pas le portefeuille", async () => {
+    setup()
+    prismaMock.patient.findMany.mockResolvedValue([{ id: 1 }, { id: 2 }] as never)
+    getSettings.mockRejectedValueOnce(new Error("db down")) // 1er patient échoue, 2e OK
+    const res = await proposalGeneratorService.generateForAllPatients()
+    expect(res.processed).toBe(2)
+    expect(res.errored).toBe(1)
+    expect(res.created).toBe(1)
   })
 })

--- a/tests/unit/proposal-generator.service.test.ts
+++ b/tests/unit/proposal-generator.service.test.ts
@@ -24,6 +24,9 @@ vi.mock("@/lib/services/adjustment.service", () => ({
 vi.mock("@/lib/db/cron-lock", () => ({
   withSessionAdvisoryLock: vi.fn((_key: string, fn: () => Promise<unknown>) => fn()),
 }))
+vi.mock("@/lib/services/audit.service", () => ({
+  auditService: { log: vi.fn().mockResolvedValue(undefined) },
+}))
 
 import { proposalGeneratorService } from "@/lib/services/proposal-generator.service"
 import { treatmentModeService } from "@/lib/services/treatment-mode.service"
@@ -31,8 +34,10 @@ import { insulinTherapyService } from "@/lib/services/insulin-therapy.service"
 import { mealtimePattern } from "@/lib/services/meal-trends.service"
 import { adjustmentService } from "@/lib/services/adjustment.service"
 import { withSessionAdvisoryLock } from "@/lib/db/cron-lock"
+import { auditService } from "@/lib/services/audit.service"
 
 const lock = vi.mocked(withSessionAdvisoryLock)
+const auditLog = vi.mocked(auditService.log)
 const mode = vi.mocked(treatmentModeService.resolveTreatmentMode)
 const getSettings = vi.mocked(insulinTherapyService.getSettings)
 const dailyJournal = vi.mocked(mealtimePattern.dailyJournal)
@@ -175,14 +180,39 @@ describe("proposalGeneratorService.generateForAllPatients (cron)", () => {
     expect(prismaMock.patient.findMany.mock.calls[0]![0]!.where).toMatchObject({
       deletedAt: null, user: { status: "active" },
     })
+    // Marqueur d'audit RUN-LEVEL immuable (HDS) : métriques + acteur système null.
+    expect(auditLog).toHaveBeenCalledWith(expect.objectContaining({
+      userId: null, action: "CREATE", resource: "ADJUSTMENT_PROPOSAL", resourceId: "cron",
+      metadata: expect.objectContaining({ kind: "proposal.generator.cron.run", processed: 2, created: 2, errored: 0 }),
+    }))
   })
 
-  it("verrou non acquis (run concurrent) → skippedConcurrent, aucun traitement", async () => {
+  it("verrou non acquis (run concurrent) → skippedConcurrent + audit skipped_locked", async () => {
     lock.mockResolvedValueOnce(null) // withSessionAdvisoryLock renvoie null
     const res = await proposalGeneratorService.generateForAllPatients()
     expect(res.skippedConcurrent).toBe(true)
     expect(res.processed).toBe(0)
     expect(prismaMock.patient.findMany).not.toHaveBeenCalled()
+    expect(auditLog).toHaveBeenCalledWith(expect.objectContaining({
+      metadata: expect.objectContaining({ kind: "proposal.generator.cron.skipped_locked" }),
+    }))
+  })
+
+  it("portefeuille vide → processed 0, aucune erreur, run tracé", async () => {
+    setup()
+    prismaMock.patient.findMany.mockResolvedValue([] as never)
+    const res = await proposalGeneratorService.generateForAllPatients()
+    expect(res).toMatchObject({ processed: 0, created: 0, errored: 0, skippedConcurrent: false })
+    expect(auditLog).toHaveBeenCalledWith(expect.objectContaining({
+      metadata: expect.objectContaining({ kind: "proposal.generator.cron.run", processed: 0 }),
+    }))
+  })
+
+  it("un patient skippé par mode (fixedDose) ne gonfle PAS errored", async () => {
+    setup({ mode: "fixedDose" }) // generateForPatient renvoie skipped:'mode' sans lever
+    prismaMock.patient.findMany.mockResolvedValue([{ id: 1 }, { id: 2 }] as never)
+    const res = await proposalGeneratorService.generateForAllPatients()
+    expect(res).toMatchObject({ processed: 2, created: 0, errored: 0 })
   })
 
   it("isolation per-patient : une erreur infra sur un patient n'arrête pas le portefeuille", async () => {


### PR DESCRIPTION
Dernière brique de câblage : **le générateur ICR devient ACTIF**.

## Contenu
- **`generateForAllPatients(ctx)`** : **verrou advisory session** (`withSessionAdvisoryLock` — réutilisé, hors transaction donc compatible avec les `createEngineProposal` imbriqués) anti double-run OVH+Vercel ; `findMany` **patients actifs** (`deletedAt null` + `user.status active`, RGPD) ; boucle → `generateForPatient` par patient avec **isolation per-patient** (une erreur infra → `errored++`, le portefeuille continue) ; idempotent (`one_pending_per_slot`). Lectures attribuées à l'**acteur système** (`CRON_AUDIT_USER_ID = null`) → **répond au suivi HDS #671**.
- **Route `GET|POST /api/cron/generate-proposals`** (clone `billing/reminders`) : Bearer `CRON_SECRET` timing-safe, 503 sans secret, 401 + audit `cron.auth.failed`, headers ANSSI. Middleware bypass `/api/cron/` déjà en place. Schedule recommandé `0 2 * * *`.
- `auditUserId` élargi à `number | null` sur `getSettings`/`dailyJournal`/`generateForPatient` (élargissement **sûr** : les appelants numériques restent valides) pour l'attribution système.
- **Tests +11** : `generateForAllPatients` (portefeuille, **verrou concurrent** → `skippedConcurrent`, **isolation per-patient**) + route (200/401/503/GET/audit/headers/ctx).
- Doc **§5ter** « cron en place » ; ROADMAP US-2651 → **EN COURS** (ICR complet de bout en bout).

## État de l'épic
Le chemin **ICR est complet** : analyseurs → garde hypo → nadir → assemblage → générateur → **cron actif**. Restent (slices ultérieures) : ISF/basal/fixedDose/nonInsulin, US-2653 (dé-escalade nadirs récurrents), et le compte de service dédié (vs `null`) si l'HDS l'exige.

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3735 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)