### PR TITLE
US-2657 (slice C1) — Socle gouvernance & persistance de l'auto-application experte

### DIFF
--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -584,3 +584,20 @@ des données récentes **prouvent** que le patient n'est pas en hyper. Bloque (�
 Sources : `src/lib/clinical-bounds.ts` (constantes + `isDeliverableFixedDose`), `src/lib/insulin/dose-safety-guards.ts`
 (`hypoWindowBlocks` mutualisé avec le générateur, `hyperDecreaseBlockReason`), `src/lib/insulin/auto-apply-envelope.ts`.
 Verrou anti-drift : `tests/unit/clinical-bounds.test.ts`.
+
+### Gouvernance de l'auto-application experte (US-2657 slice C1)
+
+**Frontière MDR — double verrou, OFF par défaut.** L'auto-application (enveloppe C1–C8 ci-dessus) ne peut
+opérer que si **les deux** sont ON :
+- **kill-switch GLOBAL** `AUTO_APPLY_GLOBALLY_ENABLED` (env, `src/lib/env.ts` → `isAutoApplyGloballyEnabled()`) —
+  fail-safe : absent/malformé/`false` → OFF ;
+- **flag par patient** `Patient.autoApply` (défaut `false`).
+
+Poser `autoApply = true` = **acte de gouvernance** (pas clinique) : rôle **ADMIN** + artefact
+`GovernanceApproval` (référence décision + `dpiaRef`) créé dans la transaction. **Désactivation toujours
+permise, sans approbation** (kill direction fail-safe). Audité `UPDATE PATIENT` (`from → to`, sans PHI).
+`AutoApplyEvent` (append-only) journalise chaque auto-application effective (alimente l'anti-cliquet C7).
+
+L'**activation en production reste subordonnée à la DPIA signée** (`docs/compliance/dpia-auto-application.md`,
+RGPD Art. 22 + MDR). Sources : `src/lib/services/governance.service.ts`, `src/app/api/governance/auto-apply/route.ts`,
+`prisma/schema.prisma` (`GovernanceApproval`, `AutoApplyEvent`).

--- a/docs/compliance/dpia-auto-application.md
+++ b/docs/compliance/dpia-auto-application.md
@@ -46,8 +46,12 @@ l'autonomie réelle d'un patient expert tout en traçant chaque décision.
    amplitude (≤ 10 % / ≤ 1 U), bornes cliniques absolues (sinon rejet dur), délivrabilité, garde hypo (hausse),
    **garde hyper/cétose asymétrique** (baisse — plancher de suffisance de données, cétonémie, TAR), anti-cliquet
    (72 h + 15 %/7 j), **fail-closed** sur tout doute. Hors enveloppe → proposition.
-4. **Traçabilité HDS/CNIL** : audit `UPDATE PATIENT` de chaque bascule de flag (`from → to` + référence, sans
-   PHI) ; `AutoApplyEvent` append-only pour l'anti-cliquet et la reconstitution forensique.
+4. **Traçabilité HDS/CNIL** : audit `UPDATE PATIENT` de chaque décision de gouvernance (`from → to` +
+   référence, sans PHI — **chaque re-approbation est tracée**, même sur un patient déjà activé) ;
+   `AutoApplyEvent` append-only pour l'anti-cliquet et la reconstitution forensique. Les tables
+   `governance_approvals`/`auto_apply_events` sont **anti-altération** (trigger PG bloquant UPDATE,
+   `prisma/sql/audit_immutability.sql`) ; DELETE reste permis pour l'effacement RGPD Art. 17 (l'action
+   demeure dans `audit_logs`, immuable et non cascadé).
 5. **Réversibilité** : désactivation immédiate (par patient ou globale via kill-switch) ; aucune donnée
    patient supprimée.
 

