### PR TITLE
US-2653 (slice A) — Dé-escalade ICR sur hypos récurrentes : prédicat + builder purs

### DIFF
--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -271,8 +271,18 @@ fois l'emballement et l'érosion du bon contrôle.
 > **À faire** : inférer un resucrage (petit glucide, sans bolus, glycémie précédente basse) et le traiter
 > comme un **signal d'hypo** (pas une simple borne). Détail : `algorithme-propositions-ajustement.md` §5ter.
 
-> **Suivi US-2653 — dé-escalade sur hypos récurrentes** : le générateur décide de proposer sur la
-> MOYENNE PPG (deadband) mais la garde hypo agit sur le NADIR. Un patient bon en moyenne mais avec
-> hypos post-repas récurrentes ne reçoit aucune proposition (sous-action, sens sûr). US-2653 ajoutera
-> un déclencheur « nadirs récurrents → moins d'insuline » transverse aux 4 analyseurs. Cf.
-> `algorithme-propositions-ajustement.md` §5ter.
+### Dé-escalade sur hypos récurrentes (US-2653, validé medical)
+
+Déclencheur **indépendant du deadband** : des hypos post-prandiales récurrentes (nadirs) doivent proposer
+**moins d'insuline** même si la moyenne est « normale ».
+
+| Constante / règle | Valeur | Sens clinique |
+|---|---|---|
+| `HYPO_DEESCALATION_PERCENT` | **+10 %** | Pas de dé-escalade ICR (≈ −9 % insuline repas) — pas de titration standard, **fixe** (pas de scaling). Persistance titre **cumulativement**. Capé par `MAX_CHANGE_PERCENT`. |
+| `recurrentPostMealHypo` | **≥ 2 nadirs < 0,70** parmi ≥ 3 | « Récurrent » = corroboration exigée. Plus strict que la garde (qui fire sur 1 sévère isolé) → un artefact capteur seul ne réduit pas l'insuline. |
+
+**Matrice de décision par créneau (chemin ICR)** — moyenne PPG × hypo récurrente :
+- `> plafond` & non → **BAISSE** (deadband) · `> plafond` & **oui** → **flag `highVariabilityPostMeal`** (pas de dose : le levier ICR ne corrige pas pic + creux) · **dans la bande** & oui → **HAUSSE +10 %** (cœur US-2653) · dans la bande & non → rien · `< borne basse` → **HAUSSE** (deadband).
+
+Slice A (prédicat + builder purs) livrée ; slice B = matrice dans le générateur + flag. Cf.
+`algorithme-propositions-ajustement.md` §5ter.

--- a/src/lib/clinical-bounds.ts
+++ b/src/lib/clinical-bounds.ts
@@ -136,6 +136,14 @@ export const CLINICAL_BOUNDS = {
    * La borne basse (`ICR_PREMEAL_MIN_GL` 0,70) reste valable (seuil hypo grossesse 0,63).
    */
   ICR_PREMEAL_MAX_PREGNANCY_GL: 1.1,
+  /**
+   * US-2653 — pas de **dé-escalade** (en %) déclenché par des hypos post-prandiales **récurrentes**,
+   * indépendamment du deadband sur la moyenne. Monter l'ICR de +10 % ≈ −9 % d'insuline repas — un pas
+   * de titration standard (DAFNE/AACE), volontairement **fixe** (pas de scaling sur la profondeur : un
+   * nadir isolé profond sur-corrigerait). La persistance titre **cumulativement** run après run. Capé
+   * par `MAX_CHANGE_PERCENT`. Déclencheur : `≥ HYPO_LEVEL1_RECURRENCE_MIN` nadirs < niveau-1 (validé medical).
+   */
+  HYPO_DEESCALATION_PERCENT: 10,
 } as const
 
 export type ClinicalBounds = typeof CLINICAL_BOUNDS

