### PR TITLE
US-2657 (slice C3c) — Route patient PUT /api/patient/insulin-slot-set

### DIFF
--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -664,7 +664,8 @@ l'index unique partiel `slot_set_proposals_one_pending_per_param` (`WHERE status
 `isUniqueViolationOn`/`driverAdapterError` robuste à Prisma 7 + adapter-pg). Statuts = `ProposalStatus`.
 Audit dédié `resource = SLOT_SET_PROPOSAL` (CREATE / PROPOSAL_ACCEPTED / PROPOSAL_REJECTED / READ), jamais de
 PHI (valeurs de config, `metadata.patientId` pivot US-2268). Sources : orchestrateur `applyExpertGroupGoverned`
-(C3b, appelant), routes patient (C3c) / médecin (C3d).
+(C3b, appelant), **route patient `PUT /api/patient/insulin-slot-set` (C3c, livrée — self-scopée own-id)**,
+route médecin d'accept/reject (C3d, à livrer).
 
 #### Orchestrateur groupé `applyExpertGroupGoverned` (C3b) — décision tout-ou-rien
 

--- a/src/app/api/patient/insulin-slot-set/route.ts
+++ b/src/app/api/patient/insulin-slot-set/route.ts
@@ -1,0 +1,82 @@
+/**
+ * PUT /api/patient/insulin-slot-set — **SOUMISSION SELF-SERVICE PATIENT** d'un jeu de créneaux ISF/ICR
+ * (US-2657 slice C3c). Le patient soumet sa **disposition complète** (mono-paramètre) ; l'orchestrateur
+ * gouverné `applyExpertGroupGoverned` décide, tout-ou-rien :
+ *  - **auto-application** (patient EXPERT, dans l'enveloppe C1–C8) ;
+ *  - **proposition médecin** groupée (hors enveloppe / restructuration / cap groupe / non-EXPERT) ;
+ *  - **rejet** (frontière MDR : patient non insuliné) ; ou **no-op** (aucune valeur modifiée).
+ *
+ * **Own-id STRICT (anti-IDOR / anti-énumération)** : patient résolu EXCLUSIVEMENT depuis `user.id` via
+ * `getOwnPatientId` — **aucun** `?patientId`, **aucun** token. Un pro (sans dossier patient) → 404 neutre
+ * (les pros éditent via `/patients/[id]`, chemin DOCTOR direct immédiat). Consentement RGPD requis.
+ * La décision est **auditée par l'orchestrateur** (AUTO_APPLIED_SETTING / AUTO_APPLY_FALLBACK /
+ * AUTO_APPLY_REJECTED). Valeurs ISF en **g/L**, ICR en **g/U** (bornes cliniques re-validées serveur).
+ *
+ * Réponse : l'`outcome` gouverné (200) — `{ outcome: "applied" | "noop" | "proposal" | "rejected", … }`.
+ * Rejet dur à la saisie (bornes/couverture invalides) ou verrou occupé → statut HTTP 4xx.
+ */
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { requireAuth, AuthError } from "@/lib/auth"
+import { getOwnPatientId } from "@/lib/access-control"
+import { requireGdprConsent } from "@/lib/gdpr"
+import { autoApplyService } from "@/lib/services/auto-apply.service"
+import { SLOT_SET_ERROR_STATUS } from "@/lib/insulin/slot-set-replace"
+import { extractRequestContext } from "@/lib/services/audit.service"
+
+const bodySchema = z.object({
+  parameterType: z.enum(["insulinSensitivityFactor", "insulinToCarbRatio"]),
+  slots: z
+    .array(
+      z.object({
+        startHour: z.number().int().min(0).max(23),
+        endHour: z.number().int().min(0).max(23),
+        // Bornes cliniques (ISF/ICR) re-validées serveur par `assertValidSlotSet` (→ valueOutOfBounds/400).
+        value: z.number().finite().positive(),
+        mealLabel: z.string().max(120).optional(),
+      }),
+    )
+    .min(1),
+})
+
+export async function PUT(req: NextRequest) {
+  try {
+    const user = requireAuth(req)
+
+    const hasConsent = await requireGdprConsent(user.id)
+    if (!hasConsent) return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
+
+    // Own-id strict : jamais depuis l'URL/token. Pas de dossier patient (pro) → 404 neutre.
+    const patientId = await getOwnPatientId(user.id)
+    if (!patientId) return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+
+    const parsed = bodySchema.safeParse(await req.json().catch(() => null))
+    if (!parsed.success) {
+      return NextResponse.json({ error: "validationFailed", details: parsed.error.flatten().fieldErrors }, { status: 400 })
+    }
+
+    try {
+      const outcome = await autoApplyService.applyExpertGroupGoverned(
+        { patientId, parameterType: parsed.data.parameterType, proposedSlots: parsed.data.slots },
+        user.id, // acteur = le patient (pour l'audit / la provenance de proposition)
+        new Date(),
+        extractRequestContext(req),
+      )
+      return NextResponse.json(outcome)
+    } catch (e) {
+      // Rejet dur à la saisie (emptySlotSet / zeroDurationSlot / slotOverlap / slotGap / valueOutOfBounds /
+      // settingsNotFound) + slotsBusy → statut HTTP stable, sans PHI.
+      const status = e instanceof Error ? SLOT_SET_ERROR_STATUS[e.message] : undefined
+      if (status) return NextResponse.json({ error: (e as Error).message }, { status })
+      if (e instanceof Error && e.message === "patientNotFound") {
+        return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+      }
+      throw e
+    }
+  } catch (error) {
+    if (error instanceof AuthError) return NextResponse.json({ error: error.message }, { status: error.status })
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    console.error("[patient/insulin-slot-set PUT]", msg)
+    return NextResponse.json({ error: "serverError" }, { status: 500 })
+  }
+}

