### PR TITLE
US-2653 (slice B) — Matrice de décision générateur + flag highVariabilityPostMeal

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -742,7 +742,7 @@ tous corrigés. Migration `20260513230000_groupe5_review_fixes` (FK + unique + p
 | US-2650 | Self-service patient : route `(patient)` + nav + lecture + proposer | front/back | 2648, 2649 | L | ⏳ TODO (#633) |
 | US-2651 | Algorithme d'ajustement multi-mode (basal-bolus / doses fixes / non insuliné) | back | 2646, 2647 | L | 🟡 EN COURS — analyseurs + garde hypo + persistance moteur + **générateur ICR de bout en bout + cron** livrés (#666→#672) ; restent ISF/basal/fixedDose/nonInsulin (#634) |
 | US-2652 | Garde-fous cliniques + i18n/acronymes + design-system + tests + docs | transverse | 2646→2651 | M | ⏳ TODO (#635) |
-| US-2653 | Propositions de **dé-escalade sur hypos récurrentes** (nadir-trigger, moins d'insuline) transverse aux 4 analyseurs, indépendant du deadband sur la moyenne | back | 2651 | M/L | 🟡 SPEC |
+| US-2653 | Propositions de **dé-escalade sur hypos récurrentes** (nadir-trigger, moins d'insuline) transverse aux 4 analyseurs, indépendant du deadband sur la moyenne | back | 2651 | M/L | 🟡 EN COURS — **chemin ICR câblé** (prédicat/builder #673, matrice + flag highVariabilityPostMeal) ; restent ISF/basal/fixedDose |
 
 > Chemin critique : `2646 → 2647 → {2648, 2651} → 2649 → 2650 → 2652`.
 > ⚠️ À reconfirmer avant dev : validateur des propositions **DOCTOR only** vs **NURSE+DOCTOR** (défaut : DOCTOR only).

--- a/docs/clinical-logic/algorithme-propositions-ajustement.md
+++ b/docs/clinical-logic/algorithme-propositions-ajustement.md
@@ -225,13 +225,17 @@ slices ultérieures.
 La **porte qualité pré-repas** est **grossesse-aware** : borne haute resserrée à `ICR_PREMEAL_MAX_PREGNANCY_GL`
 (1,10 g/L) quand `isPregnancy` — sinon un pré-repas déjà élevé pour une enceinte contaminerait le signal ICR.
 
-> **⚠️ Limite connue — deadband sur la MOYENNE, hypo sur le NADIR (→ US-2653).** La décision de proposer
-> (deadband) porte sur la **moyenne** PPG, la garde hypo sur le **nadir**. Un patient **bon en moyenne** mais
-> avec des **hypos post-repas récurrentes** ne reçoit **aucune** proposition : la moyenne (dans le deadband)
-> masque la charge hypo, et le nadir n'est utilisé que comme **frein** (bloquer « plus d'insuline »), jamais
-> comme **déclencheur** d'une **hausse** d'ICR (« moins d'insuline »). C'est de la **sous-action** (sens sûr ;
-> la charge hypo remonte par TIR/alertes/AGP), surtout sensible en grossesse. **Réponse = US-2653** :
-> déclencher une dé-escalade sur nadirs récurrents, transverse aux 4 analyseurs, indépendamment du deadband.
+> **✅ US-2653 (câblé, chemin ICR) — matrice deadband × nadir récurrent.** La décision par créneau combine
+> désormais la **moyenne** PPG (deadband) ET les **nadirs récurrents** (`recurrentPostMealHypo` : ≥ 2 nadirs
+> < 0,70 parmi ≥ 3) :
+> - `moyenne > plafond` & **récurrent** → **flag `highVariabilityPostMeal`** (pic + creux : le levier ICR ne
+>   corrige pas les deux → revue, **jamais** une dose) ;
+> - `moyenne > plafond` & non-récurrent → **baisse** (deadband) ;
+> - **dans la bande** & récurrent → **`analyzeIcrHypoDeescalation`** (hausse ICR fixe **+10 %** = moins
+>   d'insuline) — comble le trou « bon en moyenne mais hypos récurrentes » ;
+> - dans la bande & non-récurrent → rien ; `< borne basse` → hausse (deadband).
+> Deadband et dé-escalade **mutuellement exclusifs** par créneau. Extension ISF/basal/fixedDose ultérieure
+> (nadir feed **par analyseur** — ne jamais nourrir un nadir post-repas à la basale).
 
 > **⚠️ Caveat clinique — troncature par resucrage (MEDIUM, validé medical).** La fenêtre nadir se termine
 > au **prochain apport glucidique** (anti mis-attribution : la glycémie post-collation ne doit pas être

--- a/docs/clinical-logic/algorithme-propositions-ajustement.md
+++ b/docs/clinical-logic/algorithme-propositions-ajustement.md
@@ -233,7 +233,9 @@ La **porte qualité pré-repas** est **grossesse-aware** : borne haute resserré
 > - `moyenne > plafond` & non-récurrent → **baisse** (deadband) ;
 > - **dans la bande** & récurrent → **`analyzeIcrHypoDeescalation`** (hausse ICR fixe **+10 %** = moins
 >   d'insuline) — comble le trou « bon en moyenne mais hypos récurrentes » ;
-> - dans la bande & non-récurrent → rien ; `< borne basse` → hausse (deadband).
+> - dans la bande & non-récurrent → rien ; `< borne basse` → hausse (deadband), avec **fallback
+>   dé-escalade +10 %** si le deadband est sous le seuil des 2 % (moyenne juste sous la borne) ET hypos
+>   récurrentes (validé medical : ne pas laisser ce sliver sans proposition).
 > Deadband et dé-escalade **mutuellement exclusifs** par créneau. Extension ISF/basal/fixedDose ultérieure
 > (nadir feed **par analyseur** — ne jamais nourrir un nadir post-repas à la basale).
 

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -284,5 +284,5 @@ Déclencheur **indépendant du deadband** : des hypos post-prandiales récurrent
 **Matrice de décision par créneau (chemin ICR)** — moyenne PPG × hypo récurrente :
 - `> plafond` & non → **BAISSE** (deadband) · `> plafond` & **oui** → **flag `highVariabilityPostMeal`** (pas de dose : le levier ICR ne corrige pas pic + creux) · **dans la bande** & oui → **HAUSSE +10 %** (cœur US-2653) · dans la bande & non → rien · `< borne basse` → **HAUSSE** (deadband).
 
-Slice A (prédicat + builder purs) livrée ; slice B = matrice dans le générateur + flag. Cf.
+Slices A (prédicat + builder purs) **et** B (matrice dans le générateur + flag `highVariabilityPostMeal`) livrées. Cf.
 `algorithme-propositions-ajustement.md` §5ter.

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -2033,7 +2033,8 @@
     "flagReviewInConsultation": "مراجعة في الاستشارة",
     "flagHba1cStale": "الهيموغلوبين السكري (HbA1c) للتحديث",
     "flagTirBelowTarget": "الوقت ضمن النطاق (TIR) تحت الهدف",
-    "flagObservance": "التحقق من الالتزام"
+    "flagObservance": "التحقق من الالتزام",
+    "flagHighVariabilityPostMeal": "تقلب مرتفع بعد الوجبة (ذروة + نقص سكر الدم)"
   },
   "review": {
     "title": "وضع مراجعة الاستشارة",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2033,7 +2033,8 @@
     "flagReviewInConsultation": "Review in consultation",
     "flagHba1cStale": "Glycated haemoglobin (HbA1c) to refresh",
     "flagTirBelowTarget": "Time in range (TIR) below target",
-    "flagObservance": "Adherence to check"
+    "flagObservance": "Adherence to check",
+    "flagHighVariabilityPostMeal": "High post-meal variability (spike + hypoglycemia)"
   },
   "review": {
     "title": "Consultation review mode",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -2033,7 +2033,8 @@
     "flagReviewInConsultation": "À revoir en consultation",
     "flagHba1cStale": "Hémoglobine glyquée (HbA1c) à actualiser",
     "flagTirBelowTarget": "Temps dans la cible (TIR) sous l'objectif",
-    "flagObservance": "Observance à vérifier"
+    "flagObservance": "Observance à vérifier",
+    "flagHighVariabilityPostMeal": "Forte variabilité post-repas (pic + hypoglycémie)"
   },
   "review": {
     "title": "Mode revue de consultation",

--- a/prisma/migrations/20260708100000_us2653_review_flag_high_variability/migration.sql
+++ b/prisma/migrations/20260708100000_us2653_review_flag_high_variability/migration.sql
@@ -1,6 +1,8 @@
 -- US-2653 — nouveau type de flag d'orientation : forte variabilité post-prandiale
 -- (moyenne PPG > plafond ET hypos post-repas récurrentes). Le levier ICR ne peut corriger
 -- à la fois le pic et le creux → le générateur émet ce flag de REVUE au lieu d'une proposition
--- de dose. `ALTER TYPE ... ADD VALUE` est idempotent-safe hors transaction (non rejouable en une
--- même migration, d'où fichier dédié). Mirroir de la migration enum US-2651.
+-- de dose. `ALTER TYPE ... ADD VALUE` ne peut PAS tourner dans un bloc transactionnel et la valeur
+-- ajoutée n'est pas utilisable dans la même migration → fichier dédié à une seule instruction. Non
+-- idempotent en soi (échouerait au replay) : c'est le tracking `_prisma_migrations` qui garantit le
+-- non-rejeu. Mirroir de la migration enum US-2651.
 ALTER TYPE "ClinicalReviewFlagType" ADD VALUE 'highVariabilityPostMeal';

--- a/prisma/migrations/20260708100000_us2653_review_flag_high_variability/migration.sql
+++ b/prisma/migrations/20260708100000_us2653_review_flag_high_variability/migration.sql
@@ -1,0 +1,6 @@
+-- US-2653 — nouveau type de flag d'orientation : forte variabilité post-prandiale
+-- (moyenne PPG > plafond ET hypos post-repas récurrentes). Le levier ICR ne peut corriger
+-- à la fois le pic et le creux → le générateur émet ce flag de REVUE au lieu d'une proposition
+-- de dose. `ALTER TYPE ... ADD VALUE` est idempotent-safe hors transaction (non rejouable en une
+-- même migration, d'où fichier dédié). Mirroir de la migration enum US-2651.
+ALTER TYPE "ClinicalReviewFlagType" ADD VALUE 'highVariabilityPostMeal';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -131,6 +131,9 @@ enum ClinicalReviewFlagType {
   hba1cStale
   tirBelowTarget
   observance
+  // US-2653 — forte variabilité post-prandiale (pic + hypo récurrente) : le levier ICR ne corrige
+  // pas les deux bouts → orientation revue (timing bolus/composition/IOB/ISF), jamais une dose.
+  highVariabilityPostMeal
 }
 
 enum ClinicalReviewFlagStatus {

--- a/src/components/diabeo/dashboard/medecin/ReviewFlagsCard.tsx
+++ b/src/components/diabeo/dashboard/medecin/ReviewFlagsCard.tsx
@@ -27,6 +27,7 @@ const FLAG_TYPE_KEY: Record<ReviewFlagItem["type"], string> = {
   hba1cStale: "flagHba1cStale",
   tirBelowTarget: "flagTirBelowTarget",
   observance: "flagObservance",
+  highVariabilityPostMeal: "flagHighVariabilityPostMeal",
 }
 
 export function ReviewFlagsCard() {

--- a/src/lib/services/proposal-generator.service.ts
+++ b/src/lib/services/proposal-generator.service.ts
@@ -212,9 +212,17 @@ export const proposalGeneratorService = {
       // Sinon : deadband (baisse si > plafond ; hausse si < borne basse) OU, dans la bande, dé-escalade
       // sur hypos récurrentes (hausse ICR fixe = moins d'insuline).
       let candidate: ProposalCandidate | null = null
-      if (avgPostGl > ceilingGl) candidate = analyzeIcrSlot(slot, buildIcrMeals(meals, ceilingGl))
-      else if (avgPostGl < lowerGl) candidate = analyzeIcrSlot(slot, buildIcrMeals(meals, lowerGl))
-      else if (recurrentHypo) candidate = analyzeIcrHypoDeescalation(slot, nadirsGl)
+      if (avgPostGl > ceilingGl) {
+        candidate = analyzeIcrSlot(slot, buildIcrMeals(meals, ceilingGl)) // baisse (deadband)
+      } else if (avgPostGl < lowerGl) {
+        candidate = analyzeIcrSlot(slot, buildIcrMeals(meals, lowerGl)) // hausse (deadband)
+        // Fallback (validé medical) : moyenne juste sous la borne (deadband < 2 % → null) MAIS hypos
+        // récurrentes → la dé-escalade fixe +10 % (même sens sûr, plus protecteur). Ne pas laisser
+        // ce sliver sans proposition pour un patient à hypos récurrentes.
+        if (!candidate && recurrentHypo) candidate = analyzeIcrHypoDeescalation(slot, nadirsGl)
+      } else if (recurrentHypo) {
+        candidate = analyzeIcrHypoDeescalation(slot, nadirsGl) // in-band + récurrent → hausse +10 %
+      }
 
       if (candidate && (await persist(candidate, slot))) created++
     }

--- a/src/lib/services/proposal-generator.service.ts
+++ b/src/lib/services/proposal-generator.service.ts
@@ -17,7 +17,10 @@ import { logger } from "@/lib/logger"
 import { withSessionAdvisoryLock } from "@/lib/db/cron-lock"
 import { CLINICAL_BOUNDS } from "@/lib/clinical-bounds"
 import { findSlotForHour } from "@/lib/insulin-slots"
-import { analyzeIcrSlot } from "@/lib/proposal-algorithm"
+import {
+  analyzeIcrSlot, analyzeIcrHypoDeescalation, recurrentPostMealHypo, type ProposalCandidate,
+} from "@/lib/proposal-algorithm"
+import { clinicalReviewFlagService } from "@/lib/services/clinical-review-flag.service"
 import { treatmentModeService } from "@/lib/services/treatment-mode.service"
 import { insulinTherapyService } from "@/lib/services/insulin-therapy.service"
 import { mealtimePattern, type JournalMeal } from "@/lib/services/meal-trends.service"
@@ -34,6 +37,8 @@ const MIN_MEALS_PER_SLOT = 3
 /** Résultat d'un run patient — métriques d'observabilité (aucune valeur clinique). */
 export interface GenerateResult {
   created: number
+  /** US-2653 — flags `highVariabilityPostMeal` levés (cas haute-variabilité, jamais de dose). */
+  flagged: number
   slotsConsidered: number
   mealsUsable: number
   skipped: string | null
@@ -43,6 +48,7 @@ export interface GenerateResult {
 export interface GenerateAllResult {
   processed: number
   created: number
+  flagged: number
   errored: number
   skippedConcurrent: boolean
 }
@@ -54,7 +60,16 @@ const CRON_AUDIT_USER_ID: number | null = null
 /** Clé du verrou advisory global (anti double-run OVH + Vercel). */
 const CRON_LOCK_KEY = "proposal-generator-cron"
 
-const EMPTY = (skipped: string): GenerateResult => ({ created: 0, slotsConsidered: 0, mealsUsable: 0, skipped })
+const EMPTY = (skipped: string): GenerateResult =>
+  ({ created: 0, flagged: 0, slotsConsidered: 0, mealsUsable: 0, skipped })
+
+/** Construit les entrées `analyzeIcrSlot` d'un créneau pour une cible donnée (deadband). */
+const buildIcrMeals = (meals: JournalMeal[], targetGl: number) =>
+  meals.map((m) => ({
+    postGlucoseGl: m.postMgdl! / 100,
+    targetGl,
+    nadirGl: m.nadirMgdl !== null ? m.nadirMgdl / 100 : undefined,
+  }))
 
 /**
  * Un repas est exploitable pour l'ICR si : PPG 2 h mesurée, glucides ET bolus renseignés (> 0), et
@@ -135,28 +150,16 @@ export const proposalGeneratorService = {
       bySlot.set(key, bucket)
     }
 
-    // 5. Par créneau ≥ 3 repas → deadband → analyseur → persistance moteur.
+    // 5. Par créneau ≥ 3 repas → MATRICE DE DÉCISION (§5ter, validée medical US-2653) :
+    //    moyenne PPG × hypo récurrente (nadirs). Deadband et dé-escalade sont mutuellement exclusifs
+    //    par créneau. Cas HAUTE-VARIABILITÉ (moyenne > plafond ET hypos récurrentes) → FLAG de revue,
+    //    JAMAIS une dose (le levier ICR ne corrige pas à la fois le pic et le creux).
     let created = 0
+    let flagged = 0
     let slotsConsidered = 0
-    for (const { slot, meals } of bySlot.values()) {
-      if (meals.length < MIN_MEALS_PER_SLOT) continue
-      slotsConsidered++
 
-      const avgPostGl = mean(meals.map((m) => m.postMgdl! / 100))
-      // Deadband asymétrique : au-dessus du plafond → BAISSE ICR (plus d'insuline) ; en dessous de la
-      // borne basse → HAUSSE ICR (moins d'insuline) ; entre les deux → aucune proposition.
-      let targetGl: number | null = null
-      if (avgPostGl > ceilingGl) targetGl = ceilingGl
-      else if (avgPostGl < lowerGl) targetGl = lowerGl
-      if (targetGl === null) continue
-
-      const candidate = analyzeIcrSlot(slot, meals.map((m) => ({
-        postGlucoseGl: m.postMgdl! / 100,
-        targetGl,
-        nadirGl: m.nadirMgdl !== null ? m.nadirMgdl / 100 : undefined,
-      })))
-      if (!candidate) continue
-
+    // Persiste un candidat (deadband ou dé-escalade). Rejets fail-closed logués + non fatals.
+    const persist = async (candidate: ProposalCandidate, slot: (typeof slots)[number]): Promise<boolean> => {
       try {
         await adjustmentService.createEngineProposal({
           patientId,
@@ -172,10 +175,8 @@ export const proposalGeneratorService = {
           carbRatioSlotStart: slot.startHour,
           carbRatioSlotEnd: slot.endHour,
         }, ctx)
-        created++
+        return true
       } catch (err) {
-        // Rejets ATTENDUS (fail-closed, non fatals) → info + grep SOC ; on continue le portefeuille.
-        // INATTENDU (ex. erreur DB brute) → logger.error SANS interpoler le message (défense PHI, HDS #671).
         const msg = (err as Error).message
         const bucket = `${slot.startHour}-${slot.endHour}`
         if (EXPECTED_SKIP.has(msg)) {
@@ -184,10 +185,41 @@ export const proposalGeneratorService = {
           logger.error("proposal-generator", "unexpected engine proposal error",
             { patientId, bucket, failMode: "unexpected" }, err as Error)
         }
+        return false
       }
     }
 
-    return { created, slotsConsidered, mealsUsable: usable.length, skipped: null }
+    for (const { slot, meals } of bySlot.values()) {
+      if (meals.length < MIN_MEALS_PER_SLOT) continue
+      slotsConsidered++
+
+      const avgPostGl = mean(meals.map((m) => m.postMgdl! / 100))
+      const nadirsGl = meals
+        .map((m) => m.nadirMgdl)
+        .filter((n): n is number => n !== null)
+        .map((n) => n / 100)
+      const recurrentHypo = recurrentPostMealHypo(nadirsGl)
+
+      // Haute variabilité → FLAG d'orientation, pas de dose (intercepté AVANT tout builder).
+      if (avgPostGl > ceilingGl && recurrentHypo) {
+        await clinicalReviewFlagService.raise(patientId, "highVariabilityPostMeal", auditUserId, ctx)
+          .then(() => { flagged++ })
+          .catch((err) => logger.error("proposal-generator", "raise flag failed",
+            { patientId, bucket: `${slot.startHour}-${slot.endHour}` }, err as Error))
+        continue
+      }
+
+      // Sinon : deadband (baisse si > plafond ; hausse si < borne basse) OU, dans la bande, dé-escalade
+      // sur hypos récurrentes (hausse ICR fixe = moins d'insuline).
+      let candidate: ProposalCandidate | null = null
+      if (avgPostGl > ceilingGl) candidate = analyzeIcrSlot(slot, buildIcrMeals(meals, ceilingGl))
+      else if (avgPostGl < lowerGl) candidate = analyzeIcrSlot(slot, buildIcrMeals(meals, lowerGl))
+      else if (recurrentHypo) candidate = analyzeIcrHypoDeescalation(slot, nadirsGl)
+
+      if (candidate && (await persist(candidate, slot))) created++
+    }
+
+    return { created, flagged, slotsConsidered, mealsUsable: usable.length, skipped: null }
   },
 
   /**
@@ -208,11 +240,13 @@ export const proposalGeneratorService = {
       })
       let processed = 0
       let created = 0
+      let flagged = 0
       let errored = 0
       for (const { id } of patients) {
         try {
           const r = await proposalGeneratorService.generateForPatient(id, CRON_AUDIT_USER_ID, ctx)
           created += r.created
+          flagged += r.flagged
         } catch (err) {
           // Isolation : erreur infra (DB/lecture) sur un patient → on compte et on continue.
           errored++
@@ -221,7 +255,7 @@ export const proposalGeneratorService = {
         }
         processed++
       }
-      return { processed, created, errored, skippedConcurrent: false }
+      return { processed, created, flagged, errored, skippedConcurrent: false }
     })
     const durationMs = Date.now() - t0
 
@@ -235,7 +269,7 @@ export const proposalGeneratorService = {
         ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
         metadata: { kind: "proposal.generator.cron.skipped_locked", durationMs },
       }).catch((err) => logger.error("proposal-generator", "cron audit (skipped) failed", { kind: "audit.write.failed" }, err))
-      return { processed: 0, created: 0, errored: 0, skippedConcurrent: true }
+      return { processed: 0, created: 0, flagged: 0, errored: 0, skippedConcurrent: true }
     }
 
     await auditService.log({
@@ -243,7 +277,7 @@ export const proposalGeneratorService = {
       ipAddress: ctx?.ipAddress, userAgent: ctx?.userAgent, requestId: ctx?.requestId,
       metadata: {
         kind: "proposal.generator.cron.run",
-        processed: run.processed, created: run.created, errored: run.errored, durationMs,
+        processed: run.processed, created: run.created, flagged: run.flagged, errored: run.errored, durationMs,
       },
     }).catch((err) => logger.error("proposal-generator", "cron audit (run) failed", { kind: "audit.write.failed" }, err))
     return run

--- a/tests/unit/proposal-generator.service.test.ts
+++ b/tests/unit/proposal-generator.service.test.ts
@@ -27,6 +27,9 @@ vi.mock("@/lib/db/cron-lock", () => ({
 vi.mock("@/lib/services/audit.service", () => ({
   auditService: { log: vi.fn().mockResolvedValue(undefined) },
 }))
+vi.mock("@/lib/services/clinical-review-flag.service", () => ({
+  clinicalReviewFlagService: { raise: vi.fn().mockResolvedValue({ flagId: "f1", created: true }) },
+}))
 
 import { proposalGeneratorService } from "@/lib/services/proposal-generator.service"
 import { treatmentModeService } from "@/lib/services/treatment-mode.service"
@@ -35,9 +38,11 @@ import { mealtimePattern } from "@/lib/services/meal-trends.service"
 import { adjustmentService } from "@/lib/services/adjustment.service"
 import { withSessionAdvisoryLock } from "@/lib/db/cron-lock"
 import { auditService } from "@/lib/services/audit.service"
+import { clinicalReviewFlagService } from "@/lib/services/clinical-review-flag.service"
 
 const lock = vi.mocked(withSessionAdvisoryLock)
 const auditLog = vi.mocked(auditService.log)
+const raiseFlag = vi.mocked(clinicalReviewFlagService.raise)
 const mode = vi.mocked(treatmentModeService.resolveTreatmentMode)
 const getSettings = vi.mocked(insulinTherapyService.getSettings)
 const dailyJournal = vi.mocked(mealtimePattern.dailyJournal)
@@ -98,6 +103,37 @@ describe("proposalGeneratorService.generateForPatient", () => {
     const res = await proposalGeneratorService.generateForPatient(1, 99)
     expect(res.created).toBe(0)
     expect(createEngine).not.toHaveBeenCalled()
+  })
+
+  it("US-2653 haute variabilité (moyenne > plafond + hypos récurrentes) → FLAG, pas de dose", async () => {
+    setup({ meals: [
+      meal({ postMgdl: 200, nadirMgdl: 60 }), meal({ postMgdl: 200, nadirMgdl: 60 }), meal({ postMgdl: 200, nadirMgdl: 60 }),
+    ] }) // PPG 2,0 > plafond 1,80 MAIS nadirs 0,60 → récurrent
+    const res = await proposalGeneratorService.generateForPatient(1, 99)
+    expect(res.flagged).toBe(1)
+    expect(res.created).toBe(0)
+    expect(raiseFlag).toHaveBeenCalledWith(1, "highVariabilityPostMeal", 99, undefined)
+    expect(createEngine).not.toHaveBeenCalled()
+  })
+
+  it("US-2653 dans la bande + hypos récurrentes → dé-escalade ICR (hausse +10 %, icrTooLow)", async () => {
+    setup({ meals: [
+      meal({ postMgdl: 140, nadirMgdl: 60 }), meal({ postMgdl: 140, nadirMgdl: 60 }), meal({ postMgdl: 140, nadirMgdl: 60 }),
+    ] }) // PPG 1,40 dans [1,00 ; 1,80] + nadirs 0,60 → dé-escalade
+    const res = await proposalGeneratorService.generateForPatient(1, 99)
+    expect(res.created).toBe(1)
+    expect(raiseFlag).not.toHaveBeenCalled()
+    const input = createEngine.mock.calls[0]![0]
+    expect(input.reason).toBe("icrTooLow")
+    expect(input.proposedValue).toBeGreaterThan(10) // hausse ICR = moins d'insuline
+  })
+
+  it("US-2653 dans la bande SANS hypo récurrente → aucune proposition ni flag", async () => {
+    setup({ meals: [meal({ postMgdl: 140 }), meal({ postMgdl: 140 }), meal({ postMgdl: 140 })] }) // nadir défaut 160
+    const res = await proposalGeneratorService.generateForPatient(1, 99)
+    expect(res).toMatchObject({ created: 0, flagged: 0 })
+    expect(createEngine).not.toHaveBeenCalled()
+    expect(raiseFlag).not.toHaveBeenCalled()
   })
 
   it("porte qualité : repas sans glucides / bolus / pré-repas hors bande → exclus", async () => {

--- a/tests/unit/proposal-generator.service.test.ts
+++ b/tests/unit/proposal-generator.service.test.ts
@@ -128,6 +128,18 @@ describe("proposalGeneratorService.generateForPatient", () => {
     expect(input.proposedValue).toBeGreaterThan(10) // hausse ICR = moins d'insuline
   })
 
+  it("US-2653 fallback : moyenne juste sous la borne (deadband < 2 % → null) + hypos récurrentes → dé-escalade", async () => {
+    // PPG 0,99 g/L < borne 1,00 : le deadband donne +1 % → null ; hypos récurrentes → fallback +10 %.
+    setup({ meals: [
+      meal({ postMgdl: 99, nadirMgdl: 60 }), meal({ postMgdl: 99, nadirMgdl: 60 }), meal({ postMgdl: 99, nadirMgdl: 60 }),
+    ] })
+    const res = await proposalGeneratorService.generateForPatient(1, 99)
+    expect(res.created).toBe(1)
+    const input = createEngine.mock.calls[0]![0]
+    expect(input.reason).toBe("icrTooLow")
+    expect(input.proposedValue).toBe(11) // dé-escalade fixe +10 %, pas le +1 % (null) du deadband
+  })
+
   it("US-2653 dans la bande SANS hypo récurrente → aucune proposition ni flag", async () => {
     setup({ meals: [meal({ postMgdl: 140 }), meal({ postMgdl: 140 }), meal({ postMgdl: 140 })] }) // nadir défaut 160
     const res = await proposalGeneratorService.generateForPatient(1, 99)


### PR DESCRIPTION
Câble la dé-escalade (slice A #673) dans le générateur ICR via la **matrice validée medical**. La fonctionnalité demandée par l'utilisateur (proposer **moins d'insuline** sur hypos post-repas récurrentes) devient **active**.

## Matrice de décision (par créneau) — moyenne PPG × `recurrentPostMealHypo(nadirs)`
| Moyenne PPG | Récurrent ? | Action |
|---|---|---|
| > plafond | **oui** | **Flag `highVariabilityPostMeal`** (pic + creux : ICR ne corrige pas les deux → revue, **jamais** de dose) — intercepté **avant** tout builder |
| > plafond | non | **baisse** ICR (deadband) |
| dans la bande | **oui** | **`analyzeIcrHypoDeescalation`** → hausse **+10 %** (moins d'insuline) |
| dans la bande | non | rien |
| < borne basse | tout | **hausse** (deadband) |

Deadband et dé-escalade **mutuellement exclusifs** par créneau (cohérent avec l'anti-spam `one_pending_per_slot`).

## Contenu
- **Enum** : `ClinicalReviewFlagType += highVariabilityPostMeal` + **migration** `ALTER TYPE` (mirroir US-2651).
- **UI** : `ReviewFlagsCard` (carte « Ma journée » médecin) affiche le flag ; **i18n fr/en/ar**.
- `GenerateResult`/`GenerateAllResult` += `flagged` (métrique + audit run).
- **Tests +3** (haute variabilité → flag/pas de dose ; in-band récurrent → dé-escalade `icrTooLow` ; in-band sans hypo → rien).
- Doc **§5ter** matrice « câblée » ; ROADMAP/catalogue US-2653.

⚠️ **Validation medical requise** (matrice intégrée + flag). Reste : ISF/basal/fixedDose (nadir feed **par analyseur**).

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3749 tests** (drift migration validé en CI shadow DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)