### PR TITLE
US-2651 (mode c, slice 1) — Flags d'orientation nonInsulin : hba1cStale

### DIFF
--- a/docs/clinical-logic/algorithme-propositions-ajustement.md
+++ b/docs/clinical-logic/algorithme-propositions-ajustement.md
@@ -163,7 +163,7 @@ Le mode est **dérivé serveur** (`resolveTreatmentMode`, fail-closed : un DT1 n
 |---|---|
 | **(a) basalBolus** | Analyseurs ISF/ICR/basal du §4 (existant). |
 | **(b) fixedDose** | **`analyzeFixedDose(slot, readings)` (livré, pur)** : dose **directe** par **moment** (carnet BGM). Au-dessus de la cible → dose trop basse → hausse (`fixedDoseTooLow`) ; en dessous → baisse (`fixedDoseTooHigh`). Bornée : **plus petit** de ± `FIXED_DOSE_MAX_CHANGE_PERCENT` (10 %) et ± `FIXED_DOSE_MAX_DELTA_U` (2 U) ; plancher `FIXED_DOSE_MIN` (0,5 U) ; arrondi à l'incrément délivrable (0,5 U) — pas nul → aucune proposition. **Cooldown 72 h/moment** (`FIXED_DOSE_COOLDOWN_HOURS`) au câblage du générateur (pas dans l'analyseur pur). **Jamais** : convertir doses fixes → basal-bolus, ni créer ISF/ICR ex nihilo. |
-| **(c) nonInsulin** | **Aucune proposition de dose** (frontière MDR). Uniquement des `ClinicalReviewFlag` d'orientation (« à revoir en consultation », HbA1c périmée, TIR sous cible, observance). La **cible** glycémique reste ajustable **par le médecin** (bornée, plus stricte en `pregnancyMode`). |
+| **(c) nonInsulin** | **Aucune proposition de dose** (frontière MDR). Uniquement des `ClinicalReviewFlag` d'orientation. **Livré** : `generateOrientationFlags` → **`hba1cStale`** (dernière HbA1c > `HBA1C_STALE_DAYS` 180 j, **ou absente**). **À venir** : `tirBelowTarget` (extraire le calcul TIR du dashboard) + `observance` (définition à cadrer). La **cible** glycémique reste ajustable **par le médecin**. |
 
 - **Exemples mode (b) dose fixe** (dose matin `10` U, cible `1,40` g/L) :
   - *Hausse* : glycémies du moment moyennes `2,00` g/L → dose trop basse → cap `min(10 % de 10 U ; 2 U) = 1 U`

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -286,3 +286,15 @@ Déclencheur **indépendant du deadband** : des hypos post-prandiales récurrent
 
 Slices A (prédicat + builder purs) **et** B (matrice dans le générateur + flag `highVariabilityPostMeal`) livrées. Cf.
 `algorithme-propositions-ajustement.md` §5ter.
