### PR TITLE
US-2652 (fixedDose, slice 1) — Câblage persistance dose fixe (discriminateur moment)

### DIFF
--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -414,3 +414,14 @@ Reste : `fixedDose` (bloqué migration `moment`), mode-c `observance`, activatio
 plusieurs propositions en une session augmente l'insuline totale ; l'écran de revue ne montre pas encore
 d'**impact cumulé**. Atténué par le jugement médecin par-paramètre + les caps ±20 % + one-pending/créneau.
 Enhancement futur de l'écran de revue (non bloquant, validé medical #684).
+
+### Persistance des propositions DOSE FIXE (US-2652, débloqué)
+
+`createEngineProposal`/`createProposal` acceptent désormais le paramètre `fixedDose` (avant : `fixedDoseNotWired`).
+Discriminateur = **`moment`** (`DoseMoment` : morning/noon/evening/night), nouvelle colonne sur
+`AdjustmentProposal` (migration `20260710100000`, index anti-spam partiel `one_pending_per_slot` étendu à
+`moment`). `resolveCurrentValue` lit la `FixedDoseSlot` **scopée patient** via `patientInsulin`
+(anti-IDOR). `validateProposedValue` : plancher `FIXED_DOSE_MIN` (0,5 U) uniquement (pas de plafond
+bloquant — cf. §1). À l'**accept**, `fixedDoseSlot.updateMany({ patientInsulin: { patientId }, moment })`
+écrit `valueU` (fail-closed `fixedDoseSlotNotFound` si count 0). Reste : l'**assemblage** (glycémie par
+moment) + le **générateur** `fixedDose` (mode `fixedDose`, pas encore branché dans `generateForPatient`).

