### PR TITLE
US-2657 (slice C2b) — Harnais gouverné applyExpertEditGoverned (dispatch enveloppe)

### DIFF
--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -604,6 +604,13 @@ paramétrable au-delà), cétones `GlycemiaEntry.ketones` ∪ `DiabetesEvent.ket
 (`AUTO_APPLY_KETONE_BLOCK_LOOKBACK_HOURS`), anti-cliquet depuis `AutoApplyEvent` scopé (patient × paramètre ×
 créneau). Ne décide rien (le double verrou + dispatch = harnais C2b).
 
+**Harnais de dispatch (slice C2b)** : `autoApplyService.applyExpertEditGoverned` (`src/lib/services/auto-apply.service.ts`)
+— double verrou (le kill-switch global force `autoApply = false` → enveloppe C1) → `buildEnvelopeContext` →
+`evaluateAutoApplyEnvelope` → **AUTO_APPLY** (`updateIsf/updateIcr/updatePumpSlot` anti-IDOR + `AutoApplyEvent`
+enregistré **avant** l'apply = sur-comptage anti-cliquet fail-safe + audit) / **FALLBACK_PROPOSAL**
+(`createProposal`, reason `patientRequested`, voie médecin) / **HARD_REJECT** (audit, aucune action). Périmètre :
+créneaux ISF/ICR/basal (la dose fixe suit un autre chemin). L'authz (rôle/portefeuille) est portée par la route (C3).
+
 L'**activation en production reste subordonnée à la DPIA signée** (`docs/compliance/dpia-auto-application.md`,
 RGPD Art. 22 + MDR). Sources : `src/lib/services/governance.service.ts`, `src/app/api/governance/auto-apply/route.ts`,
 `prisma/schema.prisma` (`GovernanceApproval`, `AutoApplyEvent`).

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -611,6 +611,11 @@ enregistré **avant** l'apply = sur-comptage anti-cliquet fail-safe + audit) / *
 (`createProposal`, reason `patientRequested`, voie médecin) / **HARD_REJECT** (audit, aucune action). Périmètre :
 créneaux ISF/ICR/basal (la dose fixe suit un autre chemin). L'authz (rôle/portefeuille) est portée par la route (C3).
 
+**Pré-requis AVANT que C3 rende le harnais live** (revues C2b) : (1) la route DOIT gater **rôle EXPERT +
+patient-owns-record**, résoudre `patientId` côté serveur (anti-énumération, ADR #21) et passer l'`AuditContext` ;
+(2) replier `AutoApplyEvent.create` + apply + audit-décision dans **une seule transaction** (les primitives
+exposent `logWithTx`) pour rendre le marqueur « auto-appliqué sans clinicien » atomique avec l'écriture.
+
 L'**activation en production reste subordonnée à la DPIA signée** (`docs/compliance/dpia-auto-application.md`,
 RGPD Art. 22 + MDR). Sources : `src/lib/services/governance.service.ts`, `src/app/api/governance/auto-apply/route.ts`,
 `prisma/schema.prisma` (`GovernanceApproval`, `AutoApplyEvent`).

--- a/src/lib/services/auto-apply.service.ts
+++ b/src/lib/services/auto-apply.service.ts
@@ -1,0 +1,162 @@
+/**
+ * US-2657 (slice C2b) — **Harnais gouverné de l'auto-application experte** (frontière MDR).
+ *
+ * Point d'entrée où l'enveloppe est ENFIN appelée. Orchestre : **double verrou** (kill-switch global ×
+ * flag patient) → assemblage du contexte (`buildEnvelopeContext`) → décision PURE
+ * (`evaluateAutoApplyEnvelope`) → **dispatch** :
+ *  - `AUTO_APPLY` → applique la valeur du créneau (`updateIsf/updateIcr/updatePumpSlot`, anti-IDOR +
+ *    audit hérités) + enregistre l'`AutoApplyEvent` (anti-cliquet) + audite la décision ;
+ *  - `FALLBACK_PROPOSAL` → crée une `AdjustmentProposal` (reason `patientRequested`) — voie médecin ;
+ *  - `HARD_REJECT` → audite le rejet, n'applique rien.
+ *
+ * **Périmètre** : paramètres à créneau ISF/ICR/basal (ceux du dialogue d'édition de créneaux). La dose
+ * fixe (édition par moment) suit un autre chemin → non supporté ici (rejeté par le type).
+ *
+ * **Autorité** : l'appelant (route C3) est responsable de l'authz (rôle/portefeuille) ; ce service
+ * reçoit un `patientId` déjà autorisé et audite la décision. `now` injecté (pas d'horloge cachée).
+ */
+import type { AdjustableParameter, AdjustmentReason } from "@prisma/client"
+import { prisma } from "@/lib/db/client"
+import { decimalToNumber } from "@/lib/db/decimal"
+import { isAutoApplyGloballyEnabled } from "@/lib/env"
+import { KETONE_DEFAULTS } from "@/lib/services/ketone-threshold.service"
+import { buildEnvelopeContext } from "@/lib/insulin/auto-apply-context"
+import { evaluateAutoApplyEnvelope } from "@/lib/insulin/auto-apply-envelope"
+import { insulinTherapyService } from "@/lib/services/insulin-therapy.service"
+import { adjustmentService, type CreateProposalInput } from "@/lib/services/adjustment.service"
+import { auditService, type AuditContext } from "@/lib/services/audit.service"
+
+/** Paramètres à créneau gérés par le harnais (la dose fixe suit un autre chemin). */
+export type SlotParam = "insulinSensitivityFactor" | "insulinToCarbRatio" | "basalRate"
+
+export type ExpertSlotEdit = {
+  patientId: number
+  parameterType: SlotParam
+  /** Id DB du créneau (ISF/ICR) ou du slot basal — pour l'application anti-IDOR. */
+  slotId: string
+  startHour: number
+  endHour: number
+  currentValue: number
+  proposedValue: number
+  changeKind: "VALUE" | "STRUCTURAL"
+  isfUnit?: "gl" | "mgdl"
+  windowDays?: number
+}
+
+export type GovernedOutcome =
+  | { outcome: "applied" }
+  | { outcome: "proposal"; failedCheck: string; proposalId: string }
+  | { outcome: "rejected"; reason: string }
+
+/** Applique la nouvelle valeur du créneau via la primitive scopée (anti-IDOR + audit hérités). */
+async function applySlotValue(edit: ExpertSlotEdit, actorUserId: number, ctx?: AuditContext): Promise<void> {
+  const { slotId, proposedValue, patientId } = edit
+  switch (edit.parameterType) {
+    case "insulinSensitivityFactor":
+      await insulinTherapyService.updateIsf(slotId, proposedValue, actorUserId, patientId, ctx)
+      return
+    case "insulinToCarbRatio":
+      await insulinTherapyService.updateIcr(slotId, proposedValue, actorUserId, patientId, ctx)
+      return
+    case "basalRate":
+      await insulinTherapyService.updatePumpSlot(slotId, proposedValue, actorUserId, patientId, ctx)
+      return
+  }
+}
+
+/** Construit l'entrée de proposition (voie médecin) — provenance patient, reason `patientRequested`. */
+function toProposalInput(edit: ExpertSlotEdit): CreateProposalInput {
+  const base = {
+    patientId: edit.patientId,
+    parameterType: edit.parameterType as AdjustableParameter,
+    proposedValue: edit.proposedValue,
+    reason: "patientRequested" as AdjustmentReason,
+  }
+  switch (edit.parameterType) {
+    case "insulinSensitivityFactor":
+      return { ...base, timeSlotStartHour: edit.startHour, timeSlotEndHour: edit.endHour }
+    case "insulinToCarbRatio":
+      return { ...base, carbRatioSlotStart: edit.startHour, carbRatioSlotEnd: edit.endHour }
+    case "basalRate":
+      return { ...base, pumpBasalSlotId: edit.slotId }
+  }
+}
+
+/** Audit de la DÉCISION d'enveloppe (trail gouvernance/MDR, sans PHI). */
+async function auditDecision(
+  patientId: number,
+  actorUserId: number,
+  meta: Record<string, unknown>,
+  ctx?: AuditContext,
+): Promise<void> {
+  await auditService.log({
+    userId: actorUserId,
+    action: "UPDATE",
+    resource: "PATIENT",
+    resourceId: String(patientId),
+    ipAddress: ctx?.ipAddress,
+    userAgent: ctx?.userAgent,
+    metadata: { patientId, kind: "autoApplyDecision", ...meta },
+  })
+}
+
+export const autoApplyService = {
+  /**
+   * Évalue et applique/propose/rejette une édition de créneau d'un patient EXPERT, sous gouvernance.
+   * @param edit Édition de créneau (déjà validée/autorisée par l'appelant).
+   * @param actorUserId Acteur (le patient, pour la proposition et l'audit).
+   * @param now Instant de référence (injecté).
+   * @param ctx Contexte requête (audit).
+   * @throws `patientNotFound` si le patient est absent/soft-deleted.
+   */
+  async applyExpertEditGoverned(
+    edit: ExpertSlotEdit,
+    actorUserId: number,
+    now: Date,
+    ctx?: AuditContext,
+  ): Promise<GovernedOutcome> {
+    const { patientId, parameterType, startHour, endHour, currentValue, proposedValue, changeKind, isfUnit, windowDays } = edit
+
+    const patient = await prisma.patient.findFirst({
+      where: { id: patientId, deletedAt: null },
+      select: { maturityLevel: true, autoApply: true },
+    })
+    if (!patient) throw new Error("patientNotFound")
+
+    const kt = await prisma.ketoneThreshold.findUnique({ where: { patientId }, select: { moderateThreshold: true } })
+    const ketoneModerateThreshold = kt ? decimalToNumber(kt.moderateThreshold) : KETONE_DEFAULTS.moderateThreshold
+
+    // Double verrou : le kill-switch global force `autoApply = false` (→ enveloppe C1 → proposition).
+    const globalOn = isAutoApplyGloballyEnabled()
+    const slotKey = `${startHour}-${endHour}`
+
+    const context = await buildEnvelopeContext(patientId, parameterType, slotKey, ketoneModerateThreshold, now, windowDays)
+
+    const decision = evaluateAutoApplyEnvelope({
+      authority: { maturityLevel: patient.maturityLevel, autoApply: globalOn && patient.autoApply },
+      change: { parameterType, changeKind, currentValue, proposedValue, isfUnit },
+      glycemia: context.glycemia,
+      ratchet: context.ratchet,
+    })
+
+    if (decision.decision === "HARD_REJECT") {
+      await auditDecision(patientId, actorUserId, { outcome: "rejected", parameterType, slotKey, reason: decision.reason }, ctx)
+      return { outcome: "rejected", reason: decision.reason }
+    }
+
+    if (decision.decision === "AUTO_APPLY") {
+      const deltaPercent = Math.abs((proposedValue - currentValue) / currentValue) * 100
+      // Enregistré AVANT l'application : sur un échec rare d'apply, l'anti-cliquet SUR-compte
+      // (plus strict = fail-safe), jamais l'inverse (un sous-comptage relâcherait le garde-fou C7).
+      await prisma.autoApplyEvent.create({ data: { patientId, parameterType, slotKey, deltaPercent } })
+      await applySlotValue(edit, actorUserId, ctx)
+      await auditDecision(patientId, actorUserId, { outcome: "applied", parameterType, slotKey, deltaPercent }, ctx)
+      return { outcome: "applied" }
+    }
+
+    // FALLBACK_PROPOSAL — la voie médecin (createProposal audite la création).
+    const proposal = await adjustmentService.createProposal(toProposalInput(edit), { userId: actorUserId, role: "patient" }, ctx)
+    await auditDecision(patientId, actorUserId, { outcome: "proposal", parameterType, slotKey, failedCheck: decision.failedCheck }, ctx)
+    return { outcome: "proposal", failedCheck: decision.failedCheck, proposalId: proposal.id }
+  },
+}

--- a/src/lib/services/auto-apply.service.ts
+++ b/src/lib/services/auto-apply.service.ts
@@ -61,6 +61,12 @@ async function applySlotValue(edit: ExpertSlotEdit, actorUserId: number, ctx?: A
     case "basalRate":
       await insulinTherapyService.updatePumpSlot(slotId, proposedValue, actorUserId, patientId, ctx)
       return
+    default: {
+      // Garde d'exhaustivité : le type retour `void` n'impose pas l'exhaustivité — sans ce `never`,
+      // un futur SlotParam non câblé ferait un no-op silencieux (fail-open : "applied" sans dose appliquée).
+      const _never: never = edit.parameterType
+      throw new Error(`autoApply: unsupported slot parameter ${String(_never)}`)
+    }
   }
 }
 
@@ -149,7 +155,20 @@ export const autoApplyService = {
       // Enregistré AVANT l'application : sur un échec rare d'apply, l'anti-cliquet SUR-compte
       // (plus strict = fail-safe), jamais l'inverse (un sous-comptage relâcherait le garde-fou C7).
       await prisma.autoApplyEvent.create({ data: { patientId, parameterType, slotKey, deltaPercent } })
-      await applySlotValue(edit, actorUserId, ctx)
+      try {
+        await applySlotValue(edit, actorUserId, ctx)
+      } catch (e) {
+        // L'AutoApplyEvent a déjà été écrit (sur-comptage anti-cliquet, fail-safe). On trace l'échec
+        // pour ne pas laisser un événement fantôme sans explication (observabilité HDS/MDR), puis on
+        // relance. L'audit d'échec est best-effort : il ne doit pas masquer l'erreur d'origine.
+        await auditDecision(
+          patientId,
+          actorUserId,
+          { outcome: "applyFailed", parameterType, slotKey, deltaPercent, error: e instanceof Error ? e.message : "unknown" },
+          ctx,
+        ).catch(() => {})
+        throw e
+      }
       await auditDecision(patientId, actorUserId, { outcome: "applied", parameterType, slotKey, deltaPercent }, ctx)
       return { outcome: "applied" }
     }

--- a/tests/unit/auto-apply.service.test.ts
+++ b/tests/unit/auto-apply.service.test.ts
@@ -1,0 +1,114 @@
+/**
+ * US-2657 (slice C2b) — Harnais gouverné `applyExpertEditGoverned`.
+ * Comportement testé : dispatch par décision (AUTO_APPLY → apply + AutoApplyEvent + audit ;
+ * FALLBACK → proposition patient ; HARD_REJECT → audit sans action) ; **double verrou** (kill-switch
+ * global force autoApply=false) ; patient scopé.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { prismaMock } from "../helpers/prisma-mock"
+
+vi.mock("@/lib/env", () => ({ isAutoApplyGloballyEnabled: vi.fn() }))
+vi.mock("@/lib/insulin/auto-apply-context", () => ({ buildEnvelopeContext: vi.fn() }))
+vi.mock("@/lib/insulin/auto-apply-envelope", () => ({ evaluateAutoApplyEnvelope: vi.fn() }))
+vi.mock("@/lib/services/insulin-therapy.service", () => ({
+  insulinTherapyService: { updateIsf: vi.fn(), updateIcr: vi.fn(), updatePumpSlot: vi.fn() },
+}))
+vi.mock("@/lib/services/adjustment.service", () => ({
+  adjustmentService: { createProposal: vi.fn().mockResolvedValue({ id: "prop-1" }) },
+}))
+vi.mock("@/lib/services/audit.service", () => ({ auditService: { log: vi.fn() } }))
+
+const { autoApplyService } = await import("@/lib/services/auto-apply.service")
+const { isAutoApplyGloballyEnabled } = await import("@/lib/env")
+const { buildEnvelopeContext } = await import("@/lib/insulin/auto-apply-context")
+const { evaluateAutoApplyEnvelope } = await import("@/lib/insulin/auto-apply-envelope")
+const { insulinTherapyService } = await import("@/lib/services/insulin-therapy.service")
+const { adjustmentService } = await import("@/lib/services/adjustment.service")
+
+const globalOn = vi.mocked(isAutoApplyGloballyEnabled)
+const buildCtx = vi.mocked(buildEnvelopeContext)
+const evaluate = vi.mocked(evaluateAutoApplyEnvelope)
+const NOW = new Date("2026-07-08T12:00:00Z")
+
+const isfEdit = {
+  patientId: 7,
+  parameterType: "insulinSensitivityFactor" as const,
+  slotId: "isf-1",
+  startHour: 22,
+  endHour: 6,
+  currentValue: 0.5,
+  proposedValue: 0.48,
+  changeKind: "VALUE" as const,
+  isfUnit: "gl" as const,
+}
+
+describe("autoApplyService.applyExpertEditGoverned", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    globalOn.mockReturnValue(true)
+    prismaMock.patient.findFirst.mockResolvedValue({ maturityLevel: "EXPERT", autoApply: true } as never)
+    prismaMock.ketoneThreshold.findUnique.mockResolvedValue({ moderateThreshold: 1.5 } as never)
+    prismaMock.autoApplyEvent.create.mockResolvedValue({ id: 1 } as never)
+    buildCtx.mockResolvedValue({
+      glycemia: { glucosesGl: [], capturePercent: 80, windowDays: 14, recentKetonesMmol: [], ketoneModerateThreshold: 1.5 },
+      ratchet: { hoursSinceLastAutoApply: null, cumulativeAbsPercentThisWeek: 0 },
+    } as never)
+  })
+
+  it("AUTO_APPLY (ISF) → applique + AutoApplyEvent + audit ; outcome applied", async () => {
+    evaluate.mockReturnValue({ decision: "AUTO_APPLY" } as never)
+    const res = await autoApplyService.applyExpertEditGoverned(isfEdit, 7, NOW)
+    expect(res).toEqual({ outcome: "applied" })
+    expect(insulinTherapyService.updateIsf).toHaveBeenCalledWith("isf-1", 0.48, 7, 7, undefined)
+    expect(prismaMock.autoApplyEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ patientId: 7, parameterType: "insulinSensitivityFactor", slotKey: "22-6" }) }),
+    )
+    expect(adjustmentService.createProposal).not.toHaveBeenCalled()
+  })
+
+  it("AUTO_APPLY (basal) → updatePumpSlot", async () => {
+    evaluate.mockReturnValue({ decision: "AUTO_APPLY" } as never)
+    await autoApplyService.applyExpertEditGoverned(
+      { ...isfEdit, parameterType: "basalRate", slotId: "pump-3", currentValue: 0.8, proposedValue: 0.85, isfUnit: undefined },
+      7,
+      NOW,
+    )
+    expect(insulinTherapyService.updatePumpSlot).toHaveBeenCalledWith("pump-3", 0.85, 7, 7, undefined)
+  })
+
+  it("FALLBACK_PROPOSAL → proposition patient (reason patientRequested) ; outcome proposal", async () => {
+    evaluate.mockReturnValue({ decision: "FALLBACK_PROPOSAL", failedCheck: "C6b" } as never)
+    const res = await autoApplyService.applyExpertEditGoverned(isfEdit, 7, NOW)
+    expect(res).toEqual({ outcome: "proposal", failedCheck: "C6b", proposalId: "prop-1" })
+    expect(adjustmentService.createProposal).toHaveBeenCalledWith(
+      expect.objectContaining({ patientId: 7, parameterType: "insulinSensitivityFactor", reason: "patientRequested", timeSlotStartHour: 22, timeSlotEndHour: 6 }),
+      { userId: 7, role: "patient" },
+      undefined,
+    )
+    expect(insulinTherapyService.updateIsf).not.toHaveBeenCalled()
+    expect(prismaMock.autoApplyEvent.create).not.toHaveBeenCalled()
+  })
+
+  it("HARD_REJECT → aucune action, audit rejet ; outcome rejected", async () => {
+    evaluate.mockReturnValue({ decision: "HARD_REJECT", reason: "outOfClinicalBounds" } as never)
+    const res = await autoApplyService.applyExpertEditGoverned(isfEdit, 7, NOW)
+    expect(res).toEqual({ outcome: "rejected", reason: "outOfClinicalBounds" })
+    expect(insulinTherapyService.updateIsf).not.toHaveBeenCalled()
+    expect(adjustmentService.createProposal).not.toHaveBeenCalled()
+    expect(prismaMock.autoApplyEvent.create).not.toHaveBeenCalled()
+  })
+
+  it("double verrou : kill-switch global OFF → autoApply=false transmis à l'enveloppe", async () => {
+    globalOn.mockReturnValue(false)
+    evaluate.mockReturnValue({ decision: "FALLBACK_PROPOSAL", failedCheck: "C1" } as never)
+    await autoApplyService.applyExpertEditGoverned(isfEdit, 7, NOW) // patient.autoApply = true
+    expect(evaluate).toHaveBeenCalledWith(
+      expect.objectContaining({ authority: { maturityLevel: "EXPERT", autoApply: false } }),
+    )
+  })
+
+  it("patient absent/soft-deleted → patientNotFound", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue(null as never)
+    await expect(autoApplyService.applyExpertEditGoverned(isfEdit, 7, NOW)).rejects.toThrow("patientNotFound")
+  })
+})

--- a/tests/unit/auto-apply.service.test.ts
+++ b/tests/unit/auto-apply.service.test.ts
@@ -24,6 +24,7 @@ const { buildEnvelopeContext } = await import("@/lib/insulin/auto-apply-context"
 const { evaluateAutoApplyEnvelope } = await import("@/lib/insulin/auto-apply-envelope")
 const { insulinTherapyService } = await import("@/lib/services/insulin-therapy.service")
 const { adjustmentService } = await import("@/lib/services/adjustment.service")
+const { auditService } = await import("@/lib/services/audit.service")
 
 const globalOn = vi.mocked(isAutoApplyGloballyEnabled)
 const buildCtx = vi.mocked(buildEnvelopeContext)
@@ -104,6 +105,33 @@ describe("autoApplyService.applyExpertEditGoverned", () => {
     await autoApplyService.applyExpertEditGoverned(isfEdit, 7, NOW) // patient.autoApply = true
     expect(evaluate).toHaveBeenCalledWith(
       expect.objectContaining({ authority: { maturityLevel: "EXPERT", autoApply: false } }),
+    )
+  })
+
+  it("AUTO_APPLY (ICR) → updateIcr ; deltaPercent correct + audit décision 'applied'", async () => {
+    evaluate.mockReturnValue({ decision: "AUTO_APPLY" } as never)
+    await autoApplyService.applyExpertEditGoverned(
+      { ...isfEdit, parameterType: "insulinToCarbRatio", slotId: "icr-2", currentValue: 10, proposedValue: 10.5, isfUnit: undefined },
+      7,
+      NOW,
+    )
+    expect(insulinTherapyService.updateIcr).toHaveBeenCalledWith("icr-2", 10.5, 7, 7, undefined)
+    // deltaPercent = |(10.5-10)/10|*100 = 5
+    expect(prismaMock.autoApplyEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ deltaPercent: 5 }) }),
+    )
+    expect(auditService.log).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: expect.objectContaining({ kind: "autoApplyDecision", outcome: "applied" }) }),
+    )
+  })
+
+  it("échec d'apply : AutoApplyEvent déjà écrit (avant) + audit 'applyFailed' + rethrow", async () => {
+    evaluate.mockReturnValue({ decision: "AUTO_APPLY" } as never)
+    vi.mocked(insulinTherapyService.updateIsf).mockRejectedValueOnce(new Error("isfSlotNotFound"))
+    await expect(autoApplyService.applyExpertEditGoverned(isfEdit, 7, NOW)).rejects.toThrow("isfSlotNotFound")
+    expect(prismaMock.autoApplyEvent.create).toHaveBeenCalled() // écrit AVANT l'apply (sur-comptage fail-safe)
+    expect(auditService.log).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: expect.objectContaining({ outcome: "applyFailed" }) }),
     )
   })
 


### PR DESCRIPTION
Deuxième moitié du **harnais C2** : le point où l'enveloppe est **enfin appelée**. **Toujours INERTE en prod** (kill-switch global OFF force `autoApply=false` → toute édition part en proposition). Aucune route live ne l'appelle encore (**câblage = C3**).

## Contenu
`autoApplyService.applyExpertEditGoverned(edit, actorUserId, now, ctx)` :
**double verrou** (kill-switch global × `Patient.autoApply`) → `buildEnvelopeContext` → `evaluateAutoApplyEnvelope` → **dispatch** :
- **AUTO_APPLY** : `updateIsf/updateIcr/updatePumpSlot` (anti-IDOR + audit hérités) + `AutoApplyEvent` enregistré **AVANT** l'apply (sur-comptage anti-cliquet = fail-safe, jamais sous-comptage) + audit décision ;
- **FALLBACK_PROPOSAL** : `createProposal` (provenance **patient**, reason `patientRequested`) — voie médecin ;
- **HARD_REJECT** : audit du rejet, aucune action.

Périmètre : créneaux **ISF/ICR/basal** (dose fixe = autre chemin, non supporté ici). `now` injecté. L'**authz** (rôle/portefeuille) est portée par la **route C3** ; le service reçoit un `patientId` autorisé + audite la décision.

Catalogue + **tests +6**. Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3954 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)