--- a/src/lib/proposal-algorithm.ts
+++ b/src/lib/proposal-algorithm.ts
@@ -41,6 +41,56 @@ function hypoBlocksProposal(
 }
 
 /**
+ * US-2653 — détecte une **hypo post-prandiale RÉCURRENTE** sur un créneau (pour DÉCLENCHER une
+ * dé-escalade, pas seulement freiner). Vrai si **≥ `HYPO_LEVEL1_RECURRENCE_MIN` nadirs < niveau-1
+ * (0,70 g/L)** parmi ≥ 3 nadirs disponibles. NB : plus strict que `hypoBlocksProposal` (qui fire sur
+ * UN sévère isolé) — ici **corroboration exigée** : un seul relevé sévère (artefact capteur possible)
+ * ne suffit pas à réduire activement l'insuline (validé medical, garde anti-artefact). Un nadir sévère
+ * (< 0,54) compte aussi comme niveau-1.
+ *
+ * @param nadirsGl Nadirs post-prandiaux (g/L) des repas du créneau, valeurs non nulles uniquement.
+ */
+export function recurrentPostMealHypo(nadirsGl: number[]): boolean {
+  if (nadirsGl.length < 3) return false
+  const level1 = nadirsGl.filter((g) => g < LEVEL1_HYPO_GL).length
+  return level1 >= CLINICAL_BOUNDS.HYPO_LEVEL1_RECURRENCE_MIN
+}
+
+/**
+ * US-2653 — candidat de **dé-escalade ICR** (moins d'insuline/gramme) sur hypos post-prandiales
+ * récurrentes, **indépendant du deadband sur la moyenne**. Pas **fixe** `+HYPO_DEESCALATION_PERCENT`
+ * (validé medical : pas de scaling — la persistance titre cumulativement). Direction HAUSSE = sens sûr
+ * (« hyper ») → jamais bloquée par la garde hypo ; les bornes de `createEngineProposal` suffisent (un
+ * proposedValue > `ICR_MAX` est rejeté à la persistance → skip fail-closed).
+ *
+ * ⚠️ Le cas **haute-variabilité** (moyenne > plafond ET hypos récurrentes) N'est PAS traité ici : c'est
+ * à l'appelant (générateur) de router ce cas vers un **flag de revue**, pas une proposition de dose.
+ *
+ * @param slot Créneau ICR courant.
+ * @param nadirsGl Nadirs post-prandiaux (g/L) du créneau, non nuls.
+ * @returns Candidat de hausse ICR, ou `null` si l'hypo n'est pas récurrente.
+ */
+export function analyzeIcrHypoDeescalation(
+  slot: { startHour: number; endHour: number; gramsPerUnit: number },
+  nadirsGl: number[],
+): ProposalCandidate | null {
+  if (!recurrentPostMealHypo(nadirsGl)) return null
+  const proposedValue = computeProposedValue(slot.gramsPerUnit, CLINICAL_BOUNDS.HYPO_DEESCALATION_PERCENT)
+  return {
+    parameterType: "insulinToCarbRatio",
+    reason: "icrTooLow", // hausse ICR = moins d'insuline/gramme
+    currentValue: slot.gramsPerUnit,
+    proposedValue,
+    changePercent: CLINICAL_BOUNDS.HYPO_DEESCALATION_PERCENT,
+    confidence: getConfidenceLevel(nadirsGl.length),
+    supportingEvents: nadirsGl.filter((g) => g < LEVEL1_HYPO_GL).length, // nb de nadirs en hypo (> 0)
+    totalEventsConsidered: nadirsGl.length,
+    timeSlotStartHour: slot.startHour,
+    timeSlotEndHour: slot.endHour,
+  }
+}
+
+/**
  * Adjustment proposal candidate — suggested parameter change with confidence.
  * @typedef {Object} ProposalCandidate
  * @property {AdjustableParameter} parameterType - Parameter to adjust (ISF, ICR, or basal)

--- a/src/lib/proposal-algorithm.ts
+++ b/src/lib/proposal-algorithm.ts
@@ -52,7 +52,10 @@ function hypoBlocksProposal(
  */
 export function recurrentPostMealHypo(nadirsGl: number[]): boolean {
   if (nadirsGl.length < 3) return false
-  const level1 = nadirsGl.filter((g) => g < LEVEL1_HYPO_GL).length
+  // `Number.isFinite` d'abord : garde défensif — `null < 0.70` coerce à `true` en JS (null→0) et
+  // fabriquerait une fausse hypo (direction « moins d'insuline »). Le contrat exige des non-nuls,
+  // ce garde en fait une garantie runtime dans une fonction safety-relevant.
+  const level1 = nadirsGl.filter((g) => Number.isFinite(g) && g < LEVEL1_HYPO_GL).length
   return level1 >= CLINICAL_BOUNDS.HYPO_LEVEL1_RECURRENCE_MIN
 }
 
