### PR TITLE
US-2657 (slice C3a) — Modèle + service « proposition d'ensemble de créneaux »

### DIFF
--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -622,11 +622,32 @@ RGPD Art. 22 + MDR). Sources : `src/lib/services/governance.service.ts`, `src/ap
 
 ### Proposition d'ensemble de créneaux (US-2657 slice C3)
 
-`SlotSetProposal` (`prisma/schema.prisma`, service `src/lib/services/slot-set-proposal.service.ts`) — comble
-l'absence de « proposition de disposition entière » (l'`AdjustmentProposal` est par-valeur). Une édition de
-GROUPE d'un patient EXPERT (valeurs et/ou **restructuration** : ajout/suppression/déplacement d'heures) qui ne
-peut **pas** s'auto-appliquer (hors enveloppe C1–C8, ou structurelle) est stockée **en bloc** (`proposedSlots`
-JSON) pour **revue MÉDECIN** : **accepter** applique la disposition via `replaceSlotSet` (bloc atomique) ;
-**refuser** la classe `rejected`. Invariant : **une seule proposition d'ensemble PENDING par (patient ×
-paramètre)** (une nouvelle supersède la précédente). Statuts = `ProposalStatus`. Jamais de PHI (valeurs de config).
-Sources : orchestrateur `applyExpertGroupGoverned` (C3b, appelant), routes patient (C3c) / médecin (C3d).
+`SlotSetProposal` (`prisma/schema.prisma`, service `src/lib/services/slot-set-proposal.service.ts`).
+**Décision US-2657 : on ne propose plus par-valeur — toute édition patient EXPERT non auto-appliquée est
+proposée GROUPÉE (disposition entière du jeu de créneaux), quel que soit le nombre de valeurs modifiées.**
+Ce modèle REMPLACE la voie par-valeur `AdjustmentProposal` pour ce cas. Une édition de GROUPE d'un patient
+EXPERT (valeurs et/ou **restructuration** : ajout/suppression/déplacement d'heures) qui ne peut **pas**
+s'auto-appliquer (hors enveloppe C1–C8, ou structurelle) est stockée **en bloc** (`proposedSlots` JSON) pour
+**revue MÉDECIN**.
+
+- **Validation DÈS la création** (symétrie création ⇄ acceptation) : `assertValidSlotSet` applique bornes
+  cliniques ISF/ICR, durée non nulle, **no-overlap + no-gap strict** (le bolus doit toujours résoudre un
+  créneau). Une proposition inacceptable ne peut pas être créée (pas de « zombie » figée en attente).
+- **Frontière dispositif médical** : refus `nonInsulinNoDose` pour un patient NON INSULINÉ (mode dérivé
+  serveur, fail-closed) — jamais de proposition de dose. Patient soft-deleted (RGPD) exclu (`patientNotFound`).
+- **Acceptation ATOMIQUE** : lecture + flip gardé (compare-and-swap `pending → accepted`) + application
+  `replaceSlotSet` + audit dans **une seule transaction**. Un rejet/supersede concurrent (flip `count 0`) ou
+  un échec clinique de `replaceSlotSet` (bornes/couverture) **rollback tout** → jamais de config appliquée
+  sans acceptation valide, ni l'inverse (fail-closed). **Refuser** → statut `rejected`.
+- **Supersede croisé** : à la création d'une proposition d'ensemble, ET à tout remplacement direct du jeu par
+  un médecin (`replaceSlotSet`), les propositions `pending` du même `(patient × paramètre)` — **d'ensemble ET
+  par-valeur** — sont supersédées (empêche la réapplication d'un jeu périmé qui écraserait un ajustement
+  médecin plus récent, ex. baisse d'insuline post-hypo).
+
+Invariant : **une seule proposition d'ensemble PENDING par (patient × paramètre)** — **garanti en base** par
+l'index unique partiel `slot_set_proposals_one_pending_per_param` (`WHERE status = 'pending'`, migration
+20260714100000 ; violation TOCTOU → P2002 → `duplicatePendingProposal`, détection via
+`isUniqueViolationOn`/`driverAdapterError` robuste à Prisma 7 + adapter-pg). Statuts = `ProposalStatus`.
+Audit dédié `resource = SLOT_SET_PROPOSAL` (CREATE / PROPOSAL_ACCEPTED / PROPOSAL_REJECTED / READ), jamais de
+PHI (valeurs de config, `metadata.patientId` pivot US-2268). Sources : orchestrateur `applyExpertGroupGoverned`
+(C3b, appelant), routes patient (C3c) / médecin (C3d).

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -619,3 +619,14 @@ exposent `logWithTx`) pour rendre le marqueur « auto-appliqué sans clinicien �
 L'**activation en production reste subordonnée à la DPIA signée** (`docs/compliance/dpia-auto-application.md`,
 RGPD Art. 22 + MDR). Sources : `src/lib/services/governance.service.ts`, `src/app/api/governance/auto-apply/route.ts`,
 `prisma/schema.prisma` (`GovernanceApproval`, `AutoApplyEvent`).
+
+### Proposition d'ensemble de créneaux (US-2657 slice C3)
+
+`SlotSetProposal` (`prisma/schema.prisma`, service `src/lib/services/slot-set-proposal.service.ts`) — comble
+l'absence de « proposition de disposition entière » (l'`AdjustmentProposal` est par-valeur). Une édition de
+GROUPE d'un patient EXPERT (valeurs et/ou **restructuration** : ajout/suppression/déplacement d'heures) qui ne
+peut **pas** s'auto-appliquer (hors enveloppe C1–C8, ou structurelle) est stockée **en bloc** (`proposedSlots`
+JSON) pour **revue MÉDECIN** : **accepter** applique la disposition via `replaceSlotSet` (bloc atomique) ;
+**refuser** la classe `rejected`. Invariant : **une seule proposition d'ensemble PENDING par (patient ×
+paramètre)** (une nouvelle supersède la précédente). Statuts = `ProposalStatus`. Jamais de PHI (valeurs de config).
+Sources : orchestrateur `applyExpertGroupGoverned` (C3b, appelant), routes patient (C3c) / médecin (C3d).

--- a/prisma/migrations/20260714100000_us2657c3_slot_set_proposal/migration.sql
+++ b/prisma/migrations/20260714100000_us2657c3_slot_set_proposal/migration.sql
@@ -1,0 +1,23 @@
+-- US-2657 (slice C3) — Proposition d'ENSEMBLE de créneaux (fallback groupe patient EXPERT).
+-- Additif, non destructif.
+
+-- CreateTable
+CREATE TABLE "slot_set_proposals" (
+    "id" TEXT NOT NULL,
+    "patient_id" INTEGER NOT NULL,
+    "parameter_type" "AdjustableParameter" NOT NULL,
+    "proposed_slots" JSONB NOT NULL,
+    "status" "ProposalStatus" NOT NULL DEFAULT 'pending',
+    "proposed_by_user_id" INTEGER NOT NULL,
+    "reviewed_by_user_id" INTEGER,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "reviewed_at" TIMESTAMP(3),
+
+    CONSTRAINT "slot_set_proposals_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "slot_set_proposals_patient_id_status_idx" ON "slot_set_proposals"("patient_id", "status");
+
+-- AddForeignKey
+ALTER TABLE "slot_set_proposals" ADD CONSTRAINT "slot_set_proposals_patient_id_fkey" FOREIGN KEY ("patient_id") REFERENCES "patients"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260714100000_us2657c3_slot_set_proposal/migration.sql
+++ b/prisma/migrations/20260714100000_us2657c3_slot_set_proposal/migration.sql
@@ -10,14 +10,24 @@ CREATE TABLE "slot_set_proposals" (
     "status" "ProposalStatus" NOT NULL DEFAULT 'pending',
     "proposed_by_user_id" INTEGER NOT NULL,
     "reviewed_by_user_id" INTEGER,
-    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "reviewed_at" TIMESTAMP(3),
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "reviewed_at" TIMESTAMPTZ,
 
     CONSTRAINT "slot_set_proposals_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateIndex
-CREATE INDEX "slot_set_proposals_patient_id_status_idx" ON "slot_set_proposals"("patient_id", "status");
+CREATE INDEX "slot_set_proposals_patient_id_status_created_at_idx" ON "slot_set_proposals"("patient_id", "status", "created_at");
 
 -- AddForeignKey
 ALTER TABLE "slot_set_proposals" ADD CONSTRAINT "slot_set_proposals_patient_id_fkey" FOREIGN KEY ("patient_id") REFERENCES "patients"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Index UNIQUE PARTIEL : au plus UNE proposition d'ensemble `pending` par (patient, paramètre).
+-- Rend l'invariant « une seule PENDING » robuste EN BASE (pas seulement dans le supersede applicatif) :
+-- ferme la course TOCTOU de deux soumissions simultanées → violation P2002 → `duplicatePendingProposal`
+-- (cf. slot-set-proposal.service.ts::createSetProposal). Prisma ne modélise pas les index PARTIELS (WHERE)
+-- → invisible au drift-gate ; livré en migration versionnée (auto-appliqué par `migrate deploy`), comme
+-- `adjustment_proposals_one_pending_per_slot` (US-2649a, migration 20260705100000).
+CREATE UNIQUE INDEX IF NOT EXISTS "slot_set_proposals_one_pending_per_param"
+  ON "slot_set_proposals" ("patient_id", "parameter_type")
+  WHERE "status" = 'pending';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -701,6 +701,7 @@ model Patient {
   autoApply     Boolean       @default(false) @map("auto_apply")
   governanceApprovals GovernanceApproval[]
   autoApplyEvents     AutoApplyEvent[]
+  slotSetProposals    SlotSetProposal[]
   /// US-2646 — mode de traitement (basalBolus / fixedDose / nonInsulin). CACHE
   /// d'affichage/filtrage UNIQUEMENT. ⚠️ NE PAS lire cette colonne brute pour une
   /// décision logique : source de vérité = `resolveTreatmentMode()` (US-2647, dérivé
@@ -821,6 +822,28 @@ model AutoApplyEvent {
 
   @@index([patientId, parameterType, appliedAt])
   @@map("auto_apply_events")
+}
+
+/// US-2657 (slice C3) — **Proposition d'ENSEMBLE de créneaux** (US-2657 Option 2). Représente une édition
+/// de groupe (valeurs ET/OU restructuration) qu'un patient EXPERT soumet mais qui ne peut PAS s'auto-appliquer
+/// (hors enveloppe ou structurelle) : elle est stockée en bloc pour revue MÉDECIN (accept en bloc →
+/// `replaceSlotSet`, ou reject). Comble l'absence de représentation « proposition de disposition entière »
+/// (l'`AdjustmentProposal` étant par-valeur). Une seule proposition d'ensemble PENDING par (patient × paramètre).
+model SlotSetProposal {
+  id               String              @id @default(uuid())
+  patientId        Int                 @map("patient_id")
+  patient          Patient             @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  parameterType    AdjustableParameter @map("parameter_type") // isf/icr (paramètres à jeu de créneaux)
+  /// Disposition proposée : `[{ startHour, endHour, value, mealLabel? }]` (JSON — pas de PHI, valeurs de config).
+  proposedSlots    Json                @map("proposed_slots")
+  status           ProposalStatus      @default(pending)
+  proposedByUserId Int                 @map("proposed_by_user_id")
+  reviewedByUserId Int?                @map("reviewed_by_user_id")
+  createdAt        DateTime            @default(now()) @map("created_at")
+  reviewedAt       DateTime?           @map("reviewed_at")
+
+  @@index([patientId, status])
+  @@map("slot_set_proposals")
 }
 
 /// US-2603 — Dossiers patients récemment consultés par un PS (switcher de

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -827,8 +827,12 @@ model AutoApplyEvent {
 /// US-2657 (slice C3) — **Proposition d'ENSEMBLE de créneaux** (US-2657 Option 2). Représente une édition
 /// de groupe (valeurs ET/OU restructuration) qu'un patient EXPERT soumet mais qui ne peut PAS s'auto-appliquer
 /// (hors enveloppe ou structurelle) : elle est stockée en bloc pour revue MÉDECIN (accept en bloc →
-/// `replaceSlotSet`, ou reject). Comble l'absence de représentation « proposition de disposition entière »
-/// (l'`AdjustmentProposal` étant par-valeur). Une seule proposition d'ensemble PENDING par (patient × paramètre).
+/// `replaceSlotSet`, ou reject). ⚠️ US-2657 : **on ne propose plus par-valeur** — toute édition patient EXPERT
+/// non auto-appliquée est proposée GROUPÉE (disposition entière), quel que soit le nombre de valeurs modifiées ;
+/// REMPLACE la voie par-valeur `AdjustmentProposal` pour ce cas. Une seule proposition d'ensemble PENDING par
+/// (patient × paramètre) — garanti en base par l'index unique PARTIEL `slot_set_proposals_one_pending_per_param`
+/// (`WHERE status = 'pending'`), défini en SQL uniquement (Prisma ne modélise pas le WHERE côté `@@index`,
+/// cf. migration 20260714100000).
 model SlotSetProposal {
   id               String              @id @default(uuid())
   patientId        Int                 @map("patient_id")
@@ -839,10 +843,13 @@ model SlotSetProposal {
   status           ProposalStatus      @default(pending)
   proposedByUserId Int                 @map("proposed_by_user_id")
   reviewedByUserId Int?                @map("reviewed_by_user_id")
-  createdAt        DateTime            @default(now()) @map("created_at")
-  reviewedAt       DateTime?           @map("reviewed_at")
+  // Timestamptz — aligné sur le modèle sœur `AdjustmentProposal` (tri/affichage stables cross-timezone).
+  createdAt        DateTime            @default(now()) @map("created_at") @db.Timestamptz()
+  reviewedAt       DateTime?           @map("reviewed_at") @db.Timestamptz()
 
-  @@index([patientId, status])
+  // `createdAt` en 3e colonne : couvre `listSetProposals` (where patientId[+status] orderBy createdAt desc),
+  // comme `AdjustmentProposal`.
+  @@index([patientId, status, createdAt])
   @@map("slot_set_proposals")
 }
 

--- a/src/lib/db/prisma-errors.ts
+++ b/src/lib/db/prisma-errors.ts
@@ -1,0 +1,58 @@
+/**
+ * @module db/prisma-errors
+ * @description Helpers de reconnaissance d'erreurs Prisma, robustes à la stack Prisma 7 + driver adapter.
+ *
+ * ⚠️ Prisma 7 (`@prisma/adapter-pg`) a changé la forme de `PrismaClientKnownRequestError.meta` :
+ * pour un `P2002` (violation d'unicité), **`meta.target` est désormais `undefined`**. Le nom de la
+ * contrainte violée ne vit plus que dans `meta.driverAdapterError.cause.originalMessage` (message SQL brut
+ * type `duplicate key value violates unique constraint "<name>"`) et/ou `…cause.constraint`. Le code qui ne
+ * lit que `meta.target` (pattern legacy pré-adapter) ne matche donc **jamais** en production → le P2002 brut
+ * remonte au lieu de l'erreur métier attendue. Ce helper lit les DEUX formes (nouvelle + legacy fallback).
+ */
+
+/** Forme partielle d'un `PrismaClientKnownRequestError` couvrant legacy + driver adapter (Prisma 7). */
+type PrismaErrorLike = {
+  code?: string
+  meta?: {
+    /** Legacy engine (pré-adapter) : colonnes ou nom d'index. */
+    target?: unknown
+    /** Prisma 7 + adapter-pg : le nom de contrainte est dans le message SQL brut. */
+    driverAdapterError?: {
+      cause?: {
+        originalMessage?: string
+        constraint?: { index?: string; fields?: string[] }
+      }
+    }
+  }
+}
+
+/**
+ * Vrai si `e` est une violation de contrainte unique (`P2002`) dont l'identité (nom d'index/contrainte,
+ * colonnes, ou message SQL) contient `fragment`. Restreindre au fragment évite de re-mapper à tort
+ * n'importe quel P2002 sans rapport (cf. revue adjustment.service).
+ *
+ * @param e - erreur capturée (unknown).
+ * @param fragment - sous-chaîne discriminante du nom d'index/contrainte (ex. `"one_pending"`).
+ */
+export function isUniqueViolationOn(e: unknown, fragment: string): boolean {
+  const err = e as PrismaErrorLike
+  if (err?.code !== "P2002") return false
+
+  // Legacy : meta.target = string[] (colonnes) ou string.
+  const target = Array.isArray(err.meta?.target)
+    ? err.meta!.target.join(",")
+    : String(err.meta?.target ?? "")
+
+  // Prisma 7 + adapter-pg : nom de contrainte dans le message SQL brut / constraint.
+  const cause = err.meta?.driverAdapterError?.cause
+  const causeMsg = cause?.originalMessage ?? ""
+  const causeIndex = cause?.constraint?.index ?? ""
+  const causeFields = Array.isArray(cause?.constraint?.fields) ? cause.constraint!.fields!.join(",") : ""
+
+  return (
+    target.includes(fragment) ||
+    causeMsg.includes(fragment) ||
+    causeIndex.includes(fragment) ||
+    causeFields.includes(fragment)
+  )
+}

--- a/src/lib/services/audit.service.ts
+++ b/src/lib/services/audit.service.ts
@@ -114,6 +114,9 @@ export type AuditResource =
   | "INSULIN_THERAPY"
   | "BOLUS_LOG"
   | "ADJUSTMENT_PROPOSAL"
+  /** US-2657 (slice C3) — proposition d'ENSEMBLE de créneaux (table `slot_set_proposals`, distincte
+   * d'`adjustment_proposals` par-valeur) : resourceId = SlotSetProposal.id, metadata.patientId pivot. */
+  | "SLOT_SET_PROPOSAL"
   | "CLINICAL_REVIEW_FLAG"
   | "MEDICAL_DOCUMENT"
   | "PINNED_PATIENT"

--- a/src/lib/services/insulin-therapy.service.ts
+++ b/src/lib/services/insulin-therapy.service.ts
@@ -45,9 +45,48 @@ export interface BasalConfigInput {
  * @namespace insulinTherapyService
  */
 /**
+ * US-2657 — Pré-validation PURE (hors DB) d'un jeu complet de créneaux ISF/ICR, réutilisée par
+ * `replaceSlotSet` (application directe DOCTOR) ET `createSetProposal` (soumission d'une proposition
+ * d'ENSEMBLE) : une proposition qui ne pourra JAMAIS être appliquée ne doit pas pouvoir être créée
+ * (fail-fast, symétrie création ⇄ acceptation). Bornes cliniques de valeur, durée non nulle,
+ * no-overlap et **no-gap strict** (le bolus doit toujours résoudre un créneau). Source de vérité
+ * unique des invariants de couverture ISF/ICR.
+ * @param param - `"isf"` (value = g/L) ou `"icr"` (value = g/U).
+ * @param slots - jeu complet `{ startHour, endHour, value, mealLabel? }`.
+ * @returns couverture calculée (`{ hasGap, hasOverlap }`), réutilisable par l'appelant.
+ * @throws emptySlotSet | zeroDurationSlot | valueOutOfBounds | slotOverlap | slotGap
+ */
+export function assertValidSlotSet(
+  param: "isf" | "icr",
+  slots: Array<{ startHour: number; endHour: number; value: number; mealLabel?: string }>,
+): { hasGap: boolean; hasOverlap: boolean } {
+  if (slots.length === 0) throw new Error("emptySlotSet")
+  const [valMin, valMax] =
+    param === "isf"
+      ? [CLINICAL_BOUNDS.ISF_GL_MIN, CLINICAL_BOUNDS.ISF_GL_MAX]
+      : [CLINICAL_BOUNDS.ICR_MIN, CLINICAL_BOUNDS.ICR_MAX]
+  for (const s of slots) {
+    if (s.startHour === s.endHour) throw new Error("zeroDurationSlot")
+    // Bornes cliniques re-vérifiées côté service (défense en profondeur) : sûr même appelé
+    // directement, pas seulement via la route Zod (US-2655, revue medical).
+    if (s.value < valMin || s.value > valMax) throw new Error("valueOutOfBounds")
+  }
+  const coverage = analyzeSlotCoverage(slots.map((s) => ({ start: s.startHour * 60, end: s.endHour * 60 })))
+  if (coverage.hasOverlap) throw new Error("slotOverlap")
+  if (coverage.hasGap) throw new Error("slotGap") // ISF/ICR : no-gap strict (le bolus doit résoudre)
+  return coverage
+}
+
+/**
  * US-2655 — Fin commune du remplacement de groupe (ISF/ICR), dans la transaction :
- * supersède les propositions `pending` du paramètre (baseline changé → libère `one_pending_per_slot`)
- * puis journalise l'audit `replaceSet` (`from → to`, sans PHI). Retourne le résumé.
+ * supersède les propositions `pending` du paramètre (baseline changé) puis journalise l'audit
+ * `replaceSet` (`from → to`, sans PHI). Retourne le résumé.
+ *
+ * ⚠️ Supersède les DEUX familles de propositions du même `(patient × parameterType)` :
+ *  - `AdjustmentProposal` par-valeur (libère `adjustment_proposals_one_pending_per_slot`) ;
+ *  - `SlotSetProposal` d'ENSEMBLE (US-2657 : libère `slot_set_proposals_one_pending_per_param` et empêche
+ *    qu'un jeu de créneaux PÉRIMÉ soit réappliqué plus tard — sinon l'accepter écraserait un ajustement
+ *    médecin plus récent, ex. une baisse d'insuline post-hypo).
  */
 async function finishReplaceSet(
   tx: Prisma.TransactionClient,
@@ -65,6 +104,7 @@ async function finishReplaceSet(
   count: number
   coverage: { hasGap: boolean; hasOverlap: boolean }
   supersededProposalIds: string[]
+  supersededSetProposalIds: string[]
 }> {
   // findMany puis updateMany partagent le même `where`. Une proposition `pending` insérée entre les
   // deux (course TOCTOU) serait supersédée sans figurer dans `supersededProposalIds` (sous-report du
@@ -81,6 +121,21 @@ async function finishReplaceSet(
   }
   const supersededProposalIds = superseded.map((p) => p.id)
 
+  // US-2657 — mêmes semantiques pour les propositions d'ENSEMBLE (`SlotSetProposal`). Ne touche PAS
+  // la proposition en cours d'acceptation (déjà passée `accepted` avant l'apply) : seuls les `pending`
+  // restants du même paramètre sont neutralisés.
+  const supersededSet = await tx.slotSetProposal.findMany({
+    where: { patientId, parameterType, status: "pending" },
+    select: { id: true },
+  })
+  if (supersededSet.length > 0) {
+    await tx.slotSetProposal.updateMany({
+      where: { patientId, parameterType, status: "pending" },
+      data: { status: "superseded", reviewedAt: new Date(), reviewedByUserId: auditUserId },
+    })
+  }
+  const supersededSetProposalIds = supersededSet.map((p) => p.id)
+
   await auditService.logWithTx(tx, {
     userId: auditUserId,
     action: "UPDATE",
@@ -88,16 +143,24 @@ async function finishReplaceSet(
     resourceId: `${param}-set:${settingsId}`,
     ipAddress: ctx?.ipAddress,
     userAgent: ctx?.userAgent,
+    requestId: ctx?.requestId,
     metadata: {
       patientId,
       op: "replaceSet",
       from: before.map((s) => ({ startHour: s.startHour, endHour: s.endHour })),
       to: slots.map((s) => ({ startHour: s.startHour, endHour: s.endHour })),
       supersededProposalIds,
+      supersededSetProposalIds,
     },
   })
 
-  return { applied: true as const, count: slots.length, coverage, supersededProposalIds }
+  return {
+    applied: true as const,
+    count: slots.length,
+    coverage,
+    supersededProposalIds,
+    supersededSetProposalIds,
+  }
 }
 
 export const insulinTherapyService = {
@@ -408,15 +471,18 @@ export const insulinTherapyService = {
    *
    * **Anti-IDOR** : scopé `settings.patientId` ; le body ne porte jamais d'`id` de ligne.
    * **Dénormalisation** : `startHour/endHour` **et** `startTime/endTime` écrits ensemble.
-   * **Propositions** : les `pending` du même `parameterType` pour ce patient sont **supersédées**
-   * (le baseline a changé) — libère l'index `one_pending_per_slot`, pas de collision P2002.
+   * **Propositions** : les `pending` du même `parameterType` pour ce patient sont **supersédées** — le
+   * baseline a changé. S'applique aux DEUX familles : `AdjustmentProposal` par-valeur (libère
+   * `adjustment_proposals_one_pending_per_slot`) ET `SlotSetProposal` d'ensemble (US-2657, libère
+   * `slot_set_proposals_one_pending_per_param` et empêche la réapplication d'un jeu périmé).
    *
-   * Réservé au chemin **DOCTOR direct** (application immédiate). Le chemin proposition (NURSE/patient)
-   * est ouvert par US-2657 ; ici la garde `proposalAlreadyPending` n'est pas encore branchée.
+   * Chemin **DOCTOR direct** (application immédiate, `externalTx` absent) OU sous-étape de
+   * `acceptSetProposal` (US-2657, `externalTx` fourni → même transaction que le flip de proposition).
    *
    * @param param - `"isf"` ou `"icr"`.
    * @param patientId - patient scopé (résolu serveur, anti-IDOR).
    * @param slots - jeu complet `{ startHour, endHour, value, mealLabel? }` (value = ISF g/L ou ICR g/U).
+   * @param externalTx - transaction englobante optionnelle (atomicité apply + flip, cf. `acceptSetProposal`).
    * @throws emptySlotSet | zeroDurationSlot | valueOutOfBounds | slotOverlap | slotGap | settingsNotFound
    */
   async replaceSlotSet(
@@ -425,31 +491,25 @@ export const insulinTherapyService = {
     slots: Array<{ startHour: number; endHour: number; value: number; mealLabel?: string }>,
     auditUserId: number,
     ctx?: AuditContext,
+    /**
+     * US-2657 — transaction englobante optionnelle. Fournie par `acceptSetProposal` pour exécuter
+     * l'apply DANS la même transaction que le flip de statut de la proposition (atomicité : jamais de
+     * config appliquée sans acceptation valide, ni l'inverse). Absente (chemin DOCTOR direct) → on ouvre
+     * notre propre transaction.
+     */
+    externalTx?: Prisma.TransactionClient,
   ): Promise<{
     applied: true
     count: number
     coverage: { hasGap: boolean; hasOverlap: boolean }
     supersededProposalIds: string[]
+    supersededSetProposalIds: string[]
   }> {
-    // 1. Pré-validation pure (hors DB, fail-fast) sur l'état FINAL.
-    if (slots.length === 0) throw new Error("emptySlotSet")
-    const [valMin, valMax] =
-      param === "isf"
-        ? [CLINICAL_BOUNDS.ISF_GL_MIN, CLINICAL_BOUNDS.ISF_GL_MAX]
-        : [CLINICAL_BOUNDS.ICR_MIN, CLINICAL_BOUNDS.ICR_MAX]
-    for (const s of slots) {
-      if (s.startHour === s.endHour) throw new Error("zeroDurationSlot")
-      // Bornes cliniques de valeur re-vérifiées AUSSI dans le service (défense en profondeur) : le
-      // service reste sûr même appelé directement, pas seulement via la route Zod (US-2655, revue medical).
-      if (s.value < valMin || s.value > valMax) throw new Error("valueOutOfBounds")
-    }
-    const coverage = analyzeSlotCoverage(slots.map((s) => ({ start: s.startHour * 60, end: s.endHour * 60 })))
-    if (coverage.hasOverlap) throw new Error("slotOverlap")
-    if (coverage.hasGap) throw new Error("slotGap") // ISF/ICR : no-gap strict (le bolus doit résoudre)
-
+    // 1. Pré-validation pure (hors DB, fail-fast) sur l'état FINAL — source unique `assertValidSlotSet`.
+    const coverage = assertValidSlotSet(param, slots)
     const parameterType = param === "isf" ? "insulinSensitivityFactor" : "insulinToCarbRatio"
 
-    return prisma.$transaction(async (tx) => {
+    const run = async (tx: Prisma.TransactionClient) => {
       // 2a. Scope patient (anti-IDOR) — le settingsId provient du patient, jamais du body.
       const settings = await tx.insulinTherapySettings.findUnique({ where: { patientId }, select: { id: true } })
       if (!settings) throw new Error("settingsNotFound")
@@ -493,7 +553,9 @@ export const insulinTherapyService = {
         })
         return finishReplaceSet(tx, param, parameterType, patientId, settingsId, before, slots, auditUserId, coverage, ctx)
       }
-    })
+    }
+
+    return externalTx ? run(externalTx) : prisma.$transaction(run)
   },
 
   // --- Basal Config ---

--- a/src/lib/services/slot-set-proposal.service.ts
+++ b/src/lib/services/slot-set-proposal.service.ts
@@ -2,16 +2,33 @@
  * US-2657 (slice C3a) — Service des **propositions d'ENSEMBLE de créneaux**.
  *
  * Représente une édition de groupe (valeurs et/ou restructuration) soumise par un patient EXPERT mais
- * NON auto-applicable (hors enveloppe ou structurelle) : stockée en bloc pour revue MÉDECIN. Comble
- * l'absence de « proposition de disposition entière » (l'`AdjustmentProposal` étant par-valeur).
+ * NON auto-applicable (hors enveloppe ou structurelle) : stockée en bloc pour revue MÉDECIN.
  *
- * Invariant : **une seule proposition d'ensemble PENDING par (patient × paramètre)** — une nouvelle
- * soumission supersède la précédente en attente. Accepter applique en bloc via `replaceSlotSet`.
- * L'authz (rôle/portefeuille) est portée par les routes (C3c patient / C3d médecin) ; ce service est scopé patient.
+ * ⚠️ US-2657 — **on ne propose plus par-valeur** : toute édition patient EXPERT non auto-appliquée est
+ * proposée GROUPÉE (disposition entière du jeu de créneaux), quel que soit le nombre de valeurs modifiées.
+ * Ce service REMPLACE la voie par-valeur `AdjustmentProposal` pour ce cas ; le fallback unitaire du harnais
+ * C2 `applyExpertEditGoverned` est destiné à être routé via l'orchestrateur GROUPÉ C3b `applyExpertGroupGoverned`.
+ * À la création, les propositions `pending` du même `(patient × paramètre)` — d'ensemble ET par-valeur —
+ * sont supersédées (cohérent avec « plus de par-valeur »).
+ *
+ * Invariant : **une seule proposition d'ensemble PENDING par (patient × paramètre)** — garanti EN BASE par
+ * l'index unique partiel `slot_set_proposals_one_pending_per_param` (WHERE status = 'pending') ; la course
+ * TOCTOU de double-soumission remonte en `P2002` → `duplicatePendingProposal`.
+ *
+ * **Acceptation atomique** : lecture + flip `pending → accepted` (compare-and-swap) + `replaceSlotSet` +
+ * audit dans **une seule transaction**. Un rejet/supersede concurrent (flip `count 0`) ou un échec clinique
+ * de `replaceSlotSet` (bornes) rollback le tout → jamais de config appliquée sans acceptation valide, ni
+ * l'inverse. Bornes/couverture validées DÈS la création (`assertValidSlotSet`, symétrie création ⇄ accept).
+ *
+ * L'authz (rôle/portefeuille) est portée par les routes (C3c patient / C3d médecin) ; ce service est scopé
+ * patient (anti-IDOR) et filtre les patients soft-deleted (RGPD).
  */
+import { z } from "zod"
 import type { ProposalStatus } from "@prisma/client"
 import { prisma } from "@/lib/db/client"
-import { insulinTherapyService } from "@/lib/services/insulin-therapy.service"
+import { isUniqueViolationOn } from "@/lib/db/prisma-errors"
+import { insulinTherapyService, assertValidSlotSet } from "@/lib/services/insulin-therapy.service"
+import { treatmentModeService } from "@/lib/services/treatment-mode.service"
 import { auditService, type AuditContext } from "@/lib/services/audit.service"
 
 /** Créneau proposé (forme du JSON `proposedSlots`). */
@@ -25,10 +42,36 @@ const REPLACE_KEY: Record<SlotSetParam, "isf" | "icr"> = {
   insulinToCarbRatio: "icr",
 }
 
+/**
+ * Garde de FORME du JSON `proposedSlots` (encodage : `endHour ∈ [0,23]`, passage minuit via
+ * `startHour > endHour`). Les bornes CLINIQUES (ISF/ICR) et la couverture (no-gap/no-overlap) sont
+ * vérifiées séparément par `assertValidSlotSet`. Ici on garantit uniquement des entiers/valeurs finies —
+ * évite un `NaN` dans les calculs de couverture en cas de JSON corrompu.
+ */
+const proposedSlotsSchema = z.array(
+  z.object({
+    startHour: z.number().int().min(0).max(23),
+    endHour: z.number().int().min(0).max(23),
+    value: z.number().finite().positive(),
+    mealLabel: z.string().max(120).optional(),
+  }),
+) // le jeu vide passe la FORME → `emptySlotSet` levé par `assertValidSlotSet` (contrat d'erreur stable)
+
+/** Parse + valide la forme du jeu ; `invalidSlotSet` si malformé (à la création comme à la relecture). */
+function parseSlots(raw: unknown): ProposedSlot[] {
+  const parsed = proposedSlotsSchema.safeParse(raw)
+  if (!parsed.success) throw new Error("invalidSlotSet")
+  return parsed.data
+}
+
 export const slotSetProposalService = {
   /**
-   * Crée une proposition d'ensemble PENDING (supersède la précédente en attente sur le même paramètre).
-   * @throws `emptySlotSet` si aucun créneau.
+   * Crée une proposition d'ensemble PENDING. Valide la forme (`invalidSlotSet`) et la validité
+   * clinique/couverture DÈS la création (`assertValidSlotSet`), refuse un patient non insuliné
+   * (`nonInsulinNoDose`, frontière MDR) ou soft-deleted (`patientNotFound`). Supersède les propositions
+   * pending du même `(patient × paramètre)` (d'ensemble ET par-valeur).
+   * @throws invalidSlotSet | emptySlotSet | zeroDurationSlot | valueOutOfBounds | slotOverlap | slotGap
+   * @throws patientNotFound | nonInsulinNoDose | duplicatePendingProposal
    */
   async createSetProposal(
     patientId: number,
@@ -37,90 +80,159 @@ export const slotSetProposalService = {
     proposedByUserId: number,
     ctx?: AuditContext,
   ) {
-    if (!proposedSlots.length) throw new Error("emptySlotSet")
-    return prisma.$transaction(async (tx) => {
-      // Une seule PENDING par (patient × paramètre) : la précédente est superseded.
-      await tx.slotSetProposal.updateMany({
-        where: { patientId, parameterType, status: "pending" },
-        data: { status: "superseded" },
-      })
-      const proposal = await tx.slotSetProposal.create({
-        data: { patientId, parameterType, proposedSlots, proposedByUserId, status: "pending" },
-        select: { id: true },
-      })
-      await auditService.logWithTx(tx, {
-        userId: proposedByUserId,
-        action: "CREATE",
-        resource: "ADJUSTMENT_PROPOSAL",
-        resourceId: proposal.id,
-        ipAddress: ctx?.ipAddress,
-        userAgent: ctx?.userAgent,
-        metadata: { patientId, kind: "slotSetProposalCreated", parameterType, slots: proposedSlots.length },
-      })
-      return { id: proposal.id }
+    // 1. Forme (Zod) puis validité clinique/couverture — fail-fast, AVANT tout accès DB (symétrie
+    //    création ⇄ acceptation : une proposition inacceptable ne doit pas pouvoir être créée).
+    const slots = parseSlots(proposedSlots)
+    assertValidSlotSet(REPLACE_KEY[parameterType], slots)
+
+    // 2. Patient existant et NON soft-deleted (RGPD).
+    const patient = await prisma.patient.findFirst({
+      where: { id: patientId, deletedAt: null },
+      select: { id: true },
     })
+    if (!patient) throw new Error("patientNotFound")
+
+    // 3. Frontière DISPOSITIF MÉDICAL (US-2651, §12.5) : jamais de proposition de dose pour un patient
+    //    NON INSULINÉ. Mode dérivé SERVEUR (fail-closed). Aligné sur adjustmentService.createProposal.
+    const { mode } = await treatmentModeService.resolveTreatmentMode(patientId)
+    if (mode === "nonInsulin") throw new Error("nonInsulinNoDose")
+
+    try {
+      return await prisma.$transaction(async (tx) => {
+        // Une seule PENDING par (patient × paramètre) : la précédente d'ENSEMBLE est superseded.
+        await tx.slotSetProposal.updateMany({
+          where: { patientId, parameterType, status: "pending" },
+          data: { status: "superseded" },
+        })
+        // « Plus de par-valeur » : une soumission groupée supersède aussi les AdjustmentProposal pending
+        // du même paramètre (évite des propositions concurrentes/contradictoires côté médecin).
+        await tx.adjustmentProposal.updateMany({
+          where: { patientId, parameterType, status: "pending" },
+          data: { status: "superseded", reviewedAt: new Date(), reviewedBy: proposedByUserId },
+        })
+        const proposal = await tx.slotSetProposal.create({
+          data: { patientId, parameterType, proposedSlots: slots, proposedByUserId, status: "pending" },
+          select: { id: true },
+        })
+        await auditService.logWithTx(tx, {
+          userId: proposedByUserId,
+          action: "CREATE",
+          resource: "SLOT_SET_PROPOSAL",
+          resourceId: proposal.id,
+          ipAddress: ctx?.ipAddress,
+          userAgent: ctx?.userAgent,
+          requestId: ctx?.requestId,
+          metadata: { patientId, kind: "slotSetProposalCreated", parameterType, slots: slots.length },
+        })
+        return { id: proposal.id }
+      })
+    } catch (e) {
+      // Course TOCTOU (deux soumissions simultanées) rattrapée par l'index partiel unique
+      // `slot_set_proposals_one_pending_per_param`. `isUniqueViolationOn` lit la forme d'erreur Prisma 7 +
+      // adapter-pg (`meta.driverAdapterError.cause`, `meta.target` étant `undefined`) — cf. prisma-errors.
+      if (isUniqueViolationOn(e, "one_pending")) throw new Error("duplicatePendingProposal")
+      throw e
+    }
   },
 
   /**
-   * **Accepte** une proposition d'ensemble (acte MÉDECIN — gate à la route) : applique la disposition en
-   * bloc via `replaceSlotSet`, marque `accepted`. Scopé patient (anti-IDOR).
-   * @throws `slotSetProposalNotFound` si absente/non pending/hors périmètre.
+   * **Accepte** une proposition d'ensemble (acte MÉDECIN — gate à la route). ATOMIQUE : lecture + flip
+   * gardé (compare-and-swap `pending → accepted`) + application en bloc (`replaceSlotSet`) + audit dans une
+   * SEULE transaction. Un rejet/supersede concurrent (flip `count 0`) ou un échec clinique de
+   * `replaceSlotSet` (bornes) rollback tout → aucune config appliquée sans acceptation valide, ni l'inverse.
+   * Scopé patient (anti-IDOR), patient soft-deleted exclu.
+   * @throws slotSetProposalNotFound (absente/non pending/hors périmètre/soft-deleted/rejetée-supersédée en course)
+   * @throws unsupportedSlotSetParam | invalidSlotSet | settingsNotFound | valueOutOfBounds | slotOverlap | slotGap | zeroDurationSlot | emptySlotSet
    */
   async acceptSetProposal(id: string, patientId: number, reviewerUserId: number, ctx?: AuditContext) {
-    const proposal = await prisma.slotSetProposal.findFirst({
-      where: { id, patientId, status: "pending" },
-      select: { parameterType: true, proposedSlots: true },
-    })
-    if (!proposal) throw new Error("slotSetProposalNotFound")
+    return prisma.$transaction(async (tx) => {
+      const proposal = await tx.slotSetProposal.findFirst({
+        where: { id, patientId, status: "pending", patient: { deletedAt: null } },
+        select: { parameterType: true, proposedSlots: true },
+      })
+      if (!proposal) throw new Error("slotSetProposalNotFound")
 
-    const param = proposal.parameterType as SlotSetParam
-    const slots = proposal.proposedSlots as unknown as ProposedSlot[]
-    // Applique en bloc (replaceSlotSet audite le remplacement + supersède les AdjustmentProposal pending).
-    await insulinTherapyService.replaceSlotSet(REPLACE_KEY[param], patientId, slots, reviewerUserId, ctx)
+      // Garde runtime : le type DB `AdjustableParameter` est plus large (basalRate/fixedDose n'ont pas de
+      // jeu de créneaux ISF/ICR). Le cast serait unsafe sans cette vérification (REPLACE_KEY undefined).
+      const param = proposal.parameterType
+      if (param !== "insulinSensitivityFactor" && param !== "insulinToCarbRatio") {
+        throw new Error("unsupportedSlotSetParam")
+      }
+      const slots = parseSlots(proposal.proposedSlots)
 
-    await prisma.slotSetProposal.update({
-      where: { id },
-      data: { status: "accepted", reviewedByUserId: reviewerUserId, reviewedAt: new Date() },
+      // Compare-and-swap DANS la tx : verrouille l'acte pending → accepted. `count 0` = la proposition a
+      // été rejetée/supersédée (ou acceptée) en course → throw → rollback (aucune config appliquée).
+      const flipped = await tx.slotSetProposal.updateMany({
+        where: { id, patientId, status: "pending" },
+        data: { status: "accepted", reviewedByUserId: reviewerUserId, reviewedAt: new Date() },
+      })
+      if (flipped.count === 0) throw new Error("slotSetProposalNotFound")
+
+      // Apply en bloc DANS la même transaction (atomicité). Un échec (bornes/couverture) propage l'exception
+      // → rollback du flip → la proposition reste `pending` (fail-closed). `replaceSlotSet` supersède au
+      // passage les autres propositions pending du paramètre.
+      await insulinTherapyService.replaceSlotSet(REPLACE_KEY[param], patientId, slots, reviewerUserId, ctx, tx)
+
+      await auditService.logWithTx(tx, {
+        userId: reviewerUserId,
+        action: "PROPOSAL_ACCEPTED",
+        resource: "SLOT_SET_PROPOSAL",
+        resourceId: id,
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+        requestId: ctx?.requestId,
+        metadata: { patientId, kind: "slotSetProposalAccepted", parameterType: param },
+      })
+      return { id, status: "accepted" as const }
     })
-    await auditService.log({
-      userId: reviewerUserId,
-      action: "PROPOSAL_ACCEPTED",
-      resource: "ADJUSTMENT_PROPOSAL",
-      resourceId: id,
-      ipAddress: ctx?.ipAddress,
-      userAgent: ctx?.userAgent,
-      metadata: { patientId, kind: "slotSetProposalAccepted", parameterType: param },
-    })
-    return { id, status: "accepted" as const }
   },
 
   /**
-   * **Rejette** une proposition d'ensemble (acte MÉDECIN — gate à la route). Scopé patient.
-   * @throws `slotSetProposalNotFound` si absente/non pending/hors périmètre.
+   * **Rejette** une proposition d'ensemble (acte MÉDECIN — gate à la route). Flip `pending → rejected` +
+   * audit dans une seule transaction. Scopé patient, patient soft-deleted exclu.
+   * @throws slotSetProposalNotFound si absente/non pending/hors périmètre/soft-deleted.
    */
   async rejectSetProposal(id: string, patientId: number, reviewerUserId: number, ctx?: AuditContext) {
-    const res = await prisma.slotSetProposal.updateMany({
-      where: { id, patientId, status: "pending" },
-      data: { status: "rejected", reviewedByUserId: reviewerUserId, reviewedAt: new Date() },
+    return prisma.$transaction(async (tx) => {
+      const res = await tx.slotSetProposal.updateMany({
+        where: { id, patientId, status: "pending", patient: { deletedAt: null } },
+        data: { status: "rejected", reviewedByUserId: reviewerUserId, reviewedAt: new Date() },
+      })
+      if (res.count === 0) throw new Error("slotSetProposalNotFound")
+      await auditService.logWithTx(tx, {
+        userId: reviewerUserId,
+        action: "PROPOSAL_REJECTED",
+        resource: "SLOT_SET_PROPOSAL",
+        resourceId: id,
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+        requestId: ctx?.requestId,
+        metadata: { patientId, kind: "slotSetProposalRejected" },
+      })
+      return { id, status: "rejected" as const }
     })
-    if (res.count === 0) throw new Error("slotSetProposalNotFound")
-    await auditService.log({
-      userId: reviewerUserId,
-      action: "PROPOSAL_REJECTED",
-      resource: "ADJUSTMENT_PROPOSAL",
-      resourceId: id,
-      ipAddress: ctx?.ipAddress,
-      userAgent: ctx?.userAgent,
-      metadata: { patientId, kind: "slotSetProposalRejected" },
-    })
-    return { id, status: "rejected" as const }
   },
 
-  /** Liste les propositions d'ensemble d'un patient (option : filtrer par statut). */
-  async listSetProposals(patientId: number, status?: ProposalStatus) {
-    return prisma.slotSetProposal.findMany({
-      where: { patientId, ...(status ? { status } : {}) },
+  /**
+   * Liste les propositions d'ensemble d'un patient (option : filtrer par statut). Audite le READ (les
+   * `proposedSlots` sont des données de config insuline — donnée de santé). Patient soft-deleted exclu.
+   * @param auditUserId - PS effectuant la lecture (piste d'audit HDS).
+   */
+  async listSetProposals(patientId: number, auditUserId: number, status?: ProposalStatus, ctx?: AuditContext) {
+    const proposals = await prisma.slotSetProposal.findMany({
+      where: { patientId, patient: { deletedAt: null }, ...(status ? { status } : {}) },
       orderBy: { createdAt: "desc" },
     })
+    await auditService.log({
+      userId: auditUserId,
+      action: "READ",
+      resource: "SLOT_SET_PROPOSAL",
+      resourceId: String(patientId),
+      ipAddress: ctx?.ipAddress,
+      userAgent: ctx?.userAgent,
+      requestId: ctx?.requestId,
+      metadata: { patientId, kind: "slotSetProposalList", count: proposals.length },
+    })
+    return proposals
   },
 }

--- a/src/lib/services/slot-set-proposal.service.ts
+++ b/src/lib/services/slot-set-proposal.service.ts
@@ -1,0 +1,126 @@
+/**
+ * US-2657 (slice C3a) — Service des **propositions d'ENSEMBLE de créneaux**.
+ *
+ * Représente une édition de groupe (valeurs et/ou restructuration) soumise par un patient EXPERT mais
+ * NON auto-applicable (hors enveloppe ou structurelle) : stockée en bloc pour revue MÉDECIN. Comble
+ * l'absence de « proposition de disposition entière » (l'`AdjustmentProposal` étant par-valeur).
+ *
+ * Invariant : **une seule proposition d'ensemble PENDING par (patient × paramètre)** — une nouvelle
+ * soumission supersède la précédente en attente. Accepter applique en bloc via `replaceSlotSet`.
+ * L'authz (rôle/portefeuille) est portée par les routes (C3c patient / C3d médecin) ; ce service est scopé patient.
+ */
+import type { ProposalStatus } from "@prisma/client"
+import { prisma } from "@/lib/db/client"
+import { insulinTherapyService } from "@/lib/services/insulin-therapy.service"
+import { auditService, type AuditContext } from "@/lib/services/audit.service"
+
+/** Créneau proposé (forme du JSON `proposedSlots`). */
+export type ProposedSlot = { startHour: number; endHour: number; value: number; mealLabel?: string }
+
+/** Paramètres à jeu de créneaux gérés (ISF/ICR). */
+export type SlotSetParam = "insulinSensitivityFactor" | "insulinToCarbRatio"
+
+const REPLACE_KEY: Record<SlotSetParam, "isf" | "icr"> = {
+  insulinSensitivityFactor: "isf",
+  insulinToCarbRatio: "icr",
+}
+
+export const slotSetProposalService = {
+  /**
+   * Crée une proposition d'ensemble PENDING (supersède la précédente en attente sur le même paramètre).
+   * @throws `emptySlotSet` si aucun créneau.
+   */
+  async createSetProposal(
+    patientId: number,
+    parameterType: SlotSetParam,
+    proposedSlots: ProposedSlot[],
+    proposedByUserId: number,
+    ctx?: AuditContext,
+  ) {
+    if (!proposedSlots.length) throw new Error("emptySlotSet")
+    return prisma.$transaction(async (tx) => {
+      // Une seule PENDING par (patient × paramètre) : la précédente est superseded.
+      await tx.slotSetProposal.updateMany({
+        where: { patientId, parameterType, status: "pending" },
+        data: { status: "superseded" },
+      })
+      const proposal = await tx.slotSetProposal.create({
+        data: { patientId, parameterType, proposedSlots, proposedByUserId, status: "pending" },
+        select: { id: true },
+      })
+      await auditService.logWithTx(tx, {
+        userId: proposedByUserId,
+        action: "CREATE",
+        resource: "ADJUSTMENT_PROPOSAL",
+        resourceId: proposal.id,
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+        metadata: { patientId, kind: "slotSetProposalCreated", parameterType, slots: proposedSlots.length },
+      })
+      return { id: proposal.id }
+    })
+  },
+
+  /**
+   * **Accepte** une proposition d'ensemble (acte MÉDECIN — gate à la route) : applique la disposition en
+   * bloc via `replaceSlotSet`, marque `accepted`. Scopé patient (anti-IDOR).
+   * @throws `slotSetProposalNotFound` si absente/non pending/hors périmètre.
+   */
+  async acceptSetProposal(id: string, patientId: number, reviewerUserId: number, ctx?: AuditContext) {
+    const proposal = await prisma.slotSetProposal.findFirst({
+      where: { id, patientId, status: "pending" },
+      select: { parameterType: true, proposedSlots: true },
+    })
+    if (!proposal) throw new Error("slotSetProposalNotFound")
+
+    const param = proposal.parameterType as SlotSetParam
+    const slots = proposal.proposedSlots as unknown as ProposedSlot[]
+    // Applique en bloc (replaceSlotSet audite le remplacement + supersède les AdjustmentProposal pending).
+    await insulinTherapyService.replaceSlotSet(REPLACE_KEY[param], patientId, slots, reviewerUserId, ctx)
+
+    await prisma.slotSetProposal.update({
+      where: { id },
+      data: { status: "accepted", reviewedByUserId: reviewerUserId, reviewedAt: new Date() },
+    })
+    await auditService.log({
+      userId: reviewerUserId,
+      action: "PROPOSAL_ACCEPTED",
+      resource: "ADJUSTMENT_PROPOSAL",
+      resourceId: id,
+      ipAddress: ctx?.ipAddress,
+      userAgent: ctx?.userAgent,
+      metadata: { patientId, kind: "slotSetProposalAccepted", parameterType: param },
+    })
+    return { id, status: "accepted" as const }
+  },
+
+  /**
+   * **Rejette** une proposition d'ensemble (acte MÉDECIN — gate à la route). Scopé patient.
+   * @throws `slotSetProposalNotFound` si absente/non pending/hors périmètre.
+   */
+  async rejectSetProposal(id: string, patientId: number, reviewerUserId: number, ctx?: AuditContext) {
+    const res = await prisma.slotSetProposal.updateMany({
+      where: { id, patientId, status: "pending" },
+      data: { status: "rejected", reviewedByUserId: reviewerUserId, reviewedAt: new Date() },
+    })
+    if (res.count === 0) throw new Error("slotSetProposalNotFound")
+    await auditService.log({
+      userId: reviewerUserId,
+      action: "PROPOSAL_REJECTED",
+      resource: "ADJUSTMENT_PROPOSAL",
+      resourceId: id,
+      ipAddress: ctx?.ipAddress,
+      userAgent: ctx?.userAgent,
+      metadata: { patientId, kind: "slotSetProposalRejected" },
+    })
+    return { id, status: "rejected" as const }
+  },
+
+  /** Liste les propositions d'ensemble d'un patient (option : filtrer par statut). */
+  async listSetProposals(patientId: number, status?: ProposalStatus) {
+    return prisma.slotSetProposal.findMany({
+      where: { patientId, ...(status ? { status } : {}) },
+      orderBy: { createdAt: "desc" },
+    })
+  },
+}

--- a/tests/unit/insulin-therapy.service.test.ts
+++ b/tests/unit/insulin-therapy.service.test.ts
@@ -324,6 +324,11 @@ describe("insulinTherapyService", () => {
         findMany: vi.fn().mockResolvedValue([]),
         updateMany: vi.fn().mockResolvedValue({ count: 0 }),
       },
+      // US-2657 — finishReplaceSet supersède aussi les propositions d'ENSEMBLE pending.
+      slotSetProposal: {
+        findMany: vi.fn().mockResolvedValue([]),
+        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
       auditLog: { create: vi.fn().mockResolvedValue({}) },
       ...over,
     })
@@ -397,6 +402,7 @@ describe("insulinTherapyService", () => {
         count: 2,
         coverage: { hasGap: false, hasOverlap: false },
         supersededProposalIds: [],
+        supersededSetProposalIds: [],
       })
       expect(tx.insulinSensitivityFactor.deleteMany).toHaveBeenCalledWith({ where: { settingsId: 3 } })
       // Time dérivé de l'heure (dénormalisation synchronisée)

--- a/tests/unit/slot-set-proposal.service.test.ts
+++ b/tests/unit/slot-set-proposal.service.test.ts
@@ -1,13 +1,37 @@
 /**
  * US-2657 (slice C3a) — Service des propositions d'ensemble de créneaux.
- * Comportement testé : create (supersède la pending précédente + audit), accept (→ replaceSlotSet en bloc
- * + accepted), reject, scoping patient (anti-IDOR → notFound), emptySlotSet.
+ * Comportement testé :
+ *  - create : validation forme + bornes cliniques À LA CRÉATION, garde patient soft-deleted, frontière MDR
+ *    nonInsulin, supersede des pending (ensemble + par-valeur), audit, P2002 (forme Prisma 7 + adapter-pg)
+ *    → duplicatePendingProposal ;
+ *  - accept : ATOMIQUE (flip gardé compare-and-swap → apply `replaceSlotSet(tx)` → audit dans une seule
+ *    transaction), fail-closed si apply throw, pas d'apply si flip perdu (course) ou introuvable ;
+ *  - reject : flip + audit ; scoping patient (anti-IDOR → notFound) ;
+ *  - list : audit READ.
+ *
+ * `assertValidSlotSet` est la VRAIE implémentation (importActual) — la validation à la création est donc
+ * réellement exercée ; seul `insulinTherapyService.replaceSlotSet` est mocké.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { prismaMock } from "../helpers/prisma-mock"
 
-vi.mock("@/lib/services/insulin-therapy.service", () => ({
-  insulinTherapyService: { replaceSlotSet: vi.fn().mockResolvedValue({ supersededProposalIds: [] }) },
+vi.mock("@/lib/services/insulin-therapy.service", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/services/insulin-therapy.service")>()
+  return {
+    ...actual, // garde le vrai `assertValidSlotSet`
+    insulinTherapyService: {
+      replaceSlotSet: vi.fn().mockResolvedValue({
+        applied: true,
+        count: 3,
+        coverage: { hasGap: false, hasOverlap: false },
+        supersededProposalIds: [],
+        supersededSetProposalIds: [],
+      }),
+    },
+  }
+})
+vi.mock("@/lib/services/treatment-mode.service", () => ({
+  treatmentModeService: { resolveTreatmentMode: vi.fn().mockResolvedValue({ mode: "basalBolus" }) },
 }))
 vi.mock("@/lib/services/audit.service", () => ({
   auditService: { log: vi.fn(), logWithTx: vi.fn() },
@@ -15,64 +39,175 @@ vi.mock("@/lib/services/audit.service", () => ({
 
 const { slotSetProposalService } = await import("@/lib/services/slot-set-proposal.service")
 const { insulinTherapyService } = await import("@/lib/services/insulin-therapy.service")
+const { treatmentModeService } = await import("@/lib/services/treatment-mode.service")
+const { auditService } = await import("@/lib/services/audit.service")
 
+// Jeu ISF VALIDE : couverture 24 h sans trou ni chevauchement (0-8, 8-22, 22-24), valeurs ∈ [0.10, 1.00] g/L.
 const SLOTS = [
   { startHour: 0, endHour: 8, value: 0.5 },
   { startHour: 8, endHour: 22, value: 0.45 },
-  { startHour: 22, endHour: 6, value: 0.4 },
+  { startHour: 22, endHour: 0, value: 0.4 },
 ]
+
+/** Fabrique un `tx` factice dont `$transaction` exécute le callback. */
+function mockTx() {
+  const tx = {
+    slotSetProposal: { findFirst: vi.fn(), updateMany: vi.fn(), create: vi.fn() },
+    adjustmentProposal: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+  }
+  prismaMock.$transaction.mockImplementation(async (fn: any) => fn(tx))
+  return tx
+}
 
 describe("slotSetProposalService", () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it("createSetProposal : supersède la pending précédente + crée + audit", async () => {
-    const tx = {
-      slotSetProposal: {
-        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
-        create: vi.fn().mockResolvedValue({ id: "set-1" }),
-      },
-      auditLog: { create: vi.fn().mockResolvedValue({}) },
-    }
-    prismaMock.$transaction.mockImplementation(async (fn: any) => fn(tx))
+  // ── create ──────────────────────────────────────────────────────────────
+  it("createSetProposal : supersède les pending (ensemble + par-valeur) + crée + audit READ SLOT_SET_PROPOSAL", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as never)
+    const tx = mockTx()
+    tx.slotSetProposal.updateMany.mockResolvedValue({ count: 1 })
+    tx.slotSetProposal.create.mockResolvedValue({ id: "set-1" })
+
     const res = await slotSetProposalService.createSetProposal(7, "insulinSensitivityFactor", SLOTS, 7)
     expect(res).toEqual({ id: "set-1" })
     expect(tx.slotSetProposal.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({ where: { patientId: 7, parameterType: "insulinSensitivityFactor", status: "pending" }, data: { status: "superseded" } }),
     )
-    expect(tx.slotSetProposal.create).toHaveBeenCalledWith(
-      expect.objectContaining({ data: expect.objectContaining({ patientId: 7, parameterType: "insulinSensitivityFactor", status: "pending" }) }),
+    // « Plus de par-valeur » : supersede aussi les AdjustmentProposal pending du même paramètre.
+    expect(tx.adjustmentProposal.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { patientId: 7, parameterType: "insulinSensitivityFactor", status: "pending" } }),
+    )
+    expect(auditService.logWithTx).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({ action: "CREATE", resource: "SLOT_SET_PROPOSAL", resourceId: "set-1" }),
     )
   })
 
-  it("createSetProposal : jeu vide → emptySlotSet", async () => {
+  it("createSetProposal : jeu vide → emptySlotSet (avant tout accès DB)", async () => {
     await expect(slotSetProposalService.createSetProposal(7, "insulinSensitivityFactor", [], 7)).rejects.toThrow("emptySlotSet")
+    expect(prismaMock.patient.findFirst).not.toHaveBeenCalled()
   })
 
-  it("acceptSetProposal : applique en bloc (replaceSlotSet) + accepted", async () => {
-    prismaMock.slotSetProposal.findFirst.mockResolvedValue({ parameterType: "insulinToCarbRatio", proposedSlots: SLOTS } as never)
-    prismaMock.slotSetProposal.update.mockResolvedValue({} as never)
+  it("createSetProposal : valeur ISF hors bornes → valueOutOfBounds DÈS la création (M6)", async () => {
+    const bad = [{ startHour: 0, endHour: 12, value: 5.0 }, { startHour: 12, endHour: 0, value: 0.5 }] // 5.0 > ISF_GL_MAX
+    await expect(slotSetProposalService.createSetProposal(7, "insulinSensitivityFactor", bad, 7)).rejects.toThrow("valueOutOfBounds")
+    expect(prismaMock.patient.findFirst).not.toHaveBeenCalled()
+  })
+
+  it("createSetProposal : patient soft-deleted / inexistant → patientNotFound", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue(null as never)
+    await expect(slotSetProposalService.createSetProposal(7, "insulinSensitivityFactor", SLOTS, 7)).rejects.toThrow("patientNotFound")
+    expect(treatmentModeService.resolveTreatmentMode).not.toHaveBeenCalled()
+  })
+
+  it("createSetProposal : patient NON INSULINÉ → nonInsulinNoDose (frontière MDR, aucune écriture)", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as never)
+    ;(treatmentModeService.resolveTreatmentMode as any).mockResolvedValueOnce({ mode: "nonInsulin" })
+    await expect(slotSetProposalService.createSetProposal(7, "insulinSensitivityFactor", SLOTS, 7)).rejects.toThrow("nonInsulinNoDose")
+    expect(prismaMock.$transaction).not.toHaveBeenCalled()
+  })
+
+  it("createSetProposal : P2002 (forme Prisma 7 + adapter-pg) → duplicatePendingProposal", async () => {
+    prismaMock.patient.findFirst.mockResolvedValue({ id: 7 } as never)
+    // Forme RÉELLE sous @prisma/adapter-pg : meta.target = undefined ; le nom de contrainte est dans
+    // driverAdapterError.cause.originalMessage (cf. review prisma-specialist).
+    prismaMock.$transaction.mockRejectedValue(
+      Object.assign(new Error("Unique constraint failed"), {
+        code: "P2002",
+        meta: {
+          driverAdapterError: {
+            cause: {
+              originalMessage: 'duplicate key value violates unique constraint "slot_set_proposals_one_pending_per_param"',
+              constraint: { fields: ["patient_id", "parameter_type"] },
+            },
+          },
+        },
+      }) as never,
+    )
+    await expect(slotSetProposalService.createSetProposal(7, "insulinSensitivityFactor", SLOTS, 7)).rejects.toThrow("duplicatePendingProposal")
+  })
+
+  // ── accept ──────────────────────────────────────────────────────────────
+  it("acceptSetProposal : ATOMIQUE — flip gardé puis replaceSlotSet(tx) puis audit", async () => {
+    const tx = mockTx()
+    tx.slotSetProposal.findFirst.mockResolvedValue({ parameterType: "insulinToCarbRatio", proposedSlots: SLOTS })
+    tx.slotSetProposal.updateMany.mockResolvedValue({ count: 1 })
+
     const res = await slotSetProposalService.acceptSetProposal("set-1", 7, 3)
     expect(res).toEqual({ id: "set-1", status: "accepted" })
-    expect(insulinTherapyService.replaceSlotSet).toHaveBeenCalledWith("icr", 7, SLOTS, 3, undefined)
-    expect(prismaMock.slotSetProposal.update).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { id: "set-1" }, data: expect.objectContaining({ status: "accepted", reviewedByUserId: 3 }) }),
+    // Flip gardé compare-and-swap DANS la transaction, patient soft-deleted exclu à la lecture.
+    expect(tx.slotSetProposal.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "set-1", patientId: 7, status: "pending", patient: { deletedAt: null } } }),
+    )
+    expect(tx.slotSetProposal.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "set-1", patientId: 7, status: "pending" }, data: expect.objectContaining({ status: "accepted", reviewedByUserId: 3 }) }),
+    )
+    // Apply DANS la même transaction : le `tx` est passé en 6e argument à replaceSlotSet.
+    expect(insulinTherapyService.replaceSlotSet).toHaveBeenCalledWith("icr", 7, SLOTS, 3, undefined, tx)
+    expect(auditService.logWithTx).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({ action: "PROPOSAL_ACCEPTED", resource: "SLOT_SET_PROPOSAL", resourceId: "set-1" }),
     )
   })
 
-  it("acceptSetProposal : hors périmètre / non pending → slotSetProposalNotFound (pas d'apply)", async () => {
-    prismaMock.slotSetProposal.findFirst.mockResolvedValue(null as never)
+  it("acceptSetProposal : flip perdu (rejet/supersede concurrent, count 0) → notFound, PAS d'apply", async () => {
+    const tx = mockTx()
+    tx.slotSetProposal.findFirst.mockResolvedValue({ parameterType: "insulinToCarbRatio", proposedSlots: SLOTS })
+    tx.slotSetProposal.updateMany.mockResolvedValue({ count: 0 })
+    await expect(slotSetProposalService.acceptSetProposal("set-1", 7, 3)).rejects.toThrow("slotSetProposalNotFound")
+    expect(insulinTherapyService.replaceSlotSet).not.toHaveBeenCalled()
+  })
+
+  it("acceptSetProposal : introuvable / hors périmètre → notFound, PAS d'apply", async () => {
+    const tx = mockTx()
+    tx.slotSetProposal.findFirst.mockResolvedValue(null)
     await expect(slotSetProposalService.acceptSetProposal("set-x", 7, 3)).rejects.toThrow("slotSetProposalNotFound")
     expect(insulinTherapyService.replaceSlotSet).not.toHaveBeenCalled()
   })
 
-  it("rejectSetProposal : marque rejected", async () => {
-    prismaMock.slotSetProposal.updateMany.mockResolvedValue({ count: 1 } as never)
+  it("acceptSetProposal : échec clinique de replaceSlotSet → propagé (fail-closed, rollback du flip)", async () => {
+    const tx = mockTx()
+    tx.slotSetProposal.findFirst.mockResolvedValue({ parameterType: "insulinToCarbRatio", proposedSlots: SLOTS })
+    tx.slotSetProposal.updateMany.mockResolvedValue({ count: 1 })
+    ;(insulinTherapyService.replaceSlotSet as any).mockRejectedValueOnce(new Error("valueOutOfBounds"))
+    await expect(slotSetProposalService.acceptSetProposal("set-1", 7, 3)).rejects.toThrow("valueOutOfBounds")
+    // L'audit accepted n'est PAS émis (la transaction est rollback en réalité).
+    expect(auditService.logWithTx).not.toHaveBeenCalled()
+  })
+
+  // ── reject ──────────────────────────────────────────────────────────────
+  it("rejectSetProposal : marque rejected + audit", async () => {
+    const tx = mockTx()
+    tx.slotSetProposal.updateMany.mockResolvedValue({ count: 1 })
     const res = await slotSetProposalService.rejectSetProposal("set-1", 7, 3)
     expect(res).toEqual({ id: "set-1", status: "rejected" })
+    expect(tx.slotSetProposal.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "set-1", patientId: 7, status: "pending", patient: { deletedAt: null } } }),
+    )
+    expect(auditService.logWithTx).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({ action: "PROPOSAL_REJECTED", resource: "SLOT_SET_PROPOSAL", resourceId: "set-1" }),
+    )
   })
 
   it("rejectSetProposal : rien à rejeter (scoping) → slotSetProposalNotFound", async () => {
-    prismaMock.slotSetProposal.updateMany.mockResolvedValue({ count: 0 } as never)
+    const tx = mockTx()
+    tx.slotSetProposal.updateMany.mockResolvedValue({ count: 0 })
     await expect(slotSetProposalService.rejectSetProposal("set-x", 7, 3)).rejects.toThrow("slotSetProposalNotFound")
+    expect(auditService.logWithTx).not.toHaveBeenCalled()
+  })
+
+  // ── list ────────────────────────────────────────────────────────────────
+  it("listSetProposals : retourne les propositions + audite le READ", async () => {
+    prismaMock.slotSetProposal.findMany.mockResolvedValue([{ id: "set-1" }] as never)
+    const res = await slotSetProposalService.listSetProposals(7, 3, "pending")
+    expect(res).toEqual([{ id: "set-1" }])
+    expect(prismaMock.slotSetProposal.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ patientId: 7, patient: { deletedAt: null }, status: "pending" }) }),
+    )
+    expect(auditService.log).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "READ", resource: "SLOT_SET_PROPOSAL", userId: 3 }),
+    )
   })
 })

--- a/tests/unit/slot-set-proposal.service.test.ts
+++ b/tests/unit/slot-set-proposal.service.test.ts
@@ -1,0 +1,78 @@
+/**
+ * US-2657 (slice C3a) — Service des propositions d'ensemble de créneaux.
+ * Comportement testé : create (supersède la pending précédente + audit), accept (→ replaceSlotSet en bloc
+ * + accepted), reject, scoping patient (anti-IDOR → notFound), emptySlotSet.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { prismaMock } from "../helpers/prisma-mock"
+
+vi.mock("@/lib/services/insulin-therapy.service", () => ({
+  insulinTherapyService: { replaceSlotSet: vi.fn().mockResolvedValue({ supersededProposalIds: [] }) },
+}))
+vi.mock("@/lib/services/audit.service", () => ({
+  auditService: { log: vi.fn(), logWithTx: vi.fn() },
+}))
+
+const { slotSetProposalService } = await import("@/lib/services/slot-set-proposal.service")
+const { insulinTherapyService } = await import("@/lib/services/insulin-therapy.service")
+
+const SLOTS = [
+  { startHour: 0, endHour: 8, value: 0.5 },
+  { startHour: 8, endHour: 22, value: 0.45 },
+  { startHour: 22, endHour: 6, value: 0.4 },
+]
+
+describe("slotSetProposalService", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("createSetProposal : supersède la pending précédente + crée + audit", async () => {
+    const tx = {
+      slotSetProposal: {
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+        create: vi.fn().mockResolvedValue({ id: "set-1" }),
+      },
+      auditLog: { create: vi.fn().mockResolvedValue({}) },
+    }
+    prismaMock.$transaction.mockImplementation(async (fn: any) => fn(tx))
+    const res = await slotSetProposalService.createSetProposal(7, "insulinSensitivityFactor", SLOTS, 7)
+    expect(res).toEqual({ id: "set-1" })
+    expect(tx.slotSetProposal.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { patientId: 7, parameterType: "insulinSensitivityFactor", status: "pending" }, data: { status: "superseded" } }),
+    )
+    expect(tx.slotSetProposal.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ patientId: 7, parameterType: "insulinSensitivityFactor", status: "pending" }) }),
+    )
+  })
+
+  it("createSetProposal : jeu vide → emptySlotSet", async () => {
+    await expect(slotSetProposalService.createSetProposal(7, "insulinSensitivityFactor", [], 7)).rejects.toThrow("emptySlotSet")
+  })
+
+  it("acceptSetProposal : applique en bloc (replaceSlotSet) + accepted", async () => {
+    prismaMock.slotSetProposal.findFirst.mockResolvedValue({ parameterType: "insulinToCarbRatio", proposedSlots: SLOTS } as never)
+    prismaMock.slotSetProposal.update.mockResolvedValue({} as never)
+    const res = await slotSetProposalService.acceptSetProposal("set-1", 7, 3)
+    expect(res).toEqual({ id: "set-1", status: "accepted" })
+    expect(insulinTherapyService.replaceSlotSet).toHaveBeenCalledWith("icr", 7, SLOTS, 3, undefined)
+    expect(prismaMock.slotSetProposal.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "set-1" }, data: expect.objectContaining({ status: "accepted", reviewedByUserId: 3 }) }),
+    )
+  })
+
+  it("acceptSetProposal : hors périmètre / non pending → slotSetProposalNotFound (pas d'apply)", async () => {
+    prismaMock.slotSetProposal.findFirst.mockResolvedValue(null as never)
+    await expect(slotSetProposalService.acceptSetProposal("set-x", 7, 3)).rejects.toThrow("slotSetProposalNotFound")
+    expect(insulinTherapyService.replaceSlotSet).not.toHaveBeenCalled()
+  })
+
+  it("rejectSetProposal : marque rejected", async () => {
+    prismaMock.slotSetProposal.updateMany.mockResolvedValue({ count: 1 } as never)
+    const res = await slotSetProposalService.rejectSetProposal("set-1", 7, 3)
+    expect(res).toEqual({ id: "set-1", status: "rejected" })
+  })
+
+  it("rejectSetProposal : rien à rejeter (scoping) → slotSetProposalNotFound", async () => {
+    prismaMock.slotSetProposal.updateMany.mockResolvedValue({ count: 0 } as never)
+    await expect(slotSetProposalService.rejectSetProposal("set-x", 7, 3)).rejects.toThrow("slotSetProposalNotFound")
+  })
+})


### PR DESCRIPTION
Première sous-tranche de **C3 (Option 2)**. Comble l'absence de « proposition de disposition entière » (l'`AdjustmentProposal` est **par-valeur**) : une édition de **GROUPE** d'un patient EXPERT **non auto-applicable** (hors enveloppe **ou structurelle**) sera stockée **en bloc** pour revue médecin. **Aucun appelant live encore** (orchestrateur C3b, routes C3c/C3d).

## Contenu
- **Schéma** : `SlotSetProposal` (`parameterType` ISF/ICR, `proposedSlots` JSON, `status` `ProposalStatus`, `proposedBy/reviewedBy`, index `(patientId, status)`) + migration additive.
- **`slotSetProposalService`** : `createSetProposal` (**supersède** la pending précédente par paramètre + audit), `acceptSetProposal` (→ `replaceSlotSet` **en bloc** + `accepted`, **scopé patient** anti-IDOR), `rejectSetProposal`, `listSetProposals`. Invariant : **1 pending par (patient × paramètre)**.
- Catalogue + **tests +6**.

Vérifs : ✅ tsc · ✅ eslint · ✅ anti-drift 267 · ✅ **3962 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)