### PR TITLE
US-2651 (mode c) — Flag observance « suivi glycémique insuffisant » (dernier flag mode-c)

### DIFF
--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -470,3 +470,22 @@ Branche dédiée dans `generateForPatient` (`mode === "fixedDose"` → route ver
   `[patientId, moment]`). Si un patient avait 2 `PatientInsulin` actifs portant le même moment, le
   `findMany` émettrait 2 candidats ; tout reste **sûr** (`resolveCurrentValue` = `findFirst` + le 2e
   candidat → `duplicatePendingProposal` / `baselineMoved`) → proposition supprimée, **jamais fausse**.
+
+### Flag `observance` (US-2651 mode c, LIVRÉ, validé medical) — « suivi glycémique insuffisant »
+
+4ᵉ flag d'orientation du mode nonInsulin (`generateOrientationFlags`). **Honnêteté du scope** : mesure
+l'**auto-surveillance glycémique** (seule donnée disponible ; pas d'adhésion médicamenteuse ni de présence RDV).
+Libellé UI « Suivi glycémique à vérifier ». Source : `OBSERVANCE` (`clinical-bounds.ts`).
+
+- **Logique either/or** : `observancePoor = !cgmAdequate && bgmCount < seuil`. `cgmAdequate = cgmCount > 0
+  && cgmCaptureRate(cgmCount, 30) ≥ MIN_CGM_CAPTURE_RATE (30 %)`. → un **porteur CGM régulier** (capture ≥ 30 %,
+  un capteur abandonné retombe sous le seuil) OU un **testeur BGM diligent** n'est **jamais** faussement flagué ;
+  seul le double-échec l'est.
+- **Seuils BGM pathology-aware** : `BGM_MIN_READINGS_DEFAULT` = **4 / 30 j** (DT1/DT2, < ~1×/sem) ;
+  `BGM_MIN_READINGS_PREGNANCY` = **30 / 30 j** (GD/grossesse, < ~1×/j — population critique, cible 4×/j).
+- **Garde enrollment** : pas de flag si `patient.createdAt` < `MIN_ENROLLMENT_DAYS` (30 j) — fenêtre pas
+  encore observable (n'accuse pas un patient récemment inscrit).
+- **Fenêtre** `WINDOW_DAYS` = 30 j. **Chevauchement** avec `hba1cStale` acceptable (axes distincts :
+  récence HbA1c vs comportement de suivi ; un patient totalement désengagé déclenche les deux, cohérent).
+- **Direction fail-safe** : orientation-only, idempotent, doctor-gated → seuils **lenients** (err vers NE PAS
+  flaguer, anti fatigue d'alerte). Jamais une dose (frontière MDR).

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -2033,7 +2033,7 @@
     "flagReviewInConsultation": "مراجعة في الاستشارة",
     "flagHba1cStale": "الهيموغلوبين السكري (HbA1c) للإجراء أو التحديث",
     "flagTirBelowTarget": "الوقت ضمن النطاق (TIR) تحت الهدف",
-    "flagObservance": "التحقق من الالتزام",
+    "flagObservance": "التحقق من مراقبة السكر",
     "flagHighVariabilityPostMeal": "تقلب مرتفع بعد الوجبة (ذروة + نقص سكر الدم)",
     "flagHba1cAboveTarget": "الهيموغلوبين السكري (HbA1c) فوق الهدف"
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -2033,7 +2033,7 @@
     "flagReviewInConsultation": "Review in consultation",
     "flagHba1cStale": "Glycated haemoglobin (HbA1c) to obtain or refresh",
     "flagTirBelowTarget": "Time in range (TIR) below target",
-    "flagObservance": "Adherence to check",
+    "flagObservance": "Glucose monitoring to check",
     "flagHighVariabilityPostMeal": "High post-meal variability (spike + hypoglycemia)",
     "flagHba1cAboveTarget": "Glycated haemoglobin (HbA1c) above target"
   },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -2033,7 +2033,7 @@
     "flagReviewInConsultation": "À revoir en consultation",
     "flagHba1cStale": "Hémoglobine glyquée (HbA1c) à réaliser ou actualiser",
     "flagTirBelowTarget": "Temps dans la cible (TIR) sous l'objectif",
-    "flagObservance": "Observance à vérifier",
+    "flagObservance": "Suivi glycémique à vérifier",
     "flagHighVariabilityPostMeal": "Forte variabilité post-repas (pic + hypoglycémie)",
     "flagHba1cAboveTarget": "Hémoglobine glyquée (HbA1c) au-dessus de la cible"
   },