--- a/src/app/api/patient/insulin-slot-set/route.ts
+++ b/src/app/api/patient/insulin-slot-set/route.ts
@@ -7,22 +7,26 @@
  *  - **rejet** (frontière MDR : patient non insuliné) ; ou **no-op** (aucune valeur modifiée).
  *
  * **Own-id STRICT (anti-IDOR / anti-énumération)** : patient résolu EXCLUSIVEMENT depuis `user.id` via
- * `getOwnPatientId` — **aucun** `?patientId`, **aucun** token. Un pro (sans dossier patient) → 404 neutre
- * (les pros éditent via `/patients/[id]`, chemin DOCTOR direct immédiat). Consentement RGPD requis.
+ * `getOwnPatientId` — **aucun** `?patientId`, **aucun** token. Frontière d'autorisation = `getOwnPatientId`
+ * seul (pas de garde de rôle). **Invariant dont dépend l'anti-IDOR** : `Patient.userId @unique` → un
+ * `user.id` mappe AU PLUS un dossier (le sien) ; un pro sans dossier → 404 neutre. Si cette cardinalité
+ * change un jour, ré-introduire un garde de rôle explicite. Consentement RGPD requis ; rate-limit anti-abus.
  * La décision est **auditée par l'orchestrateur** (AUTO_APPLIED_SETTING / AUTO_APPLY_FALLBACK /
- * AUTO_APPLY_REJECTED). Valeurs ISF en **g/L**, ICR en **g/U** (bornes cliniques re-validées serveur).
+ * AUTO_APPLY_REJECTED) ; la route trace en plus les issues non couvertes (no-op, rejet dur à la saisie)
+ * via `INSULIN_SLOT_SUBMISSION`. Valeurs ISF en **g/L**, ICR en **g/U** (bornes re-validées serveur).
  *
  * Réponse : l'`outcome` gouverné (200) — `{ outcome: "applied" | "noop" | "proposal" | "rejected", … }`.
- * Rejet dur à la saisie (bornes/couverture invalides) ou verrou occupé → statut HTTP 4xx.
+ * Rejet dur à la saisie (bornes/couverture) / doublon / verrou occupé → statut HTTP 4xx.
  */
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
 import { requireAuth, AuthError } from "@/lib/auth"
+import { checkApiRateLimit, RATE_LIMITS } from "@/lib/auth/api-rate-limit"
 import { getOwnPatientId } from "@/lib/access-control"
 import { requireGdprConsent } from "@/lib/gdpr"
 import { autoApplyService } from "@/lib/services/auto-apply.service"