--- a/prisma/migrations/20260710100000_us2652_fixeddose_moment_discriminator/migration.sql
+++ b/prisma/migrations/20260710100000_us2652_fixeddose_moment_discriminator/migration.sql
@@ -1,0 +1,25 @@
+-- ═══════════════════════════════════════════════════════════════
+-- US-2652 — Dose fixe : discriminateur `moment` sur adjustment_proposals
+-- ═══════════════════════════════════════════════════════════════
+-- Débloque `createEngineProposal`/`createProposal` pour le paramètre `fixedDose` : sans colonne
+-- de moment, impossible de cibler/dédoublonner une `FixedDoseSlot` → l'ancien code levait
+-- `fixedDoseNotWired` (fail-closed). Colonne NULLABLE (les 3 autres paramètres restent `moment` NULL).
+ALTER TABLE "adjustment_proposals" ADD COLUMN "moment" "DoseMoment";
+
+-- L'index UNIQUE PARTIEL anti-spam (1 pending / créneau) doit inclure `moment` : sinon deux
+-- propositions `fixedDose` pending sur des moments DIFFÉRENTS violeraient l'unicité à tort. Drop +
+-- recreate avec `moment` ajouté. `NULLS NOT DISTINCT` : pour ISF/ICR/basal, `moment` vaut NULL et ne
+-- doit pas casser l'unicité existante (deux NULL comptent comme égaux). Index partiel non modélisé par
+-- Prisma (WHERE) → invisible au drift-gate, livré en migration versionnée.
+DROP INDEX IF EXISTS "adjustment_proposals_one_pending_per_slot";
+CREATE UNIQUE INDEX IF NOT EXISTS "adjustment_proposals_one_pending_per_slot"
+  ON "adjustment_proposals" (
+    "patient_id",
+    "parameter_type",
+    "time_slot_start_hour",
+    "carb_ratio_slot_start",
+    "pump_basal_slot_id",
+    "moment"
+  )
+  NULLS NOT DISTINCT
+  WHERE "status" = 'pending';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1349,6 +1349,10 @@ model AdjustmentProposal {
   carbRatioSlotStart    Int?                @map("carb_ratio_slot_start") @db.SmallInt
   carbRatioSlotEnd      Int?                @map("carb_ratio_slot_end") @db.SmallInt
   pumpBasalSlotId       String?             @map("pump_basal_slot_id")
+  // US-2646/2652 — discriminateur de créneau pour la DOSE FIXE (mode « doses simples ») : le moment
+  // (morning/noon/evening/night) cible/dédoublonne une `FixedDoseSlot`. Fait partie du tuple d'unicité
+  // anti-spam (index partiel `adjustment_proposals_one_pending_per_slot`).
+  moment                DoseMoment?         @map("moment")
   analysisPeriod        String?             @map("analysis_period") @db.VarChar(10)
   dataQuality           String?             @map("data_quality") @db.VarChar(20)
   status                ProposalStatus      @default(pending)

--- a/src/app/api/adjustment-proposals/route.ts
+++ b/src/app/api/adjustment-proposals/route.ts
@@ -41,7 +41,8 @@ export async function GET(req: NextRequest) {
 }
 
 // US-2648a — création d'une PROPOSITION humaine (NURSE / patient / DOCTOR).
-// `fixedDose` volontairement absent (non câblé, cf. createProposal). `patientId`
+// `fixedDose` volontairement absent du SCHÉMA HTTP : câblé au niveau service (US-2652, moment +
+// persistance + apply), mais son exposition à l'UI humaine est une slice ultérieure. `patientId`
 // ignoré pour un VIEWER (résolu sur son propre dossier).
 const createSchema = z.object({
   patientId: z.number().int().positive().optional(),
@@ -63,7 +64,6 @@ const ERROR_STATUS: Record<string, number> = {
   patientDecreaseForbidden: 422,
   patientDeltaTooLarge: 422,
   slotRequired: 400,
-  fixedDoseNotWired: 400,
   currentValueNotFound: 404,
   duplicatePendingProposal: 409,
   patientProposalCooldown: 429, // US-2650 — cooldown anti-churn (proposition patient trop rapprochée)

--- a/src/lib/services/adjustment.service.ts
+++ b/src/lib/services/adjustment.service.ts
@@ -17,7 +17,7 @@ import { isDeliverableBasalRate } from "@/lib/clinical-bounds"
 import { encryptField } from "@/lib/crypto/fields"
 import type { AuditContext } from "./patient.service"
 import type {
-  ProposalStatus, Prisma, AdjustableParameter, AdjustmentReason, ProposalSource, ConfidenceLevel,
+  ProposalStatus, Prisma, AdjustableParameter, AdjustmentReason, ProposalSource, ConfidenceLevel, DoseMoment,
 } from "@prisma/client"
 
 /**
@@ -43,6 +43,8 @@ export type CreateEngineProposalInput = {
   carbRatioSlotStart?: number | null
   carbRatioSlotEnd?: number | null
   pumpBasalSlotId?: string | null
+  /** Discriminateur de créneau pour la DOSE FIXE (mode « doses simples »). */
+  moment?: DoseMoment | null
 }
 
 /** Sources humaines d'une proposition (l'algorithme passe par le chemin `algorithm`). */
@@ -60,6 +62,8 @@ export type CreateProposalInput = {
   carbRatioSlotStart?: number | null
   carbRatioSlotEnd?: number | null
   pumpBasalSlotId?: string | null
+  /** Discriminateur de créneau pour la DOSE FIXE (mode « doses simples »). */
+  moment?: DoseMoment | null
   /** Justification texte libre — chiffrée AES-256-GCM au stockage. */
   proposerComment?: string | null
 }
@@ -160,10 +164,17 @@ async function resolveCurrentValue(
       if (!row) throw new Error("currentValueNotFound")
       return Number(row.rate)
     }
-    // Dose fixe : AdjustmentProposal n'a pas de colonne « moment » → impossible de cibler
-    // /dédupliquer une FixedDoseSlot. Fail-closed jusqu'au câblage UI + discriminateur.
-    case "fixedDose":
-      throw new Error("fixedDoseNotWired")
+    // Dose fixe (US-2652) : ciblée par `moment` (colonne discriminante sur AdjustmentProposal).
+    // Valeur courante lue SERVEUR depuis la `FixedDoseSlot` du patient (anti-IDOR : scopée patient).
+    case "fixedDose": {
+      if (!input.moment) throw new Error("slotRequired")
+      const row = await prisma.fixedDoseSlot.findFirst({
+        where: { patientInsulin: { patientId }, moment: input.moment },
+        select: { valueU: true },
+      })
+      if (!row) throw new Error("currentValueNotFound")
+      return Number(row.valueU)
+    }
     default:
       throw new Error("unsupportedParameter")
   }
@@ -183,6 +194,7 @@ function slotFieldsFor(parameterType: AdjustableParameter, input: CreateProposal
     carbRatioSlotStart: null as number | null,
     carbRatioSlotEnd: null as number | null,
     pumpBasalSlotId: null as string | null,
+    moment: null as DoseMoment | null,
   }
   switch (parameterType) {
     case "insulinSensitivityFactor":
@@ -191,6 +203,8 @@ function slotFieldsFor(parameterType: AdjustableParameter, input: CreateProposal
       return { ...empty, carbRatioSlotStart: input.carbRatioSlotStart ?? null, carbRatioSlotEnd: input.carbRatioSlotEnd ?? null }
     case "basalRate":
       return { ...empty, pumpBasalSlotId: input.pumpBasalSlotId ?? null }
+    case "fixedDose":
+      return { ...empty, moment: input.moment ?? null }
     default:
       return empty
   }
@@ -707,13 +721,6 @@ export const adjustmentService = {
           throw new Error("valueOutOfBounds")
         }
 
-        // US-2646 — l'écriture d'une dose fixe (fixed_dose_slots) est câblée en
-        // US-2647/2649. Tant qu'elle ne l'est pas, on REFUSE l'application immédiate
-        // (fail-closed) plutôt que de renvoyer un faux `applied: true` sur un no-op.
-        if (proposal.parameterType === "fixedDose") {
-          throw new Error("fixedDoseApplyNotImplemented")
-        }
-
         // US-2649b — COMPARE-AND-SWAP (garde d'accès concurrent). `proposedValue` est une
         // valeur ABSOLUE calculée sur la base `currentValue` (snapshot de création). Si le
         // créneau a bougé depuis (édition médecin, autre proposition acceptée), l'appliquer
@@ -760,6 +767,14 @@ export const adjustmentService = {
             data: { rate: proposed },
           })
           assertRowApplied(res.count, "pumpSlotNotFound")
+        } else if (proposal.parameterType === "fixedDose" && proposal.moment != null) {
+          // Dose fixe (US-2652) — scopée patient via la relation `patientInsulin` (anti-IDOR) : un
+          // moment hors patient ne matche pas → count 0 → fail-closed (créneau introuvable).
+          const res = await tx.fixedDoseSlot.updateMany({
+            where: { patientInsulin: { patientId: proposal.patientId }, moment: proposal.moment },
+            data: { valueU: proposed },
+          })
+          assertRowApplied(res.count, "fixedDoseSlotNotFound")
         }
       }
 