--- a/src/lib/clinical-bounds.ts
+++ b/src/lib/clinical-bounds.ts
@@ -305,6 +305,24 @@ export const BGM_CARNET = {
 } as const
 
 /**
+ * US-2651 (mode c) — flag d'orientation `observance` = **suivi glycémique insuffisant** d'un patient
+ * NON insuliné (on n'a pas de donnée d'adhésion médicamenteuse ni de présence RDV ; seule la fréquence
+ * d'auto-surveillance est mesurable). Validé medical. Logique **either/or** (ne flague QUE si les DEUX
+ * canaux échouent) pour ne JAMAIS faussement flaguer un porteur CGM ni un testeur BGM diligent :
+ * `observancePoor = !cgmAdequate && !bgmAdequate`, avec `cgmAdequate = capture ≥ MIN_CGM_CAPTURE_RATE`
+ * (un capteur abandonné → capture basse → détecté) et `bgmAdequate = comptage BGM ≥ seuil pathology-aware`.
+ * **Garde enrollment** : pas de flag si le patient est inscrit depuis < `MIN_ENROLLMENT_DAYS` (fenêtre
+ * pas encore observable). Seuils lenients (orientation-only → err vers NE PAS flaguer, anti fatigue d'alerte).
+ */
+export const OBSERVANCE = {
+  WINDOW_DAYS: 30,
+  MIN_CGM_CAPTURE_RATE: 30, // % — aligné sur DASHBOARD_TIR.MIN_CAPTURE_RATE (capture suffisante = observant)
+  BGM_MIN_READINGS_DEFAULT: 4, // DT1/DT2/défaut : < ~1×/semaine sur 30 j = sous-surveillance
+  BGM_MIN_READINGS_PREGNANCY: 30, // GD/grossesse : < ~1×/jour sur 30 j (cible GD = 4×/jour)
+  MIN_ENROLLMENT_DAYS: 30, // ne pas flaguer un patient inscrit depuis moins d'une fenêtre
+} as const
+
+/**
  * US-2637 — Tendances de repas (définitions cliniques validées par
  * `medical-domain-validator`). Durées en minutes, relatives à l'heure du repas
  * `t0`.

--- a/src/lib/services/proposal-generator.service.ts
+++ b/src/lib/services/proposal-generator.service.ts
@@ -23,9 +23,10 @@ import { prisma } from "@/lib/db/client"
 import { logger } from "@/lib/logger"
 import { withSessionAdvisoryLock } from "@/lib/db/cron-lock"
 import {
-  CLINICAL_BOUNDS, HBA1C_STALE_DAYS, DASHBOARD_TIR,
+  CLINICAL_BOUNDS, HBA1C_STALE_DAYS, DASHBOARD_TIR, OBSERVANCE,
   HBA1C_HIGH_DEFAULT_PERCENT, HBA1C_HIGH_DEFAULT_PREGNANCY_PERCENT, HBA1C_TARGET_MARGIN_PERCENT,
 } from "@/lib/clinical-bounds"
+import { cgmCaptureRate } from "@/lib/statistics"
 import { findSlotForHour } from "@/lib/insulin-slots"
 import {
   analyzeIcrSlot, analyzeIcrHypoDeescalation, recurrentPostMealHypo, analyzeBasalTrend, analyzeIsfSlot,
@@ -457,10 +458,12 @@ export const proposalGeneratorService = {
    * Mode (c) — patient NON insuliné : **aucune proposition de dose** (frontière MDR / IEC 62304),
    * uniquement des `ClinicalReviewFlag` d'**orientation** (« à revoir en consultation »).
    *
-   * Slice 1 : `hba1cStale` — la dernière HbA1c (labo, dans `GlycemiaEntry` ou `DiabetesEvent`) date de
-   * plus de `HBA1C_STALE_DAYS` (180 j), **ou est absente** (un DT2/GD suivi doit avoir une HbA1c
-   * récente). Idempotent (raise dédoublonne un flag ouvert du même type). `tirBelowTarget` et
-   * `observance` = slices ultérieures (nécessitent l'extraction du calcul TIR / une définition observance).
+   * 4 flags (tous idempotents — `raise` dédoublonne un flag ouvert du même type) :
+   * - `hba1cStale` : dernière HbA1c (labo) > `HBA1C_STALE_DAYS` (180 j) ou absente.
+   * - `hba1cAboveTarget` : HbA1c RÉCENTE au-dessus de la cible (comble le trou BGM-only).
+   * - `tirBelowTarget` : TIR 14 j < cible (CGM, pathology-aware).
+   * - `observance` : **suivi glycémique insuffisant** (either/or CGM-capture / comptage BGM ; garde
+   *   enrollment ; jamais l'adhésion médicamenteuse, non mesurable — cf. `OBSERVANCE`, validé medical).
    *
    * @param patientId Patient non insuliné.
    * @param auditUserId Acteur d'audit (système `null` pour le cron).
@@ -486,7 +489,7 @@ export const proposalGeneratorService = {
         where: { patientId, hba1c: { not: null } }, orderBy: { eventDate: "desc" }, select: { eventDate: true, hba1c: true },
       }),
       prisma.patient.findFirst({
-        where: { id: patientId, deletedAt: null }, select: { pathology: true, pregnancyMode: true },
+        where: { id: patientId, deletedAt: null }, select: { pathology: true, pregnancyMode: true, createdAt: true },
       }),
       prisma.annexObjective.findUnique({ where: { patientId }, select: { objectiveHba1c: true } }),
     ])
@@ -533,6 +536,28 @@ export const proposalGeneratorService = {
         await clinicalReviewFlagService.raise(patientId, "tirBelowTarget", auditUserId, ctx)
           .then(() => { flagged++ })
           .catch((err) => logger.error("proposal-generator", "raise tirBelowTarget failed", { patientId }, err as Error))
+      }
+    }
+
+    // observance — « suivi glycémique insuffisant » (validé medical). Logique EITHER/OR : ne flague QUE
+    // si les DEUX canaux échouent → jamais un porteur CGM régulier (capture ≥ 30 %, capteur abandonné
+    // détecté) ni un testeur BGM diligent (≥ seuil pathology-aware). Garde enrollment : pas de flag si
+    // le patient est inscrit depuis < une fenêtre (données pas encore observables). Jamais une dose.
+    if (patient) {
+      const enrolledDays = (Date.now() - patient.createdAt.getTime()) / 86_400_000
+      if (enrolledDays >= OBSERVANCE.MIN_ENROLLMENT_DAYS) {
+        const since = new Date(Date.now() - OBSERVANCE.WINDOW_DAYS * 86_400_000)
+        const [cgmCount, bgmCount] = await Promise.all([
+          prisma.cgmEntry.count({ where: { patientId, timestamp: { gte: since } } }),
+          prisma.glycemiaEntry.count({ where: { patientId, date: { gte: since } } }),
+        ])
+        const cgmAdequate = cgmCount > 0 && cgmCaptureRate(cgmCount, OBSERVANCE.WINDOW_DAYS) >= OBSERVANCE.MIN_CGM_CAPTURE_RATE
+        const bgmMin = isPregnancy ? OBSERVANCE.BGM_MIN_READINGS_PREGNANCY : OBSERVANCE.BGM_MIN_READINGS_DEFAULT
+        if (!cgmAdequate && bgmCount < bgmMin) {
+          await clinicalReviewFlagService.raise(patientId, "observance", auditUserId, ctx)
+            .then(() => { flagged++ })
+            .catch((err) => logger.error("proposal-generator", "raise observance failed", { patientId }, err as Error))
+        }
       }
     }
 

--- a/tests/unit/clinical-bounds.test.ts
+++ b/tests/unit/clinical-bounds.test.ts
@@ -16,7 +16,7 @@ import { describe, it, expect } from "vitest"
 import { readFileSync } from "node:fs"
 import {
   CLINICAL_BOUNDS, CGM_AGGREGATE_RANGE_GL,
-  DASHBOARD_TIR, AGP_SUFFICIENCY, HBA1C_STALE_DAYS,
+  DASHBOARD_TIR, AGP_SUFFICIENCY, HBA1C_STALE_DAYS, OBSERVANCE,
   HBA1C_HIGH_DEFAULT_PERCENT, HBA1C_HIGH_DEFAULT_PREGNANCY_PERCENT, HBA1C_TARGET_MARGIN_PERCENT,
   isDeliverableBasalRate,
 } from "@/lib/clinical-bounds"
@@ -145,6 +145,19 @@ describe("DASHBOARD_TIR / AGP_SUFFICIENCY / HBA1C_STALE_DAYS — anti-drift (fic
     expect(HBA1C_HIGH_DEFAULT_PREGNANCY_PERCENT).toBe(6.0)
     expect(HBA1C_TARGET_MARGIN_PERCENT).toBe(0.5)
     expect(HBA1C_HIGH_DEFAULT_PREGNANCY_PERCENT).toBeLessThan(HBA1C_HIGH_DEFAULT_PERCENT)
+  })
+
+  it("fige les seuils du flag observance (US-2651 mode c, validé medical)", () => {
+    expect(OBSERVANCE).toEqual({
+      WINDOW_DAYS: 30,
+      MIN_CGM_CAPTURE_RATE: 30,
+      BGM_MIN_READINGS_DEFAULT: 4,
+      BGM_MIN_READINGS_PREGNANCY: 30,
+      MIN_ENROLLMENT_DAYS: 30,
+    })
+    // Grossesse plus stricte (population critique) + capture CGM alignée sur le plancher TIR.
+    expect(OBSERVANCE.BGM_MIN_READINGS_PREGNANCY).toBeGreaterThan(OBSERVANCE.BGM_MIN_READINGS_DEFAULT)
+    expect(OBSERVANCE.MIN_CGM_CAPTURE_RATE).toBe(DASHBOARD_TIR.MIN_CAPTURE_RATE)
   })
 
   it("invariants : cible TIR > plancher ; suffisance bornée", () => {

--- a/tests/unit/proposal-generator.service.test.ts
+++ b/tests/unit/proposal-generator.service.test.ts
@@ -409,6 +409,9 @@ describe("proposalGeneratorService.generateOrientationFlags (mode c — nonInsul
     tir: number | null = null, // TIR retourné par computeTirPercent (null = capture insuffisante)
     patient: { pathology?: string; pregnancyMode?: boolean } = {},
     objectiveHba1c: number | null = null, // cible individualisée (AnnexObjective)
+    // observance : par défaut `createdAt` = maintenant → garde enrollment (< 30 j) neutralise le flag
+    // pour les tests des AUTRES flags. Les tests observance passent un createdAt ancien + les comptes.
+    monitoring: { createdAt?: Date; cgmCount?: number; bgmCount?: number } = {},
   ) {
     const v = hba1c.value ?? 6 // valeur HbA1c par défaut (< 8 → pas de flag aboveTarget)
     mode.mockResolvedValue({ mode: "nonInsulin", coherent: true } as never)
@@ -416,8 +419,11 @@ describe("proposalGeneratorService.generateOrientationFlags (mode c — nonInsul
     prismaMock.diabetesEvent.findFirst.mockResolvedValue(hba1c.evt ? ({ eventDate: hba1c.evt, hba1c: v } as never) : null)
     prismaMock.patient.findFirst.mockResolvedValue({
       pathology: patient.pathology ?? "DT2", pregnancyMode: patient.pregnancyMode ?? false,
+      createdAt: monitoring.createdAt ?? new Date(),
     } as never)
     prismaMock.annexObjective.findUnique.mockResolvedValue(objectiveHba1c !== null ? ({ objectiveHba1c } as never) : null)
+    prismaMock.cgmEntry.count.mockResolvedValue((monitoring.cgmCount ?? 0) as never)
+    prismaMock.glycemiaEntry.count.mockResolvedValue((monitoring.bgmCount ?? 0) as never)
     vi.spyOn(objectivesService, "computeTirPercent").mockResolvedValue(tir)
   }
 
@@ -548,7 +554,7 @@ describe("proposalGeneratorService.generateOrientationFlags (mode c — nonInsul
     mode.mockResolvedValue({ mode: "nonInsulin", coherent: true } as never)
     prismaMock.glycemiaEntry.findFirst.mockResolvedValue({ date: new Date(Date.now() - 30 * DAY), hba1c: 7.0 } as never)
     prismaMock.diabetesEvent.findFirst.mockResolvedValue({ eventDate: new Date(Date.now() - 200 * DAY), hba1c: 9.0 } as never)
-    prismaMock.patient.findFirst.mockResolvedValue({ pathology: "DT2", pregnancyMode: false } as never)
+    prismaMock.patient.findFirst.mockResolvedValue({ pathology: "DT2", pregnancyMode: false, createdAt: new Date() } as never)
     prismaMock.annexObjective.findUnique.mockResolvedValue(null)
     vi.spyOn(objectivesService, "computeTirPercent").mockResolvedValue(null)
     await proposalGeneratorService.generateForPatient(1, 99)
@@ -560,6 +566,43 @@ describe("proposalGeneratorService.generateOrientationFlags (mode c — nonInsul
     setupNonInsulin({ gly: new Date(), value: 8.0 }, null)
     await proposalGeneratorService.generateForPatient(1, 99)
     expect(raiseFlag).not.toHaveBeenCalledWith(1, "hba1cAboveTarget", 99, undefined)
+  })
+
+  // ── observance (US-2651, validé medical) : either/or CGM-capture / comptage BGM + garde enrollment ──
+  const daysAgo = (n: number) => new Date(Date.now() - n * 86_400_000)
+
+  it("observance : les DEUX canaux échouent (pas de CGM, 2 BGM, DT2, inscrit 60 j) → flag levé", async () => {
+    setupNonInsulin({ evt: new Date() }, null, {}, null, { createdAt: daysAgo(60), cgmCount: 0, bgmCount: 2 })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(raiseFlag).toHaveBeenCalledWith(1, "observance", 99, undefined)
+  })
+
+  it("observance : testeur BGM diligent (5 ≥ 4, DT2) → PAS de flag", async () => {
+    setupNonInsulin({ evt: new Date() }, null, {}, null, { createdAt: daysAgo(60), cgmCount: 0, bgmCount: 5 })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(raiseFlag).not.toHaveBeenCalledWith(1, "observance", 99, undefined)
+  })
+
+  it("observance : porteur CGM régulier (capture ≥ 30 %) → PAS de flag (jamais faussement flagué)", async () => {
+    setupNonInsulin({ evt: new Date() }, null, {}, null, { createdAt: daysAgo(60), cgmCount: 3000, bgmCount: 0 })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(raiseFlag).not.toHaveBeenCalledWith(1, "observance", 99, undefined)
+  })
+
+  it("observance : garde enrollment — patient inscrit depuis 10 j (< 30) → PAS de flag même si tout échoue", async () => {
+    setupNonInsulin({ evt: new Date() }, null, {}, null, { createdAt: daysAgo(10), cgmCount: 0, bgmCount: 0 })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(raiseFlag).not.toHaveBeenCalledWith(1, "observance", 99, undefined)
+  })
+
+  it("observance : seuil pathology-aware — GD avec 10 BGM (< 30) → flag ; un DT2 avec 10 (≥ 4) → non", async () => {
+    setupNonInsulin({ evt: new Date() }, null, { pathology: "GD" }, null, { createdAt: daysAgo(60), cgmCount: 0, bgmCount: 10 })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(raiseFlag).toHaveBeenCalledWith(1, "observance", 99, undefined) // GD exige ≥ 30
+    raiseFlag.mockClear()
+    setupNonInsulin({ evt: new Date() }, null, { pathology: "DT2" }, null, { createdAt: daysAgo(60), cgmCount: 0, bgmCount: 10 })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(raiseFlag).not.toHaveBeenCalledWith(1, "observance", 99, undefined) // DT2 : 10 ≥ 4 → observant
   })
 })
 


### PR DESCRIPTION
**Dernier flag du mode-c.** Sa définition était volontairement reportée (ambiguë) → **design validé medical AVANT code**. Le flag est **honnêtement scopé** sur l'**auto-surveillance glycémique** (seule donnée mesurable ; pas d'adhésion médicamenteuse ni de présence RDV). Déjà dans l'enum + `FLAG_TYPE_KEY` + i18n → **pas de migration**.

## Contenu
- 4ᵉ flag de `generateOrientationFlags`. **Logique either/or** : `observancePoor = !cgmAdequate && bgmCount < seuil`, avec `cgmAdequate = cgmCount > 0 && cgmCaptureRate(…, 30) ≥ MIN_CGM_CAPTURE_RATE (30 %)`. → **jamais** un porteur CGM régulier ni un testeur BGM diligent ; seul le **double-échec** est flagué (un capteur abandonné → capture basse → détecté).
- **Seuils BGM pathology-aware** : **4/30 j** (DT1/DT2, < ~1×/sem) ; **30/30 j** (GD/grossesse, population critique). **Garde enrollment** (< 30 j → pas de flag). Fenêtre 30 j.
- **Constante `OBSERVANCE`** + anti-drift + catalogue. **i18n précisé** (« Suivi glycémique à vérifier » — scope honnête vs « Observance à vérifier »). JSDoc + spec MAJ.
- **Tests +5** (double-échec → flag ; BGM diligent → non ; CGM régulier → non ; garde enrollment ; seuil GD vs DT2).

## Mode c COMPLET
`hba1cStale` + `hba1cAboveTarget` + `tirBelowTarget` + **`observance`**.

⚠️ **Validation medical** utile (seuils + logique either/or + garde enrollment).

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3831 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)