### PR TITLE
US-2651 (basal, slice 1) — analyzeBasalTrend : nadir nocturne séparé (garde ≠ moyenne)

### DIFF
--- a/docs/clinical-logic/algorithme-propositions-ajustement.md
+++ b/docs/clinical-logic/algorithme-propositions-ajustement.md
@@ -134,8 +134,9 @@ Base d'erreur relative = écart moyen à la cible. `confidence` = `getConfidence
     `+20 %` → `0,80 → 0,96` U/h (`basalTooLow`).
   - *Baisse* : à jeun moyennes `0,80` g/L → `−27 %` → clampé `−20 %` → `0,80 → 0,64` U/h (`basalTooHigh`).
   - *Effet Somogyi (garde hypo)* : à jeun moyennes `1,40` (⇒ hausse) **mais** le **nadir** nocturne à
-    3 h vaut `0,45` g/L → **supprimé** (une hausse basale aggraverait l'hypo). ⚠️ N'est capté que si le
-    nadir figure dans `fastingValues` (contrat JSDoc `analyzeBasalTrend`).
+    3 h vaut `0,45` g/L → **supprimé** (une hausse basale aggraverait l'hypo). ✅ Le nadir est un **param
+    séparé** `nocturnalNadirs` (symétrique de `analyzeIcrSlot`) : il nourrit la garde hypo sans biaiser
+    la moyenne à jeun (repli sur `fastingValues` si absent). Reste à **peupler** au câblage (slice assemblage).
 
 > **⚠️ Portée : basale POMPE uniquement — le stylo/MDI n'est PAS géré (limite connue).**
 > `analyzeBasalTrend` raisonne sur un **débit U/h** et cible un `pumpBasalSlotId`

--- a/src/lib/proposal-algorithm.ts
+++ b/src/lib/proposal-algorithm.ts
@@ -287,20 +287,24 @@ export function analyzeIcrSlot(
  * Detects systematic overnight drift (rising = too low, falling = too high).
  * Only proposes if 3+ fasting values AND change is meaningful (> 2%).
  *
- * ⚠️ **Contrat garde-hypo (US-2651, validé medical)** : `fastingValues` DOIT inclure le **nadir
- * glycémique nocturne** (relevé CGM le plus bas de la nuit), pas seulement le pré-petit-déjeuner.
- * Sinon une hypo nocturne à 3 h qui **rebondit** en hyperglycémie au réveil (effet Somogyi) reste
- * invisible et la garde hypo n'empêchera pas une hausse basale dangereuse. À respecter par
- * l'appelant (générateur) lors du câblage.
- * @param {number[]} fastingValues - Pre-breakfast glucose readings (g/L)
- * @param {number} targetGl - Fasting glucose target (g/L)
- * @param {number} currentRate - Current basal rate (U/h)
+ * Contrat garde-hypo (US-2651, validé medical — symétrique de `analyzeIcrSlot`) : la MOYENNE/direction
+ * est pilotée par `fastingValues` (pré-petit-déj), tandis que la garde hypo regarde les **nadirs
+ * NOCTURNES** (`nocturnalNadirs`, creux CGM le plus bas de chaque nuit) quand ils sont fournis — sinon
+ * une hypo à 3 h qui **rebondit** en hyperglycémie au réveil (effet Somogyi) resterait invisible et la
+ * garde n'empêcherait pas une hausse basale dangereuse. Repli sur `fastingValues` si absents. Ne JAMAIS
+ * injecter le nadir dans `fastingValues` (cela biaiserait la moyenne à jeun vers le bas).
+ *
+ * @param fastingValues - Glycémies pré-petit-déjeuner (g/L) — pilotent la moyenne/direction.
+ * @param targetGl - Cible glycémique à jeun (g/L).
+ * @param currentRate - Débit basal courant (U/h).
+ * @param nocturnalNadirs - Creux nocturnes (g/L), optionnels — fournis UNIQUEMENT à la garde hypo.
  * @returns {ProposalCandidate | null} Proposal if detected, null otherwise
  */
 export function analyzeBasalTrend(
   fastingValues: number[],
   targetGl: number,
   currentRate: number,
+  nocturnalNadirs?: number[],
 ): ProposalCandidate | null {
   if (fastingValues.length < 3) return null
 
@@ -313,9 +317,11 @@ export function analyzeBasalTrend(
   if (Math.abs(clampedChange) < 2) return null
 
   const proposedValue = computeProposedValue(currentRate, clampedChange)
-  // Garde HYPO : hausser la basale = plus d'insuline → supprimé si une glycémie à jeun de la fenêtre
-  // est en hypo sévère (hypo nocturne masquée par la moyenne du dawn phenomenon).
-  if (hypoBlocksProposal("basalRate", currentRate, proposedValue, fastingValues)) return null
+  // Garde HYPO : hausser la basale = plus d'insuline → supprimé si un creux NOCTURNE est en hypo
+  // (hypo à 3 h masquée par une moyenne à jeun élevée = effet Somogyi). Repli sur `fastingValues`
+  // si les nadirs nocturnes ne sont pas fournis. La moyenne/direction reste sur `fastingValues`.
+  const guardValues = nocturnalNadirs && nocturnalNadirs.length > 0 ? nocturnalNadirs : fastingValues
+  if (hypoBlocksProposal("basalRate", currentRate, proposedValue, guardValues)) return null
 
   const reason: AdjustmentReason = clampedChange > 0 ? "basalTooLow" : "basalTooHigh"
 

--- a/tests/unit/proposal-algorithm.test.ts
+++ b/tests/unit/proposal-algorithm.test.ts
@@ -288,6 +288,26 @@ describe("proposal-algorithm", () => {
       const r = analyzeBasalTrend(fasting, 1.20, 0.80)
       expect(r!.reason).toBe("basalTooHigh")
     })
+
+    it("garde HYPO : le NADIR nocturne supprime une hausse que le à-jeun seul laisserait passer (Somogyi)", () => {
+      const fasting = [1.50, 1.55, 1.60] // à jeun HAUT → basalTooLow (hausse) ; effet Somogyi
+      const nadirs = [0.50, 1.30, 1.40] // MAIS un creux nocturne sévère (0,50)
+      expect(analyzeBasalTrend(fasting, 1.20, 0.80, nadirs)).toBeNull() // hausse supprimée
+    })
+
+    it("garde HYPO : SANS nadir nocturne, le même à-jeun haut propose la hausse (contrôle)", () => {
+      const fasting = [1.50, 1.55, 1.60]
+      expect(analyzeBasalTrend(fasting, 1.20, 0.80)!.reason).toBe("basalTooLow")
+    })
+
+    it("le nadir ne corrompt PAS la moyenne/direction (% identique avec et sans nadir)", () => {
+      const fasting = [0.70, 0.72, 0.71] // basalTooHigh (baisse, sens sûr)
+      const r1 = analyzeBasalTrend(fasting, 1.20, 0.80)
+      const r2 = analyzeBasalTrend(fasting, 1.20, 0.80, [0.60, 0.62, 0.61])
+      expect(r1!.reason).toBe("basalTooHigh")
+      expect(r2!.reason).toBe("basalTooHigh")
+      expect(r2!.changePercent).toBe(r1!.changePercent)
+    })
   })
 
   describe("analyzeFixedDose (mode b, US-2651)", () => {


### PR DESCRIPTION
Première brique du levier **basal** (pompe). Même correction que #669 (ICR) : la garde hypo doit voir le **creux nocturne** — **effet Somogyi** (hypo à 3 h qui rebondit en hyper au réveil) — **sans corrompre la moyenne à jeun** qui pilote la direction.

## Contenu
- **`analyzeBasalTrend`** gagne un param **`nocturnalNadirs?`** (g/L). La garde hypo utilise `(nocturnalNadirs ?? fastingValues)` ; la **moyenne/direction reste sur `fastingValues`**. Remplace le contrat JSDoc « `fastingValues` doit inclure le nadir » (muddy, biaisait la moyenne) par un **champ propre**, symétrique de `analyzeIcrSlot`. **Rétro-compatible** (param optionnel → repli `fastingValues`).
- **Tests +3** : le nadir nocturne **supprime** une hausse que le à-jeun seul laisserait passer (Somogyi) ; **contrôle** sans nadir → hausse proposée ; le nadir **ne change ni la direction ni le %** (moyenne intacte).
- Doc §4.3.

## Suite
Assemblage (à jeun pré-petit-déj + **nadir nocturne CGM par nuit**) puis générateur basal **par créneau pompe** (`pumpBasalSlotId`). Rappel : basale **stylo/MDI hors scope** (limite connue documentée).

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3777 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)