### PR TITLE
US-2657 (slice C2a) — Assemblage du contexte d'auto-application (glycémie + cétones + anti-cliquet)

### DIFF
--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -598,6 +598,12 @@ Poser `autoApply = true` = **acte de gouvernance** (pas clinique) : rôle **ADMI
 permise, sans approbation** (kill direction fail-safe). Audité `UPDATE PATIENT` (`from → to`, sans PHI).
 `AutoApplyEvent` (append-only) journalise chaque auto-application effective (alimente l'anti-cliquet C7).
 
+**Assemblage du contexte d'évaluation (slice C2a)** : `buildEnvelopeContext` (`src/lib/insulin/auto-apply-context.ts`)
+met en forme l'entrée de l'enveloppe — fenêtre glycémie (**plancher `AUTO_APPLY_MIN_WINDOW_DAYS` = 14 j**,
+paramétrable au-delà), cétones `GlycemiaEntry.ketones` ∪ `DiabetesEvent.ketones` sur 48 h
+(`AUTO_APPLY_KETONE_BLOCK_LOOKBACK_HOURS`), anti-cliquet depuis `AutoApplyEvent` scopé (patient × paramètre ×
+créneau). Ne décide rien (le double verrou + dispatch = harnais C2b).
+
 L'**activation en production reste subordonnée à la DPIA signée** (`docs/compliance/dpia-auto-application.md`,
 RGPD Art. 22 + MDR). Sources : `src/lib/services/governance.service.ts`, `src/app/api/governance/auto-apply/route.ts`,
 `prisma/schema.prisma` (`GovernanceApproval`, `AutoApplyEvent`).

--- a/src/lib/insulin/auto-apply-context.ts
+++ b/src/lib/insulin/auto-apply-context.ts
@@ -67,6 +67,10 @@ export async function buildEnvelopeContext(
       },
       select: { valueGl: true },
     }),