+
+### Flag d'orientation `hba1cStale` (mode c nonInsulin, US-2651)
+
+`generateOrientationFlags` lève `hba1cStale` si la **dernière HbA1c enregistrée** (plus récente de
+`GlycemiaEntry.hba1c` / `DiabetesEvent.hba1c`) date de > `HBA1C_STALE_DAYS` (180 j) **ou est absente**.
+- **Seuil conditionnel (à venir)** : 180 j = borne ADA « stable / à l'objectif ». Un DT2 **non contrôlé**
+  devrait être re-dosé à **90 j**. Tant que le TIR (`tirBelowTarget`, slice 2) n'est pas câblé, le
+  générateur n'a pas le contexte de contrôle → seuil unique 180 j (faux-négatif possible, jamais de
+  sur-dosage). À rendre conditionnel (90 j hors-cible / 180 j à l'objectif) une fois le TIR disponible.
+- **Provenance** : HbA1c **saisie in-app** (potentiellement auto-déclarée), pas garantie labo — suffisant
+  pour un signal de **récence** (flag gaté médecin, non dosant ; le soignant voit valeur + date).
+- **Cas absent** : un diabétique suivi doit avoir une HbA1c → flag = **vrai positif** (« à réaliser »).

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -2031,7 +2031,7 @@
     "review": "فتح",
     "reviewAria": "فتح ملف {name}",
     "flagReviewInConsultation": "مراجعة في الاستشارة",
-    "flagHba1cStale": "الهيموغلوبين السكري (HbA1c) للتحديث",
+    "flagHba1cStale": "الهيموغلوبين السكري (HbA1c) للإجراء أو التحديث",
     "flagTirBelowTarget": "الوقت ضمن النطاق (TIR) تحت الهدف",
     "flagObservance": "التحقق من الالتزام",
     "flagHighVariabilityPostMeal": "تقلب مرتفع بعد الوجبة (ذروة + نقص سكر الدم)"

--- a/messages/en.json
+++ b/messages/en.json
@@ -2031,7 +2031,7 @@
     "review": "Open",
     "reviewAria": "Open {name}'s record",
     "flagReviewInConsultation": "Review in consultation",
-    "flagHba1cStale": "Glycated haemoglobin (HbA1c) to refresh",
+    "flagHba1cStale": "Glycated haemoglobin (HbA1c) to obtain or refresh",
     "flagTirBelowTarget": "Time in range (TIR) below target",
     "flagObservance": "Adherence to check",
     "flagHighVariabilityPostMeal": "High post-meal variability (spike + hypoglycemia)"

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -2031,7 +2031,7 @@
     "review": "Ouvrir",
     "reviewAria": "Ouvrir la fiche de {name}",
     "flagReviewInConsultation": "À revoir en consultation",
-    "flagHba1cStale": "Hémoglobine glyquée (HbA1c) à actualiser",
+    "flagHba1cStale": "Hémoglobine glyquée (HbA1c) à réaliser ou actualiser",
     "flagTirBelowTarget": "Temps dans la cible (TIR) sous l'objectif",
     "flagObservance": "Observance à vérifier",
     "flagHighVariabilityPostMeal": "Forte variabilité post-repas (pic + hypoglycémie)"

--- a/src/lib/clinical-bounds.ts
+++ b/src/lib/clinical-bounds.ts
@@ -233,11 +233,21 @@ export const AGP_SUFFICIENCY = {
 } as const
 
 /**
- * Péremption clinique d'un HbA1c de **laboratoire** (jours). L'HbA1c reflète la
- * glycémie moyenne des ~8–12 dernières semaines ; au-delà de ~180 j la valeur
- * est caduque comme indicateur de contrôle courant. `getLastHba1c` expose
- * `ageDays` + `stale` (> ce seuil) ; la valeur reste affichée mais datée/avertie
- * (mode BGM, où GMI/eA1c CGM sont invalides).
+ * Péremption clinique d'un HbA1c (jours). L'HbA1c reflète la glycémie moyenne des
+ * ~8–12 dernières semaines. `getLastHba1c` expose `ageDays` + `stale` (> ce seuil).
+ *
+ * ⚠️ **Seuil « stable / à l'objectif ».** 180 j (~6 mois) = intervalle ADA de re-dosage
+ * pour un patient **contrôlé et à la cible**. Pour un diabétique **NON contrôlé** (ou
+ * changement thérapeutique récent), l'ADA recommande **90 j**. Ce seuil unique est donc
+ * volontairement **lâche** : tant que le générateur mode c (US-2651) n'a pas de contexte de
+ * contrôle (le TIR — `tirBelowTarget` — arrive en slice 2), il ne peut distinguer contrôlé de
+ * non-contrôlé sans sur-flaguer tout patient stable. **À rendre conditionnel** (90 j hors-cible /
+ * 180 j à l'objectif) une fois le TIR câblé (validé medical #675).
+ *
+ * **Provenance** : `hba1cStale` lit la **dernière HbA1c enregistrée** (`GlycemiaEntry.hba1c` /
+ * `DiabetesEvent.hba1c`) — valeur **saisie in-app, potentiellement auto-déclarée**, pas
+ * nécessairement vérifiée labo. Suffisant pour un signal de **récence** (flag d'orientation gaté
+ * médecin, non dosant), le soignant voyant la valeur + la date.
  */
 export const HBA1C_STALE_DAYS = 180
 

--- a/src/lib/services/proposal-generator.service.ts
+++ b/src/lib/services/proposal-generator.service.ts
@@ -15,7 +15,7 @@
 import { prisma } from "@/lib/db/client"
 import { logger } from "@/lib/logger"
 import { withSessionAdvisoryLock } from "@/lib/db/cron-lock"
-import { CLINICAL_BOUNDS } from "@/lib/clinical-bounds"
+import { CLINICAL_BOUNDS, HBA1C_STALE_DAYS } from "@/lib/clinical-bounds"
 import { findSlotForHour } from "@/lib/insulin-slots"
 import {
   analyzeIcrSlot, analyzeIcrHypoDeescalation, recurrentPostMealHypo, type ProposalCandidate,
@@ -112,8 +112,10 @@ export const proposalGeneratorService = {
    * @returns Métriques du run (sans PHI).
    */
   async generateForPatient(patientId: number, auditUserId: number | null, ctx?: AuditContext): Promise<GenerateResult> {
-    // 0. Mode — seul `basalBolus` a des ratios ICR par créneau à titrer.
+    // 0. Mode — routage : `nonInsulin` → flags d'orientation (mode c, jamais de dose, frontière MDR) ;
+    //    `basalBolus` → propositions ICR (ci-dessous) ; `fixedDose` → hors scope (slice ultérieure).
     const { mode } = await treatmentModeService.resolveTreatmentMode(patientId)
+    if (mode === "nonInsulin") return proposalGeneratorService.generateOrientationFlags(patientId, auditUserId, ctx)
     if (mode !== "basalBolus") return EMPTY("mode")
 
     // 1. Config (créneaux ICR) + patient (pathologie / grossesse pour la cible).
@@ -228,6 +230,45 @@ export const proposalGeneratorService = {
     }
 
     return { created, flagged, slotsConsidered, mealsUsable: usable.length, skipped: null }
+  },
+
+  /**
+   * Mode (c) — patient NON insuliné : **aucune proposition de dose** (frontière MDR / IEC 62304),
+   * uniquement des `ClinicalReviewFlag` d'**orientation** (« à revoir en consultation »).
+   *
+   * Slice 1 : `hba1cStale` — la dernière HbA1c (labo, dans `GlycemiaEntry` ou `DiabetesEvent`) date de
+   * plus de `HBA1C_STALE_DAYS` (180 j), **ou est absente** (un DT2/GD suivi doit avoir une HbA1c
+   * récente). Idempotent (raise dédoublonne un flag ouvert du même type). `tirBelowTarget` et
+   * `observance` = slices ultérieures (nécessitent l'extraction du calcul TIR / une définition observance).
+   *
+   * @param patientId Patient non insuliné.
+   * @param auditUserId Acteur d'audit (système `null` pour le cron).
+   * @param ctx Contexte requête (audit).
+   * @returns Métriques ; `flagged` = nb de flags levés (jamais de dose).
+   */
+  async generateOrientationFlags(patientId: number, auditUserId: number | null, ctx?: AuditContext): Promise<GenerateResult> {
+    let flagged = 0
+
+    // Dernière HbA1c = plus récente des deux sources (carnet glycémie + événements).
+    const [gly, evt] = await Promise.all([
+      prisma.glycemiaEntry.findFirst({
+        where: { patientId, hba1c: { not: null } }, orderBy: { date: "desc" }, select: { date: true },
+      }),
+      prisma.diabetesEvent.findFirst({
+        where: { patientId, hba1c: { not: null } }, orderBy: { eventDate: "desc" }, select: { eventDate: true },
+      }),
+    ])
+    const dates = [gly?.date, evt?.eventDate].filter((d): d is Date => d != null)
+    const lastHba1c = dates.length ? Math.max(...dates.map((d) => d.getTime())) : null
+    const staleMs = HBA1C_STALE_DAYS * 86_400_000
+
+    if (lastHba1c === null || Date.now() - lastHba1c > staleMs) {
+      await clinicalReviewFlagService.raise(patientId, "hba1cStale", auditUserId, ctx)
+        .then(() => { flagged++ })
+        .catch((err) => logger.error("proposal-generator", "raise hba1cStale failed", { patientId }, err as Error))
+    }
+
+    return { created: 0, flagged, slotsConsidered: 0, mealsUsable: 0, skipped: null }
   },
 
   /**

--- a/tests/unit/proposal-generator.service.test.ts
+++ b/tests/unit/proposal-generator.service.test.ts
@@ -214,6 +214,45 @@ describe("proposalGeneratorService.generateForPatient", () => {
   })
 })
 
+describe("proposalGeneratorService.generateOrientationFlags (mode c — nonInsulin)", () => {
+  const DAY = 86_400_000
+  beforeEach(() => vi.clearAllMocks())
+
+  function setupNonInsulin(hba1c: { gly?: Date | null; evt?: Date | null } = {}) {
+    mode.mockResolvedValue({ mode: "nonInsulin", coherent: true } as never)
+    prismaMock.glycemiaEntry.findFirst.mockResolvedValue(hba1c.gly ? ({ date: hba1c.gly } as never) : null)
+    prismaMock.diabetesEvent.findFirst.mockResolvedValue(hba1c.evt ? ({ eventDate: hba1c.evt } as never) : null)
+  }
+
+  it("nonInsulin → route vers les flags d'orientation, JAMAIS une dose (frontière MDR)", async () => {
+    setupNonInsulin({ evt: new Date() }) // HbA1c récente → pas de flag, mais surtout aucune dose
+    const res = await proposalGeneratorService.generateForPatient(1, 99)
+    expect(res.created).toBe(0)
+    expect(createEngine).not.toHaveBeenCalled()
+  })
+
+  it("HbA1c absente → flag hba1cStale", async () => {
+    setupNonInsulin({}) // aucune HbA1c
+    const res = await proposalGeneratorService.generateForPatient(1, 99)
+    expect(res.flagged).toBe(1)
+    expect(raiseFlag).toHaveBeenCalledWith(1, "hba1cStale", 99, undefined)
+  })
+
+  it("HbA1c périmée (> 180 j) → flag hba1cStale", async () => {
+    setupNonInsulin({ evt: new Date(Date.now() - 200 * DAY) })
+    const res = await proposalGeneratorService.generateForPatient(1, 99)
+    expect(res.flagged).toBe(1)
+    expect(raiseFlag).toHaveBeenCalledWith(1, "hba1cStale", 99, undefined)
+  })
+
+  it("HbA1c récente (< 180 j) → aucun flag", async () => {
+    setupNonInsulin({ gly: new Date(Date.now() - 30 * DAY) })
+    const res = await proposalGeneratorService.generateForPatient(1, 99)
+    expect(res.flagged).toBe(0)
+    expect(raiseFlag).not.toHaveBeenCalled()
+  })
+})
+
 describe("proposalGeneratorService.generateForAllPatients (cron)", () => {
   beforeEach(() => vi.clearAllMocks())
 

--- a/tests/unit/proposal-generator.service.test.ts
+++ b/tests/unit/proposal-generator.service.test.ts
@@ -251,6 +251,14 @@ describe("proposalGeneratorService.generateOrientationFlags (mode c — nonInsul
     expect(res.flagged).toBe(0)
     expect(raiseFlag).not.toHaveBeenCalled()
   })
+
+  it("prend la PLUS RÉCENTE des 2 sources (carnet récent + événement vieux → pas de flag)", async () => {
+    // gly 30 j (récent) + evt 200 j (vieux) → max = 30 j → non périmé. (Math.min → flaguerait à tort.)
+    setupNonInsulin({ gly: new Date(Date.now() - 30 * DAY), evt: new Date(Date.now() - 200 * DAY) })
+    const res = await proposalGeneratorService.generateForPatient(1, 99)
+    expect(res.flagged).toBe(0)
+    expect(raiseFlag).not.toHaveBeenCalled()
+  })
 })
 
 describe("proposalGeneratorService.generateForAllPatients (cron)", () => {


### PR DESCRIPTION
Le générateur route désormais les patients **non insulinés** vers des **flags d'orientation** (frontière MDR / IEC 62304 : **jamais de dose**), au lieu de les skipper.

## Contenu
- **`generateForPatient`** : mode `nonInsulin` → **`generateOrientationFlags`** (au lieu de `EMPTY("mode")`).
- **`generateOrientationFlags`** : lève **`hba1cStale`** si la dernière HbA1c — plus récente de `GlycemiaEntry.date` et `DiabetesEvent.eventDate` (hba1c non null) — date de **> `HBA1C_STALE_DAYS` (180 j)** **ou est absente** (un DT2/GD suivi doit avoir une HbA1c récente). **Idempotent** (raise dédoublonne un flag ouvert). Le **cron** le couvre déjà (`generateForAllPatients` boucle tous les patients).
- **Tests +4** : routage `nonInsulin` (jamais de dose) ; HbA1c **absente/périmée** → flag ; **récente** → rien.
- Doc §5 mode c « livré (hba1cStale) ».

## Suite (tracée)
`tirBelowTarget` (nécessite d'**extraire le calcul TIR** inline du dashboard) + `observance` (définition à cadrer).

⚠️ **Validation medical** (US-2651) : seuil/scope + faut-il flaguer une HbA1c **absente** comme « à actualiser ».

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3754 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)