### PR TITLE
US-2651 (basal, slice 3a) — Snapping délivrable dans analyzeBasalTrend (fix no-op silencieux)

### DIFF
--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -343,3 +343,23 @@ les 2 caveats medical #678). Le petit-déjeuner = premier repas du moment « mor
   direction). Amélioration future possible : ancre de repli à fenêtre fixe.
 - **Suivi câblage (slice 3)** : `FastingDay` est en **mg/dL** ; `analyzeBasalTrend` attend **g/L** → le
   générateur devra **÷ 100 + filtrer les null** (sinon garde hypo silencieusement désactivée).
+
+### Générateur basal (US-2651, validé medical) — snapping délivrable + spec slice 3b
+
+**Snapping (slice 3a, livré)** : `analyzeBasalTrend` **arrondit** le débit proposé au multiple de
+`PUMP_BASAL_INCREMENT` (0,05 U/h) le plus proche ; sinon `createEngineProposal` le **rejette**
+(`isDeliverableBasalRate`) → quasi toutes les propositions basales seraient silencieusement droppées.
+Le **sens** (`basalTooLow`/`basalTooHigh`) et la **garde hypo** utilisent la valeur **snappée**. Une
+variation qui s'arrondit à < 1 incrément → aucune proposition. (Mirror `analyzeFixedDose`.)
+
+**Spec slice 3b (générateur basal, à câbler)** — validé medical :
+- **Scope pompe** (`configType === "pump"` + `pumpSlots`) ; stylo/MDI = dose fixe (autre chemin).
+- **Créneau titré** = celui actif à `NOCTURNAL_TITRATION_REF_HOUR` (**05:00** — action insuline ~05:00 →
+  effet 06:00-08:00 = fasting). Seul le nocturne ; créneaux de jour différés.
+- **Cible à jeun** : `glucoseTargets.targetGlucose/100` clampée `[FASTING_TARGET_MIN_GL 0,80 ;
+  FASTING_TARGET_MAX_GL 1,30]` (grossesse `[0,80 ; FASTING_TARGET_MAX_PREGNANCY_GL 1,00]`), sinon
+  **défaut** `FASTING_TARGET_DEFAULT_GL 1,00` / `FASTING_TARGET_PREGNANCY_GL 0,90`. **JAMAIS `titrLow`**
+  (plancher hypo → sur-titration vers l'hypo).
+- **Deadband** : aucun (basal = titrate-to-target symétrique ; ±2 %/±20 % + garde nadir suffisent).
+- **Coverage guard** : n'autoriser une **hausse** que si ≥ 3 nuits de nadir CGM (sinon Somogyi invisible) ;
+  **baisses** inconditionnelles. `source: "cgm"`.

--- a/src/lib/proposal-algorithm.ts
+++ b/src/lib/proposal-algorithm.ts
@@ -316,21 +316,29 @@ export function analyzeBasalTrend(
 
   if (Math.abs(clampedChange) < 2) return null
 
-  const proposedValue = computeProposedValue(currentRate, clampedChange)
+  // Snapping DÉLIVRABLE (US-2651 basal, validé medical) : la pompe ne délivre qu'un multiple de
+  // PUMP_BASAL_INCREMENT (0,05 U/h) ; `createEngineProposal` REJETTE un débit non délivrable
+  // (`isDeliverableBasalRate`) → sans snap, quasi toutes les propositions basales seraient
+  // silencieusement droppées (no-op). Mirror `analyzeFixedDose`. Le SENS et la GARDE utilisent la
+  // valeur SNAPPÉE (cohérence avec ce qui est persisté), pas le % pré-snap.
+  const inc = CLINICAL_BOUNDS.PUMP_BASAL_INCREMENT
+  const proposedValue = Math.round(computeProposedValue(currentRate, clampedChange) / inc) * inc
+  if (Math.abs(proposedValue - currentRate) < inc) return null // non actionnable après snap
+
   // Garde HYPO : hausser la basale = plus d'insuline → supprimé si un creux NOCTURNE est en hypo
   // (hypo à 3 h masquée par une moyenne à jeun élevée = effet Somogyi). Repli sur `fastingValues`
   // si les nadirs nocturnes ne sont pas fournis. La moyenne/direction reste sur `fastingValues`.
   const guardValues = nocturnalNadirs && nocturnalNadirs.length > 0 ? nocturnalNadirs : fastingValues
   if (hypoBlocksProposal("basalRate", currentRate, proposedValue, guardValues)) return null
 
-  const reason: AdjustmentReason = clampedChange > 0 ? "basalTooLow" : "basalTooHigh"
+  const reason: AdjustmentReason = proposedValue > currentRate ? "basalTooLow" : "basalTooHigh"
 
   return {
     parameterType: "basalRate",
     reason,
     currentValue: currentRate,
     proposedValue,
-    changePercent: Math.round(clampedChange * 100) / 100,
+    changePercent: Math.round(((proposedValue - currentRate) / currentRate) * 10000) / 100,
     confidence: getConfidenceLevel(fastingValues.length),
     supportingEvents: fastingValues.length,
     totalEventsConsidered: fastingValues.length,

--- a/tests/unit/proposal-algorithm.test.ts
+++ b/tests/unit/proposal-algorithm.test.ts
@@ -308,6 +308,19 @@ describe("proposal-algorithm", () => {
       expect(r2!.reason).toBe("basalTooHigh")
       expect(r2!.changePercent).toBe(r1!.changePercent)
     })
+
+    it("snapping délivrable : proposedValue = multiple de 0,05 U/h (US-2651, sinon rejeté à la persistance)", () => {
+      // 0,50 × 1,07 = 0,535 (non délivrable) → snap au multiple de 0,05 le plus proche = 0,55.
+      const r = analyzeBasalTrend([1.07, 1.07, 1.07], 1.0, 0.5)
+      expect(r!.reason).toBe("basalTooLow")
+      expect(r!.proposedValue).toBeCloseTo(0.55) // pas 0,535
+      expect(Math.round(r!.proposedValue / 0.05)).toBeCloseTo(r!.proposedValue / 0.05) // multiple exact
+    })
+
+    it("snapping : variation qui s'arrondit à zéro (< 1 incrément) → null (non actionnable)", () => {
+      // 0,05 × 1,03 = 0,0515 → snap = 0,05 → delta nul → aucune proposition.
+      expect(analyzeBasalTrend([1.03, 1.03, 1.03], 1.0, 0.05)).toBeNull()
+    })
   })
 
   describe("analyzeFixedDose (mode b, US-2651)", () => {


### PR DESCRIPTION
Le **design du générateur basal a été validé medical AVANT code** — révélant **2 CRITICAL**. Cette slice corrige le plus insidieux (**no-op silencieux**) ; la cible à jeun + le vertical suivent en slice 3b.

## Le CRITICAL corrigé (#6 de la revue design)
`analyzeBasalTrend` produisait des débits **non arrondis à 0,05 U/h** (ex. `0,50 × 1,07 = 0,535`) que `createEngineProposal` **REJETTE** (`isDeliverableBasalRate`) → **quasi toutes les propositions basales seraient silencieusement droppées** (bug qui passe tsc/unit, meurt en prod).

## Contenu
- **Snapping** au multiple de `PUMP_BASAL_INCREMENT` (0,05) le plus proche. **Sens** + **garde hypo** dérivés de la valeur **snappée** (cohérence avec ce qui est persisté). Variation snappée **< 1 incrément → `null`** (non actionnable). Mirror `analyzeFixedDose`.
- **Tests +2** (`proposedValue` = multiple de 0,05 ; sub-incrément → null). Existants verts.
- **Catalogue** : snapping + **spec slice 3b** (créneau **05:00**, cible à jeun **défaut 1,00 / grossesse 0,90 — JAMAIS `titrLow`** qui titrerait vers l'hypo, coverage guard hausse ≥ 3 nuits nadir).

## Suite
**Slice 3b** : le vertical basal (gate pompe + créneau 05:00 + cible + coverage guard + ÷100 + `createEngineProposal` par `pumpBasalSlotId`) + les constantes cible à jeun.

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3784 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)