--- a/docs/compliance/dpia-auto-application.md
+++ b/docs/compliance/dpia-auto-application.md
@@ -1,0 +1,68 @@
+# DPIA — Auto-application experte des ajustements d'insulinothérapie (US-2657)
+
+**Statut** : Brouillon — **à signer DPO + RSSI + responsable qualité/réglementaire (MDR) avant toute
+activation en production**. Tant que non signée : `AUTO_APPLY_GLOBALLY_ENABLED` = OFF, tous les
+`Patient.autoApply` = OFF.
+**Périmètre (slice C1 — socle gouvernance & persistance, additif)** : champ `Patient.autoApply` (OFF par
+défaut), modèles `GovernanceApproval` et `AutoApplyEvent`, service `governanceService.setAutoApply`
+(ADMIN + approbation), route `PATCH /api/governance/auto-apply`, kill-switch global
+`AUTO_APPLY_GLOBALLY_ENABLED` (`src/lib/env.ts`). **Le harnais qui applique effectivement n'est PAS livré
+en C1** (slices C2/C3) ; l'auto-application reste **inopérante** tant que les deux verrous ne sont pas ON.
+**Lié à** : `docs/UserStory/insulinotherapie-edition/US-2657-maturite-autonomie-graduee.md`,
+`docs/clinical-logic/regles-et-constantes-diabete.md` (enveloppe C1–C8 + C6b),
+`src/lib/insulin/auto-apply-envelope.ts`.
+
+## 1. Finalité & nature du traitement
+
+Permettre qu'un ajustement de configuration d'insulinothérapie proposé par un **patient EXPERT** (niveau
+de maturité le plus élevé, US-2657 A) s'applique à sa configuration active **sans validation médicale
+préalable, événement par événement**, lorsqu'il reste dans une **enveloppe de sécurité** stricte
+(conditions C1–C8 + C6b). Hors enveloppe → proposition soumise au médecin (comportement actuel). Reproduit
+l'autonomie réelle d'un patient expert tout en traçant chaque décision.
+
+## 2. Qualification réglementaire
+
+- **RGPD Art. 9** — données de santé (glycémies, cétonémie, doses). Chiffrement AES-256-GCM at-rest inchangé.
+- **RGPD Art. 22 — décision individuelle automatisée.** L'auto-application est une décision automatisée
+  produisant des effets sur la personne. Garanties : (a) **périmètre volontaire et gradué** (opt-in
+  gouvernance + niveau EXPERT posé par un médecin) ; (b) **droit à l'intervention humaine préservé** — le
+  patient et son médecin peuvent à tout moment revenir en voie proposition (désactivation du flag, toujours
+  permise) ; (c) **transparence & traçabilité** — chaque auto-application est auditée (`before → after`,
+  paramètre, créneau, décision d'enveloppe) et journalisée (`AutoApplyEvent`).
+- **MDR — frontière dispositif médical.** Faire varier une dose sans clinicien dans la boucle relève du
+  marquage. **L'activation en production est une décision de gouvernance qualité/réglementaire, jamais une
+  décision de développement.** Ce document et le code n'**autorisent** rien : ils **outillent** une bascule
+  qui reste subordonnée à signature.
+
+## 3. Garde-fous (défense en profondeur)
+
+1. **Double verrou OFF par défaut** : kill-switch **global** `AUTO_APPLY_GLOBALLY_ENABLED` (env, fail-safe
+   sur valeur absente/malformée) **ET** flag **par patient** `Patient.autoApply`. Le harnais n'auto-applique
+   que si les **deux** sont ON.
+2. **Activation gouvernée** : poser `autoApply = true` exige le rôle **ADMIN** **et** un artefact
+   `GovernanceApproval` (référence de décision + lien DPIA) créé dans la même transaction. **Désactivation
+   toujours permise, sans approbation** (kill direction fail-safe).
+3. **Enveloppe de sécurité C1–C8 + C6b** (slice B, validée medical) : type de changement (valeur seule),
+   amplitude (≤ 10 % / ≤ 1 U), bornes cliniques absolues (sinon rejet dur), délivrabilité, garde hypo (hausse),
+   **garde hyper/cétose asymétrique** (baisse — plancher de suffisance de données, cétonémie, TAR), anti-cliquet
+   (72 h + 15 %/7 j), **fail-closed** sur tout doute. Hors enveloppe → proposition.
+4. **Traçabilité HDS/CNIL** : audit `UPDATE PATIENT` de chaque bascule de flag (`from → to` + référence, sans
+   PHI) ; `AutoApplyEvent` append-only pour l'anti-cliquet et la reconstitution forensique.
+5. **Réversibilité** : désactivation immédiate (par patient ou globale via kill-switch) ; aucune donnée
+   patient supprimée.
+
+## 4. Risques résiduels & mesures
+
+| Risque | Mesure |
+|---|---|
+| Sur-dosage / hypo par auto-hausse | Garde C6 (hypo) + amplitude C3 + anti-cliquet C7 ; hors enveloppe → proposition. |
+| Sous-dosage / acidocétose par auto-baisse | Garde **C6b** : plancher de données (14 j/70 %/≥100 relevés), cétonémie ≥ seuil, TAR>180/250 → proposition. |
+| Activation par erreur | Double verrou OFF + approbation gouvernance + audit + kill-switch global. |
+| Dérive lente (cliquet) | C7 : cooldown 72 h + cumul 15 %/7 j par (paramètre × créneau). |
+| Donnée manquante/corrompue | C8 fail-closed → proposition, jamais d'auto-application sur doute. |
+
+## 5. Décision
+
+Traitement **à haut risque** justifiant cette DPIA. **Non activable** avant signature conjointe DPO + RSSI +
+responsable MDR. Le socle (C1) est livré **inerte** (double verrou OFF) pour permettre l'instruction et les
+tests sans exposer aucun patient.

--- a/prisma/migrations/20260713100000_us2657c_governance_auto_apply/migration.sql
+++ b/prisma/migrations/20260713100000_us2657c_governance_auto_apply/migration.sql
@@ -1,0 +1,43 @@
+-- US-2657 (slice C) — Socle gouvernance & persistance de l'auto-application experte.
+-- Additif, non destructif. `auto_apply` OFF par défaut (backfill false) ; subordonné au
+-- kill-switch global `AUTO_APPLY_GLOBALLY_ENABLED` et à une GovernanceApproval valide.
+
+-- AlterTable
+ALTER TABLE "patients" ADD COLUMN "auto_apply" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "governance_approvals" (
+    "id" SERIAL NOT NULL,
+    "patient_id" INTEGER NOT NULL,
+    "approved_by_id" INTEGER NOT NULL,
+    "reference" TEXT NOT NULL,
+    "dpia_ref" TEXT,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "governance_approvals_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "auto_apply_events" (
+    "id" SERIAL NOT NULL,
+    "patient_id" INTEGER NOT NULL,
+    "parameter_type" "AdjustableParameter" NOT NULL,
+    "slot_key" TEXT NOT NULL,
+    "delta_percent" DOUBLE PRECISION NOT NULL,
+    "applied_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "auto_apply_events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "governance_approvals_patient_id_idx" ON "governance_approvals"("patient_id");
+
+-- CreateIndex
+CREATE INDEX "auto_apply_events_patient_id_parameter_type_applied_at_idx" ON "auto_apply_events"("patient_id", "parameter_type", "applied_at");
+
+-- AddForeignKey
+ALTER TABLE "governance_approvals" ADD CONSTRAINT "governance_approvals_patient_id_fkey" FOREIGN KEY ("patient_id") REFERENCES "patients"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "auto_apply_events" ADD CONSTRAINT "auto_apply_events_patient_id_fkey" FOREIGN KEY ("patient_id") REFERENCES "patients"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -695,6 +695,12 @@ model Patient {
   pregnancyMode Boolean        @default(false) @map("pregnancy_mode")
   /// US-2657 — niveau d'autonomie (ETP), posé par le soignant. Défaut JUNIOR (le plus restrictif).
   maturityLevel MaturityLevel  @default(JUNIOR) @map("maturity_level")
+  /// US-2657 (slice C) — auto-application experte ACTIVÉE pour ce patient. OFF par défaut,
+  /// gouvernance-gated (activation ADMIN conditionnée à une GovernanceApproval valide) et
+  /// SUBORDONNÉE au kill-switch global `AUTO_APPLY_GLOBALLY_ENABLED`. Frontière MDR.
+  autoApply     Boolean       @default(false) @map("auto_apply")
+  governanceApprovals GovernanceApproval[]
+  autoApplyEvents     AutoApplyEvent[]
   /// US-2646 — mode de traitement (basalBolus / fixedDose / nonInsulin). CACHE
   /// d'affichage/filtrage UNIQUEMENT. ⚠️ NE PAS lire cette colonne brute pour une
   /// décision logique : source de vérité = `resolveTreatmentMode()` (US-2647, dérivé
@@ -781,6 +787,40 @@ model Patient {
   @@unique([publicRef], map: "patients_public_ref_key")
   @@index([deletedAt])
   @@map("patients")
+}
+
+/// US-2657 (slice C) — Artefact de gouvernance autorisant l'auto-application experte d'un patient.
+/// PRÉ-REQUIS pour poser `Patient.autoApply = true` (décision qualité/réglementaire tracée, MDR).
+/// Immuable en pratique (append-only) ; `approvedById` = ADMIN acteur, `reference`/`dpiaRef` = liens
+/// vers la décision de gouvernance et la DPIA. Jamais de PHI.
+model GovernanceApproval {
+  id           Int      @id @default(autoincrement())
+  patientId    Int      @map("patient_id")
+  patient      Patient  @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  approvedById Int      @map("approved_by_id") // ADMIN ayant enregistré l'approbation
+  reference    String   // référence de la décision de gouvernance
+  dpiaRef      String?  @map("dpia_ref") // lien DPIA
+  enabled      Boolean  @default(true) // l'approbation autorise l'activation
+  createdAt    DateTime @default(now()) @map("created_at")
+
+  @@index([patientId])
+  @@map("governance_approvals")
+}
+
+/// US-2657 (slice C) — Registre (append-only) des auto-applications effectives. Alimente l'anti-cliquet
+/// C7 de l'enveloppe : `hoursSinceLastAutoApply` + cumul des |Δ%| sur (patient × paramètre × créneau)
+/// sur 7 j glissants. `deltaPercent` en %. Jamais de PHI.
+model AutoApplyEvent {
+  id            Int               @id @default(autoincrement())
+  patientId     Int               @map("patient_id")
+  patient       Patient           @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  parameterType AdjustableParameter @map("parameter_type")
+  slotKey       String            @map("slot_key") // identifie le créneau (ex. "22-06")
+  deltaPercent  Float             @map("delta_percent") // |Δ%| appliqué (anti-cliquet)
+  appliedAt     DateTime          @default(now()) @map("applied_at")
+
+  @@index([patientId, parameterType, appliedAt])
+  @@map("auto_apply_events")
 }
 
 /// US-2603 — Dossiers patients récemment consultés par un PS (switcher de

--- a/prisma/sql/audit_immutability.sql
+++ b/prisma/sql/audit_immutability.sql
@@ -19,3 +19,32 @@ $$ LANGUAGE plpgsql;
 CREATE TRIGGER audit_logs_immutable
   BEFORE UPDATE OR DELETE ON audit_logs
   FOR EACH ROW EXECUTE FUNCTION prevent_audit_log_mutation();
+
+-- ═══════════════════════════════════════════════════════════════
+-- US-2657 (slice C) — Immutabilité des artefacts de gouvernance
+-- ═══════════════════════════════════════════════════════════════
+-- governance_approvals & auto_apply_events sont append-only : une
+-- approbation enregistrée ou un événement d'auto-application ne doit
+-- JAMAIS être ALTÉRÉ silencieusement (tamper-evidence HDS/MDR).
+--
+-- ⚠️ On bloque UPDATE UNIQUEMENT (pas DELETE) : ces tables ont un FK
+-- ON DELETE CASCADE vers patients, requis pour l'effacement RGPD
+-- Art. 17 (deletion.service.ts). L'ACTION de gouvernance reste tracée
+-- dans audit_logs (immuable UPDATE+DELETE, non cascadé) même si
+-- l'artefact est effacé avec le patient.
+-- ═══════════════════════════════════════════════════════════════
+
+CREATE OR REPLACE FUNCTION prevent_governance_row_update()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION '% is append-only: UPDATE is forbidden (governance tamper-evidence)', TG_TABLE_NAME;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER governance_approvals_no_update
+  BEFORE UPDATE ON governance_approvals
+  FOR EACH ROW EXECUTE FUNCTION prevent_governance_row_update();
+
+CREATE TRIGGER auto_apply_events_no_update
+  BEFORE UPDATE ON auto_apply_events
+  FOR EACH ROW EXECUTE FUNCTION prevent_governance_row_update();

--- a/src/app/api/governance/auto-apply/route.ts
+++ b/src/app/api/governance/auto-apply/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireRole, AuthError } from "@/lib/auth"
+import { resolvePatientId } from "@/lib/access-control"
+import { requireGdprConsent } from "@/lib/gdpr"
+import { governanceService } from "@/lib/services/governance.service"
+import { extractRequestContext } from "@/lib/services/audit.service"
+
+// US-2657 (slice C) — activation/désactivation gouvernée de l'auto-application experte d'un patient.
+// Activer exige une `reference` de décision de gouvernance (fail-closed) ; désactiver non (kill direction).
+const bodySchema = z
+  .object({
+    patientId: z.number().int().positive(),
+    enabled: z.boolean(),
+    reference: z.string().trim().min(1).optional(),
+    dpiaRef: z.string().trim().min(1).optional(),
+  })
+  .refine((b) => !b.enabled || (b.reference !== undefined && b.reference.length > 0), {
+    message: "reference required to enable",
+    path: ["reference"],
+  })
+
+/**
+ * PATCH — pose `Patient.autoApply` (frontière MDR). **Réservé au rôle ADMIN** (acte de gouvernance).
+ * Activer crée une `GovernanceApproval` (référence + DPIA) dans la transaction ; désactiver est
+ * toujours permis. Le flag reste **subordonné au kill-switch global** `AUTO_APPLY_GLOBALLY_ENABLED`
+ * (le harnais ne l'auto-applique que si les DEUX sont ON). Anti-IDOR (→ 404), audité sans PHI.
+ */
+export async function PATCH(req: NextRequest) {
+  try {
+    const user = requireRole(req, "ADMIN")
+    const hasConsent = await requireGdprConsent(user.id)
+    if (!hasConsent) return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
+
+    const parsed = bodySchema.safeParse(await req.json().catch(() => null))
+    if (!parsed.success) {
+      return NextResponse.json({ error: "validationFailed", details: parsed.error.flatten().fieldErrors }, { status: 400 })
+    }
+
+    const patientId = await resolvePatientId(user.id, user.role, parsed.data.patientId)
+    if (!patientId) return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+
+    try {
+      const result = await governanceService.setAutoApply(
+        patientId,
+        parsed.data.enabled,
+        parsed.data.enabled ? { reference: parsed.data.reference!, dpiaRef: parsed.data.dpiaRef ?? null } : null,
+        user.id,
+        extractRequestContext(req),
+      )
+      return NextResponse.json(result)
+    } catch (e) {
+      if (e instanceof Error && (e.message === "patientNotFound" || e.message === "approvalRequired")) {
+        const status = e.message === "patientNotFound" ? 404 : 400
+        return NextResponse.json({ error: e.message }, { status })
+      }
+      throw e
+    }
+  } catch (error) {
+    if (error instanceof AuthError) return NextResponse.json({ error: error.message }, { status: error.status })
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    console.error("[governance/auto-apply PATCH]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -297,6 +297,15 @@ export function getEnvBoolean(name: string): boolean | undefined {
   return false
 }
 
+/**
+ * US-2657 (slice C) — kill-switch GLOBAL de l'auto-application experte. `true` UNIQUEMENT si la variable
+ * vaut explicitement `"true"` ; tout autre cas (absente, `"false"`, malformée) → `false` (**fail-safe**,
+ * l'auto-application n'existe pas). Prioritaire sur les flags `Patient.autoApply`. Frontière MDR.
+ */
+export function isAutoApplyGloballyEnabled(): boolean {
+  return getEnvBoolean("AUTO_APPLY_GLOBALLY_ENABLED") === true
+}
+
 function assertSpecs(specs: readonly EnvSpec[]): void {
   const problems: string[] = []
 
@@ -342,6 +351,9 @@ export function assertRequiredEnv(): void {
   assertSpecs(REQUIRED_FULL)
   // US-2123 — fail-fast on misconfigured FHIR feature flag.
   assertOptionalBoolean("FHIR_ENABLED")
+  // US-2657 (slice C) — kill-switch GLOBAL de l'auto-application experte (frontière MDR).
+  // Défaut OFF ; une valeur malformée ne doit JAMAIS activer silencieusement l'auto-application → fail-fast.
+  assertOptionalBoolean("AUTO_APPLY_GLOBALLY_ENABLED")
   // Socle d'accès (F2) — flag pilote ouvrant le mode `provisional` de la porte
   // clinique en prod. Fail-fast sur valeur malformée : une faute de saisie ne
   // doit pas désactiver silencieusement le pilote (cf. capabilities.pilotAllowed).

--- a/src/lib/services/governance.service.ts
+++ b/src/lib/services/governance.service.ts
@@ -1,0 +1,76 @@
+/**
+ * US-2657 (slice C) — Service de **gouvernance de l'auto-application experte** (frontière MDR).
+ *
+ * Poser `Patient.autoApply = true` est un **acte de gouvernance** (décision qualité/réglementaire),
+ * pas un acte clinique : réservé au rôle ADMIN (garde à la route) et **conditionné à un artefact
+ * `GovernanceApproval`** (référence de décision + lien DPIA) créé dans la même transaction. La
+ * **désactivation** (kill direction) est toujours permise, sans approbation (fail-safe). Le flag reste
+ * de plus **subordonné au kill-switch global** `AUTO_APPLY_GLOBALLY_ENABLED` (lu par le harnais, slice C2).
+ *
+ * Tout est audité (`UPDATE PATIENT`, `from → to`, sans PHI).
+ */
+import { prisma } from "@/lib/db/client"
+import { auditService, type AuditContext } from "@/lib/services/audit.service"
+
+export type AutoApplyApproval = { reference: string; dpiaRef?: string | null }
+
+export const governanceService = {
+  /**
+   * Active/désactive l'auto-application experte d'un patient.
+   * @param patientId Patient cible (déjà autorisé par la route).
+   * @param enabled Cible du flag.
+   * @param approval Artefact de gouvernance — **obligatoire pour activer** (`reference` non vide) ; ignoré à la désactivation.
+   * @param adminUserId ADMIN acteur.
+   * @param ctx Contexte requête (audit).
+   * @throws `patientNotFound` si absent/soft-deleted ; `approvalRequired` si activation sans référence.
+   */
+  async setAutoApply(
+    patientId: number,
+    enabled: boolean,
+    approval: AutoApplyApproval | null,
+    adminUserId: number,
+    ctx?: AuditContext,
+  ) {
+    if (enabled && (!approval || approval.reference.trim() === "")) {
+      throw new Error("approvalRequired") // fail-closed : jamais d'activation sans artefact de gouvernance
+    }
+
+    return prisma.$transaction(async (tx) => {
+      const before = await tx.patient.findFirst({
+        where: { id: patientId, deletedAt: null },
+        select: { autoApply: true },
+      })
+      if (!before) throw new Error("patientNotFound")
+      if (before.autoApply === enabled) return { autoApply: enabled, changed: false }
+
+      if (enabled && approval) {
+        await tx.governanceApproval.create({
+          data: {
+            patientId,
+            approvedById: adminUserId,
+            reference: approval.reference,
+            dpiaRef: approval.dpiaRef ?? null,
+            enabled: true,
+          },
+        })
+      }
+      await tx.patient.update({ where: { id: patientId }, data: { autoApply: enabled } })
+      await auditService.logWithTx(tx, {
+        userId: adminUserId,
+        action: "UPDATE",
+        resource: "PATIENT",
+        resourceId: String(patientId),
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+        metadata: {
+          patientId,
+          kind: "autoApplyChanged",
+          from: before.autoApply,
+          to: enabled,
+          ...(enabled && approval ? { reference: approval.reference, dpiaRef: approval.dpiaRef ?? null } : {}),
+        },
+      })
+      return { autoApply: enabled, changed: true }
+    })
+  },
+}

--- a/src/lib/services/governance.service.ts
+++ b/src/lib/services/governance.service.ts
@@ -41,8 +41,11 @@ export const governanceService = {
         select: { autoApply: true },
       })
       if (!before) throw new Error("patientNotFound")
-      if (before.autoApply === enabled) return { autoApply: enabled, changed: false }
+      const changed = before.autoApply !== enabled
 
+      // Activation : on enregistre TOUJOURS l'artefact de gouvernance — y compris une re-approbation
+      // d'un patient déjà activé (chaque décision de gouvernance doit être tracée), même si le flag
+      // ne change pas. Une désactivation idempotente (déjà OFF) reste un no-op complet.
       if (enabled && approval) {
         await tx.governanceApproval.create({
           data: {
@@ -54,23 +57,28 @@ export const governanceService = {
           },
         })
       }
-      await tx.patient.update({ where: { id: patientId }, data: { autoApply: enabled } })
-      await auditService.logWithTx(tx, {
-        userId: adminUserId,
-        action: "UPDATE",
-        resource: "PATIENT",
-        resourceId: String(patientId),
-        ipAddress: ctx?.ipAddress,
-        userAgent: ctx?.userAgent,
-        metadata: {
-          patientId,
-          kind: "autoApplyChanged",
-          from: before.autoApply,
-          to: enabled,
-          ...(enabled && approval ? { reference: approval.reference, dpiaRef: approval.dpiaRef ?? null } : {}),
-        },
-      })
-      return { autoApply: enabled, changed: true }
+      if (changed) {
+        await tx.patient.update({ where: { id: patientId }, data: { autoApply: enabled } })
+      }
+      // Audit dès qu'une décision de gouvernance a eu lieu (approbation enregistrée OU flag modifié).
+      if ((enabled && approval) || changed) {
+        await auditService.logWithTx(tx, {
+          userId: adminUserId,
+          action: "UPDATE",
+          resource: "PATIENT",
+          resourceId: String(patientId),
+          ipAddress: ctx?.ipAddress,
+          userAgent: ctx?.userAgent,
+          metadata: {
+            patientId,
+            kind: "autoApplyChanged",
+            from: before.autoApply,
+            to: enabled,
+            ...(enabled && approval ? { reference: approval.reference, dpiaRef: approval.dpiaRef ?? null } : {}),
+          },
+        })
+      }
+      return { autoApply: enabled, changed }
     })
   },
 }

--- a/tests/integration/api-governance-auto-apply.test.ts
+++ b/tests/integration/api-governance-auto-apply.test.ts
@@ -1,0 +1,72 @@
+/**
+ * US-2657 (slice C) — Route de gouvernance `PATCH /api/governance/auto-apply` (frontière MDR).
+ * Sécurité : **ADMIN seulement** (DOCTOR/NURSE/VIEWER → 403) ; activer exige une référence (→ 400) ;
+ * anti-IDOR (→ 404) ; désactivation permise.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { NextRequest } from "next/server"
+
+vi.mock("@/lib/db/client", () => ({ prisma: {} }))
+vi.mock("@/lib/gdpr", () => ({ requireGdprConsent: vi.fn().mockResolvedValue(true) }))
+vi.mock("@/lib/access-control", () => ({ resolvePatientId: vi.fn() }))
+vi.mock("@/lib/services/governance.service", () => ({ governanceService: { setAutoApply: vi.fn() } }))
+vi.mock("@/lib/services/audit.service", () => ({
+  extractRequestContext: vi.fn().mockReturnValue({ ipAddress: "127.0.0.1", userAgent: "test" }),
+}))
+
+const { PATCH } = await import("@/app/api/governance/auto-apply/route")
+const { resolvePatientId } = await import("@/lib/access-control")
+const { governanceService } = await import("@/lib/services/governance.service")
+
+const resolve = vi.mocked(resolvePatientId)
+const setFlag = vi.mocked(governanceService.setAutoApply)
+
+function req(role: string, body: unknown): NextRequest {
+  return new NextRequest(new URL("http://localhost/api/governance/auto-apply"), {
+    method: "PATCH",
+    headers: { "content-type": "application/json", "x-user-id": "3", "x-user-role": role },
+    body: JSON.stringify(body),
+  })
+}
+
+describe("PATCH /api/governance/auto-apply", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resolve.mockResolvedValue(7)
+    setFlag.mockResolvedValue({ autoApply: true, changed: true } as never)
+  })
+
+  it("ADMIN active avec référence → 200", async () => {
+    const res = await PATCH(req("ADMIN", { patientId: 7, enabled: true, reference: "GOV-1", dpiaRef: "DPIA-1" }))
+    expect(res.status).toBe(200)
+    expect(setFlag).toHaveBeenCalledWith(7, true, { reference: "GOV-1", dpiaRef: "DPIA-1" }, 3, expect.anything())
+  })
+
+  it("ADMIN désactive sans référence → 200", async () => {
+    setFlag.mockResolvedValue({ autoApply: false, changed: true } as never)
+    const res = await PATCH(req("ADMIN", { patientId: 7, enabled: false }))
+    expect(res.status).toBe(200)
+    expect(setFlag).toHaveBeenCalledWith(7, false, null, 3, expect.anything())
+  })
+
+  it("activation SANS référence → 400 (ne pose rien)", async () => {
+    const res = await PATCH(req("ADMIN", { patientId: 7, enabled: true }))
+    expect(res.status).toBe(400)
+    expect(setFlag).not.toHaveBeenCalled()
+  })
+
+  for (const role of ["DOCTOR", "NURSE", "VIEWER"]) {
+    it(`${role} → 403 (acte de gouvernance réservé ADMIN)`, async () => {
+      const res = await PATCH(req(role, { patientId: 7, enabled: true, reference: "GOV-1" }))
+      expect(res.status).toBe(403)
+      expect(setFlag).not.toHaveBeenCalled()
+    })
+  }
+
+  it("patient hors périmètre → 404 (anti-IDOR)", async () => {
+    resolve.mockResolvedValue(null)
+    const res = await PATCH(req("ADMIN", { patientId: 99, enabled: true, reference: "GOV-1" }))
+    expect(res.status).toBe(404)
+    expect(setFlag).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/access-control.test.ts
+++ b/tests/unit/access-control.test.ts
@@ -57,7 +57,7 @@ describe("canAccessPatient", () => {
 
   it("ADMIN can access any non-deleted patient", async () => {
     prismaMock.patient.findFirst.mockResolvedValue({
-      id: 99, userId: 50, pathology: "DT1", pregnancyMode: false, maturityLevel: "JUNIOR", treatmentMode: null,
+      id: 99, userId: 50, pathology: "DT1", pregnancyMode: false, maturityLevel: "JUNIOR", autoApply: false, treatmentMode: null,
       // US-2076bis-V2 (Issue #442) — publicRef requis dans le shape Patient.
       publicRef: "99000000-0000-4000-8000-000000000000",
       createdAt: new Date(), deletedAt: null,
@@ -74,7 +74,7 @@ describe("canAccessPatient", () => {
 
   it("VIEWER can access own patient record", async () => {
     prismaMock.patient.findFirst.mockResolvedValue({
-      id: 5, userId: 42, pathology: "DT1", pregnancyMode: false, maturityLevel: "JUNIOR", treatmentMode: null,
+      id: 5, userId: 42, pathology: "DT1", pregnancyMode: false, maturityLevel: "JUNIOR", autoApply: false, treatmentMode: null,
       // US-2076bis-V2 (Issue #442) — publicRef requis dans le shape Patient.
       publicRef: "05000000-0000-4000-8000-000000000000",
       createdAt: new Date(), deletedAt: null,

--- a/tests/unit/env.test.ts
+++ b/tests/unit/env.test.ts
@@ -17,7 +17,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import { generateKeyPairSync, randomBytes } from "node:crypto"
-import { assertRequiredEnv } from "@/lib/env"
+import { assertRequiredEnv, isAutoApplyGloballyEnabled } from "@/lib/env"
 
 // Valeurs valides — utilisées comme baseline pour tester un seul champ
 // invalide à la fois.
@@ -258,5 +258,22 @@ describe("assertRequiredEnv", () => {
     vi.stubEnv("MOCK_MODE", "true")
     vi.stubEnv("MOCK_ANTIVIRUS", "true")
     expect(() => assertRequiredEnv()).not.toThrow()
+  })
+})
+
+describe("isAutoApplyGloballyEnabled — kill-switch MDR (fail-safe)", () => {
+  afterEach(() => vi.unstubAllEnvs())
+
+  it("true UNIQUEMENT si la variable vaut exactement \"true\"", () => {
+    vi.stubEnv("AUTO_APPLY_GLOBALLY_ENABLED", "true")
+    expect(isAutoApplyGloballyEnabled()).toBe(true)
+  })
+
+  it("OFF (fail-safe) pour absent / \"false\" / malformé / casse / espaces", () => {
+    for (const v of [undefined, "false", "TRUE", "True", "1", "yes", " true ", ""]) {
+      if (v === undefined) vi.stubEnv("AUTO_APPLY_GLOBALLY_ENABLED", "")
+      else vi.stubEnv("AUTO_APPLY_GLOBALLY_ENABLED", v)
+      expect(isAutoApplyGloballyEnabled()).toBe(false)
+    }
   })
 })

--- a/tests/unit/governance.service.test.ts
+++ b/tests/unit/governance.service.test.ts
@@ -1,0 +1,64 @@
+/**
+ * US-2657 (slice C) — Service de gouvernance de l'auto-application (frontière MDR).
+ * Comportement de sécurité testé : activer EXIGE un artefact d'approbation (fail-closed) ; désactiver
+ * est toujours permis ; idempotent ; audité `from → to` sans PHI ; patient scopé.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { prismaMock } from "../helpers/prisma-mock"
+import { governanceService } from "@/lib/services/governance.service"
+
+const mkTx = (currentAutoApply: boolean | null) => ({
+  patient: {
+    findFirst: vi.fn().mockResolvedValue(currentAutoApply === null ? null : { autoApply: currentAutoApply }),
+    update: vi.fn().mockResolvedValue({}),
+  },
+  governanceApproval: { create: vi.fn().mockResolvedValue({ id: 1 }) },
+  auditLog: { create: vi.fn().mockResolvedValue({}) },
+})
+
+describe("governanceService.setAutoApply", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("activation : crée GovernanceApproval + pose le flag + audit", async () => {
+    const tx = mkTx(false)
+    prismaMock.$transaction.mockImplementation(async (fn: any) => fn(tx))
+    const res = await governanceService.setAutoApply(7, true, { reference: "GOV-2026-12", dpiaRef: "DPIA-AA" }, 3)
+    expect(res).toEqual({ autoApply: true, changed: true })
+    expect(tx.governanceApproval.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ patientId: 7, approvedById: 3, reference: "GOV-2026-12" }) }),
+    )
+    expect(tx.patient.update).toHaveBeenCalledWith({ where: { id: 7 }, data: { autoApply: true } })
+    expect(tx.auditLog.create).toHaveBeenCalled()
+  })
+
+  it("activation SANS référence → approvalRequired (fail-closed, aucune écriture)", async () => {
+    const tx = mkTx(false)
+    prismaMock.$transaction.mockImplementation(async (fn: any) => fn(tx))
+    await expect(governanceService.setAutoApply(7, true, null, 3)).rejects.toThrow("approvalRequired")
+    await expect(governanceService.setAutoApply(7, true, { reference: "  " }, 3)).rejects.toThrow("approvalRequired")
+  })
+
+  it("désactivation : pose le flag false SANS approbation", async () => {
+    const tx = mkTx(true)
+    prismaMock.$transaction.mockImplementation(async (fn: any) => fn(tx))
+    const res = await governanceService.setAutoApply(7, false, null, 3)
+    expect(res).toEqual({ autoApply: false, changed: true })
+    expect(tx.governanceApproval.create).not.toHaveBeenCalled()
+    expect(tx.patient.update).toHaveBeenCalledWith({ where: { id: 7 }, data: { autoApply: false } })
+  })
+
+  it("idempotent : déjà à la cible → no-op (pas d'approbation, pas d'update)", async () => {
+    const tx = mkTx(true)
+    prismaMock.$transaction.mockImplementation(async (fn: any) => fn(tx))
+    const res = await governanceService.setAutoApply(7, true, { reference: "GOV-X" }, 3)
+    expect(res).toEqual({ autoApply: true, changed: false })
+    expect(tx.governanceApproval.create).not.toHaveBeenCalled()
+    expect(tx.patient.update).not.toHaveBeenCalled()
+  })
+
+  it("patient absent → patientNotFound", async () => {
+    const tx = mkTx(null)
+    prismaMock.$transaction.mockImplementation(async (fn: any) => fn(tx))
+    await expect(governanceService.setAutoApply(7, false, null, 3)).rejects.toThrow("patientNotFound")
+  })
+})

--- a/tests/unit/governance.service.test.ts
+++ b/tests/unit/governance.service.test.ts
@@ -47,13 +47,24 @@ describe("governanceService.setAutoApply", () => {
     expect(tx.patient.update).toHaveBeenCalledWith({ where: { id: 7 }, data: { autoApply: false } })
   })
 
-  it("idempotent : déjà à la cible → no-op (pas d'approbation, pas d'update)", async () => {
+  it("re-approbation d'un patient déjà ON : trace l'approbation + audit, SANS update de flag", async () => {
     const tx = mkTx(true)
     prismaMock.$transaction.mockImplementation(async (fn: any) => fn(tx))
-    const res = await governanceService.setAutoApply(7, true, { reference: "GOV-X" }, 3)
+    const res = await governanceService.setAutoApply(7, true, { reference: "GOV-REDECISION" }, 3)
     expect(res).toEqual({ autoApply: true, changed: false })
+    expect(tx.governanceApproval.create).toHaveBeenCalled() // la re-décision est tracée
+    expect(tx.auditLog.create).toHaveBeenCalled()
+    expect(tx.patient.update).not.toHaveBeenCalled() // flag inchangé
+  })
+
+  it("désactivation idempotente (déjà OFF) → no-op complet (ni approbation, ni update, ni audit)", async () => {
+    const tx = mkTx(false)
+    prismaMock.$transaction.mockImplementation(async (fn: any) => fn(tx))
+    const res = await governanceService.setAutoApply(7, false, null, 3)
+    expect(res).toEqual({ autoApply: false, changed: false })
     expect(tx.governanceApproval.create).not.toHaveBeenCalled()
     expect(tx.patient.update).not.toHaveBeenCalled()
+    expect(tx.auditLog.create).not.toHaveBeenCalled()
   })
 
   it("patient absent → patientNotFound", async () => {


### PR DESCRIPTION
Première sous-tranche de **Slice C** (auto-application gouvernée). **Frontière MDR — livré INERTE** (double verrou OFF) : rien n'auto-applique. Le **harnais** = C2 ; le **câblage soumission patient** = C3.

## Contenu
- **Schéma** : `Patient.autoApply` (Bool, **défaut false**) + `GovernanceApproval` (artefact d'approbation) + `AutoApplyEvent` (registre append-only, anti-cliquet C7) + migration additive.
- **Kill-switch GLOBAL** `AUTO_APPLY_GLOBALLY_ENABLED` (`env.ts`, `isAutoApplyGloballyEnabled()`, fail-safe + fail-fast au boot) — **prioritaire** sur les flags patient.
- **`governanceService.setAutoApply`** : **activer** exige rôle **ADMIN** + `GovernanceApproval` (référence + DPIA) dans la transaction ; **désactiver** toujours permis (kill fail-safe). Audité `from → to` sans PHI.
- **Route** `PATCH /api/governance/auto-apply` (ADMIN, anti-IDOR, référence obligatoire à l'activation).
- **DPIA** `docs/compliance/dpia-auto-application.md` (RGPD Art. 22 + MDR ; **activation ON subordonnée à signature** DPO/RSSI/MDR).
- Catalogue + tests +12 (service + route RBAC/IDOR).

**Double verrou OFF par défaut** → le harnais (C2) n'auto-appliquera que si kill-switch global **ET** flag patient sont ON.

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **build** · ✅ **3937 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)