--- a/src/lib/services/adjustment.service.ts
+++ b/src/lib/services/adjustment.service.ts
@@ -336,7 +336,7 @@ export const adjustmentService = {
       // « config modifiée » sans trace (observabilité).
       const expected =
         err instanceof Error &&
-        ["slotRequired", "currentValueNotFound", "fixedDoseNotWired"].includes(err.message)
+        ["slotRequired", "currentValueNotFound"].includes(err.message)
       if (!expected) logger.error("adjustment", "liveCurrentValue read failed", { patientId }, err)
       return null
     }

--- a/src/lib/services/adjustment.service.ts
+++ b/src/lib/services/adjustment.service.ts
@@ -127,9 +127,8 @@ function validateProposedValue(parameterType: string, value: number): boolean {
  * US-2649a — valeur COURANTE de confiance d'un paramètre, lue **serveur** depuis la
  * config réelle du patient (jamais du body → garde-fous ininviolables) et **scopée
  * patient** (anti-IDOR : le créneau doit appartenir au patient).
- * @throws `slotRequired` (créneau manquant), `currentValueNotFound` (créneau absent /
- *   autre patient), `fixedDoseNotWired` (dose fixe non câblée — pas de discriminateur
- *   de moment sur AdjustmentProposal, cf. US-2648/2649b).
+ * @throws `slotRequired` (créneau/`moment` manquant), `currentValueNotFound` (créneau absent /
+ *   autre patient). La dose fixe (US-2652) est ciblée par `moment` (scopée patient via `patientInsulin`).
  */
 async function resolveCurrentValue(
   patientId: number,
@@ -305,7 +304,7 @@ export const adjustmentService = {
    * US-2649b — valeur COURANTE **LIVE** du créneau d'une proposition (re-lecture serveur au
    * moment de la revue), pour signaler au médecin si la config a changé depuis la proposition
    * (le `currentValue` stocké est un snapshot de création). Renvoie `null` si le créneau a
-   * disparu/bougé (ISF/ICR par heure, basal par id) ou n'est pas résoluble → l'UI n'affiche
+   * disparu/bougé (ISF/ICR par heure, basal par id, dose fixe par moment) ou n'est pas résoluble → l'UI n'affiche
    * alors pas de comparaison. Réutilise la lecture scopée patient de `resolveCurrentValue`.
    */
   async liveCurrentValue(
@@ -315,6 +314,9 @@ export const adjustmentService = {
       timeSlotStartHour: number | null
       carbRatioSlotStart: number | null
       pumpBasalSlotId: string | null
+      // US-2652 : sans `moment`, `resolveCurrentValue` lève `slotRequired` pour une dose fixe → CAS
+      // `baselineMoved` inactif (une dose absolue périmée serait écrite). Doit être forwardé.
+      moment: DoseMoment | null
     },
   ): Promise<number | null> {
     try {
@@ -326,6 +328,7 @@ export const adjustmentService = {
         timeSlotStartHour: proposal.timeSlotStartHour,
         carbRatioSlotStart: proposal.carbRatioSlotStart,
         pumpBasalSlotId: proposal.pumpBasalSlotId,
+        moment: proposal.moment,
       })
     } catch (err) {
       // Cas ATTENDUS (créneau absent/non résoluble) → null silencieux. Une erreur INATTENDUE
@@ -475,6 +478,7 @@ export const adjustmentService = {
           timeSlotStartHour: slot.timeSlotStartHour,
           carbRatioSlotStart: slot.carbRatioSlotStart,
           pumpBasalSlotId: slot.pumpBasalSlotId,
+          moment: slot.moment, // US-2652 : cooldown PAR MOMENT (sinon morning bloque evening)
         },
         orderBy: { createdAt: "desc" },
         select: { reviewedAt: true, createdAt: true },
@@ -498,6 +502,7 @@ export const adjustmentService = {
         timeSlotStartHour: slot.timeSlotStartHour,
         carbRatioSlotStart: slot.carbRatioSlotStart,
         pumpBasalSlotId: slot.pumpBasalSlotId,
+        moment: slot.moment, // US-2652 : 1 pending PAR MOMENT (aligne le pré-check sur l'index partiel)
       },
       select: { id: true },
     })
@@ -602,6 +607,7 @@ export const adjustmentService = {
       carbRatioSlotStart: input.carbRatioSlotStart,
       carbRatioSlotEnd: input.carbRatioSlotEnd,
       pumpBasalSlotId: input.pumpBasalSlotId,
+      moment: input.moment, // US-2652 : sans ça, `resolveCurrentValue` lève slotRequired → moteur fixedDose mort
     }
     const currentValue = await resolveCurrentValue(patientId, parameterType, asInput)
 
@@ -637,6 +643,7 @@ export const adjustmentService = {
         timeSlotStartHour: slot.timeSlotStartHour,
         carbRatioSlotStart: slot.carbRatioSlotStart,
         pumpBasalSlotId: slot.pumpBasalSlotId,
+        moment: slot.moment, // US-2652 : 1 pending PAR MOMENT (aligne le pré-check sur l'index partiel)
       },
       select: { id: true },
     })

