### PR TITLE
US-2652 — Activation cron générateur : durcissement POST-only + runbook + garde DPO

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,4 +70,8 @@ EMAIL_FROM="Diabeo <noreply@diabeo.fr>"
 # Sans cette var, la route /api/cron/* retourne 503 (defense-in-depth).
 # Generer avec : node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 CRON_SECRET=""
+# US-2652 — kill-switch d'activation du cron generateur de propositions. Defaut OFF : la route
+# /api/cron/generate-proposals repond 503 (apres auth) tant que != "true". A passer a "true" par ops
+# APRES signature DPO de la DPIA (docs/runbook/cron-proposal-generator.md).
+PROPOSAL_CRON_ENABLED="false"
 NEXT_PUBLIC_APP_URL="http://localhost:3000"

--- a/docs/runbook/cron-proposal-generator.md
+++ b/docs/runbook/cron-proposal-generator.md
@@ -1,0 +1,102 @@
+# Runbook — Cron générateur de propositions d'ajustement (US-2651/2652)
+
+> Générateur multi-levier de titration (ICR + basal + ISF + fixedDose + flags mode c).
+> Dernière mise à jour : 2026-07-07 (activation prod).
+
+## 0. ⚠️ Bloqueur pré-prod — signature DPO/RSSI
+
+**Ne PAS activer le scheduler avant** la signature de la DPIA `docs/compliance/dpia-us2651-proposal-generator.md`
+par le **DPO** (et RSSI si requis). Le cron accède à des données de santé (glycémie, insuline) sous un
+acteur système (`userId = null`) et produit des propositions cliniques (jamais auto-appliquées, ADR #13,
+gate médecin). Comme US-2108, l'activation est conditionnée à la validation conformité.
+
+## 1. Vue d'ensemble
+
+| Cron | Route | Schedule recommandé | Service |
+|------|-------|---------------------|---------|
+| Générateur de propositions | `POST /api/cron/generate-proposals` | `0 2 * * *` (2 h Paris — analyse nocturne, hors pics) | `proposalGeneratorService.generateForAllPatients` |
+
+Partage le secret `CRON_SECRET` et le pattern d'auth (Bearer timing-safe) des crons rappels
+(`cron-reminders.md`). Sélection des patients : actifs uniquement (`deletedAt: null` + `user.status: active`),
+mode-routés (basalBolus → doses ; nonInsulin → flags ; fixedDose → doses par moment).
+
+## 2. ⚠️ POST uniquement (durcissement US-2652, aligné rappels round 2 H3)
+
+```bash
+curl -X POST https://app.diabeo.fr/api/cron/generate-proposals \
+  -H "Authorization: Bearer ${CRON_SECRET}" \
+  -H "Content-Length: 0"
+```
+
+**Ne pas utiliser GET.** Le secret partirait dans les access logs Nginx, le `Referer` CDN et serait
+potentiellement cacheable. `GET` n'est pas exporté → Next.js répond **405**.
+
+## 3. Configuration scheduler
+
+### OVH Web Cloud Scheduler
+```yaml
+- name: proposal-generator
+  schedule: "0 2 * * *"
+  method: POST
+  url: https://app.diabeo.fr/api/cron/generate-proposals
+  headers:
+    Authorization: Bearer ${CRON_SECRET}
+    Content-Length: "0"
+  timeout: 60s
+```
+
+### Vercel Cron (vercel.json)
+Vercel Cron envoie `GET` par défaut → **incompatible** avec le POST-only. Utiliser l'OVH scheduler
+(ou un proxy POST) — ne pas router Vercel Cron directement sur cette route.
+
+## 4. Métriques attendues (success)
+
+```json
+{
+  "processed": 120,
+  "created": 34,
+  "flagged": 8,
+  "errored": 0,
+  "skippedConcurrent": false
+}
+```
+
+- `processed` : patients actifs parcourus. `created` : propositions moteur générées (toutes `pending`,
+  gate médecin). `flagged` : `ClinicalReviewFlag` d'orientation levés (mode c). `errored` : patients en
+  échec infra (**isolés** — n'arrêtent pas le portefeuille). `skippedConcurrent: true` → un autre run
+  détient le verrou advisory (NORMAL si 2 schedulers).
+
+## 5. ⚠️ Advisory lock
+
+Identique aux crons rappels : `withSessionAdvisoryLock` (`src/lib/db/cron-lock.ts`), `pg.Pool({ max: 1 })`
+dédié → `pg_try_advisory_lock`/`pg_advisory_unlock` sur la même connexion physique. Audit run-level :
+`proposal.generator.cron.run` (succès) / `...skipped_locked` (verrou tenu). Procédure lock orphelin :
+voir `cron-reminders.md` §5.
+
+## 6. Forensique by runId
+
+Le run émet un audit run-level ; les accès aux données de santé sont audités par patient
+(`metadata.patientId`, index GIN partiel US-2268). Tracer un run/patient :
+
+```sql
+SELECT created_at, action, resource, resource_id, metadata
+FROM audit_logs
+WHERE metadata @> jsonb_build_object('patientId', <id>)
+  AND created_at >= now() - interval '2 days'
+ORDER BY created_at;
+```
+
+## 7. SLO et alertes recommandées
+
+| Métrique | Seuil alerte | Action |
+|----------|--------------|--------|
+| `proposal.generator.cron.run` absent > 25 h | PagerDuty | Scheduler down ou route 401/503 |
+| `cron.auth.failed` en rafale | Slack SOC | Tentative d'accès / secret rotaté sans MAJ scheduler |
+| `skipped_locked` > 3 jours consécutifs | Slack | Lock orphelin — voir `cron-reminders.md` §5 |
+| `errored` > 10 % des `processed` | Email ops | Panne DB / config patients incohérente |
+
+## 8. Rétention secret & rotation
+
+`CRON_SECRET` partagé avec les crons rappels — voir `cron-reminders.md` §9-§10 (≥ 32 bytes hex,
+OVH Vault, rotation annuelle, jamais commité/loggé). Un run refusé émet `cron.auth.failed` sans exposer
+le secret reçu.

--- a/docs/runbook/cron-proposal-generator.md
+++ b/docs/runbook/cron-proposal-generator.md
@@ -3,12 +3,19 @@
 > Générateur multi-levier de titration (ICR + basal + ISF + fixedDose + flags mode c).
 > Dernière mise à jour : 2026-07-07 (activation prod).
 
-## 0. ⚠️ Bloqueur pré-prod — signature DPO/RSSI
+## 0. ⚠️ Bloqueur pré-prod — signature DPO/RSSI + flag d'activation
 
-**Ne PAS activer le scheduler avant** la signature de la DPIA `docs/compliance/dpia-us2651-proposal-generator.md`
+**Ne PAS activer avant** la signature de la DPIA `docs/compliance/dpia-us2651-proposal-generator.md`
 par le **DPO** (et RSSI si requis). Le cron accède à des données de santé (glycémie, insuline) sous un
 acteur système (`userId = null`) et produit des propositions cliniques (jamais auto-appliquées, ADR #13,
 gate médecin). Comme US-2108, l'activation est conditionnée à la validation conformité.
+
+**Contrôle d'activation = `PROPOSAL_CRON_ENABLED`** (défaut **OFF**). Tant que la variable n'est pas
+`"true"`, la route répond **503 APRÈS auth** et le générateur n'est **jamais** appelé. Séquence go-live :
+1. DPO signe la DPIA. 2. Ops pose `PROPOSAL_CRON_ENABLED=true` (OVH Vault) + restart. 3. Ops ajoute le
+scheduler (§3). C'est aussi le **kill-switch d'incident** : repasser à `false` (ou retirer la variable)
++ restart désactive le cron **sans casser le boot** — contrairement à vider `CRON_SECRET`, que
+`assertRequiredEnv()` exige au démarrage (la branche 503 « no-secret » est donc dead code en prod).
 
 ## 1. Vue d'ensemble
 

--- a/src/app/api/cron/generate-proposals/route.ts
+++ b/src/app/api/cron/generate-proposals/route.ts
@@ -15,6 +15,10 @@
  *
  * **Auth failure audit** : un Bearer manquant/faux émet un audit `cron.auth.failed` (burst detection SOC).
  *
+ * **Kill-switch d'activation** (US-2652) : le cron ne s'exécute que si `PROPOSAL_CRON_ENABLED === "true"`
+ * (défaut OFF, vérifié APRÈS auth → 503). Contrôle d'activation DPO-gaté + kill-switch d'incident réel
+ * (vider `CRON_SECRET` casserait le boot via `assertRequiredEnv`).
+ *
  * **Retour** : métriques JSON `{ processed, created, flagged, errored, skippedConcurrent }` (aucune PHI).
  *
  * **Cron schedule recommandé** : `0 2 * * *` (2 h locale — analyse nocturne, hors pics d'usage).
@@ -77,6 +81,16 @@ async function handle(req: NextRequest): Promise<NextResponse> {
     if (!submittedSecret || !constantTimeEqual(submittedSecret, expectedSecret)) {
       await emitAuthFailedAudit(req, ctx)
       return jsonResponse({ error: "unauthorized" }, 401)
+    }
+
+    // Kill-switch d'activation (US-2652) — APRÈS auth (un anonyme reçoit 401, pas l'état d'activation).
+    // Le cron ne tourne que si `PROPOSAL_CRON_ENABLED === "true"` (défaut OFF). Sert de contrôle
+    // d'activation DPO-gaté (ops l'active après signature de la DPIA) ET de kill-switch d'incident
+    // exécutable SANS casser le boot — contrairement à vider `CRON_SECRET` que `assertRequiredEnv`
+    // exige au démarrage (la branche 503 « no-secret » est donc dead code en prod).
+    if (process.env.PROPOSAL_CRON_ENABLED !== "true") {
+      logger.info("cron-generate-proposals", "disabled by PROPOSAL_CRON_ENABLED flag", { statusCode: 503 })
+      return jsonResponse({ error: "cronDisabled" }, 503)
     }
 
     const t0 = Date.now()

--- a/src/app/api/cron/generate-proposals/route.ts
+++ b/src/app/api/cron/generate-proposals/route.ts
@@ -1,10 +1,13 @@
 /**
- * @route GET|POST /api/cron/generate-proposals
- * @description US-2651 — Cron entry du générateur de propositions d'ajustement (ICR).
+ * @route POST /api/cron/generate-proposals
+ * @description US-2651 — Cron entry du générateur de propositions d'ajustement (ICR + basal + ISF +
+ *   fixedDose + flags mode c).
  *
  * **Authentification** : Bearer `CRON_SECRET` (env var), pas de JWT user — cron externe
  * (OVHcloud cron / Vercel cron / GitHub Action). `CRON_SECRET` validé par `assertRequiredEnv()`
- * au boot. GET **et** POST acceptés (les crons basiques utilisent souvent GET).
+ * au boot. **POST uniquement** (US-2652 activation prod, aligné sur les crons rappels round 2 H3) :
+ * GET ferait fuiter le `Bearer` dans les access logs Nginx / le header `Referer` CDN / le cache →
+ * `GET` non exporté → Next.js répond **405**. Le scheduler DOIT utiliser `curl -X POST`.
  *
  * **Idempotent + anti double-run** : `generateForAllPatients` prend un verrou advisory session
  * (`withSessionAdvisoryLock`) ; deux runs concurrents (OVH + Vercel) → l'un skip (`skippedConcurrent`).
@@ -12,9 +15,10 @@
  *
  * **Auth failure audit** : un Bearer manquant/faux émet un audit `cron.auth.failed` (burst detection SOC).
  *
- * **Retour** : métriques JSON `{ processed, created, errored, skippedConcurrent }` (aucune PHI).
+ * **Retour** : métriques JSON `{ processed, created, flagged, errored, skippedConcurrent }` (aucune PHI).
  *
  * **Cron schedule recommandé** : `0 2 * * *` (2 h locale — analyse nocturne, hors pics d'usage).
+ * **Runbook** : `docs/runbook/cron-proposal-generator.md` (⚠️ bloqueur pré-prod : signature DPO).
  */
 import { NextResponse, type NextRequest } from "next/server"
 import { timingSafeEqual } from "crypto"
@@ -86,11 +90,8 @@ async function handle(req: NextRequest): Promise<NextResponse> {
   }
 }
 
+// Action mutante (génère des propositions) = POST uniquement (RFC 7231 §4.3.3). `GET` non exporté →
+// Next.js répond 405 → évite le leak de `CRON_SECRET` via access logs / Referer / cache CDN.
 export async function POST(req: NextRequest): Promise<NextResponse> {
-  return handle(req)
-}
-
-// GET accepté aussi (Vercel cron / OVH cron basic utilisent GET).
-export async function GET(req: NextRequest): Promise<NextResponse> {
   return handle(req)
 }

--- a/tests/integration/api-cron-generate-proposals.test.ts
+++ b/tests/integration/api-cron-generate-proposals.test.ts
@@ -2,7 +2,7 @@
  * @description US-2651 — Cron route générateur de propositions : tests d'intégration.
  *
  * Couvre : auth Bearer CRON_SECRET (timing-safe), 503 sans secret, 401 sans/mauvais Bearer,
- * 200 + métriques, GET accepté, audit `cron.auth.failed`, headers ANSSI, ctx audit propagé.
+ * 200 + métriques, GET NON exporté (POST-only anti-leak), audit `cron.auth.failed`, headers ANSSI, ctx audit propagé.
  */
 import { beforeEach, describe, expect, it, vi, afterEach } from "vitest"
 import { NextRequest } from "next/server"
@@ -27,7 +27,10 @@ vi.mock("@/lib/services/audit.service", async (orig) => {
 
 import { proposalGeneratorService } from "@/lib/services/proposal-generator.service"
 import { auditService } from "@/lib/services/audit.service"
-const { POST, GET } = await import("@/app/api/cron/generate-proposals/route")
+const routeModule = await import("@/app/api/cron/generate-proposals/route")
+const { POST } = routeModule
+// GET n'est plus exporté (POST-only) → accès via cast, `undefined` attendu (cf. test dédié).
+const GET = (routeModule as Record<string, unknown>).GET
 
 const VALID_SECRET = "test-cron-secret-32-bytes-long-aaa"
 
@@ -71,8 +74,10 @@ describe("POST /api/cron/generate-proposals", () => {
     expect((await res.json()).error).toBe("cronDisabled")
   })
 
-  it("GET accepté (200) avec Bearer correct", async () => {
-    expect((await GET(makeReq(VALID_SECRET))).status).toBe(200)
+  it("GET NON exporté (POST-only, anti-leak du Bearer → 405 Next.js)", () => {
+    // Durcissement US-2652 (aligné rappels round 2 H3) : un GET ferait fuiter CRON_SECRET dans les
+    // access logs / Referer / cache CDN. `GET` n'est plus exporté → Next.js répond 405.
+    expect(GET).toBeUndefined()
   })
 
   it("émet un audit cron.auth.failed (userId null) sur 401", async () => {

--- a/tests/integration/api-cron-generate-proposals.test.ts
+++ b/tests/integration/api-cron-generate-proposals.test.ts
@@ -12,7 +12,7 @@ vi.mock("@/lib/db/client", () => ({ prisma: {} }))
 vi.mock("@/lib/services/proposal-generator.service", () => ({
   proposalGeneratorService: {
     generateForAllPatients: vi.fn().mockResolvedValue({
-      processed: 3, created: 2, errored: 0, skippedConcurrent: false,
+      processed: 3, created: 2, flagged: 1, errored: 0, skippedConcurrent: false,
     }),
   },
 }))
@@ -43,16 +43,27 @@ function makeReq(bearer?: string): NextRequest {
 beforeEach(() => {
   vi.clearAllMocks()
   process.env.CRON_SECRET = VALID_SECRET
+  process.env.PROPOSAL_CRON_ENABLED = "true" // kill-switch d'activation ON par défaut dans les tests
 })
-afterEach(() => { delete process.env.CRON_SECRET })
+afterEach(() => {
+  delete process.env.CRON_SECRET
+  delete process.env.PROPOSAL_CRON_ENABLED
+})
 
 describe("POST /api/cron/generate-proposals", () => {
   it("200 + métriques si Bearer correct", async () => {
     const res = await POST(makeReq(VALID_SECRET))
     expect(res.status).toBe(200)
     const body = await res.json()
-    expect(body).toMatchObject({ processed: 3, created: 2, errored: 0, skippedConcurrent: false })
+    expect(body).toMatchObject({ processed: 3, created: 2, flagged: 1, errored: 0, skippedConcurrent: false })
     expect(proposalGeneratorService.generateForAllPatients).toHaveBeenCalledTimes(1)
+  })
+
+  it("503 si PROPOSAL_CRON_ENABLED ≠ true (kill-switch), APRÈS auth (générateur non appelé)", async () => {
+    delete process.env.PROPOSAL_CRON_ENABLED // désactivé
+    const res = await POST(makeReq(VALID_SECRET)) // Bearer VALIDE → mais flag off
+    expect(res.status).toBe(503)
+    expect(proposalGeneratorService.generateForAllPatients).not.toHaveBeenCalled()
   })
 
   it("401 sans header authorization (générateur non appelé)", async () => {


### PR DESCRIPTION
Prépare l'**activation en prod** du cron générateur multi-levier. La route existait déjà ; il manquait le **durcissement sécurité** + le **runbook** + le cadrage du **bloqueur conformité**.

## Contenu
- **Route POST-only** : `GET` retiré → Next.js répond **405**. Un GET ferait **fuiter le Bearer `CRON_SECRET`** dans les access logs Nginx / le `Referer` CDN / le cache — **même durcissement que les crons rappels (round 2 H3)**. Un cron **clinique** ne doit pas exposer son secret. JSDoc MAJ (métriques + `flagged`, lien runbook).
- **Runbook dédié** `docs/runbook/cron-proposal-generator.md` : **⚠️ bloqueur pré-prod = signature DPO** de la DPIA `dpia-us2651`, invocation POST-only, config **OVH scheduler** (`0 2 * * *`), métriques attendues, advisory lock, forensique par `patientId`, SLO/alertes, rotation secret.
- **Test intégration** : « GET accepté » → « GET non exporté » (`undefined` → 405).

## ⚠️ Activation effective
= action **ops** (ajouter le crontab OVH), **conditionnée à la signature DPO** (comme US-2108). Cette PR livre le **prérequis technique** ; elle **n'active pas** le scheduler.

## État de l'épic générateur après cette PR
ICR + basal + ISF + fixedDose + mode-c (4 flags) livrés ; il ne reste **que l'action ops + DPO** pour le rendre actif en prod.

⚠️ Revue **sécurité** utile (auth cron, POST-only).

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3831 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)