### PR TITLE
US-2658 — Génération de propositions à la demande (fenêtre 2 j–14 j, médecin/infirmier)

### DIFF
--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -515,3 +515,19 @@ confiance au client) sur l'état **final** :
 - **Profil « une seule valeur sur 24 h »** : s'exprime en **≥ 2 créneaux** de même valeur (ex. `[0,12)`+`[12,0)`).
   Inhérent au résolveur `findSlotForHour` (aucun `[h,h)` ne couvre 24 h) — un mono-créneau reçoit `slotGap` (422),
   fail-closed. À gérer en confort UI (auto-split) côté US-2656.
+
+### Génération de propositions à la demande (US-2658)
+
+Au-delà du run nocturne (cron), un **DOCTOR ou NURSE** peut déclencher la génération pour un patient sur
+une **fenêtre d'analyse choisie**, via `POST /api/patients/[id]/proposals/generate` (`windowDays` ∈ **[2,14]** ;
+hors bornes → 400 `windowOutOfBounds`).
+- **Réutilise le générateur** (`generateForPatient` + paramètre `windowDays`) — aucun nouveau chemin de dose.
+  `windowDays` s'applique aux chemins **ICR / basal / dose fixe** (repas, à-jeun, creux pré-dose) ; l'**ISF
+  garde sa fenêtre 30 j** (corrections propres rares — décision US-2658 §3). Absente (cron) → 14 j inchangé.
+- **Plancher 2 j** : sous les seuils de suffisance (`MIN_MEALS_PER_SLOT` = 3, `MIN_NADIR_NIGHTS` = 3, etc.) le
+  moteur ne propose rien — c'est un **succès** (`created: 0`, `reason`), pas une erreur. **Plafond 14 j** :
+  au-delà, les données ne reflètent plus la titration actuelle (aligné `AGP_SUFFICIENCY.MIN_DAYS`).
+- Tous les garde-fous existants restent actifs (garde hypo, bornes cliniques, anti-empilement
+  `one_pending_per_slot`, frontière MDR `nonInsulin`). **Propose, n'applique jamais** (ADR #13).
+- **RBAC** : DOCTOR/NURSE (min NURSE) ; patient/VIEWER → 403. Scopé patient (anti-IDOR → 404). Audité
+  (`proposal.generator.on_demand` : acteur soignant réel, fenêtre, résultat, sans PHI).

--- a/src/app/api/patients/[id]/proposals/generate/route.ts
+++ b/src/app/api/patients/[id]/proposals/generate/route.ts
@@ -3,7 +3,9 @@ import { z } from "zod"
 import { requireRole, AuthError } from "@/lib/auth"
 import { resolvePatientId } from "@/lib/access-control"
 import { requireGdprConsent } from "@/lib/gdpr"
-import { proposalGeneratorService } from "@/lib/services/proposal-generator.service"
+import { checkApiRateLimit, RATE_LIMITS } from "@/lib/auth/api-rate-limit"
+import { logger } from "@/lib/logger"
+import { proposalGeneratorService, ISF_ANALYSIS_WINDOW_DAYS } from "@/lib/services/proposal-generator.service"
 import { auditService, extractRequestContext } from "@/lib/services/audit.service"
 
 const paramsSchema = z.object({ id: z.coerce.number().int().positive() })
@@ -28,6 +30,23 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     const hasConsent = await requireGdprConsent(user.id)
     if (!hasConsent) return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
 
+    // Rate-limit (ANSSI, anti-abus) : chaque run relance un pipeline analytique non trivial. Fail-open
+    // (dispo d'abord) ; la confidentialité repose sur le RBAC/anti-IDOR, pas le limiter. Saturation auditée.
+    const rl = await checkApiRateLimit(String(user.id), RATE_LIMITS.analytics)
+    if (!rl.allowed) {
+      await auditService
+        .rateLimited({
+          userId: user.id, resource: "ADJUSTMENT_PROPOSAL", resourceId: "generate",
+          ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId,
+          metadata: { surface: "api", kind: "proposalGenerateOnDemand" },
+        })
+        .catch((err) => logger.error("audit", "[proposals/generate] rateLimited audit failed", {}, err))
+      return NextResponse.json(
+        { error: "rateLimitExceeded" },
+        { status: 429, headers: { "Retry-After": String(rl.retryAfterSec) } },
+      )
+    }
+
     const parsedParams = paramsSchema.safeParse(await params)
     if (!parsedParams.success) return NextResponse.json({ error: "validationFailed" }, { status: 400 })
 
