### PR TITLE
US-2652 (fixedDose, slice 2) — Assemblage fixedDoseTrend (creux pré-dose par moment, shift Option B)

### DIFF
--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -443,3 +443,12 @@ pré-dose** qui jugent la dose de ce moment.
 - **Garde hypo** : déjà dans `analyzeFixedDose` (`hypoBlocksProposal` sur les creux) — avec le shift, les
   creux SONT les nadirs → la garde protège le bon moment. ⚠️ Garde hypo **pathology-AGNOSTIQUE** (seuils
   `SEVERE_HYPO_GL`/`LEVEL1_HYPO_GL` fixes) tandis que la **cible** est pathology-aware.
+
+**Limites connues (assemblage dose fixe, validé medical #686)** :
+- *Earliest-in-window pas garanti pré-prandial pour les fenêtres de JOUR* (`morning→noon`, `noon→evening`) :
+  un relevé post-prandial (ex. 10:30 post-petit-déj) peut être le plus tôt de la fenêtre → `avgPost`
+  biaisé vers le haut → léger nudge de **hausse** de la dose. Borné (caps ±10 %/±2 U, doctor-gated) ;
+  pas de risque hypo (valeurs hautes). Le cas `night→morning` (à jeun) est immunisé.
+- *Fenêtre `night` (22–04, cross-minuit)* : sur le jour-frontière, `earliest-par-jour` garde le relevé
+  ~02-04 h (plus proche du vrai nadir nocturne) et écarte le ~22 h → réduit légèrement N pour la dose
+  `evening`, conservateur, **pas de mauvaise direction**. Amélioration future possible (appariement nuit réelle).

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -425,3 +425,21 @@ Discriminateur = **`moment`** (`DoseMoment` : morning/noon/evening/night), nouve
 bloquant — cf. §1). À l'**accept**, `fixedDoseSlot.updateMany({ patientInsulin: { patientId }, moment })`
 écrit `valueU` (fail-closed `fixedDoseSlotNotFound` si count 0). Reste : l'**assemblage** (glycémie par
 moment) + le **générateur** `fixedDose` (mode `fixedDose`, pas encore branché dans `generateForPatient`).
+
+### Assemblage DOSE FIXE `fixedDoseTrend` (US-2652 slice 2, validé medical)
+
+Peuple `analyzeFixedDose` pour un patient « doses simples » (BGM-only). Par `DoseMoment`, les **creux
+pré-dose** qui jugent la dose de ce moment.
+- **Décalage (Option B, `FIXED_DOSE_NEXT_WINDOW`)** : une dose fixe agit **en aval** → jugée sur la
+  **fenêtre SUIVANTE** (morning→noon, noon→evening, evening→night, night→morning). Le relevé de la même
+  fenêtre reflète, lui, la dose PRÉCÉDENTE (attribuer au même moment = Option A, **cliniquement fausse**).
+  Miroir du basal (créneau nocturne ← glycémie à jeun).
+- **Creux** = relevé le **plus tôt par jour** dans la fenêtre (proxy pré-dose, évite le biais post-prandial).
+  Relevés BGM **bruts** en g/L (chacun un `postGlucoseGl` ; `analyzeFixedDose` moyenne, plancher ≥3).
+- **Cible** (appliquée par le générateur, slice 3) = `resolveFastingTarget` (pré-prandial 1,00/0,90 g/L,
+  clampé, individualisé) — **JAMAIS** la bande carnet ni `titrLow`. Même cible aux 4 moments.
+- **Période 14 j** (comme le basal, réactif). Pas de hard-filtre de confondeur (shift + earliest/jour +
+  moyenne + caps + doctor-gating suffisent).
+- **Garde hypo** : déjà dans `analyzeFixedDose` (`hypoBlocksProposal` sur les creux) — avec le shift, les
+  creux SONT les nadirs → la garde protège le bon moment. ⚠️ Garde hypo **pathology-AGNOSTIQUE** (seuils
+  `SEVERE_HYPO_GL`/`LEVEL1_HYPO_GL` fixes) tandis que la **cible** est pathology-aware.

--- a/src/lib/services/analytics.service.ts
+++ b/src/lib/services/analytics.service.ts
@@ -23,6 +23,21 @@ import {
 import { decimalToNumber } from "@/lib/db/decimal"
 import { CGM_AGGREGATE_RANGE_GL, BGM_CARNET } from "@/lib/clinical-bounds"
 import { DAY_MOMENTS, momentForHour, momentBoundsFrom } from "@/lib/day-moments"
+import type { DoseMoment } from "@prisma/client"
+
+/**
+ * US-2652 (dose fixe) — décalage dose → fenêtre de JUGEMENT (validé medical). Une dose fixe est
+ * injectée au début de son moment et agit **en aval** ; elle se juge donc sur le **creux pré-dose du
+ * moment SUIVANT** (le relevé de la même fenêtre reflète, lui, la dose PRÉCÉDENTE). Miroir du basal
+ * (créneau nocturne jugé par la glycémie à jeun). Ne PAS attribuer le relevé du même moment (Option A,
+ * cliniquement fausse — titrerait le mauvais moment).
+ */
+const FIXED_DOSE_NEXT_WINDOW: Record<DoseMoment, DoseMoment> = {
+  morning: "noon", // dose du petit-déj → jugée au pré-déjeuner
+  noon: "evening", // dose du déjeuner → jugée au pré-dîner
+  evening: "night", // dose du dîner → jugée au coucher
+  night: "morning", // dose du soir/coucher → jugée à jeun (pré-petit-déj)
+}
 
 /** Warn if CGM capture rate below this % */
 const MIN_CAPTURE_RATE = 70 // percent
@@ -418,6 +433,93 @@ export const analyticsService = {
       },
       moments,
     }