-import { SLOT_SET_ERROR_STATUS } from "@/lib/insulin/slot-set-replace"
-import { extractRequestContext } from "@/lib/services/audit.service"
+import { SLOT_SET_ERROR_STATUS } from "@/lib/insulin/slot-set-errors"
+import { auditService, extractRequestContext } from "@/lib/services/audit.service"
 
 const bodySchema = z.object({
   parameterType: z.enum(["insulinSensitivityFactor", "insulinToCarbRatio"]),
@@ -36,40 +40,71 @@ const bodySchema = z.object({
         mealLabel: z.string().max(120).optional(),
       }),
     )
-    .min(1),
+    .min(1)
+    .max(24), // borne anti-abus : 24 créneaux couvrent 24 h
 })
 
 export async function PUT(req: NextRequest) {
   try {
     const user = requireAuth(req)
+    const ctx = extractRequestContext(req)
+
+    // Rate-limit (ANSSI, anti-abus) : écriture déclenchant une décision automatisée de dosage. Fail-open
+    // (dispo d'abord ; le vrai garde-fou de dosage est l'enveloppe C1–C8 + anti-cliquet C7). Saturation auditée.
+    const rl = await checkApiRateLimit(String(user.id), RATE_LIMITS.insulinSubmission)
+    if (!rl.allowed) {
+      await auditService
+        .rateLimited({
+          userId: user.id,
+          resource: "PATIENT",
+          resourceId: "insulin-slot-set",
+          ipAddress: ctx.ipAddress,
+          userAgent: ctx.userAgent,
+          requestId: ctx.requestId,
+          metadata: { surface: "api", kind: "insulinSlotSetSubmission" },
+        })
+        .catch(() => {})
+      return NextResponse.json({ error: "rateLimitExceeded" }, { status: 429, headers: { "Retry-After": String(rl.retryAfterSec) } })
+    }
+
+    // Own-id strict AVANT le consent (ordre canonique : établir le périmètre avant de statuer sur le consent).
+    // Pas de dossier patient (pro) → 404 neutre.
+    const patientId = await getOwnPatientId(user.id)
+    if (!patientId) return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
 
     const hasConsent = await requireGdprConsent(user.id)
     if (!hasConsent) return NextResponse.json({ error: "gdprConsentRequired" }, { status: 403 })
-
-    // Own-id strict : jamais depuis l'URL/token. Pas de dossier patient (pro) → 404 neutre.
-    const patientId = await getOwnPatientId(user.id)
-    if (!patientId) return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
 
     const parsed = bodySchema.safeParse(await req.json().catch(() => null))
     if (!parsed.success) {
       return NextResponse.json({ error: "validationFailed", details: parsed.error.flatten().fieldErrors }, { status: 400 })
     }
+    const { parameterType, slots } = parsed.data
 
     try {
       const outcome = await autoApplyService.applyExpertGroupGoverned(
-        { patientId, parameterType: parsed.data.parameterType, proposedSlots: parsed.data.slots },
+        { patientId, parameterType, proposedSlots: slots },
         user.id, // acteur = le patient (pour l'audit / la provenance de proposition)
         new Date(),
-        extractRequestContext(req),
+        ctx,
       )
+      // No-op non couvert par l'audit de l'orchestrateur → trace HDS de la soumission (sans PHI).
+      if (outcome.outcome === "noop") {
+        await auditService
+          .log({ userId: user.id, action: "INSULIN_SLOT_SUBMISSION", resource: "PATIENT", resourceId: String(patientId), ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId, metadata: { patientId, parameterType, outcome: "noop" } })
+          .catch(() => {})
+      }
       return NextResponse.json(outcome)
     } catch (e) {
-      // Rejet dur à la saisie (emptySlotSet / zeroDurationSlot / slotOverlap / slotGap / valueOutOfBounds /
-      // settingsNotFound) + slotsBusy → statut HTTP stable, sans PHI.
-      const status = e instanceof Error ? SLOT_SET_ERROR_STATUS[e.message] : undefined
-      if (status) return NextResponse.json({ error: (e as Error).message }, { status })
-      if (e instanceof Error && e.message === "patientNotFound") {
-        return NextResponse.json({ error: "patientNotFound" }, { status: 404 })
+      // Rejet dur à la saisie (bornes/couverture) / doublon / verrou / bascule MDR concurrente → statut HTTP
+      // stable + trace HDS de la tentative (jamais 500 ni fuite de stack).
+      const reason = e instanceof Error ? e.message : "unknown"
+      const status = SLOT_SET_ERROR_STATUS[reason] ?? (reason === "patientNotFound" ? 404 : undefined)
+      if (status) {
+        await auditService
+          .log({ userId: user.id, action: "INSULIN_SLOT_SUBMISSION", resource: "PATIENT", resourceId: String(patientId), ipAddress: ctx.ipAddress, userAgent: ctx.userAgent, requestId: ctx.requestId, metadata: { patientId, parameterType, outcome: "rejected", reason } })
+          .catch(() => {})
+        return NextResponse.json({ error: reason }, { status })
       }
       throw e
     }

--- a/src/lib/auth/api-rate-limit.ts
+++ b/src/lib/auth/api-rate-limit.ts
@@ -151,6 +151,17 @@ export const RATE_LIMITS = {
     max: 30,
     failMode: "open",
   } satisfies ApiRateLimitConfig,
+  /**
+   * US-2657 (C3c) — soumission patient d'un jeu de créneaux insuline (écriture déclenchant une décision
+   * automatisée de dosage) : 20 req/60 s/user. Fail-open — dispo d'abord (un patient ne doit pas être bloqué
+   * de gérer son insuline en cas de panne Redis ; le vrai garde-fou de dosage est l'enveloppe C1–C8 + C7).
+   */
+  insulinSubmission: {
+    bucket: "insulin-submission",
+    windowSec: 60,
+    max: 20,
+    failMode: "open",
+  } satisfies ApiRateLimitConfig,
   /** Per-patient detail reads (BGM, glycemia): 60 req/60 s/user. Fail-open. */
   patientDataRead: {
     bucket: "patient-data-read",

--- a/src/lib/insulin/slot-set-errors.ts
+++ b/src/lib/insulin/slot-set-errors.ts
@@ -1,0 +1,19 @@
+/**
+ * Codes d'erreur métier du remplacement/soumission de jeu de créneaux ISF/ICR → statut HTTP (stables,
+ * sans PHI). **Module SANS dépendance** — réutilisé par la voie DOCTOR (`slot-set-replace`) ET la route
+ * patient C3c (`api/patient/insulin-slot-set`), sans coupler cette dernière au handler DOCTOR.
+ */
+export const SLOT_SET_ERROR_STATUS: Record<string, number> = {
+  emptySlotSet: 409,
+  zeroDurationSlot: 400,
+  slotOverlap: 409,
+  slotGap: 422,
+  valueOutOfBounds: 400,
+  settingsNotFound: 404,
+  invalidSlotSet: 400, // forme JSON invalide (parseSlots)
+  slotsBusy: 409, // mutation concurrente en cours (verrou non bloquant) — réessayer
+  // C3c — levées par `createSetProposal` sur la voie fallback proposition (course de double-soumission /
+  // bascule MDR concurrente) : à mapper en 4xx, jamais en 500 (cohérent avec `slotsBusy`).
+  duplicatePendingProposal: 409,
+  nonInsulinNoDose: 409,
+}

--- a/src/lib/insulin/slot-set-replace.ts
+++ b/src/lib/insulin/slot-set-replace.ts
@@ -12,23 +12,13 @@ import { resolvePatientId } from "@/lib/access-control"
 import { requireGdprConsent } from "@/lib/gdpr"
 import { insulinTherapyService } from "@/lib/services/insulin-therapy.service"
 import { extractRequestContext } from "@/lib/services/audit.service"
+import { SLOT_SET_ERROR_STATUS } from "@/lib/insulin/slot-set-errors"
 
 /** Créneau normalisé (valeur = ISF g/L ou ICR g/U), forme attendue par `replaceSlotSet`. */
 export type NormalizedSlot = { startHour: number; endHour: number; value: number; mealLabel?: string }
 
 /** Corps normalisé d'un PUT de remplacement de groupe. */
 export type ReplaceSetBody = { patientId?: number; slots: NormalizedSlot[] }
-
-/** Codes d'erreur métier du remplacement de groupe → statut HTTP (stables, sans PHI). Réutilisé par C3c. */
-export const SLOT_SET_ERROR_STATUS: Record<string, number> = {
-  emptySlotSet: 409,
-  zeroDurationSlot: 400,
-  slotOverlap: 409,
-  slotGap: 422,
-  valueOutOfBounds: 400,
-  settingsNotFound: 404,
-  slotsBusy: 409, // mutation concurrente en cours (verrou non bloquant) — réessayer
-}
 
 /**
  * PUT mutualisé — remplace atomiquement TOUT le jeu de créneaux (`param`) du patient. DOCTOR only,

--- a/src/lib/insulin/slot-set-replace.ts
+++ b/src/lib/insulin/slot-set-replace.ts
@@ -19,8 +19,8 @@ export type NormalizedSlot = { startHour: number; endHour: number; value: number
 /** Corps normalisé d'un PUT de remplacement de groupe. */
 export type ReplaceSetBody = { patientId?: number; slots: NormalizedSlot[] }
 
-/** Codes d'erreur métier du remplacement de groupe → statut HTTP (stables, sans PHI). */
-const SLOT_SET_ERROR_STATUS: Record<string, number> = {
+/** Codes d'erreur métier du remplacement de groupe → statut HTTP (stables, sans PHI). Réutilisé par C3c. */
+export const SLOT_SET_ERROR_STATUS: Record<string, number> = {
   emptySlotSet: 409,
   zeroDurationSlot: 400,
   slotOverlap: 409,

--- a/src/lib/services/audit.service.ts
+++ b/src/lib/services/audit.service.ts
@@ -85,6 +85,9 @@ export type AuditAction =
   | "AUTO_APPLY_FALLBACK"
   /** Édition rejetée (valeur hors bornes cliniques) ou échec d'application auto-appliquée. */
   | "AUTO_APPLY_REJECTED"
+  /** C3c — trace HDS d'une SOUMISSION patient de jeu de créneaux non couverte par une décision gouvernée
+   *  (no-op, ou rejet dur à la saisie : bornes/couverture/verrou/doublon). Sans PHI. */
+  | "INSULIN_SLOT_SUBMISSION"
   | "IMPORT"
   | "ANONYMIZE"
   /** US-2265 — RBAC-breach burst signal (50+ UNAUTHORIZED in 60s by same userId). */

--- a/tests/integration/api-patient-insulin-slot-set.test.ts
+++ b/tests/integration/api-patient-insulin-slot-set.test.ts
@@ -1,28 +1,35 @@
 /**
  * US-2657 (slice C3c) — Route self-service patient `PUT /api/patient/insulin-slot-set`.
- * Sécurité : own-id STRICT (`getOwnPatientId`, anti-IDOR → 404 neutre pour un pro sans dossier),
- * consentement RGPD, validation Zod (ISF/ICR seulement) ; dispatch de l'`outcome` gouverné ; mapping des
- * rejets durs (bornes) / verrou occupé → 4xx. L'orchestrateur `applyExpertGroupGoverned` est mocké.
+ * Sécurité : own-id STRICT (`getOwnPatientId`, anti-IDOR → 404 neutre pour un pro sans dossier), rate-limit,
+ * consentement RGPD, validation Zod (ISF/ICR seulement, ≤24 créneaux) ; dispatch de l'`outcome` gouverné ;
+ * mapping des rejets durs / doublon / verrou → 4xx + audit `INSULIN_SLOT_SUBMISSION`. Orchestrateur mocké.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { NextRequest } from "next/server"
 
 vi.mock("@/lib/db/client", () => ({ prisma: {} }))
 vi.mock("@/lib/gdpr", () => ({ requireGdprConsent: vi.fn().mockResolvedValue(true) }))
-// `resolvePatientId` requis par le module `slot-set-replace` (importé pour SLOT_SET_ERROR_STATUS).
-vi.mock("@/lib/access-control", () => ({ getOwnPatientId: vi.fn(), resolvePatientId: vi.fn() }))
+vi.mock("@/lib/access-control", () => ({ getOwnPatientId: vi.fn() }))
+vi.mock("@/lib/auth/api-rate-limit", () => ({
+  checkApiRateLimit: vi.fn().mockResolvedValue({ allowed: true, remaining: 19, retryAfterSec: 60 }),
+  RATE_LIMITS: { insulinSubmission: { bucket: "insulin-submission", windowSec: 60, max: 20, failMode: "open" } },
+}))
 vi.mock("@/lib/services/auto-apply.service", () => ({ autoApplyService: { applyExpertGroupGoverned: vi.fn() } }))
 vi.mock("@/lib/services/audit.service", () => ({
   extractRequestContext: vi.fn().mockReturnValue({ ipAddress: "127.0.0.1", userAgent: "test", requestId: "r1" }),
+  auditService: { log: vi.fn().mockResolvedValue(undefined), rateLimited: vi.fn().mockResolvedValue({}) },
 }))
 
 const { PUT } = await import("@/app/api/patient/insulin-slot-set/route")
 const { getOwnPatientId } = await import("@/lib/access-control")
 const { requireGdprConsent } = await import("@/lib/gdpr")
+const { checkApiRateLimit } = await import("@/lib/auth/api-rate-limit")
 const { autoApplyService } = await import("@/lib/services/auto-apply.service")
+const { auditService } = await import("@/lib/services/audit.service")
 
 const ownPatient = vi.mocked(getOwnPatientId)
 const govern = vi.mocked(autoApplyService.applyExpertGroupGoverned)
+const rateLimit = vi.mocked(checkApiRateLimit)
 
 const SLOTS = [
   { startHour: 0, endHour: 8, value: 0.5 },
@@ -36,16 +43,18 @@ function req(role: string, body: unknown): NextRequest {
     body: JSON.stringify(body),
   })
 }
+const isf = (slots: unknown = SLOTS) => req("VIEWER", { parameterType: "insulinSensitivityFactor", slots })
 
 describe("PUT /api/patient/insulin-slot-set (C3c)", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     ownPatient.mockResolvedValue(7)
+    rateLimit.mockResolvedValue({ allowed: true, remaining: 19, retryAfterSec: 60 } as never)
     govern.mockResolvedValue({ outcome: "proposal", failedCheck: "C1", proposalId: "set-1" } as never)
   })
 
   it("patient soumet → 200 + orchestrateur appelé avec patientId scopé (own-id) + acteur = user", async () => {
-    const res = await PUT(req("VIEWER", { parameterType: "insulinSensitivityFactor", slots: SLOTS }))
+    const res = await PUT(isf())
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ outcome: "proposal", failedCheck: "C1", proposalId: "set-1" })
     expect(govern).toHaveBeenCalledWith(
@@ -58,9 +67,22 @@ describe("PUT /api/patient/insulin-slot-set (C3c)", () => {
 
   it("outcome applied → 200", async () => {
     govern.mockResolvedValue({ outcome: "applied" } as never)
-    const res = await PUT(req("VIEWER", { parameterType: "insulinToCarbRatio", slots: SLOTS }))
+    expect((await PUT(isf())).status).toBe(200)
+  })
+
+  it("outcome rejected (MDR) → 200 (décision gouvernée, pas une erreur)", async () => {
+    govern.mockResolvedValue({ outcome: "rejected", reason: "nonInsulinNoDose" } as never)
+    const res = await PUT(isf())
     expect(res.status).toBe(200)
-    expect(await res.json()).toEqual({ outcome: "applied" })
+    expect(await res.json()).toEqual({ outcome: "rejected", reason: "nonInsulinNoDose" })
+  })
+
+  it("outcome no-op → 200 + audit INSULIN_SLOT_SUBMISSION (trace HDS)", async () => {
+    govern.mockResolvedValue({ outcome: "noop" } as never)
+    expect((await PUT(isf())).status).toBe(200)
+    expect(auditService.log).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "INSULIN_SLOT_SUBMISSION", metadata: expect.objectContaining({ outcome: "noop" }) }),
+    )
   })
 
   it("pas de dossier patient (pro) → 404 neutre, orchestrateur NON appelé (anti-IDOR)", async () => {
@@ -71,24 +93,62 @@ describe("PUT /api/patient/insulin-slot-set (C3c)", () => {
   })
 
   it("paramètre non ISF/ICR (basalRate) → 400", async () => {
-    const res = await PUT(req("VIEWER", { parameterType: "basalRate", slots: SLOTS }))
-    expect(res.status).toBe(400)
+    expect((await PUT(req("VIEWER", { parameterType: "basalRate", slots: SLOTS }))).status).toBe(400)
     expect(govern).not.toHaveBeenCalled()
   })
 
-  it("rejet dur bornes (valueOutOfBounds) → 400", async () => {
+  it("payload > 24 créneaux → 400 (borne anti-abus)", async () => {
+    const many = Array.from({ length: 25 }, (_, i) => ({ startHour: i % 24, endHour: (i + 1) % 24, value: 0.5 }))
+    expect((await PUT(isf(many))).status).toBe(400)
+  })
+
+  it("rejet dur bornes (valueOutOfBounds) → 400 + audit tentative", async () => {
     govern.mockRejectedValue(new Error("valueOutOfBounds"))
-    expect((await PUT(req("VIEWER", { parameterType: "insulinSensitivityFactor", slots: SLOTS }))).status).toBe(400)
+    expect((await PUT(isf())).status).toBe(400)
+    expect(auditService.log).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "INSULIN_SLOT_SUBMISSION", metadata: expect.objectContaining({ outcome: "rejected", reason: "valueOutOfBounds" }) }),
+    )
+  })
+
+  it("double-soumission concurrente (duplicatePendingProposal) → 409 (pas 500)", async () => {
+    govern.mockRejectedValue(new Error("duplicatePendingProposal"))
+    expect((await PUT(isf())).status).toBe(409)
+  })
+
+  it("bascule MDR concurrente (nonInsulinNoDose levé) → 409 (pas 500)", async () => {
+    govern.mockRejectedValue(new Error("nonInsulinNoDose"))
+    expect((await PUT(isf())).status).toBe(409)
+  })
+
+  it("settingsNotFound → 404 (pas 500)", async () => {
+    govern.mockRejectedValue(new Error("settingsNotFound"))
+    expect((await PUT(isf())).status).toBe(404)
   })
 
   it("verrou occupé (slotsBusy) → 409", async () => {
     govern.mockRejectedValue(new Error("slotsBusy"))
-    expect((await PUT(req("VIEWER", { parameterType: "insulinSensitivityFactor", slots: SLOTS }))).status).toBe(409)
+    expect((await PUT(isf())).status).toBe(409)
+  })
+
+  it("erreur inattendue (non mappée) → 500 générique sans fuite", async () => {
+    govern.mockRejectedValue(new Error("boom-internal"))
+    const res = await PUT(isf())
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: "serverError" })
+  })
+
+  it("rate-limit dépassé → 429 + audit rateLimited (orchestrateur non appelé)", async () => {
+    rateLimit.mockResolvedValue({ allowed: false, remaining: 0, retryAfterSec: 42 } as never)
+    const res = await PUT(isf())
+    expect(res.status).toBe(429)
+    expect(res.headers.get("Retry-After")).toBe("42")
+    expect(govern).not.toHaveBeenCalled()
+    expect(auditService.rateLimited).toHaveBeenCalled()
   })
 
   it("consentement RGPD absent → 403 (orchestrateur non appelé)", async () => {
     vi.mocked(requireGdprConsent).mockResolvedValueOnce(false)
-    const res = await PUT(req("VIEWER", { parameterType: "insulinSensitivityFactor", slots: SLOTS }))
+    const res = await PUT(isf())
     expect(res.status).toBe(403)
     expect(govern).not.toHaveBeenCalled()
   })

--- a/tests/integration/api-patient-insulin-slot-set.test.ts
+++ b/tests/integration/api-patient-insulin-slot-set.test.ts
@@ -1,0 +1,95 @@
+/**
+ * US-2657 (slice C3c) — Route self-service patient `PUT /api/patient/insulin-slot-set`.
+ * Sécurité : own-id STRICT (`getOwnPatientId`, anti-IDOR → 404 neutre pour un pro sans dossier),
+ * consentement RGPD, validation Zod (ISF/ICR seulement) ; dispatch de l'`outcome` gouverné ; mapping des
+ * rejets durs (bornes) / verrou occupé → 4xx. L'orchestrateur `applyExpertGroupGoverned` est mocké.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { NextRequest } from "next/server"
+
+vi.mock("@/lib/db/client", () => ({ prisma: {} }))
+vi.mock("@/lib/gdpr", () => ({ requireGdprConsent: vi.fn().mockResolvedValue(true) }))
+// `resolvePatientId` requis par le module `slot-set-replace` (importé pour SLOT_SET_ERROR_STATUS).
+vi.mock("@/lib/access-control", () => ({ getOwnPatientId: vi.fn(), resolvePatientId: vi.fn() }))
+vi.mock("@/lib/services/auto-apply.service", () => ({ autoApplyService: { applyExpertGroupGoverned: vi.fn() } }))
+vi.mock("@/lib/services/audit.service", () => ({
+  extractRequestContext: vi.fn().mockReturnValue({ ipAddress: "127.0.0.1", userAgent: "test", requestId: "r1" }),
+}))
+
+const { PUT } = await import("@/app/api/patient/insulin-slot-set/route")
+const { getOwnPatientId } = await import("@/lib/access-control")
+const { requireGdprConsent } = await import("@/lib/gdpr")
+const { autoApplyService } = await import("@/lib/services/auto-apply.service")
+
+const ownPatient = vi.mocked(getOwnPatientId)
+const govern = vi.mocked(autoApplyService.applyExpertGroupGoverned)
+
+const SLOTS = [
+  { startHour: 0, endHour: 8, value: 0.5 },
+  { startHour: 8, endHour: 22, value: 0.45 },
+  { startHour: 22, endHour: 0, value: 0.4 },
+]
+function req(role: string, body: unknown): NextRequest {
+  return new NextRequest(new URL("http://localhost/api/patient/insulin-slot-set"), {
+    method: "PUT",
+    headers: { "content-type": "application/json", "x-user-id": "42", "x-user-role": role },
+    body: JSON.stringify(body),
+  })
+}
+
+describe("PUT /api/patient/insulin-slot-set (C3c)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ownPatient.mockResolvedValue(7)
+    govern.mockResolvedValue({ outcome: "proposal", failedCheck: "C1", proposalId: "set-1" } as never)
+  })
+
+  it("patient soumet → 200 + orchestrateur appelé avec patientId scopé (own-id) + acteur = user", async () => {
+    const res = await PUT(req("VIEWER", { parameterType: "insulinSensitivityFactor", slots: SLOTS }))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ outcome: "proposal", failedCheck: "C1", proposalId: "set-1" })
+    expect(govern).toHaveBeenCalledWith(
+      { patientId: 7, parameterType: "insulinSensitivityFactor", proposedSlots: SLOTS },
+      42,
+      expect.any(Date),
+      expect.anything(),
+    )
+  })
+
+  it("outcome applied → 200", async () => {
+    govern.mockResolvedValue({ outcome: "applied" } as never)
+    const res = await PUT(req("VIEWER", { parameterType: "insulinToCarbRatio", slots: SLOTS }))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ outcome: "applied" })
+  })
+
+  it("pas de dossier patient (pro) → 404 neutre, orchestrateur NON appelé (anti-IDOR)", async () => {
+    ownPatient.mockResolvedValue(null)
+    const res = await PUT(req("DOCTOR", { parameterType: "insulinSensitivityFactor", slots: SLOTS }))
+    expect(res.status).toBe(404)
+    expect(govern).not.toHaveBeenCalled()
+  })
+
+  it("paramètre non ISF/ICR (basalRate) → 400", async () => {
+    const res = await PUT(req("VIEWER", { parameterType: "basalRate", slots: SLOTS }))
+    expect(res.status).toBe(400)
+    expect(govern).not.toHaveBeenCalled()
+  })
+
+  it("rejet dur bornes (valueOutOfBounds) → 400", async () => {
+    govern.mockRejectedValue(new Error("valueOutOfBounds"))
+    expect((await PUT(req("VIEWER", { parameterType: "insulinSensitivityFactor", slots: SLOTS }))).status).toBe(400)
+  })
+
+  it("verrou occupé (slotsBusy) → 409", async () => {
+    govern.mockRejectedValue(new Error("slotsBusy"))
+    expect((await PUT(req("VIEWER", { parameterType: "insulinSensitivityFactor", slots: SLOTS }))).status).toBe(409)
+  })
+
+  it("consentement RGPD absent → 403 (orchestrateur non appelé)", async () => {
+    vi.mocked(requireGdprConsent).mockResolvedValueOnce(false)
+    const res = await PUT(req("VIEWER", { parameterType: "insulinSensitivityFactor", slots: SLOTS }))
+    expect(res.status).toBe(403)
+    expect(govern).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Point d'entrée **self-service patient** pour soumettre une disposition complète de créneaux ISF/ICR. Délègue à l'orchestrateur gouverné `applyExpertGroupGoverned` (C3b, mergé #707) qui décide tout-ou-rien : **auto-application** (dans l'enveloppe C1–C8), **proposition médecin** groupée, **rejet** (MDR) ou **no-op**.

## Sécurité
- **Own-id STRICT** (`getOwnPatientId`, anti-IDOR / anti-énumération) : patient résolu depuis `user.id` seul — **aucun `?patientId`, aucun token**. Un pro sans dossier patient → **404 neutre** (les pros éditent via `/patients/[id]`, chemin DOCTOR direct). Consentement RGPD requis.
- Même pattern que `GET /api/patient/insulin-settings` (US-2650).

## Contrat
- Zod : `parameterType` ∈ {ISF, ICR} + `slots[]` (`{startHour,endHour,value,mealLabel?}`, value en g/L / g/U). Bornes cliniques **re-validées serveur** par `assertValidSlotSet`.
- Réponse : l'**`outcome` gouverné** (200) — `{ outcome: "applied" | "noop" | "proposal" | "rejected", … }`.
- Rejet dur à la saisie (`valueOutOfBounds`/`slotGap`/`slotOverlap`/…) + `slotsBusy` (verrou occupé) → **4xx** (`SLOT_SET_ERROR_STATUS` exporté et réutilisé). Audit émis par l'orchestrateur (sans PHI).

## Portée / reste à livrer
- **C3d** (route médecin d'accept/reject des `SlotSetProposal`) — à livrer.
- Tout reste **inerte en prod** (kill-switch OFF + DPIA non signée) : la route fonctionne mais l'auto-application ne s'exécute pas tant que la gouvernance n'est pas activée.

## Vérifs
✅ **4006 tests** verts (7 cas C3c) · **0 erreur `tsc`** · **ESLint** propre · pas de changement de schéma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)