@@ -41,27 +60,34 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
 
     const result = await proposalGeneratorService.generateForPatient(patientId, user.id, ctx, windowDays)
 
-    await auditService.log({
-      userId: user.id,
-      action: "CREATE",
-      resource: "ADJUSTMENT_PROPOSAL",
-      resourceId: String(patientId),
-      ipAddress: ctx.ipAddress,
-      userAgent: ctx.userAgent,
-      metadata: {
-        kind: "proposal.generator.on_demand",
-        patientId,
-        windowDays,
-        created: result.created,
-        flagged: result.flagged,
-        skipped: result.skipped,
-      },
-    })
+    // Audit best-effort (comme les autres audits du service) : un échec d'audit ne doit PAS renvoyer
+    // 500 sur un run qui a déjà persisté ses propositions.
+    await auditService
+      .log({
+        userId: user.id,
+        action: "CREATE",
+        resource: "ADJUSTMENT_PROPOSAL",
+        resourceId: String(patientId),
+        ipAddress: ctx.ipAddress,
+        userAgent: ctx.userAgent,
+        metadata: {
+          kind: "proposal.generator.on_demand",
+          patientId,
+          windowDays,
+          created: result.created,
+          flagged: result.flagged,
+          skipped: result.skipped,
+        },
+      })
+      .catch((err) => logger.error("audit", "[proposals/generate] audit failed", {}, err))
 
     return NextResponse.json({
       created: result.created,
       flagged: result.flagged,
       windowDays,
+      // L'ISF n'utilise PAS `windowDays` : il titre toujours sur 30 j (décision §3). Exposé pour que
+      // l'UI de déclenchement précise « l'analyse des corrections reste sur 30 jours ».
+      isfWindowDays: ISF_ANALYSIS_WINDOW_DAYS,
       // Rien produit → motif explicite (données insuffisantes / bon contrôle / mode). Succès, pas erreur.
       reason: result.created === 0 && result.flagged === 0 ? (result.skipped ?? "nothingToPropose") : null,
     })