@@ -83,7 +86,7 @@ export function analyzeIcrHypoDeescalation(
     proposedValue,
     changePercent: CLINICAL_BOUNDS.HYPO_DEESCALATION_PERCENT,
     confidence: getConfidenceLevel(nadirsGl.length),
-    supportingEvents: nadirsGl.filter((g) => g < LEVEL1_HYPO_GL).length, // nb de nadirs en hypo (> 0)
+    supportingEvents: nadirsGl.filter((g) => Number.isFinite(g) && g < LEVEL1_HYPO_GL).length, // nb de nadirs en hypo (> 0)
     totalEventsConsidered: nadirsGl.length,
     timeSlotStartHour: slot.startHour,
     timeSlotEndHour: slot.endHour,

--- a/tests/unit/clinical-bounds.test.ts
+++ b/tests/unit/clinical-bounds.test.ts
@@ -69,6 +69,7 @@ describe("CLINICAL_BOUNDS — anti-drift (A3)", () => {
       ICR_PREMEAL_MIN_GL: 0.7,
       ICR_PREMEAL_MAX_GL: 1.4,
       ICR_PREMEAL_MAX_PREGNANCY_GL: 1.1,
+      HYPO_DEESCALATION_PERCENT: 10,
     })
   })
 

--- a/tests/unit/proposal-algorithm.test.ts
+++ b/tests/unit/proposal-algorithm.test.ts
@@ -42,6 +42,7 @@ import { describe, it, expect } from "vitest"
 import {
   getConfidenceLevel, clampChangePercent, computeProposedValue,
   analyzeIsfSlot, analyzeIcrSlot, analyzeBasalTrend, analyzeFixedDose,
+  recurrentPostMealHypo, analyzeIcrHypoDeescalation,
 } from "@/lib/proposal-algorithm"
 
 describe("proposal-algorithm", () => {
@@ -213,6 +214,40 @@ describe("proposal-algorithm", () => {
       expect(r1!.reason).toBe("icrTooLow")
       expect(r2!.reason).toBe("icrTooLow")
       expect(r2!.changePercent).toBe(r1!.changePercent)
+    })
+  })
+
+  describe("recurrentPostMealHypo (US-2653)", () => {
+    it("< 3 nadirs → false (échantillon insuffisant)", () => {
+      expect(recurrentPostMealHypo([0.5, 0.6])).toBe(false)
+    })
+    it("≥ 2 nadirs niveau-1 (< 0,70) → true (récurrent)", () => {
+      expect(recurrentPostMealHypo([0.6, 0.65, 1.2])).toBe(true)
+    })
+    it("1 seul nadir niveau-1 → false (non récurrent)", () => {
+      expect(recurrentPostMealHypo([0.65, 1.2, 1.3])).toBe(false)
+    })
+    it("1 sévère ISOLÉ (< 0,54) → false (garde anti-artefact : corroboration exigée)", () => {
+      expect(recurrentPostMealHypo([0.5, 1.2, 1.3])).toBe(false)
+    })
+    it("1 sévère + 1 niveau-1 → true (le sévère compte comme niveau-1 → 2)", () => {
+      expect(recurrentPostMealHypo([0.5, 0.65, 1.2])).toBe(true)
+    })
+  })
+
+  describe("analyzeIcrHypoDeescalation (US-2653)", () => {
+    const slot = { startHour: 12, endHour: 14, gramsPerUnit: 10 }
+    it("hypo récurrente → HAUSSE ICR +10 % (moins d'insuline), icrTooLow", () => {
+      const r = analyzeIcrHypoDeescalation(slot, [0.6, 0.65, 1.2])
+      expect(r).not.toBeNull()
+      expect(r!.reason).toBe("icrTooLow")
+      expect(r!.changePercent).toBe(10)
+      expect(r!.proposedValue).toBe(11) // 10 × 1,10
+      expect(r!.proposedValue).toBeGreaterThan(slot.gramsPerUnit)
+      expect(r!.supportingEvents).toBe(2) // 2 nadirs en hypo
+    })
+    it("hypo non récurrente → null", () => {
+      expect(analyzeIcrHypoDeescalation(slot, [0.65, 1.2, 1.3])).toBeNull()
     })
   })
 