--- a/src/lib/services/proposal-generator.service.ts
+++ b/src/lib/services/proposal-generator.service.ts
@@ -131,7 +131,7 @@ function resolveFastingTarget(individualizedGl: number | null, isPregnancy: bool
 const EXPECTED_SKIP = new Set([
   "baselineMovedAtPersist", "duplicatePendingProposal", "valueOutOfBounds",
   "reasonDirectionMismatch", "nonInsulinNoDose", "invalidSupportingEvents",
-  "slotRequired", "currentValueNotFound", "fixedDoseNotWired",
+  "slotRequired", "currentValueNotFound",
 ])
 
 export const proposalGeneratorService = {

--- a/tests/unit/adjustment-create-proposal.test.ts
+++ b/tests/unit/adjustment-create-proposal.test.ts
@@ -265,6 +265,18 @@ describe("createProposal — fixedDose (câblé US-2652) & anti-spam", () => {
     expect(data.timeSlotStartHour).toBeNull() // discriminateurs parasites zéroés
   })
 
+  it("pré-check anti-spam scopé PAR MOMENT (un pending morning ne bloque pas evening)", async () => {
+    mocks.fixedDoseFindFirst.mockResolvedValue({ valueU: 10 })
+    mocks.adjFindFirst.mockResolvedValue(null)
+    await adjustmentService.createProposal(
+      { patientId: 5, parameterType: "fixedDose", proposedValue: 12, reason: "manualAdjustment", moment: "evening" },
+      nurse,
+    )
+    // Le pré-check `existing` (status pending) doit filtrer sur `moment` → sinon morning bloquerait evening.
+    const precheck = mocks.adjFindFirst.mock.calls.find((c) => (c[0] as any)?.where?.status === "pending")
+    expect((precheck?.[0] as any).where).toMatchObject({ moment: "evening" })
+  })
+
   it("pending existant (pré-check) → duplicatePendingProposal", async () => {
     mocks.adjFindFirst.mockResolvedValue({ id: "existing" })
     await expect(adjustmentService.createProposal(isf(0.52), nurse)).rejects.toThrow("duplicatePendingProposal")

--- a/tests/unit/adjustment-create-proposal.test.ts
+++ b/tests/unit/adjustment-create-proposal.test.ts
@@ -17,6 +17,7 @@ const { prismaMock, mocks } = vi.hoisted(() => {
     isfFindFirst: vi.fn(),
     icrFindFirst: vi.fn(),
     basalFindFirst: vi.fn(),
+    fixedDoseFindFirst: vi.fn(),
     create: vi.fn((args: { data: Record<string, unknown> }) => ({ id: "p1", ...args.data })),
     logWithTx: vi.fn(),
     auditLog: vi.fn(),
@@ -32,6 +33,7 @@ const { prismaMock, mocks } = vi.hoisted(() => {
       insulinSensitivityFactor: { findFirst: m.isfFindFirst },
       carbRatio: { findFirst: m.icrFindFirst },
       pumpBasalSlot: { findFirst: m.basalFindFirst },
+      fixedDoseSlot: { findFirst: m.fixedDoseFindFirst },
       patientReferent: { findFirst: m.referentFindFirst },
       $transaction: async (fn: (tx: unknown) => unknown) =>
         fn({ adjustmentProposal: { create: m.create } }),
@@ -231,14 +233,36 @@ describe("createProposal — bornes, overflow, garde-fous patient", () => {
   })
 })
 
-describe("createProposal — fixedDose non câblé & anti-spam", () => {
-  it("fixedDose → fixedDoseNotWired (fail-closed)", async () => {
+describe("createProposal — fixedDose (câblé US-2652) & anti-spam", () => {
+  it("fixedDose SANS moment → slotRequired (discriminateur obligatoire)", async () => {
     await expect(
       adjustmentService.createProposal(
         { patientId: 5, parameterType: "fixedDose", proposedValue: 12, reason: "manualAdjustment" },
         nurse,
       ),
-    ).rejects.toThrow("fixedDoseNotWired")
+    ).rejects.toThrow("slotRequired")
+  })
+
+  it("fixedDose avec moment mais slot inexistant → currentValueNotFound (anti-IDOR)", async () => {
+    mocks.fixedDoseFindFirst.mockResolvedValue(null)
+    await expect(
+      adjustmentService.createProposal(
+        { patientId: 5, parameterType: "fixedDose", proposedValue: 12, reason: "manualAdjustment", moment: "morning" },
+        nurse,
+      ),
+    ).rejects.toThrow("currentValueNotFound")
+  })
+
+  it("fixedDose avec moment + slot existant → proposition créée (moment persisté)", async () => {
+    mocks.fixedDoseFindFirst.mockResolvedValue({ valueU: 10 }) // dose courante 10 U
+    await adjustmentService.createProposal(
+      { patientId: 5, parameterType: "fixedDose", proposedValue: 12, reason: "manualAdjustment", moment: "morning" },
+      nurse,
+    )
+    expect(mocks.create).toHaveBeenCalledTimes(1)
+    const data = mocks.create.mock.calls[0]![0].data as Record<string, unknown>
+    expect(data).toMatchObject({ parameterType: "fixedDose", moment: "morning" })
+    expect(data.timeSlotStartHour).toBeNull() // discriminateurs parasites zéroés
   })
 
   it("pending existant (pré-check) → duplicatePendingProposal", async () => {

--- a/tests/unit/adjustment.service.test.ts
+++ b/tests/unit/adjustment.service.test.ts
@@ -82,6 +82,33 @@ describe("adjustmentService", () => {
       expect(mockTx.insulinSensitivityFactor.updateMany).toHaveBeenCalled()
     })
 
+    // US-2652 — dose fixe câblée : l'accept écrit la FixedDoseSlot ciblée par `moment` (scopée patient).
+    it("accepts a fixedDose proposal → writes the FixedDoseSlot by moment", async () => {
+      prismaMock.fixedDoseSlot.findFirst.mockResolvedValue({ valueU: 10 } as never) // live = snapshot (pas de dérive)
+      const updateMany = vi.fn().mockResolvedValue({ count: 1 })
+      const mockTx = {
+        adjustmentProposal: {
+          findUnique: vi.fn().mockResolvedValue({
+            id: "p1", patientId: 1, status: "pending",
+            parameterType: "fixedDose", proposedValue: 12, currentValue: 10, moment: "morning",
+          }),
+          update: vi.fn().mockResolvedValue({}),
+        },
+        fixedDoseSlot: { updateMany },
+        auditLog: { create: vi.fn().mockResolvedValue({}) },
+      }
+      prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+
+      const result = await adjustmentService.accept("p1", 2, true)
+      expect(result.applied).toBe(true)
+      expect(updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ moment: "morning", patientInsulin: { patientId: 1 } }),
+          data: { valueU: 12 },
+        }),
+      )
+    })
+
     // US-2649b — compare-and-swap : la base a bougé depuis la proposition → refuser (fail-closed).
     it("throws 'baselineMoved' and applies nothing when the live slot moved since the proposal", async () => {
       // Valeur LIVE (0.99) ≠ snapshot currentValue (0.5) → sur-correction refusée.

--- a/tests/unit/adjustment.service.test.ts
+++ b/tests/unit/adjustment.service.test.ts
@@ -109,6 +109,28 @@ describe("adjustmentService", () => {
       )
     })
 
+    // US-2652 (fix revue) — le CAS baselineMoved DOIT s'appliquer à la dose fixe (avant : inactif car
+    // `moment` non forwardé → resolveCurrentValue levait slotRequired → CAS sauté → dose périmée écrite).
+    it("throws 'baselineMoved' for fixedDose when the live dose drifted since the proposal", async () => {
+      prismaMock.fixedDoseSlot.findFirst.mockResolvedValue({ valueU: 8 } as never) // live 8 ≠ snapshot 10
+      const updateMany = vi.fn().mockResolvedValue({ count: 1 })
+      const mockTx = {
+        adjustmentProposal: {
+          findUnique: vi.fn().mockResolvedValue({
+            id: "p1", patientId: 1, status: "pending",
+            parameterType: "fixedDose", proposedValue: 12, currentValue: 10, moment: "morning",
+          }),
+          update: vi.fn().mockResolvedValue({}),
+        },
+        fixedDoseSlot: { updateMany },
+        auditLog: { create: vi.fn().mockResolvedValue({}) },
+      }
+      prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+
+      await expect(adjustmentService.accept("p1", 2, true)).rejects.toThrow("baselineMoved")
+      expect(updateMany).not.toHaveBeenCalled() // rollback → dose jamais écrite sur une base déplacée
+    })
+
     // US-2649b — compare-and-swap : la base a bougé depuis la proposition → refuser (fail-closed).
     it("throws 'baselineMoved' and applies nothing when the live slot moved since the proposal", async () => {
       // Valeur LIVE (0.99) ≠ snapshot currentValue (0.5) → sur-correction refusée.


### PR DESCRIPTION
**Débloque** `createEngineProposal`/`createProposal` pour le paramètre **`fixedDose`** (avant : `fixedDoseNotWired`, fail-closed faute de discriminateur de moment sur `AdjustmentProposal`). L'analyseur `analyzeFixedDose` (snapping 0,5 U) existe déjà ; cette slice câble la **persistance + l'application** (mirror des chemins ISF/ICR/basal).

## Contenu
- **Migration** `20260710100000` : colonne **`moment`** (`DoseMoment`, nullable) sur `adjustment_proposals` + **index unique partiel** anti-spam `one_pending_per_slot` **étendu à `moment`** (drop/recreate, `NULLS NOT DISTINCT`).
- **schema.prisma** : `AdjustmentProposal.moment DoseMoment?`. Types d'input (engine + humain) : `moment?`.
- **`resolveCurrentValue`** fixedDose : lit la `FixedDoseSlot` **scopée patient** via `patientInsulin` (anti-IDOR) par moment ; `slotRequired` si absent, `currentValueNotFound` si slot inexistant.
- **`slotFieldsFor`** : `moment` ajouté au tuple d'unicité (zéroé pour les 3 autres params → pas de doublon pending).
- **Apply (accept)** : remplace le throw `fixedDoseApplyNotImplemented` par `fixedDoseSlot.updateMany({ patientInsulin: { patientId }, moment })` → `valueU` ; **fail-closed** `fixedDoseSlotNotFound` (count 0).
- **Tests** : create (sans moment→slotRequired ; slot absent→currentValueNotFound ; câblé→créé avec moment persisté + discriminateurs parasites null) ; **accept** (écrit `FixedDoseSlot` par moment, scopé patient). Catalogue.

## Suite
Assemblage (glycémie par moment) + générateur `fixedDose` (mode `fixedDose`, pas encore branché dans `generateForPatient`).

⚠️ **Migration + apply de dose** → revue **prisma** (migration/index) + **sécurité** (anti-IDOR) + medical bienvenues.

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3813 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)