--- a/src/app/api/patients/[id]/proposals/generate/route.ts
+++ b/src/app/api/patients/[id]/proposals/generate/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireRole, AuthError } from "@/lib/auth"
+import { resolvePatientId } from "@/lib/access-control"
+import { requireGdprConsent } from "@/lib/gdpr"
+import { proposalGeneratorService } from "@/lib/services/proposal-generator.service"
+import { auditService, extractRequestContext } from "@/lib/services/audit.service"
+
+const paramsSchema = z.object({ id: z.coerce.number().int().positive() })
+const bodySchema = z.object({ windowDays: z.number().int().min(2).max(14) })
+
+/**
+ * POST — **génération de propositions à la demande** (US-2658). Réservé **DOCTOR/NURSE** (min NURSE ;
+ * patient/VIEWER → 403). Fenêtre d'analyse bornée **[2,14] jours** — hors bornes → 400 `windowOutOfBounds`.
+ *
+ * Réutilise le générateur existant (`generateForPatient`) avec la fenêtre en paramètre : **propose,
+ * n'applique jamais** (`pending`, gaté médecin, ADR #13) ; tous les garde-fous s'appliquent (garde hypo,
+ * bornes cliniques, seuils de suffisance, anti-empilement `one_pending_per_slot`). « Rien à proposer »
+ * (données minces / bon contrôle) est un **succès** (`created: 0`, `reason`), pas une erreur.
+ *
+ * Scopé patient (anti-IDOR via `resolvePatientId` → 404 si hors périmètre). Audité (acteur soignant
+ * réel — ≠ acteur système `null` du cron — fenêtre, résultat, sans PHI).
+ */
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const ctx = extractRequestContext(req)
+  try {
+    const user = requireRole(req, "NURSE")
+    const hasConsent = await requireGdprConsent(user.id)
+    if (!hasConsent) return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
+
+    const parsedParams = paramsSchema.safeParse(await params)
+    if (!parsedParams.success) return NextResponse.json({ error: "validationFailed" }, { status: 400 })
+
+    const parsedBody = bodySchema.safeParse(await req.json().catch(() => null))
+    if (!parsedBody.success) return NextResponse.json({ error: "windowOutOfBounds" }, { status: 400 })
+    const windowDays = parsedBody.data.windowDays
+
+    // Anti-IDOR : le patient ciblé doit être dans le périmètre du soignant (sinon 404, anti-énumération).
+    const patientId = await resolvePatientId(user.id, user.role, parsedParams.data.id)
+    if (!patientId) return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+
+    const result = await proposalGeneratorService.generateForPatient(patientId, user.id, ctx, windowDays)
+
+    await auditService.log({
+      userId: user.id,
+      action: "CREATE",
+      resource: "ADJUSTMENT_PROPOSAL",
+      resourceId: String(patientId),
+      ipAddress: ctx.ipAddress,
+      userAgent: ctx.userAgent,
+      metadata: {
+        kind: "proposal.generator.on_demand",
+        patientId,
+        windowDays,
+        created: result.created,
+        flagged: result.flagged,
+        skipped: result.skipped,
+      },
+    })
+
+    return NextResponse.json({
+      created: result.created,
+      flagged: result.flagged,
+      windowDays,
+      // Rien produit → motif explicite (données insuffisantes / bon contrôle / mode). Succès, pas erreur.
+      reason: result.created === 0 && result.flagged === 0 ? (result.skipped ?? "nothingToPropose") : null,
+    })
+  } catch (error) {
+    if (error instanceof AuthError) return NextResponse.json({ error: error.message }, { status: error.status })
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    console.error("[proposals/generate POST]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/lib/services/proposal-generator.service.ts
+++ b/src/lib/services/proposal-generator.service.ts
@@ -44,8 +44,10 @@ import type { AuditContext } from "@/lib/services/patient.service"
 
 /** Fenêtre d'analyse (14 j — standard AGP, aligné `AGP_SUFFICIENCY.MIN_DAYS`). */
 const ANALYSIS_PERIOD = "14d"
-/** US-2651 ISF — période plus longue (30 j) : les corrections propres sont rares (validé medical #683). */
-const ISF_ANALYSIS_PERIOD = "30d"
+/** US-2651 ISF — période plus longue (30 j) : les corrections propres sont rares (validé medical #683).
+ *  US-2658 — fixe MÊME quand une fenêtre à la demande est choisie (l'ISF ne suit pas `windowDays`, §3). */
+export const ISF_ANALYSIS_WINDOW_DAYS = 30
+const ISF_ANALYSIS_PERIOD = `${ISF_ANALYSIS_WINDOW_DAYS}d`
 /** Minimum de repas appariés par créneau (aligné `analyzeIcrSlot` + `BGM_CARNET.MIN_READINGS_PER_MOMENT`). */
 const MIN_MEALS_PER_SLOT = 3
 /** US-2651 basal — nb minimal de nuits avec un nadir nocturne CGM pour autoriser une HAUSSE basale
@@ -406,6 +408,8 @@ export const proposalGeneratorService = {
    * @param patientId Patient en mode doses simples.
    * @param auditUserId Acteur d'audit (système `null` pour le cron).
    * @param ctx Contexte requête (audit).
+   * @param windowDays US-2658 — fenêtre d'analyse des creux pré-dose à la demande (bornée [2,14] par
+   *   l'appelant). Absente (cron) → `ANALYSIS_PERIOD` (14 j).
    * @returns Métriques ; `slotsConsidered` = nb de doses fixes, `created` = propositions générées.
    */
   async generateFixedDoseProposals(
@@ -437,7 +441,8 @@ export const proposalGeneratorService = {
     })
     const targetGl = resolveFastingTarget(targetRow ? Number(targetRow.targetGlucose) / 100 : null, isPregnancy)
 
-    // Creux pré-dose par moment (shift Option B, BGM). Période 14 j (réactif, comme le basal).
+    // Creux pré-dose par moment (shift Option B, BGM). Fenêtre = `analysisPeriod` (à la demande si
+    // fournie, sinon 14 j — réactif, comme le basal).
     const troughs = await analyticsService.fixedDoseTrend(patientId, analysisPeriod, auditUserId, ctx)
 
     let created = 0

--- a/src/lib/services/proposal-generator.service.ts
+++ b/src/lib/services/proposal-generator.service.ts
@@ -138,19 +138,32 @@ const EXPECTED_SKIP = new Set([
 
 export const proposalGeneratorService = {
   /**
-   * Génère les propositions ICR moteur pour un patient (ne persiste que des `pending`).
+   * Génère les propositions moteur d'un patient (mode-aware : ICR + basal + ISF en `basalBolus` ;
+   * doses simples en `fixedDose` ; flags d'orientation en `nonInsulin`). Ne persiste que des `pending`.
    * @param patientId Patient cible.
-   * @param auditUserId Acteur d'audit (le cron passe un ID système).
+   * @param auditUserId Acteur d'audit (le cron passe un ID système `null`).
    * @param ctx Contexte requête (audit).
+   * @param windowDays US-2658 — fenêtre d'analyse à la demande, bornée [2,14] par l'appelant. Applique
+   *   `${windowDays}d` aux chemins ICR / basal / dose fixe (repas, à-jeun, creux pré-dose). **L'ISF garde
+   *   délibérément sa fenêtre 30 j** (corrections propres rares — décision US-2658 §3). Absente (cron) →
+   *   `ANALYSIS_PERIOD` (14 j), comportement inchangé.
    * @returns Métriques du run (sans PHI).
    */
-  async generateForPatient(patientId: number, auditUserId: number | null, ctx?: AuditContext): Promise<GenerateResult> {
+  async generateForPatient(
+    patientId: number,
+    auditUserId: number | null,
+    ctx?: AuditContext,
+    windowDays?: number,
+  ): Promise<GenerateResult> {
     // 0. Mode — routage : `nonInsulin` → flags d'orientation (mode c, jamais de dose, frontière MDR) ;
     //    `fixedDose` → titration des doses simples par moment ; `basalBolus` → ICR + basal + ISF (ci-dessous).
     const { mode } = await treatmentModeService.resolveTreatmentMode(patientId)
     if (mode === "nonInsulin") return proposalGeneratorService.generateOrientationFlags(patientId, auditUserId, ctx)
-    if (mode === "fixedDose") return proposalGeneratorService.generateFixedDoseProposals(patientId, auditUserId, ctx)
+    if (mode === "fixedDose") return proposalGeneratorService.generateFixedDoseProposals(patientId, auditUserId, ctx, windowDays)
     if (mode !== "basalBolus") return EMPTY("mode")
+
+    // Fenêtre d'analyse (ICR/basal/dose fixe) : à la demande si fournie, sinon période cron par défaut.
+    const analysisPeriod = windowDays != null ? `${windowDays}d` : ANALYSIS_PERIOD
 
     // 1. Config (créneaux ICR) + patient (pathologie / grossesse pour la cible).
     const settings = await insulinTherapyService.getSettings(patientId, auditUserId, ctx)
@@ -171,7 +184,7 @@ export const proposalGeneratorService = {
       : CLINICAL_BOUNDS.POSTPRANDIAL_TITRATION_LOW_GL
 
     // 3. Repas (14 j, CGM) → portes qualité.
-    const journal = await mealtimePattern.dailyJournal(patientId, ANALYSIS_PERIOD, auditUserId, ctx, { source: "cgm" })
+    const journal = await mealtimePattern.dailyJournal(patientId, analysisPeriod, auditUserId, ctx, { source: "cgm" })
     const usable = journal.filter((m) => isMealUsableForIcr(m, isPregnancy))
 
     // 4. Bucketing par créneau ICR à l'HEURE RÉELLE du repas (pas le moment).
@@ -207,7 +220,7 @@ export const proposalGeneratorService = {
           supportingEvents: candidate.supportingEvents,
           totalEventsConsidered: candidate.totalEventsConsidered,
           averageObservedValue: candidate.averageObservedValue ?? null,
-          analysisPeriod: ANALYSIS_PERIOD,
+          analysisPeriod,
           carbRatioSlotStart: slot.startHour,
           carbRatioSlotEnd: slot.endHour,
         }, ctx)
@@ -282,7 +295,7 @@ export const proposalGeneratorService = {
         const rawTarget = settings?.glucoseTargets?.[0]?.targetGlucose
         const targetGl = resolveFastingTarget(rawTarget != null ? Number(rawTarget) / 100 : null, isPregnancy)
         // À jeun (pré-petit-déj) + nadirs nocturnes par nuit. mg/dL → g/L, null filtrés.
-        const fasting = await mealtimePattern.fastingTrend(patientId, ANALYSIS_PERIOD, auditUserId, ctx, { source: "cgm" })
+        const fasting = await mealtimePattern.fastingTrend(patientId, analysisPeriod, auditUserId, ctx, { source: "cgm" })
         const fastingValues = fasting
           .map((f) => f.fastingMgdl)
           .filter((v): v is number => v !== null && Number.isFinite(v))
@@ -307,7 +320,7 @@ export const proposalGeneratorService = {
               supportingEvents: candidate.supportingEvents,
               totalEventsConsidered: candidate.totalEventsConsidered,
               averageObservedValue: candidate.averageObservedValue ?? null,
-              analysisPeriod: ANALYSIS_PERIOD,
+              analysisPeriod,
               pumpBasalSlotId: nocturnalSlot.id,
             }, ctx)
             created++
@@ -395,7 +408,14 @@ export const proposalGeneratorService = {
    * @param ctx Contexte requête (audit).
    * @returns Métriques ; `slotsConsidered` = nb de doses fixes, `created` = propositions générées.
    */
-  async generateFixedDoseProposals(patientId: number, auditUserId: number | null, ctx?: AuditContext): Promise<GenerateResult> {
+  async generateFixedDoseProposals(
+    patientId: number,
+    auditUserId: number | null,
+    ctx?: AuditContext,
+    windowDays?: number,
+  ): Promise<GenerateResult> {
+    // Fenêtre d'analyse des creux pré-dose : à la demande si fournie (US-2658), sinon 14 j (cron).
+    const analysisPeriod = windowDays != null ? `${windowDays}d` : ANALYSIS_PERIOD
     const fixedSlots = await prisma.fixedDoseSlot.findMany({
       where: { patientInsulin: { patientId } },
       select: { moment: true, valueU: true },
@@ -418,7 +438,7 @@ export const proposalGeneratorService = {
     const targetGl = resolveFastingTarget(targetRow ? Number(targetRow.targetGlucose) / 100 : null, isPregnancy)
 
     // Creux pré-dose par moment (shift Option B, BGM). Période 14 j (réactif, comme le basal).
-    const troughs = await analyticsService.fixedDoseTrend(patientId, ANALYSIS_PERIOD, auditUserId, ctx)
+    const troughs = await analyticsService.fixedDoseTrend(patientId, analysisPeriod, auditUserId, ctx)
 
     let created = 0
     for (const slot of fixedSlots) {
@@ -437,7 +457,7 @@ export const proposalGeneratorService = {
           supportingEvents: candidate.supportingEvents,
           totalEventsConsidered: candidate.totalEventsConsidered,
           averageObservedValue: candidate.averageObservedValue ?? null,
-          analysisPeriod: ANALYSIS_PERIOD,
+          analysisPeriod,
         }, ctx)
         created++
       } catch (err) {

--- a/tests/integration/api-proposals-generate.test.ts
+++ b/tests/integration/api-proposals-generate.test.ts
@@ -1,0 +1,110 @@
+/**
+ * US-2658 — Route de génération de propositions à la demande (`POST /api/patients/[id]/proposals/generate`).
+ *
+ * Comportement clinique/sécurité testé :
+ *  - RBAC : DOCTOR/NURSE autorisés ; VIEWER/patient → 403 (pas de déclenchement moteur par un non-soignant).
+ *  - Fenêtre bornée [2,14] : hors bornes → 400 `windowOutOfBounds` (jamais de run silencieux sur fenêtre invalide).
+ *  - Anti-IDOR : patient hors périmètre → 404.
+ *  - « Rien à proposer » = succès (200 + reason), pas une erreur.
+ *  - La fenêtre choisie est transmise au générateur ; l'acte est audité (acteur soignant réel).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { NextRequest } from "next/server"
+
+vi.mock("@/lib/db/client", () => ({ prisma: {} }))
+vi.mock("@/lib/gdpr", () => ({ requireGdprConsent: vi.fn().mockResolvedValue(true) }))
+vi.mock("@/lib/access-control", () => ({ resolvePatientId: vi.fn() }))
+vi.mock("@/lib/services/proposal-generator.service", () => ({
+  proposalGeneratorService: { generateForPatient: vi.fn() },
+}))
+vi.mock("@/lib/services/audit.service", () => ({
+  auditService: { log: vi.fn().mockResolvedValue(undefined) },
+  extractRequestContext: vi.fn().mockReturnValue({ ipAddress: "127.0.0.1", userAgent: "test" }),
+}))
+
+const { POST } = await import("@/app/api/patients/[id]/proposals/generate/route")
+const { resolvePatientId } = await import("@/lib/access-control")
+const { proposalGeneratorService } = await import("@/lib/services/proposal-generator.service")
+const { auditService } = await import("@/lib/services/audit.service")
+
+const resolve = vi.mocked(resolvePatientId)
+const generate = vi.mocked(proposalGeneratorService.generateForPatient)
+const auditLog = vi.mocked(auditService.log)
+
+const params = (id: string) => ({ params: Promise.resolve({ id }) })
+function req(role: string, body: unknown): NextRequest {
+  return new NextRequest(new URL("http://localhost/api/patients/42/proposals/generate"), {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": "7", "x-user-role": role },
+    body: JSON.stringify(body),
+  })
+}
+
+describe("POST /api/patients/[id]/proposals/generate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resolve.mockResolvedValue(42)
+    generate.mockResolvedValue({ created: 2, flagged: 0, slotsConsidered: 3, mealsUsable: 6, skipped: null })
+  })
+
+  it("NURSE, fenêtre valide → 200, générateur appelé avec la fenêtre, audité", async () => {
+    const res = await POST(req("NURSE", { windowDays: 4 }), params("42"))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toMatchObject({ created: 2, flagged: 0, windowDays: 4, reason: null })
+    // generateForPatient(patientId, userId, ctx, windowDays)
+    expect(generate).toHaveBeenCalledWith(42, 7, expect.anything(), 4)
+    expect(auditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "CREATE",
+        resource: "ADJUSTMENT_PROPOSAL",
+        metadata: expect.objectContaining({ kind: "proposal.generator.on_demand", windowDays: 4, created: 2 }),
+      }),
+    )
+  })
+
+  it("DOCTOR autorisé aussi", async () => {
+    const res = await POST(req("DOCTOR", { windowDays: 7 }), params("42"))
+    expect(res.status).toBe(200)
+  })
+
+  it("fenêtre < 2 → 400 windowOutOfBounds (aucun run)", async () => {
+    const res = await POST(req("NURSE", { windowDays: 1 }), params("42"))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe("windowOutOfBounds")
+    expect(generate).not.toHaveBeenCalled()
+  })
+
+  it("fenêtre > 14 → 400 windowOutOfBounds", async () => {
+    const res = await POST(req("NURSE", { windowDays: 30 }), params("42"))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe("windowOutOfBounds")
+  })
+
+  it("VIEWER → 403 (non-soignant ne déclenche pas)", async () => {
+    const res = await POST(req("VIEWER", { windowDays: 4 }), params("42"))
+    expect(res.status).toBe(403)
+    expect(generate).not.toHaveBeenCalled()
+  })
+
+  it("patient hors périmètre → 404 (anti-IDOR)", async () => {
+    resolve.mockResolvedValue(null)
+    const res = await POST(req("NURSE", { windowDays: 4 }), params("99"))
+    expect(res.status).toBe(404)
+    expect(generate).not.toHaveBeenCalled()
+  })
+
+  it("rien à proposer (created 0) → 200 avec reason (pas une erreur)", async () => {
+    generate.mockResolvedValue({ created: 0, flagged: 0, slotsConsidered: 2, mealsUsable: 1, skipped: null })
+    const res = await POST(req("NURSE", { windowDays: 2 }), params("42"))
+    expect(res.status).toBe(200)
+    expect((await res.json()).reason).toBe("nothingToPropose")
+  })
+
+  it("mode non exploitable → 200 avec le motif du générateur", async () => {
+    generate.mockResolvedValue({ created: 0, flagged: 0, slotsConsidered: 0, mealsUsable: 0, skipped: "noCarbRatios" })
+    const res = await POST(req("NURSE", { windowDays: 5 }), params("42"))
+    expect(res.status).toBe(200)
+    expect((await res.json()).reason).toBe("noCarbRatios")
+  })
+})

--- a/tests/integration/api-proposals-generate.test.ts
+++ b/tests/integration/api-proposals-generate.test.ts
@@ -14,15 +14,24 @@ import { NextRequest } from "next/server"
 vi.mock("@/lib/db/client", () => ({ prisma: {} }))
 vi.mock("@/lib/gdpr", () => ({ requireGdprConsent: vi.fn().mockResolvedValue(true) }))
 vi.mock("@/lib/access-control", () => ({ resolvePatientId: vi.fn() }))
+vi.mock("@/lib/auth/api-rate-limit", () => ({
+  checkApiRateLimit: vi.fn().mockResolvedValue({ allowed: true, remaining: 29, retryAfterSec: 60 }),
+  RATE_LIMITS: { analytics: { bucket: "analytics" } },
+}))
 vi.mock("@/lib/services/proposal-generator.service", () => ({
   proposalGeneratorService: { generateForPatient: vi.fn() },
+  ISF_ANALYSIS_WINDOW_DAYS: 30,
 }))
 vi.mock("@/lib/services/audit.service", () => ({
-  auditService: { log: vi.fn().mockResolvedValue(undefined) },
-  extractRequestContext: vi.fn().mockReturnValue({ ipAddress: "127.0.0.1", userAgent: "test" }),
+  auditService: {
+    log: vi.fn().mockResolvedValue(undefined),
+    rateLimited: vi.fn().mockResolvedValue({ rateLimitedRow: {}, burstRow: null }),
+  },
+  extractRequestContext: vi.fn().mockReturnValue({ ipAddress: "127.0.0.1", userAgent: "test", requestId: "r1" }),
 }))
 
 const { POST } = await import("@/app/api/patients/[id]/proposals/generate/route")
+const { checkApiRateLimit } = await import("@/lib/auth/api-rate-limit")
 const { resolvePatientId } = await import("@/lib/access-control")
 const { proposalGeneratorService } = await import("@/lib/services/proposal-generator.service")
 const { auditService } = await import("@/lib/services/audit.service")
@@ -45,6 +54,8 @@ describe("POST /api/patients/[id]/proposals/generate", () => {
     vi.clearAllMocks()
     resolve.mockResolvedValue(42)
     generate.mockResolvedValue({ created: 2, flagged: 0, slotsConsidered: 3, mealsUsable: 6, skipped: null })
+    vi.mocked(checkApiRateLimit).mockResolvedValue({ allowed: true, remaining: 29, retryAfterSec: 60 } as never)
+    auditLog.mockResolvedValue(undefined as never)
   })
 
   it("NURSE, fenêtre valide → 200, générateur appelé avec la fenêtre, audité", async () => {
@@ -52,6 +63,8 @@ describe("POST /api/patients/[id]/proposals/generate", () => {
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body).toMatchObject({ created: 2, flagged: 0, windowDays: 4, reason: null })
+    // L'ISF titre toujours sur 30 j (décision §3), exposé pour la future UI de déclenchement.
+    expect(body.isfWindowDays).toBe(30)
     // generateForPatient(patientId, userId, ctx, windowDays)
     expect(generate).toHaveBeenCalledWith(42, 7, expect.anything(), 4)
     expect(auditLog).toHaveBeenCalledWith(
@@ -99,6 +112,14 @@ describe("POST /api/patients/[id]/proposals/generate", () => {
     const res = await POST(req("NURSE", { windowDays: 2 }), params("42"))
     expect(res.status).toBe(200)
     expect((await res.json()).reason).toBe("nothingToPropose")
+  })
+
+  it("rate-limit saturé → 429 (aucun run, audité)", async () => {
+    vi.mocked(checkApiRateLimit).mockResolvedValueOnce({ allowed: false, remaining: 0, retryAfterSec: 42 } as never)
+    const res = await POST(req("NURSE", { windowDays: 4 }), params("42"))
+    expect(res.status).toBe(429)
+    expect(res.headers.get("Retry-After")).toBe("42")
+    expect(generate).not.toHaveBeenCalled()
   })
 
   it("mode non exploitable → 200 avec le motif du générateur", async () => {

--- a/tests/unit/proposal-generator.service.test.ts
+++ b/tests/unit/proposal-generator.service.test.ts
@@ -666,3 +666,43 @@ describe("proposalGeneratorService.generateForAllPatients (cron)", () => {
     expect(res.created).toBe(1)
   })
 })
+
+describe("US-2658 — fenêtre d'analyse à la demande (windowDays)", () => {
+  beforeEach(() => vi.clearAllMocks())
+  const fixedDoseTrend = vi.mocked(analyticsService.fixedDoseTrend)
+  const basalCfg = { configType: "pump", pumpSlots: [{ id: "p1", rate: 0.8, startHour: 0, endHour: 6 }] }
+
+  it("windowDays applique `${windowDays}d` à ICR/basal, l'ISF garde 30 j", async () => {
+    setup({
+      basalConfig: basalCfg,
+      glucoseTargets: [{ targetGlucose: 120 }],
+      fasting: [{ fastingMgdl: 110, nocturnalNadirMgdl: 100 }],
+      sensitivityFactors: [{ startHour: 0, endHour: 24, sensitivityFactorGl: 0.5 }],
+      corrections: [],
+    })
+    await proposalGeneratorService.generateForPatient(1, 99, undefined, 4)
+
+    expect(dailyJournal.mock.calls[0]?.[1]).toBe("4d") // ICR → fenêtre choisie
+    expect(fastingTrend.mock.calls[0]?.[1]).toBe("4d") // basal → fenêtre choisie
+    expect(correctionTrend.mock.calls[0]?.[1]).toBe("30d") // ISF → 30 j inchangé (décision §3)
+  })
+
+  it("sans windowDays (cron) → 14 j par défaut (comportement inchangé)", async () => {
+    setup({ basalConfig: basalCfg, glucoseTargets: [{ targetGlucose: 120 }], fasting: [{ fastingMgdl: 110, nocturnalNadirMgdl: 100 }] })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(dailyJournal.mock.calls[0]?.[1]).toBe("14d")
+    expect(fastingTrend.mock.calls[0]?.[1]).toBe("14d")
+  })
+
+  it("mode fixedDose : windowDays applique `${windowDays}d` aux creux pré-dose", async () => {
+    mode.mockResolvedValue({ mode: "fixedDose", coherent: true } as never)
+    prismaMock.fixedDoseSlot.findMany.mockResolvedValue([{ moment: "morning", valueU: 10 }] as never)
+    prismaMock.patient.findFirst.mockResolvedValue({ pathology: "DT2", pregnancyMode: false } as never)
+    prismaMock.glucoseTarget.findFirst.mockResolvedValue(null as never)
+    fixedDoseTrend.mockResolvedValue({} as never)
+    createEngine.mockResolvedValue({ id: "e1" } as never)
+
+    await proposalGeneratorService.generateForPatient(1, 99, undefined, 3)
+    expect(fixedDoseTrend.mock.calls[0]?.[1]).toBe("3d")
+  })
+})


### PR DESCRIPTION
Tranche 4 de l'épic **US-2654** (back, **indépendante**). Un **médecin ou infirmier** peut déclencher la génération pour un patient sur une **fenêtre choisie [2,14] j**, sans attendre le cron.

## Contenu
- **`generateForPatient`** (+ `generateFixedDoseProposals`) gagnent un **`windowDays?`** optionnel : `${windowDays}d` appliqué à **ICR/basal/dose fixe** ; **l'ISF garde 30 j** (décision §3) ; absent (cron) → **14 j inchangé**.
- **Route** `POST /api/patients/[id]/proposals/generate` : **DOCTOR/NURSE** (min NURSE ; patient/VIEWER → **403**), Zod `windowDays` **[2,14]** (hors bornes → **400 windowOutOfBounds**), **anti-IDOR** (`resolvePatientId` → 404), **propose sans appliquer** (ADR #13), **« rien à proposer » = 200 + reason** (pas une erreur), **audité** (acteur soignant réel, fenêtre, sans PHI).
- Tous les **garde-fous existants intacts** (garde hypo, bornes, `one_pending_per_slot`, frontière MDR) — c'est le **même moteur, fenêtré**, zéro nouveau chemin de dose.
- Catalogue + JSDoc. **Tests +11** (3 threading service, 8 route).

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3868 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)