### PR TITLE
US-2652 (fixedDose, slice 3) — Générateur fixedDose vertical (clôt le générateur multi-levier)

### DIFF
--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -452,3 +452,13 @@ pré-dose** qui jugent la dose de ce moment.
 - *Fenêtre `night` (22–04, cross-minuit)* : sur le jour-frontière, `earliest-par-jour` garde le relevé
   ~02-04 h (plus proche du vrai nadir nocturne) et écarte le ~22 h → réduit légèrement N pour la dose
   `evening`, conservateur, **pas de mauvaise direction**. Amélioration future possible (appariement nuit réelle).
+
+### Générateur DOSE FIXE (US-2652 slice 3, LIVRÉ) — `generateFixedDoseProposals`, mode `fixedDose`
+
+Branche dédiée dans `generateForPatient` (`mode === "fixedDose"` → route vers `generateFixedDoseProposals`).
+- Charge les `FixedDoseSlot` (via `patientInsulin`, **pas** `InsulinTherapySettings`). Aucune dose → `EMPTY("noFixedDose")`.
+- Cible : `resolveFastingTarget(glucoseTargets individualisée, isPregnancy)` — pré-prandiale 1,00/0,90, **JAMAIS `titrLow`**.
+- Creux pré-dose par moment : `analyticsService.fixedDoseTrend(patientId, "14d")` (shift Option B).
+- Par moment : `{postGlucoseGl, targetGl}[]` → `analyzeFixedDose(slot, readings)` → `createEngineProposal({ parameterType: "fixedDose", moment })` ; rejets fail-closed non fatals (bucket `fixedDose:<moment>`).
+
+**Générateur multi-levier COMPLET** : ICR + basal + ISF + **fixedDose** de bout en bout, doctor-gated (ADR #13).

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -462,3 +462,11 @@ Branche dédiée dans `generateForPatient` (`mode === "fixedDose"` → route ver
 - Par moment : `{postGlucoseGl, targetGl}[]` → `analyzeFixedDose(slot, readings)` → `createEngineProposal({ parameterType: "fixedDose", moment })` ; rejets fail-closed non fatals (bucket `fixedDose:<moment>`).
 
 **Générateur multi-levier COMPLET** : ICR + basal + ISF + **fixedDose** de bout en bout, doctor-gated (ADR #13).
+
+**Limites connues (générateur dose fixe)** :
+- *Garde soft-delete* : `generateFixedDoseProposals` renvoie `EMPTY("noPatient")` si le patient est
+  soft-deleted (fail-closed RGPD, ADR #4 ; symétrie avec le chemin basalBolus).
+- *Edge multi-`PatientInsulin`* : `FixedDoseSlot` est unique sur `[patientInsulinId, moment]` (pas
+  `[patientId, moment]`). Si un patient avait 2 `PatientInsulin` actifs portant le même moment, le
+  `findMany` émettrait 2 candidats ; tout reste **sûr** (`resolveCurrentValue` = `findFirst` + le 2e
+  candidat → `duplicatePendingProposal` / `baselineMoved`) → proposition supprimée, **jamais fausse**.

--- a/src/lib/services/proposal-generator.service.ts
+++ b/src/lib/services/proposal-generator.service.ts
@@ -145,7 +145,7 @@ export const proposalGeneratorService = {
    */
   async generateForPatient(patientId: number, auditUserId: number | null, ctx?: AuditContext): Promise<GenerateResult> {
     // 0. Mode — routage : `nonInsulin` → flags d'orientation (mode c, jamais de dose, frontière MDR) ;
-    //    `basalBolus` → propositions ICR (ci-dessous) ; `fixedDose` → hors scope (slice ultérieure).
+    //    `fixedDose` → titration des doses simples par moment ; `basalBolus` → ICR + basal + ISF (ci-dessous).
     const { mode } = await treatmentModeService.resolveTreatmentMode(patientId)
     if (mode === "nonInsulin") return proposalGeneratorService.generateOrientationFlags(patientId, auditUserId, ctx)
     if (mode === "fixedDose") return proposalGeneratorService.generateFixedDoseProposals(patientId, auditUserId, ctx)
@@ -405,7 +405,10 @@ export const proposalGeneratorService = {
       where: { id: patientId, deletedAt: null },
       select: { pathology: true, pregnancyMode: true },
     })
-    const isPregnancy = patient?.pregnancyMode === true || patient?.pathology === "GD"
+    // Fail-closed RGPD (ADR #4, symétrie avec le chemin basalBolus) : un patient soft-deleted ne reçoit
+    // aucune proposition moteur (le cron pré-filtre déjà `deletedAt`, mais protège l'appel direct).
+    if (!patient) return EMPTY("noPatient")
+    const isPregnancy = patient.pregnancyMode === true || patient.pathology === "GD"
     // Cible pré-prandiale individualisée si plausible, sinon défaut (JAMAIS titrLow). Scopée patient.
     const targetRow = await prisma.glucoseTarget.findFirst({
       where: { settings: { patientId }, isActive: true },

--- a/src/lib/services/proposal-generator.service.ts
+++ b/src/lib/services/proposal-generator.service.ts
@@ -11,8 +11,8 @@
  * Périmètre actuel (mode `basalBolus`) : **ICR** (par créneau) + **basal** (`basalRate`, POMPE
  * uniquement, créneau nocturne titré par la glycémie à jeun) + **ISF** (par créneau, titré par les
  * corrections propres appariées). `nonInsulin` → uniquement des `ClinicalReviewFlag` d'orientation
- * (mode c). `fixedDose` relève d'une slice ultérieure. La frontière MDR (`nonInsulin` → aucune dose)
- * est de toute façon re-imposée par `createEngineProposal`.
+ * (mode c) + **fixedDose** (« doses simples » — chaque dose par moment titrée sur les creux pré-dose).
+ * La frontière MDR (`nonInsulin` → aucune dose) est de toute façon re-imposée par `createEngineProposal`.
  *
  * ⚠️ Le chemin basal est **couplé à l'existence des carb-ratios** : `generateForPatient` renvoie tôt
  * (`EMPTY("noCarbRatios")`) si aucun ICR n'est configuré, donc un patient pompe avec basale mais **sans**
@@ -29,8 +29,9 @@ import {
 import { findSlotForHour } from "@/lib/insulin-slots"
 import {
   analyzeIcrSlot, analyzeIcrHypoDeescalation, recurrentPostMealHypo, analyzeBasalTrend, analyzeIsfSlot,
-  type ProposalCandidate,
+  analyzeFixedDose, type ProposalCandidate,
 } from "@/lib/proposal-algorithm"
+import { analyticsService } from "@/lib/services/analytics.service"
 import { clinicalReviewFlagService } from "@/lib/services/clinical-review-flag.service"
 import { treatmentModeService } from "@/lib/services/treatment-mode.service"
 import { insulinTherapyService } from "@/lib/services/insulin-therapy.service"
@@ -147,6 +148,7 @@ export const proposalGeneratorService = {
     //    `basalBolus` → propositions ICR (ci-dessous) ; `fixedDose` → hors scope (slice ultérieure).
     const { mode } = await treatmentModeService.resolveTreatmentMode(patientId)
     if (mode === "nonInsulin") return proposalGeneratorService.generateOrientationFlags(patientId, auditUserId, ctx)
+    if (mode === "fixedDose") return proposalGeneratorService.generateFixedDoseProposals(patientId, auditUserId, ctx)
     if (mode !== "basalBolus") return EMPTY("mode")
 
     // 1. Config (créneaux ICR) + patient (pathologie / grossesse pour la cible).
@@ -378,6 +380,74 @@ export const proposalGeneratorService = {
     }
 
     return { created, flagged, slotsConsidered, mealsUsable: usable.length, skipped: null }
+  },
+
+  /**
+   * Mode `fixedDose` (« doses simples ») — titre chaque DOSE FIXE par moment (US-2652). Les creux
+   * pré-dose viennent de `fixedDoseTrend` (shift Option B, BGM). Cible = `resolveFastingTarget`
+   * (pré-prandiale 1,00/0,90, JAMAIS `titrLow`). `analyzeFixedDose` : plancher ≥ 3 relevés, snap 0,5 U,
+   * cap ±10 %/±2 U, **garde hypo** (bloque une hausse sur un creux hypo). Persistance par `moment`
+   * (discriminateur #685). Les `FixedDoseSlot` vivent sur `PatientInsulin` (pas `InsulinTherapySettings`).
+   *
+   * @param patientId Patient en mode doses simples.
+   * @param auditUserId Acteur d'audit (système `null` pour le cron).
+   * @param ctx Contexte requête (audit).
+   * @returns Métriques ; `slotsConsidered` = nb de doses fixes, `created` = propositions générées.
+   */
+  async generateFixedDoseProposals(patientId: number, auditUserId: number | null, ctx?: AuditContext): Promise<GenerateResult> {
+    const fixedSlots = await prisma.fixedDoseSlot.findMany({
+      where: { patientInsulin: { patientId } },
+      select: { moment: true, valueU: true },
+    })
+    if (fixedSlots.length === 0) return EMPTY("noFixedDose")
+
+    const patient = await prisma.patient.findFirst({
+      where: { id: patientId, deletedAt: null },
+      select: { pathology: true, pregnancyMode: true },
+    })
+    const isPregnancy = patient?.pregnancyMode === true || patient?.pathology === "GD"
+    // Cible pré-prandiale individualisée si plausible, sinon défaut (JAMAIS titrLow). Scopée patient.
+    const targetRow = await prisma.glucoseTarget.findFirst({
+      where: { settings: { patientId }, isActive: true },
+      select: { targetGlucose: true },
+    })
+    const targetGl = resolveFastingTarget(targetRow ? Number(targetRow.targetGlucose) / 100 : null, isPregnancy)
+
+    // Creux pré-dose par moment (shift Option B, BGM). Période 14 j (réactif, comme le basal).
+    const troughs = await analyticsService.fixedDoseTrend(patientId, ANALYSIS_PERIOD, auditUserId, ctx)
+
+    let created = 0
+    for (const slot of fixedSlots) {
+      const readings = (troughs[slot.moment] ?? []).map((g) => ({ postGlucoseGl: g, targetGl }))
+      const candidate = analyzeFixedDose({ moment: slot.moment, valueU: Number(slot.valueU) }, readings)
+      if (!candidate) continue
+      try {
+        await adjustmentService.createEngineProposal({
+          patientId,
+          parameterType: "fixedDose",
+          moment: slot.moment,
+          proposedValue: candidate.proposedValue,
+          expectedCurrentValue: candidate.currentValue,
+          reason: candidate.reason,
+          confidence: candidate.confidence,
+          supportingEvents: candidate.supportingEvents,
+          totalEventsConsidered: candidate.totalEventsConsidered,
+          averageObservedValue: candidate.averageObservedValue ?? null,
+          analysisPeriod: ANALYSIS_PERIOD,
+        }, ctx)
+        created++
+      } catch (err) {
+        const msg = (err as Error).message
+        const bucket = `fixedDose:${slot.moment}`
+        if (EXPECTED_SKIP.has(msg)) {
+          logger.info("proposal-generator", "engine proposal skipped", { patientId, bucket, failMode: msg })
+        } else {
+          logger.error("proposal-generator", "unexpected engine proposal error",
+            { patientId, bucket, failMode: "unexpected" }, err as Error)
+        }
+      }
+    }
+    return { created, flagged: 0, slotsConsidered: fixedSlots.length, mealsUsable: 0, skipped: null }
   },
 
   /**

--- a/tests/unit/proposal-generator.service.test.ts
+++ b/tests/unit/proposal-generator.service.test.ts
@@ -20,6 +20,9 @@ vi.mock("@/lib/services/meal-trends.service", () => ({
 vi.mock("@/lib/services/adjustment.service", () => ({
   adjustmentService: { createEngineProposal: vi.fn() },
 }))
+vi.mock("@/lib/services/analytics.service", () => ({
+  analyticsService: { fixedDoseTrend: vi.fn() },
+}))
 // Verrou advisory : par défaut « acquis » → exécute le travail. Surchargé pour le cas concurrent.
 vi.mock("@/lib/db/cron-lock", () => ({
   withSessionAdvisoryLock: vi.fn((_key: string, fn: () => Promise<unknown>) => fn()),
@@ -36,6 +39,7 @@ import { treatmentModeService } from "@/lib/services/treatment-mode.service"
 import { insulinTherapyService } from "@/lib/services/insulin-therapy.service"
 import { mealtimePattern } from "@/lib/services/meal-trends.service"
 import { adjustmentService } from "@/lib/services/adjustment.service"
+import { analyticsService } from "@/lib/services/analytics.service"
 import { withSessionAdvisoryLock } from "@/lib/db/cron-lock"
 import { auditService } from "@/lib/services/audit.service"
 import { clinicalReviewFlagService } from "@/lib/services/clinical-review-flag.service"
@@ -49,6 +53,7 @@ const getSettings = vi.mocked(insulinTherapyService.getSettings)
 const dailyJournal = vi.mocked(mealtimePattern.dailyJournal)
 const fastingTrend = vi.mocked(mealtimePattern.fastingTrend)
 const correctionTrend = vi.mocked(mealtimePattern.correctionTrend)
+const fixedDoseTrend = vi.mocked(analyticsService.fixedDoseTrend)
 const createEngine = vi.mocked(adjustmentService.createEngineProposal)
 
 /** Repas exploitable par défaut : midi (13 h), glucides/bolus OK, pré-repas 1,0 g/L (en bande). */
@@ -113,10 +118,11 @@ describe("proposalGeneratorService.generateForPatient", () => {
     expect(input.proposedValue).toBeLessThan(10) // baisse ICR
   })
 
-  it("ne fait rien hors mode basalBolus (fixedDose/nonInsulin)", async () => {
-    setup({ mode: "fixedDose" })
+  it("mode fixedDose SANS dose configurée → skipped noFixedDose (aucune proposition)", async () => {
+    mode.mockResolvedValue({ mode: "fixedDose", coherent: true } as never)
+    prismaMock.fixedDoseSlot.findMany.mockResolvedValue([] as never)
     const res = await proposalGeneratorService.generateForPatient(1, 99)
-    expect(res.skipped).toBe("mode")
+    expect(res.skipped).toBe("noFixedDose")
     expect(createEngine).not.toHaveBeenCalled()
   })
 
@@ -286,6 +292,65 @@ describe("proposalGeneratorService.generateForPatient — chemin basal (US-2651)
     const res = await proposalGeneratorService.generateForPatient(1, 99)
     expect(res.skipped).toBe("noCarbRatios") // le early-return ICR gate le chemin basal
     expect(basalCalls()).toHaveLength(0)
+  })
+})
+
+describe("proposalGeneratorService.generateForPatient — mode fixedDose (US-2652)", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  const fixedCalls = () =>
+    createEngine.mock.calls.map((c) => c[0] as Record<string, unknown>).filter((a) => a.parameterType === "fixedDose")
+  const emptyTroughs = { morning: [] as number[], noon: [] as number[], evening: [] as number[], night: [] as number[] }
+  function setupFixed(opts: {
+    slots?: { moment: string; valueU: number }[]
+    troughs?: Record<string, number[]>
+    target?: { targetGlucose: number } | null
+    pregnancyMode?: boolean
+    pathology?: string
+  } = {}) {
+    mode.mockResolvedValue({ mode: "fixedDose", coherent: true } as never)
+    prismaMock.fixedDoseSlot.findMany.mockResolvedValue((opts.slots ?? []) as never)
+    prismaMock.patient.findFirst.mockResolvedValue({ pathology: opts.pathology ?? "DT2", pregnancyMode: opts.pregnancyMode ?? false } as never)
+    prismaMock.glucoseTarget.findFirst.mockResolvedValue((opts.target ?? null) as never)
+    fixedDoseTrend.mockResolvedValue((opts.troughs ?? emptyTroughs) as never)
+    createEngine.mockResolvedValue({ id: "e1" } as never)
+  }
+
+  it("dose fixe : creux au-dessus de la cible → proposition fixedDoseTooLow (hausse) par moment", async () => {
+    setupFixed({ slots: [{ moment: "morning", valueU: 10 }], troughs: { ...emptyTroughs, morning: [1.8, 1.8, 1.8] } })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    const fixed = fixedCalls()
+    expect(fixed).toHaveLength(1)
+    expect(fixed[0]).toMatchObject({ moment: "morning", reason: "fixedDoseTooLow", expectedCurrentValue: 10 })
+  })
+
+  it("< 3 creux dans le moment → aucune proposition (plancher analyseur)", async () => {
+    setupFixed({ slots: [{ moment: "morning", valueU: 10 }], troughs: { ...emptyTroughs, morning: [1.8, 1.8] } })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(fixedCalls()).toHaveLength(0)
+  })
+
+  it("garde hypo : un creux sévère (0,50) supprime la hausse de dose", async () => {
+    setupFixed({ slots: [{ moment: "morning", valueU: 10 }], troughs: { ...emptyTroughs, morning: [1.8, 1.8, 0.5] } })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(fixedCalls()).toHaveLength(0)
+  })
+
+  it("aucune dose fixe configurée → EMPTY(noFixedDose), aucune proposition", async () => {
+    setupFixed({ slots: [] })
+    const res = await proposalGeneratorService.generateForPatient(1, 99)
+    expect(res.skipped).toBe("noFixedDose")
+    expect(fixedCalls()).toHaveLength(0)
+  })
+
+  it("cible individualisée utilisée (jamais titrLow) : cible 1,30 → creux 1,20 → BAISSE", async () => {
+    setupFixed({
+      slots: [{ moment: "evening", valueU: 12 }],
+      troughs: { ...emptyTroughs, evening: [1.2, 1.2, 1.2] },
+      target: { targetGlucose: 130 }, // 1,30 g/L
+    })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(fixedCalls()[0]).toMatchObject({ moment: "evening", reason: "fixedDoseTooHigh" })
   })
 })
 
@@ -532,8 +597,9 @@ describe("proposalGeneratorService.generateForAllPatients (cron)", () => {
     }))
   })
 
-  it("un patient skippé par mode (fixedDose) ne gonfle PAS errored", async () => {
-    setup({ mode: "fixedDose" }) // generateForPatient renvoie skipped:'mode' sans lever
+  it("un patient fixedDose sans dose ne gonfle PAS errored (skipped noFixedDose proprement)", async () => {
+    setup({ mode: "fixedDose" })
+    prismaMock.fixedDoseSlot.findMany.mockResolvedValue([] as never) // aucune dose → EMPTY(noFixedDose), pas d'erreur
     prismaMock.patient.findMany.mockResolvedValue([{ id: 1 }, { id: 2 }] as never)
     const res = await proposalGeneratorService.generateForAllPatients()
     expect(res).toMatchObject({ processed: 2, created: 0, errored: 0 })

--- a/tests/unit/proposal-generator.service.test.ts
+++ b/tests/unit/proposal-generator.service.test.ts
@@ -352,6 +352,14 @@ describe("proposalGeneratorService.generateForPatient — mode fixedDose (US-265
     await proposalGeneratorService.generateForPatient(1, 99)
     expect(fixedCalls()[0]).toMatchObject({ moment: "evening", reason: "fixedDoseTooHigh" })
   })
+
+  it("patient soft-deleted (findFirst null) → EMPTY(noPatient), aucune proposition (fail-closed RGPD)", async () => {
+    setupFixed({ slots: [{ moment: "morning", valueU: 10 }], troughs: { ...emptyTroughs, morning: [1.8, 1.8, 1.8] } })
+    prismaMock.patient.findFirst.mockResolvedValue(null as never)
+    const res = await proposalGeneratorService.generateForPatient(1, 99)
+    expect(res.skipped).toBe("noPatient")
+    expect(fixedCalls()).toHaveLength(0)
+  })
 })
 
 describe("proposalGeneratorService.generateForPatient — chemin ISF (US-2651)", () => {


### PR DESCRIPTION
**Dernière brique de l'épic générateur.** Nouvelle branche `mode === "fixedDose"` dans `generateForPatient` → `generateFixedDoseProposals`. La persistance (#685) + l'assemblage (#686) sont déjà validés medical ; ce câblage est de l'orchestration (mirror des autres verticaux).

## Contenu
- **`generateFixedDoseProposals`** : charge les `FixedDoseSlot` (**via `patientInsulin`**, pas `InsulinTherapySettings` — `getSettings` ne les inclut pas) ; aucune dose → `EMPTY("noFixedDose")`.
- **Cible** = `resolveFastingTarget` (individualisée/défaut **1,00/0,90**, **JAMAIS `titrLow`**), pathology/grossesse-aware.
- Creux pré-dose par moment via `analyticsService.fixedDoseTrend("14d")` (shift Option B).
- Par moment : `analyzeFixedDose` → `createEngineProposal({ parameterType: "fixedDose", moment })` ; rejets **fail-closed** non fatals.
- Routing mode : fixedDose ne tombe plus dans `EMPTY("mode")`. JSDoc de tête + catalogue.
- **Tests +5** (creux haut → `fixedDoseTooLow` par moment ; < 3 → rien ; **garde hypo** supprime la hausse ; pas de dose → `noFixedDose` ; cible individualisée inverse le sens) + **2 tests existants mis à jour** (fixedDose n'est plus un no-op).

## Générateur multi-levier COMPLET
**ICR + basal + ISF + fixedDose** de bout en bout, doctor-gated (ADR #13).

⚠️ **Validation medical** utile (câblage end-to-end + cible + garde hypo).

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3824 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)