+    // Récence par `createdAt` (heure d'enregistrement) plutôt que `date`+`time` clinique : `createdAt`
+    // ≥ heure de mesure, donc une cétone ancienne peut au pire paraître PLUS récente (sur-blocage
+    // conservateur) — jamais l'inverse. Fail-safe pour une garde DKA. `DiabetesEvent` a un vrai
+    // timestamp unique (`eventDate`) → filtré dessus directement.
     prisma.glycemiaEntry.findMany({
       where: { patientId, ketones: { not: null }, createdAt: { gte: ketoneStart, lte: now } },
       select: { ketones: true },

--- a/src/lib/insulin/auto-apply-context.ts
+++ b/src/lib/insulin/auto-apply-context.ts
@@ -1,0 +1,107 @@
+/**
+ * US-2657 (slice C2a) — Assemblage du **contexte d'entrée** de l'enveloppe d'auto-application experte.
+ *
+ * Lit (I/O) la fenêtre glycémique, les cétonémies récentes et l'historique anti-cliquet, et les met en
+ * forme pour `evaluateAutoApplyEnvelope` (qui, lui, reste PUR). Ne décide RIEN : ni double verrou, ni
+ * application — c'est le rôle du harnais (C2b). `now` est injecté (testabilité / pas d'horloge cachée).
+ *
+ * Choix de design (US-2657, validés) :
+ *  - **fenêtre paramétrable, plancher 14 j** (`AUTO_APPLY_MIN_WINDOW_DAYS`) — l'auto-application n'évalue
+ *    jamais sur moins que le plancher de suffisance C6b ;
+ *  - **cétones = `GlycemiaEntry.ketones` ∪ `DiabetesEvent.ketones`** sur la fenêtre de récence
+ *    (`AUTO_APPLY_KETONE_BLOCK_LOOKBACK_HOURS` = 48 h) — couvre les deux voies de saisie ;
+ *  - **anti-cliquet** depuis `AutoApplyEvent` scopé (patient × paramètre × créneau).
+ */
+import type { AdjustableParameter } from "@prisma/client"
+import { prisma } from "@/lib/db/client"
+import { decimalToNumber } from "@/lib/db/decimal"
+import { cgmCaptureRate } from "@/lib/statistics"
+import { CLINICAL_BOUNDS, CGM_AGGREGATE_RANGE_GL } from "@/lib/clinical-bounds"
+
+const HOUR_MS = 3_600_000
+const DAY_MS = 86_400_000
+
+export type EnvelopeContext = {
+  glycemia: {
+    glucosesGl: number[]
+    capturePercent: number
+    windowDays: number
+    recentKetonesMmol: number[]
+    ketoneModerateThreshold: number
+  }
+  ratchet: {
+    hoursSinceLastAutoApply: number | null
+    cumulativeAbsPercentThisWeek: number
+  }
+}
+
+/**
+ * Assemble le contexte glycémie + anti-cliquet pour un patient et un créneau donné.
+ * @param patientId Patient (déjà autorisé par l'appelant).
+ * @param parameterType Paramètre édité (pour scoper l'anti-cliquet).
+ * @param slotKey Identifiant du créneau (ex. `"22-06"`) — scope l'anti-cliquet par créneau.
+ * @param ketoneModerateThreshold Seuil modéré cétone du patient (mmol/L ; défaut 1,5 côté appelant).
+ * @param now Instant de référence (injecté).
+ * @param windowDays Fenêtre demandée ; **planchée à `AUTO_APPLY_MIN_WINDOW_DAYS`** (14 j).
+ */
+export async function buildEnvelopeContext(
+  patientId: number,
+  parameterType: AdjustableParameter,
+  slotKey: string,
+  ketoneModerateThreshold: number,
+  now: Date,
+  windowDays?: number,
+): Promise<EnvelopeContext> {
+  const days = Math.max(CLINICAL_BOUNDS.AUTO_APPLY_MIN_WINDOW_DAYS, windowDays ?? CLINICAL_BOUNDS.AUTO_APPLY_MIN_WINDOW_DAYS)
+  const nowMs = now.getTime()
+  const windowStart = new Date(nowMs - days * DAY_MS)
+  const ketoneStart = new Date(nowMs - CLINICAL_BOUNDS.AUTO_APPLY_KETONE_BLOCK_LOOKBACK_HOURS * HOUR_MS)
+  const weekStart = new Date(nowMs - 7 * DAY_MS)
+
+  const [cgm, glyKetones, eventKetones, lastEvent, weekEvents] = await Promise.all([
+    prisma.cgmEntry.findMany({
+      where: {
+        patientId,
+        timestamp: { gte: windowStart, lte: now },
+        valueGl: { gte: CGM_AGGREGATE_RANGE_GL.MIN, lte: CGM_AGGREGATE_RANGE_GL.MAX },
+      },
+      select: { valueGl: true },
+    }),
+    prisma.glycemiaEntry.findMany({
+      where: { patientId, ketones: { not: null }, createdAt: { gte: ketoneStart, lte: now } },
+      select: { ketones: true },
+    }),
+    prisma.diabetesEvent.findMany({
+      where: { patientId, ketones: { not: null }, eventDate: { gte: ketoneStart, lte: now } },
+      select: { ketones: true },
+    }),
+    prisma.autoApplyEvent.findFirst({
+      where: { patientId, parameterType, slotKey },
+      orderBy: { appliedAt: "desc" },
+      select: { appliedAt: true },
+    }),
+    prisma.autoApplyEvent.findMany({
+      where: { patientId, parameterType, slotKey, appliedAt: { gte: weekStart, lte: now } },
+      select: { deltaPercent: true },
+    }),
+  ])
+
+  const glucosesGl = cgm.map((e) => decimalToNumber(e.valueGl))
+  const recentKetonesMmol = [...glyKetones, ...eventKetones]
+    .map((k) => decimalToNumber(k.ketones))
+    .filter((v): v is number => Number.isFinite(v))
+
+  const cumulativeAbsPercentThisWeek = weekEvents.reduce((s, e) => s + Math.abs(e.deltaPercent), 0)
+  const hoursSinceLastAutoApply = lastEvent ? (nowMs - lastEvent.appliedAt.getTime()) / HOUR_MS : null
+
+  return {
+    glycemia: {
+      glucosesGl,
+      capturePercent: cgmCaptureRate(glucosesGl.length, days),
+      windowDays: days,
+      recentKetonesMmol,
+      ketoneModerateThreshold,
+    },
+    ratchet: { hoursSinceLastAutoApply, cumulativeAbsPercentThisWeek },
+  }
+}

--- a/tests/unit/auto-apply-context.test.ts
+++ b/tests/unit/auto-apply-context.test.ts
@@ -1,0 +1,58 @@
+/**
+ * US-2657 (slice C2a) — Assemblage du contexte d'auto-application (glycémie + cétones + anti-cliquet).
+ * Comportement testé : fenêtre planchée à 14 j, union des cétones (2 sources) filtrée, anti-cliquet
+ * scopé (heures depuis dernier + cumul %/7 j).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { prismaMock } from "../helpers/prisma-mock"
+import { buildEnvelopeContext } from "@/lib/insulin/auto-apply-context"
+
+const NOW = new Date("2026-07-08T12:00:00.000Z")
+
+describe("buildEnvelopeContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    prismaMock.cgmEntry.findMany.mockResolvedValue(
+      Array.from({ length: 200 }, () => ({ valueGl: 1.2 })) as never,
+    )
+    prismaMock.glycemiaEntry.findMany.mockResolvedValue([{ ketones: 0.8 }, { ketones: 1.6 }] as never)
+    prismaMock.diabetesEvent.findMany.mockResolvedValue([{ ketones: 2.1 }] as never)
+    prismaMock.autoApplyEvent.findFirst.mockResolvedValue({
+      appliedAt: new Date(NOW.getTime() - 10 * 3_600_000), // 10 h avant
+    } as never)
+    prismaMock.autoApplyEvent.findMany.mockResolvedValue([{ deltaPercent: 4 }, { deltaPercent: -3 }] as never)
+  })
+
+  it("plancher : windowDays 5 demandé → 14 j effectifs", async () => {
+    const ctx = await buildEnvelopeContext(7, "insulinSensitivityFactor", "22-06", 1.5, NOW, 5)
+    expect(ctx.glycemia.windowDays).toBe(14)
+  })
+
+  it("fenêtre plus large respectée (≥ 14)", async () => {
+    const ctx = await buildEnvelopeContext(7, "insulinSensitivityFactor", "22-06", 1.5, NOW, 30)
+    expect(ctx.glycemia.windowDays).toBe(30)
+  })
+
+  it("glucosesGl + capture assemblés ; cétones = union des 2 sources (finies)", async () => {
+    const ctx = await buildEnvelopeContext(7, "insulinSensitivityFactor", "22-06", 1.5, NOW)
+    expect(ctx.glycemia.glucosesGl).toHaveLength(200)
+    expect(ctx.glycemia.glucosesGl[0]).toBe(1.2)
+    expect(ctx.glycemia.capturePercent).toBeGreaterThan(0)
+    expect(ctx.glycemia.recentKetonesMmol).toEqual([0.8, 1.6, 2.1]) // glycemia ∪ event
+    expect(ctx.glycemia.ketoneModerateThreshold).toBe(1.5)
+  })
+
+  it("anti-cliquet : heures depuis dernier + cumul |Δ%| sur 7 j", async () => {
+    const ctx = await buildEnvelopeContext(7, "insulinSensitivityFactor", "22-06", 1.5, NOW)
+    expect(ctx.ratchet.hoursSinceLastAutoApply).toBeCloseTo(10, 5)
+    expect(ctx.ratchet.cumulativeAbsPercentThisWeek).toBe(7) // |4| + |-3|
+  })
+
+  it("aucune auto-application antérieure → hoursSinceLastAutoApply null, cumul 0", async () => {
+    prismaMock.autoApplyEvent.findFirst.mockResolvedValue(null as never)
+    prismaMock.autoApplyEvent.findMany.mockResolvedValue([] as never)
+    const ctx = await buildEnvelopeContext(7, "insulinSensitivityFactor", "22-06", 1.5, NOW)
+    expect(ctx.ratchet.hoursSinceLastAutoApply).toBeNull()
+    expect(ctx.ratchet.cumulativeAbsPercentThisWeek).toBe(0)
+  })
+})

--- a/tests/unit/auto-apply-context.test.ts
+++ b/tests/unit/auto-apply-context.test.ts
@@ -55,4 +55,42 @@ describe("buildEnvelopeContext", () => {
     expect(ctx.ratchet.hoursSinceLastAutoApply).toBeNull()
     expect(ctx.ratchet.cumulativeAbsPercentThisWeek).toBe(0)
   })
+
+  it("scoping : chaque requête est filtrée par patientId (+ plage physiologique CGM, + créneau anti-cliquet)", async () => {
+    await buildEnvelopeContext(7, "insulinSensitivityFactor", "22-06", 1.5, NOW)
+    // CGM : patientId + plage valueGl (empêche une fuite inter-patient ou des valeurs hors plage).
+    expect(prismaMock.cgmEntry.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ patientId: 7, valueGl: expect.objectContaining({ gte: expect.any(Number), lte: expect.any(Number) }) }),
+      }),
+    )
+    // Cétones : patientId + non null, sur les 2 sources.
+    expect(prismaMock.glycemiaEntry.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ patientId: 7, ketones: { not: null } }) }),
+    )
+    expect(prismaMock.diabetesEvent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ patientId: 7, ketones: { not: null } }) }),
+    )
+    // Anti-cliquet : scopé (patient × paramètre × créneau).
+    expect(prismaMock.autoApplyEvent.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ patientId: 7, parameterType: "insulinSensitivityFactor", slotKey: "22-06" }) }),
+    )
+    expect(prismaMock.autoApplyEvent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ patientId: 7, parameterType: "insulinSensitivityFactor", slotKey: "22-06" }) }),
+    )
+  })
+
+  it("CGM vide → glucosesGl [] + capture 0 (données manquantes non masquées)", async () => {
+    prismaMock.cgmEntry.findMany.mockResolvedValue([] as never)
+    const ctx = await buildEnvelopeContext(7, "insulinSensitivityFactor", "22-06", 1.5, NOW)
+    expect(ctx.glycemia.glucosesGl).toEqual([])
+    expect(ctx.glycemia.capturePercent).toBe(0)
+  })
+
+  it("aucune cétone (2 sources vides) → recentKetonesMmol []", async () => {
+    prismaMock.glycemiaEntry.findMany.mockResolvedValue([] as never)
+    prismaMock.diabetesEvent.findMany.mockResolvedValue([] as never)
+    const ctx = await buildEnvelopeContext(7, "insulinSensitivityFactor", "22-06", 1.5, NOW)
+    expect(ctx.glycemia.recentKetonesMmol).toEqual([])
+  })
 })

--- a/tests/unit/auto-apply-context.test.ts
+++ b/tests/unit/auto-apply-context.test.ts
@@ -58,25 +58,35 @@ describe("buildEnvelopeContext", () => {
 
   it("scoping : chaque requête est filtrée par patientId (+ plage physiologique CGM, + créneau anti-cliquet)", async () => {
     await buildEnvelopeContext(7, "insulinSensitivityFactor", "22-06", 1.5, NOW)
-    // CGM : patientId + plage valueGl (empêche une fuite inter-patient ou des valeurs hors plage).
+    // CGM : patientId + plage valueGl + fenêtre temporelle bornée [start, now].
     expect(prismaMock.cgmEntry.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({ patientId: 7, valueGl: expect.objectContaining({ gte: expect.any(Number), lte: expect.any(Number) }) }),
+        where: expect.objectContaining({
+          patientId: 7,
+          valueGl: expect.objectContaining({ gte: expect.any(Number), lte: expect.any(Number) }),
+          timestamp: expect.objectContaining({ gte: expect.any(Date), lte: NOW }),
+        }),
       }),
     )
-    // Cétones : patientId + non null, sur les 2 sources.
+    // Cétones : patientId + non null + récence 48 h bornée, sur les 2 sources.
     expect(prismaMock.glycemiaEntry.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: expect.objectContaining({ patientId: 7, ketones: { not: null } }) }),
+      expect.objectContaining({
+        where: expect.objectContaining({ patientId: 7, ketones: { not: null }, createdAt: expect.objectContaining({ gte: expect.any(Date), lte: NOW }) }),
+      }),
     )
     expect(prismaMock.diabetesEvent.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: expect.objectContaining({ patientId: 7, ketones: { not: null } }) }),
+      expect.objectContaining({
+        where: expect.objectContaining({ patientId: 7, ketones: { not: null }, eventDate: expect.objectContaining({ gte: expect.any(Date), lte: NOW }) }),
+      }),
     )
-    // Anti-cliquet : scopé (patient × paramètre × créneau).
+    // Anti-cliquet : scopé (patient × paramètre × créneau) ; le cumul est borné sur 7 j.
     expect(prismaMock.autoApplyEvent.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({ where: expect.objectContaining({ patientId: 7, parameterType: "insulinSensitivityFactor", slotKey: "22-06" }) }),
     )
     expect(prismaMock.autoApplyEvent.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: expect.objectContaining({ patientId: 7, parameterType: "insulinSensitivityFactor", slotKey: "22-06" }) }),
+      expect.objectContaining({
+        where: expect.objectContaining({ patientId: 7, parameterType: "insulinSensitivityFactor", slotKey: "22-06", appliedAt: expect.objectContaining({ gte: expect.any(Date), lte: NOW }) }),
+      }),
     )
   })
 


### PR DESCRIPTION
Première moitié du **harnais C2**. `buildEnvelopeContext` **lit et met en forme** l'entrée de `evaluateAutoApplyEnvelope` — **ne décide rien** (double verrou + dispatch = **C2b**). Rien ne l'appelle encore.

## Contenu
`buildEnvelopeContext(patientId, parameterType, slotKey, ketoneModerateThreshold, now, windowDays?)` → `{ glycemia, ratchet }` :
- **Fenêtre glycémie** paramétrable, **planchée à `AUTO_APPLY_MIN_WINDOW_DAYS` (14 j)** ; `glucosesGl` (g/L), `capturePercent` (`cgmCaptureRate`), `windowDays`.
- **Cétones** = `GlycemiaEntry.ketones` ∪ `DiabetesEvent.ketones` sur **48 h** (couvre les 2 voies de saisie), valeurs finies.
- **Anti-cliquet** depuis `AutoApplyEvent` scopé (patient × paramètre × créneau) : heures depuis dernier + cumul |Δ%|/7 j.
- `now` **injecté** (pas d'horloge cachée, testable). Réutilise `decimalToNumber`/`cgmCaptureRate`/`CGM_AGGREGATE_RANGE_GL`.

Catalogue + **tests +5**. Vérifs : ✅ tsc · ✅ eslint · ✅ **3945 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)