### PR TITLE
US-2651 (ISF, slice 1) — analyzeIsfSlot : nadir post-correction séparé (garde ≠ moyenne)

### DIFF
--- a/src/lib/proposal-algorithm.ts
+++ b/src/lib/proposal-algorithm.ts
@@ -164,19 +164,21 @@ export function computeProposedValue(currentValue: number, changePercent: number
  * Detects systematic over/under-correction from post-correction glucose patterns.
  * Only proposes if 3+ events AND change is meaningful (> 2%).
  *
- * ⚠️ **Contrat nadir à câbler (US-2651, suivi medical)** : comme l'ICR, une correction d'analogue
- * rapide fait son creux à ~3-4 h, APRÈS la glycémie post-correction ponctuelle utilisée ici. La garde
- * hypo ne voit donc pas un creux tardif → angle mort. Quand l'ISF sera relié au générateur, ajouter un
- * champ `nadirGl` par correction (symétrique de `analyzeIcrSlot`), fourni UNIQUEMENT à la garde hypo,
- * la moyenne/direction restant sur `postGlucoseGl`. En attendant, l'ISF n'est câblé à aucun générateur.
+ * Contrat garde-hypo (US-2651, validé medical — symétrique de `analyzeIcrSlot`/`analyzeBasalTrend`) :
+ * une correction d'analogue rapide fait son creux à ~3-4 h, APRÈS la glycémie post-correction. La
+ * MOYENNE/direction reste pilotée par `postGlucoseGl` (résultat de la correction), tandis que la garde
+ * hypo regarde le **nadir** `nadirGl` (creux post-correction) quand il est fourni — sinon un creux tardif
+ * (sur-correction) resterait invisible. Repli sur `postGlucoseGl` si absent. Ne JAMAIS injecter le nadir
+ * dans `postGlucoseGl` (cela biaiserait la moyenne vers le bas → fausse hausse d'ISF).
  *
  * @param slot - ISF slot configuration (startHour, endHour, sensitivityFactorGl)
- * @param corrections - Post-correction readings and targets (postGlucoseGl, targetGl)
+ * @param corrections - Par correction : `postGlucoseGl` (résultat, pilote la direction), `targetGl`,
+ *   et `nadirGl` optionnel (creux post-correction → garde hypo uniquement). g/L.
  * @returns {ProposalCandidate | null} Proposal if detected, null otherwise
  */
 export function analyzeIsfSlot(
   slot: { startHour: number; endHour: number; sensitivityFactorGl: number },
-  corrections: { postGlucoseGl: number; targetGl: number }[],
+  corrections: { postGlucoseGl: number; targetGl: number; nadirGl?: number }[],
 ): ProposalCandidate | null {
   if (corrections.length < 3) return null
 
@@ -196,9 +198,11 @@ export function analyzeIsfSlot(
   if (Math.abs(clampedChange) < 2) return null
 
   const proposedValue = computeProposedValue(slot.sensitivityFactorGl, clampedChange)
-  // Garde HYPO : baisser l'ISF = corrections plus fortes (plus d'insuline) → supprimé si une
-  // glycémie post-correction de la fenêtre est en hypo sévère (une correction a sur-shooté).
-  if (hypoBlocksProposal("insulinSensitivityFactor", slot.sensitivityFactorGl, proposedValue, corrections.map((c) => c.postGlucoseGl))) {
+  // Garde HYPO : baisser l'ISF = corrections plus fortes (plus d'insuline) → supprimé si un creux
+  // post-correction est en hypo (une correction a sur-shooté ~3-4 h plus tard). Nadir séparé si fourni,
+  // repli sur `postGlucoseGl` sinon. La moyenne/direction reste sur `postGlucoseGl`.
+  const guardValues = corrections.map((c) => c.nadirGl ?? c.postGlucoseGl)
+  if (hypoBlocksProposal("insulinSensitivityFactor", slot.sensitivityFactorGl, proposedValue, guardValues)) {
     return null
   }
 

--- a/tests/unit/proposal-algorithm.test.ts
+++ b/tests/unit/proposal-algorithm.test.ts
@@ -144,6 +144,26 @@ describe("proposal-algorithm", () => {
       ]
       expect(analyzeIsfSlot(slot, corrections)).toBeNull()
     })
+
+    it("garde HYPO : le NADIR post-correction supprime une baisse que le post-correction seul laisserait passer", () => {
+      // Post-corrections toutes HAUTES (correction trop faible → isfTooHigh, baisse) MAIS un creux tardif sévère.
+      const corrections = Array.from({ length: 4 }, () => ({ postGlucoseGl: 1.80, targetGl: 1.20, nadirGl: 0.50 }))
+      expect(analyzeIsfSlot(slot, corrections)).toBeNull() // baisse supprimée par le nadir
+    })
+
+    it("garde HYPO : SANS nadir, les mêmes post-corrections hautes proposent la baisse (contrôle)", () => {
+      const corrections = Array.from({ length: 4 }, () => ({ postGlucoseGl: 1.80, targetGl: 1.20 }))
+      expect(analyzeIsfSlot(slot, corrections)!.reason).toBe("isfTooHigh")
+    })
+
+    it("le nadir ne corrompt PAS la moyenne/direction (% identique avec et sans nadir)", () => {
+      const base = Array.from({ length: 5 }, () => ({ postGlucoseGl: 0.60, targetGl: 1.20 })) // sur-correction → isfTooLow (sens sûr)
+      const r1 = analyzeIsfSlot(slot, base)
+      const r2 = analyzeIsfSlot(slot, base.map((c) => ({ ...c, nadirGl: 0.50 })))
+      expect(r1!.reason).toBe("isfTooLow")
+      expect(r2!.reason).toBe("isfTooLow")
+      expect(r2!.changePercent).toBe(r1!.changePercent)
+    })
   })
 
   describe("analyzeIcrSlot", () => {


### PR DESCRIPTION
Première brique du **levier ISF** (le dernier de titration). Même correction que #669 (ICR) / #678 (basal) : une correction d'analogue rapide fait son **creux à ~3-4 h**, APRÈS la glycémie post-correction ponctuelle → la garde hypo doit voir ce creux tardif **sans corrompre la moyenne** qui pilote la direction.

## Contenu
- **`analyzeIsfSlot`** : chaque correction gagne un champ **`nadirGl?`** (g/L). La garde hypo utilise `(nadirGl ?? postGlucoseGl)` ; la **moyenne/direction reste sur `postGlucoseGl`**. Remplace le contrat JSDoc « à câbler » par un champ propre, **symétrique** de `analyzeIcrSlot`/`analyzeBasalTrend`. **Rétro-compatible** (champ optionnel).
- **Tests +3** : le nadir **supprime** une baisse ISF que le post-correction seul laisserait passer ; **contrôle** sans nadir ; le nadir **ne change ni la direction ni le %** (moyenne intacte).

## Rappel direction (ISF = dénominateur)
Baisser l'ISF = corrections **plus fortes** = **plus d'insuline** (`isfTooHigh`, sens à risque gardé) ; hausser = **moins d'insuline** (`isfTooLow`, sûr).

## Suite
Assemblage (appariement **corrections** `BolusCalculationLog` + glycémie post-correction + nadir CGM) puis générateur ISF par créneau — **design à valider medical** (correction-only, fenêtre de mesure, confounding IOB).

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3793 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)