--- a/tests/unit/proposal-algorithm.test.ts
+++ b/tests/unit/proposal-algorithm.test.ts
@@ -233,6 +233,12 @@ describe("proposal-algorithm", () => {
     it("1 sévère + 1 niveau-1 → true (le sévère compte comme niveau-1 → 2)", () => {
       expect(recurrentPostMealHypo([0.5, 0.65, 1.2])).toBe(true)
     })
+    it("borne exacte 0,70 exclue (< strict) → non compté niveau-1", () => {
+      expect(recurrentPostMealHypo([0.7, 0.7, 1.2])).toBe(false)
+    })
+    it("garde anti-null : un null ne fabrique PAS une hypo (Number.isFinite)", () => {
+      expect(recurrentPostMealHypo([null as unknown as number, null as unknown as number, 1.2])).toBe(false)
+    })
   })
 
   describe("analyzeIcrHypoDeescalation (US-2653)", () => {


### PR DESCRIPTION
**Répond à une demande utilisateur** : que l'app propose de **réduire l'insuline** quand un patient fait des **hypos post-repas récurrentes**, même si sa glycémie **moyenne** est « normale » (le deadband sur la moyenne masque la charge hypo — la limite `mean-vs-nadir` documentée en §5ter).

Design **validé medical AVANT code** (le pattern qui nous a évité un générateur dangereux). Verdict : idée correcte, avec un **carve-out HIGH** — le cas haute-variabilité (moyenne > plafond ET hypos récurrentes) ne doit **pas** proposer de dose (le levier ICR ne corrige pas pic + creux) → **flag de revue** (slice B).

## Slice A — logique pure (keystone)
- **`HYPO_DEESCALATION_PERCENT = 10`** (pas fixe, +10 % ICR ≈ −9 % insuline repas ; pas de scaling ; la persistance titre cumulativement). +anti-drift +catalogue.
- **`recurrentPostMealHypo(nadirsGl)`** : ≥ `HYPO_LEVEL1_RECURRENCE_MIN` (2) nadirs < niveau-1 (0,70) parmi ≥ 3. **Plus strict que la garde hypo** : un sévère isolé (artefact capteur possible) **ne réduit pas** activement l'insuline (garde anti-artefact, validé medical).
- **`analyzeIcrHypoDeescalation(slot, nadirsGl)`** : candidat **HAUSSE ICR +10 %** (`icrTooLow`, moins d'insuline). Direction sûre (« hyper ») → jamais bloquée par la garde ; bornes `createEngineProposal` suffisent (ICR > 30 → skip fail-closed).
- **+7 tests** (seuils, garde anti-artefact, hausse +10 %, non-récurrent → null).

## Slice B (à suivre)
**Matrice de décision** dans le générateur (mutuellement exclusive avec le deadband) + flag **`highVariabilityPostMeal`** (migration enum + wiring).

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3744 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)