### PR TITLE
US-2651 (ISF, slice 3) — Générateur ISF vertical (par créneau, corrections appariées)

### DIFF
--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -408,3 +408,9 @@ garde nadir (ISF slice 1) + le doctor-gating (ADR #13).
 
 **Générateur multi-levier complet** : ICR + basal + ISF de bout en bout (doctor-gated, ADR #13).
 Reste : `fixedDose` (bloqué migration `moment`), mode-c `observance`, activation cron prod.
+
+**Suivi (impact cumulé multi-levier)** : le générateur produit des propositions ICR/basal/ISF
+**indépendantes** (par paramètre, jeux d'événements disjoints — pas de double-titration). Mais accepter
+plusieurs propositions en une session augmente l'insuline totale ; l'écran de revue ne montre pas encore
+d'**impact cumulé**. Atténué par le jugement médecin par-paramètre + les caps ±20 % + one-pending/créneau.
+Enhancement futur de l'écran de revue (non bloquant, validé medical #684).

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -395,3 +395,16 @@ avant le début de la fenêtre d'analyse est **exclue** (fail-closed — glucide
 chargés, COB non vérifiable). (2) Les **glucides non loggés** (patient mange sans saisir) ne peuvent
 être exclus par aucun filtre d'événement : limite data intrinsèque de la titration, atténuée par la
 garde nadir (ISF slice 1) + le doctor-gating (ADR #13).
+
+### Générateur ISF (US-2651 ISF slice 3, LIVRÉ) — `generateForPatient`, mode `basalBolus`, après ICR + basal
+
+- `correctionTrend(patientId, ISF_ANALYSIS_PERIOD 30 j)` → corrections propres appariées.
+- Grouper par **créneau ISF appliqué** : `findSlotForHour(sensitivityFactors, point.localHour)`.
+- Par créneau : `analyzeIsfSlot(slot, points)` → `createEngineProposal({ parameterType:
+  "insulinSensitivityFactor", timeSlotStartHour/EndHour })` ; rejets fail-closed non fatals.
+- **Pas de coverage guard dédié** (≠ basal) : `correctionTrend` est CGM-only + fail-closed, donc chaque
+  point a un nadir → la garde hypo d'`analyzeIsfSlot` (baisse ISF = plus d'insuline) suffit. Plancher
+  analyseur = 3 corrections/créneau. Sens : baisse ISF gardée, hausse (moins d'insuline) libre.
+
+**Générateur multi-levier complet** : ICR + basal + ISF de bout en bout (doctor-gated, ADR #13).
+Reste : `fixedDose` (bloqué migration `moment`), mode-c `observance`, activation cron prod.

--- a/src/lib/services/proposal-generator.service.ts
+++ b/src/lib/services/proposal-generator.service.ts
@@ -325,6 +325,8 @@ export const proposalGeneratorService = {
     // 7. Chemin ISF (US-2651) — titre chaque créneau ISF par les CORRECTIONS propres appariées.
     // Pas de coverage guard dédié (≠ basal) : `correctionTrend` est CGM-only + fail-closed, donc chaque
     // point a un nadir → la garde hypo d'`analyzeIsfSlot` (baisse ISF = plus d'insuline) suffit (medical #683).
+    // Bord : sous une rareté CGM extrême (trou de ~5 h), `nadirGl` peut être null → la garde se replie
+    // sur `postGlucoseGl` (valeur settled à 5 h). Cas rare (haut à 5 h + hypo nadir = rebond), borné ±20 %.
     const isfSlots = settings?.sensitivityFactors ?? []
     if (isfSlots.length > 0) {
       const corrections = await mealtimePattern.correctionTrend(patientId, ISF_ANALYSIS_PERIOD, auditUserId, ctx)

--- a/src/lib/services/proposal-generator.service.ts
+++ b/src/lib/services/proposal-generator.service.ts
@@ -9,10 +9,10 @@
  * `docs/clinical-logic/algorithme-propositions-ajustement.md` §5ter.
  *
  * Périmètre actuel (mode `basalBolus`) : **ICR** (par créneau) + **basal** (`basalRate`, POMPE
- * uniquement, créneau nocturne titré par la glycémie à jeun). `nonInsulin` → uniquement des
- * `ClinicalReviewFlag` d'orientation (mode c). `fixedDose` et le paramètre **ISF** relèvent de slices
- * ultérieures. La frontière MDR (`nonInsulin` → aucune dose) est de toute façon re-imposée par
- * `createEngineProposal`.
+ * uniquement, créneau nocturne titré par la glycémie à jeun) + **ISF** (par créneau, titré par les
+ * corrections propres appariées). `nonInsulin` → uniquement des `ClinicalReviewFlag` d'orientation
+ * (mode c). `fixedDose` relève d'une slice ultérieure. La frontière MDR (`nonInsulin` → aucune dose)
+ * est de toute façon re-imposée par `createEngineProposal`.
  *
  * ⚠️ Le chemin basal est **couplé à l'existence des carb-ratios** : `generateForPatient` renvoie tôt
  * (`EMPTY("noCarbRatios")`) si aucun ICR n'est configuré, donc un patient pompe avec basale mais **sans**
@@ -28,13 +28,13 @@ import {
 } from "@/lib/clinical-bounds"
 import { findSlotForHour } from "@/lib/insulin-slots"
 import {
-  analyzeIcrSlot, analyzeIcrHypoDeescalation, recurrentPostMealHypo, analyzeBasalTrend,
+  analyzeIcrSlot, analyzeIcrHypoDeescalation, recurrentPostMealHypo, analyzeBasalTrend, analyzeIsfSlot,
   type ProposalCandidate,
 } from "@/lib/proposal-algorithm"
 import { clinicalReviewFlagService } from "@/lib/services/clinical-review-flag.service"
 import { treatmentModeService } from "@/lib/services/treatment-mode.service"
 import { insulinTherapyService } from "@/lib/services/insulin-therapy.service"
-import { mealtimePattern, type JournalMeal } from "@/lib/services/meal-trends.service"
+import { mealtimePattern, type JournalMeal, type CorrectionPoint } from "@/lib/services/meal-trends.service"
 import { getCgmDefaults, objectivesService } from "@/lib/services/objectives.service"
 import { adjustmentService } from "@/lib/services/adjustment.service"
 import { auditService } from "@/lib/services/audit.service"
@@ -42,6 +42,8 @@ import type { AuditContext } from "@/lib/services/patient.service"
 
 /** Fenêtre d'analyse (14 j — standard AGP, aligné `AGP_SUFFICIENCY.MIN_DAYS`). */
 const ANALYSIS_PERIOD = "14d"
+/** US-2651 ISF — période plus longue (30 j) : les corrections propres sont rares (validé medical #683). */
+const ISF_ANALYSIS_PERIOD = "30d"
 /** Minimum de repas appariés par créneau (aligné `analyzeIcrSlot` + `BGM_CARNET.MIN_READINGS_PER_MOMENT`). */
 const MIN_MEALS_PER_SLOT = 3
 /** US-2651 basal — nb minimal de nuits avec un nadir nocturne CGM pour autoriser une HAUSSE basale
@@ -315,6 +317,59 @@ export const proposalGeneratorService = {
               logger.error("proposal-generator", "unexpected engine proposal error",
                 { patientId, bucket, failMode: "unexpected" }, err as Error)
             }
+          }
+        }
+      }
+    }
+
+    // 7. Chemin ISF (US-2651) — titre chaque créneau ISF par les CORRECTIONS propres appariées.
+    // Pas de coverage guard dédié (≠ basal) : `correctionTrend` est CGM-only + fail-closed, donc chaque
+    // point a un nadir → la garde hypo d'`analyzeIsfSlot` (baisse ISF = plus d'insuline) suffit (medical #683).
+    const isfSlots = settings?.sensitivityFactors ?? []
+    if (isfSlots.length > 0) {
+      const corrections = await mealtimePattern.correctionTrend(patientId, ISF_ANALYSIS_PERIOD, auditUserId, ctx)
+      const isfSlotShapes = isfSlots.map((s) => ({
+        startHour: s.startHour, endHour: s.endHour, sensitivityFactorGl: Number(s.sensitivityFactorGl),
+      }))
+      // Grouper les corrections par créneau ISF APPLIQUÉ (heure de la correction).
+      const byIsfSlot = new Map<number, { slot: (typeof isfSlotShapes)[number]; points: CorrectionPoint[] }>()
+      for (const pt of corrections) {
+        const slot = findSlotForHour(isfSlotShapes, pt.localHour)
+        if (!slot) continue
+        const entry = byIsfSlot.get(slot.startHour) ?? { slot, points: [] }
+        entry.points.push(pt)
+        byIsfSlot.set(slot.startHour, entry)
+      }
+      for (const { slot, points } of byIsfSlot.values()) {
+        const candidate = analyzeIsfSlot(
+          slot,
+          points.map((p) => ({ postGlucoseGl: p.postGlucoseGl, targetGl: p.targetGl, nadirGl: p.nadirGl ?? undefined })),
+        )
+        if (!candidate) continue
+        try {
+          await adjustmentService.createEngineProposal({
+            patientId,
+            parameterType: "insulinSensitivityFactor",
+            proposedValue: candidate.proposedValue,
+            expectedCurrentValue: candidate.currentValue,
+            reason: candidate.reason,
+            confidence: candidate.confidence,
+            supportingEvents: candidate.supportingEvents,
+            totalEventsConsidered: candidate.totalEventsConsidered,
+            averageObservedValue: candidate.averageObservedValue ?? null,
+            analysisPeriod: ISF_ANALYSIS_PERIOD,
+            timeSlotStartHour: slot.startHour,
+            timeSlotEndHour: slot.endHour,
+          }, ctx)
+          created++
+        } catch (err) {
+          const msg = (err as Error).message
+          const bucket = `isf:${slot.startHour}-${slot.endHour}`
+          if (EXPECTED_SKIP.has(msg)) {
+            logger.info("proposal-generator", "engine proposal skipped", { patientId, bucket, failMode: msg })
+          } else {
+            logger.error("proposal-generator", "unexpected engine proposal error",
+              { patientId, bucket, failMode: "unexpected" }, err as Error)
           }
         }
       }

--- a/tests/unit/proposal-generator.service.test.ts
+++ b/tests/unit/proposal-generator.service.test.ts
@@ -15,7 +15,7 @@ vi.mock("@/lib/services/insulin-therapy.service", () => ({
   insulinTherapyService: { getSettings: vi.fn() },
 }))
 vi.mock("@/lib/services/meal-trends.service", () => ({
-  mealtimePattern: { dailyJournal: vi.fn(), fastingTrend: vi.fn() },
+  mealtimePattern: { dailyJournal: vi.fn(), fastingTrend: vi.fn(), correctionTrend: vi.fn() },
 }))
 vi.mock("@/lib/services/adjustment.service", () => ({
   adjustmentService: { createEngineProposal: vi.fn() },
@@ -48,6 +48,7 @@ const mode = vi.mocked(treatmentModeService.resolveTreatmentMode)
 const getSettings = vi.mocked(insulinTherapyService.getSettings)
 const dailyJournal = vi.mocked(mealtimePattern.dailyJournal)
 const fastingTrend = vi.mocked(mealtimePattern.fastingTrend)
+const correctionTrend = vi.mocked(mealtimePattern.correctionTrend)
 const createEngine = vi.mocked(adjustmentService.createEngineProposal)
 
 /** Repas exploitable par défaut : midi (13 h), glucides/bolus OK, pré-repas 1,0 g/L (en bande). */
@@ -67,10 +68,13 @@ function setup(opts: {
   basalConfig?: { configType: string; pumpSlots: { id: string; rate: number; startHour: number; endHour: number }[] }
   glucoseTargets?: { targetGlucose: number }[]
   fasting?: { fastingMgdl: number | null; nocturnalNadirMgdl: number | null }[]
+  sensitivityFactors?: { startHour: number; endHour: number; sensitivityFactorGl: number }[]
+  corrections?: { localHour: number; postGlucoseGl: number; targetGl: number; nadirGl: number | null }[]
 } = {}) {
   mode.mockResolvedValue({ mode: opts.mode ?? "basalBolus", coherent: true } as never)
   getSettings.mockResolvedValue({
     carbRatios: opts.carbRatios ?? [{ startHour: 12, endHour: 14, gramsPerUnit: 10 }],
+    sensitivityFactors: opts.sensitivityFactors ?? [],
     basalConfiguration: opts.basalConfig
       ? {
           configType: opts.basalConfig.configType,
@@ -88,6 +92,7 @@ function setup(opts: {
   } as never)
   dailyJournal.mockResolvedValue((opts.meals ?? [meal(), meal(), meal()]) as never)
   fastingTrend.mockResolvedValue((opts.fasting ?? []) as never)
+  correctionTrend.mockResolvedValue((opts.corrections ?? []) as never)
   createEngine.mockResolvedValue({ id: "e1" } as never)
 }
 
@@ -281,6 +286,42 @@ describe("proposalGeneratorService.generateForPatient — chemin basal (US-2651)
     const res = await proposalGeneratorService.generateForPatient(1, 99)
     expect(res.skipped).toBe("noCarbRatios") // le early-return ICR gate le chemin basal
     expect(basalCalls()).toHaveLength(0)
+  })
+})
+
+describe("proposalGeneratorService.generateForPatient — chemin ISF (US-2651)", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  const ISF_SLOT = { startHour: 8, endHour: 12, sensitivityFactorGl: 0.5 }
+  const isfCalls = () =>
+    createEngine.mock.calls.map((c) => c[0] as Record<string, unknown>).filter((a) => a.parameterType === "insulinSensitivityFactor")
+  const corrections = (post: number, nadir: number | null, n = 4) =>
+    Array.from({ length: n }, () => ({ localHour: 9, postGlucoseGl: post, targetGl: 1.2, nadirGl: nadir }))
+
+  it("corrections au-dessus de la cible → proposition isfTooHigh (baisse) sur le créneau ISF appliqué", async () => {
+    setup({ meals: [], sensitivityFactors: [ISF_SLOT], corrections: corrections(1.8, 1.4) })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    const isf = isfCalls()
+    expect(isf).toHaveLength(1)
+    expect(isf[0]).toMatchObject({ timeSlotStartHour: 8, timeSlotEndHour: 12, reason: "isfTooHigh", expectedCurrentValue: 0.5 })
+  })
+
+  it("garde hypo : un nadir sévère (0,50) supprime la baisse ISF", async () => {
+    setup({ meals: [], sensitivityFactors: [ISF_SLOT], corrections: corrections(1.8, 0.5) })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(isfCalls()).toHaveLength(0)
+  })
+
+  it("< 3 corrections dans le créneau → aucune proposition ISF (plancher analyseur)", async () => {
+    setup({ meals: [], sensitivityFactors: [ISF_SLOT], corrections: corrections(1.8, 1.4, 2) })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(isfCalls()).toHaveLength(0)
+  })
+
+  it("aucun créneau ISF configuré → aucune proposition ISF (même avec des corrections)", async () => {
+    setup({ meals: [], sensitivityFactors: [], corrections: corrections(1.8, 1.4) })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(isfCalls()).toHaveLength(0)
   })
 })
 


### PR DESCRIPTION
**Dernière brique du levier ISF — et des 3 leviers de titration.** Le chemin ISF tourne **de bout en bout** dans `generateForPatient` (mode `basalBolus`, après ICR + basal). L'analyseur (#682) + l'assemblage (#683) sont déjà validés medical ; ce câblage est un **mirror du chemin ICR** (pas de nouveau paramètre clinique — la cible vient déjà de chaque `CorrectionPoint`).

## Contenu
- `correctionTrend(patientId, **30 j**)` → corrections propres, **groupées par créneau ISF appliqué** (`findSlotForHour(sensitivityFactors, point.localHour)`).
- Par créneau : `analyzeIsfSlot(slot, points)` → `createEngineProposal({ parameterType: "insulinSensitivityFactor", timeSlotStartHour/EndHour })` ; rejets **fail-closed** non fatals.
- **Pas de coverage guard dédié** (≠ basal) : `correctionTrend` est CGM-only + fail-closed → chaque point a un nadir → la garde hypo d'`analyzeIsfSlot` (baisse ISF = plus d'insuline) suffit. Plancher analyseur = 3 corrections/créneau.
- JSDoc de tête + catalogue (ICR + basal + ISF). **Tests +4** (isfTooHigh sur créneau appliqué ; garde nadir supprime la baisse ; < 3 → rien ; pas de créneau ISF → rien).

## Générateur multi-levier COMPLET
**ICR + basal + ISF** de bout en bout, doctor-gated (ADR #13). Reste : `fixedDose` (bloqué migration `moment`), mode-c `observance`, activation cron prod.

⚠️ **Validation medical** utile (câblage end-to-end + attribution créneau).

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3810 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)