+  },
+
+  /**
+   * Assemblage DOSE FIXE (US-2652 slice 2, validé medical) : par `DoseMoment`, les **creux pré-dose**
+   * (relevés capillaires) qui jugent la dose de ce moment, via le décalage `FIXED_DOSE_NEXT_WINDOW`
+   * (une dose agit en aval → jugée sur la fenêtre suivante). Pour chaque fenêtre, on retient le relevé
+   * le **plus tôt par jour** (proxy du creux, évite le biais post-prandial). Relevés BGM bruts en **g/L**
+   * (chacun devient un `postGlucoseGl` pour `analyzeFixedDose`, qui moyenne et plancherne à ≥3). La
+   * cible + l'analyse sont faites par l'appelant (générateur, slice 3). BGM-only (patients « doses
+   * simples »). Aucun hard-filtre de confondeur (BGM épars ; le shift + earliest/jour + moyenne + caps
+   * + doctor-gating suffisent — validé medical).
+   *
+   * @param patientId Patient.
+   * @param period Période d'analyse (défaut appelant : 14 j).
+   * @param auditUserId Acteur d'audit (système `null` pour le cron).
+   * @param ctx Contexte requête (audit).
+   * @returns Par moment, la liste des creux g/L (peut être vide → l'analyseur renverra `null`).
+   */
+  async fixedDoseTrend(
+    patientId: number,
+    period: string,
+    auditUserId: number | null,
+    ctx?: AuditContext,
+    opts?: { skipAudit?: boolean },
+  ): Promise<Record<DoseMoment, number[]>> {
+    const days = parsePeriod(period)
+    const now = new Date()
+    const since = new Date(now.getTime() - days * 24 * 3600_000)
+
+    const dayMoments = await prisma.userDayMoment.findMany({
+      where: { user: { patient: { id: patientId } } },
+      select: { type: true, startTime: true, endTime: true },
+    })
+    const bounds = momentBoundsFrom(dayMoments)
+
+    const rows = await prisma.glycemiaEntry.findMany({
+      where: {
+        patientId,
+        date: { gte: since, lte: now },
+        time: { not: null },
+        OR: [{ glycemiaGl: { not: null } }, { glycemiaMgdl: { not: null } }],
+      },
+      select: { glycemiaGl: true, glycemiaMgdl: true, time: true, date: true },
+    })
+
+    if (!opts?.skipAudit) {
+      await auditService.log({
+        userId: auditUserId,
+        action: "READ",
+        resource: "GLYCEMIA_ENTRY",
+        resourceId: String(patientId),
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+        requestId: ctx?.requestId,
+        metadata: { patientId, kind: "fixedDoseTrend", period: `${days}d` },
+      })
+    }
+
+    // Par fenêtre de moment : le relevé le plus TÔT de chaque jour calendaire (proxy du creux pré-dose).
+    const earliestByWindow: Record<DoseMoment, Map<string, { min: number; gl: number }>> = {
+      morning: new Map(),
+      noon: new Map(),
+      evening: new Map(),
+      night: new Map(),
+    }
+    for (const r of rows) {
+      const gl =
+        r.glycemiaGl != null
+          ? decimalToNumber(r.glycemiaGl)
+          : r.glycemiaMgdl != null
+            ? decimalToNumber(r.glycemiaMgdl) / 100
+            : NaN
+      if (!Number.isFinite(gl) || gl < CGM_AGGREGATE_RANGE_GL.MIN || gl > CGM_AGGREGATE_RANGE_GL.MAX) continue
+      if (!r.time) continue
+      const minutesOfDay = r.time.getUTCHours() * 60 + r.time.getUTCMinutes()
+      const window = momentForHour(minutesOfDay / 60, bounds)
+      const dayIso = r.date.toISOString().slice(0, 10)
+      const cur = earliestByWindow[window].get(dayIso)
+      if (!cur || minutesOfDay < cur.min) earliestByWindow[window].set(dayIso, { min: minutesOfDay, gl })
+    }
+
+    // Shift : la dose du moment M est jugée sur les creux (earliest/jour) de la fenêtre SUIVANTE.
+    const out: Record<DoseMoment, number[]> = { morning: [], noon: [], evening: [], night: [] }
+    for (const dose of DAY_MOMENTS) {
+      out[dose] = [...earliestByWindow[FIXED_DOSE_NEXT_WINDOW[dose]].values()].map((v) => v.gl)
+    }
+    return out
   },
 
   /**

--- a/tests/unit/analytics.service.test.ts
+++ b/tests/unit/analytics.service.test.ts
@@ -337,3 +337,56 @@ describe("analyticsService", () => {
     })
   })
 })
+
+describe("analyticsService.fixedDoseTrend (US-2652 — assemblage dose fixe par moment)", () => {
+  // Relevé capillaire : `time` = heure murale (Date 1970), `date` = jour calendaire, valeur g/L.
+  const gEntry = (dateIso: string, hour: number, gl: number) => ({
+    glycemiaGl: d(gl), glycemiaMgdl: null,
+    time: new Date(Date.UTC(1970, 0, 1, hour, 0)), date: new Date(dateIso),
+  })
+  const setup = (rows: unknown[]) => {
+    prismaMock.userDayMoment.findMany.mockResolvedValue([] as any) // bornes par défaut
+    prismaMock.glycemiaEntry.findMany.mockResolvedValue(rows as any)
+    prismaMock.auditLog.create.mockResolvedValue({} as any)
+  }
+
+  it("shift Option B : la dose se juge sur le creux de la fenêtre SUIVANTE", async () => {
+    // 07h→morning, 12h→noon, 18h→evening, 23h→night (bornes par défaut).
+    setup([
+      gEntry("2026-07-01", 7, 1.1),  // fenêtre morning → juge la dose NIGHT
+      gEntry("2026-07-01", 12, 1.6), // fenêtre noon → juge la dose MORNING
+      gEntry("2026-07-01", 18, 1.4), // fenêtre evening → juge la dose NOON
+      gEntry("2026-07-01", 23, 0.9), // fenêtre night → juge la dose EVENING
+    ])
+    const out = await analyticsService.fixedDoseTrend(42, "14d", 1)
+    expect(out.night[0]).toBeCloseTo(1.1)
+    expect(out.morning[0]).toBeCloseTo(1.6)
+    expect(out.noon[0]).toBeCloseTo(1.4)
+    expect(out.evening[0]).toBeCloseTo(0.9)
+  })
+
+  it("retient le relevé le plus TÔT par jour (proxy creux, évite le post-prandial)", async () => {
+    setup([
+      gEntry("2026-07-01", 11, 1.2), // pré-déjeuner (tôt) → gardé
+      gEntry("2026-07-01", 14, 1.9), // post-prandial (tard) → ignoré
+    ])
+    const out = await analyticsService.fixedDoseTrend(42, "14d", 1)
+    expect(out.morning).toHaveLength(1)
+    expect(out.morning[0]).toBeCloseTo(1.2)
+  })
+
+  it("accumule un creux PAR JOUR (3 jours → 3 relevés pour la dose)", async () => {
+    setup([gEntry("2026-07-01", 11, 1.3), gEntry("2026-07-02", 11, 1.4), gEntry("2026-07-03", 11, 1.5)])
+    const out = await analyticsService.fixedDoseTrend(42, "14d", 1)
+    expect(out.morning).toHaveLength(3)
+  })
+
+  it("exclut les relevés hors plage physiologique et sans heure", async () => {
+    setup([
+      { glycemiaGl: d(0.1), glycemiaMgdl: null, time: new Date(Date.UTC(1970, 0, 1, 12, 0)), date: new Date("2026-07-01") }, // < 0,20
+      { glycemiaGl: d(1.5), glycemiaMgdl: null, time: null, date: new Date("2026-07-01") }, // pas d'heure
+    ])
+    const out = await analyticsService.fixedDoseTrend(42, "14d", 1)
+    expect(out.morning).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Peuple ce qu'`analyzeFixedDose` attend, pour un patient « doses simples » (**BGM-only**). **Design validé medical AVANT code** — la validation a corrigé mon **Option A (cliniquement fausse)** en **Option B (shift)**.

## Contenu — `analyticsService.fixedDoseTrend` → `Record<DoseMoment, number[]>`
Par moment, les **creux pré-dose** (g/L bruts) qui jugent la dose de ce moment :
- **Décalage `FIXED_DOSE_NEXT_WINDOW` (Option B)** : une dose fixe agit **en aval** → jugée sur la **fenêtre SUIVANTE** (`morning→noon`, `noon→evening`, `evening→night`, `night→morning`). Le relevé du **même** moment reflète la dose PRÉCÉDENTE → l'attribuer là (Option A) titrerait le **mauvais** moment. Miroir du basal (créneau nocturne ← glycémie à jeun).
- **Creux** = relevé le **plus tôt par jour** dans la fenêtre (proxy pré-dose, évite le biais post-prandial).
- Relevés BGM **bruts** (pas pré-moyennés) → chacun un `postGlucoseGl` ; `analyzeFixedDose` moyenne + plancher ≥ 3. Filtre physiologique + `time` non nul. **Audité**.
- **Tests +4** (shift des 4 moments ; earliest/jour ; multi-jours ; filtre).

## Suite
**Slice 3** : générateur `fixedDose` (cible `resolveFastingTarget` — **jamais `titrLow`** — + `analyzeFixedDose` + `createEngineProposal` par moment).

⚠️ **Validation medical** utile (le shift Option B + la définition du creux).

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3819 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)