### PR TITLE
US-2653 (correctif) — anti-cliquet : porte d'observation POST-changement (Q6a) + surfaçage hypo sévère bloquée (Q6b)

### DIFF
--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -329,6 +329,23 @@ même si la moyenne est « normale ». **Extension complète à 4 leviers** : ch
 n'est pas gatée (self-limiting par les bornes cliniques). Prévient l'accumulation itérative 10%+10%+10% avant 
 jugement de l'effet sur ≥ 3 j CGM/BGM.
 
+**Porte d'observation POST-changement (fix Q6a, 2026-07)** — invariant de sécurité complétant le délai :
+une dé-escalade à magnitude fixe ne se juge **que sur les observations datées APRÈS le dernier changement
+accepté** (`dayIso > cutoff`, `cutoff` = jour local du `reviewedAt` de l'ACCEPTÉE précédente). Le délai des
+72 h seul ne suffit pas : sans ce filtre, une récurrence d'hypos **périmées** (antérieures au changement)
+re-déclencherait une baisse alors que l'effet du dernier ajustement n'a pas encore été observé. Deux verrous
+cumulatifs, donc : **(1)** délai `≥ 72 h` écoulé **ET (2)** signal récurrent tenant sur ≥ 3 observations
+*post-changement*. `cutoff = null` (aucun changement antérieur) → première dé-escalade jugée sur la fenêtre
+entière. Implémentation : helpers `lastAcceptedChangeAt` / `deescalationTiming` / `afterCutoff`
+(`proposal-generator.service.ts`) ; `dayIso` propagé jusqu'aux relevés (`CorrectionPoint`, `fixedDoseTrend`,
+nadirs à jeun, nadirs repas) via `localDay` (`meal-trends.service.ts`).
+
+**Surfaçage de sévérité pendant blocage (fix Q6b, 2026-07)** — si une dé-escalade est **bloquée** (délai
+non écoulé **ou** données post-changement insuffisantes) mais qu'une **hypo sévère** (`< 0,54 g/L`,
+`hasSevereHypo`) est présente sur la fenêtre, l'événement n'est **jamais tu silencieusement** : levée d'un
+flag de revue clinique (`highVariabilityPostCorrection` ISF, `nocturnalHypoHighFasting` basal). Garantit
+qu'un anti-ratchet ne masque jamais un signal de danger patient.
+
 **Three new contextual flag types** (`reviewFlags` namespace i18n FR/EN/AR) :
 - `highVariabilityPostCorrection` — ISF : pics + creux post-correction → revue (pas de dose)
 - `nocturnalHypoHighFasting` — Basal : Somogyi soupçonné, glycémie à jeun élevée + hypos nocturnes récurrentes → revue (pas de baisse)

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -342,9 +342,22 @@ nadirs à jeun, nadirs repas) via `localDay` (`meal-trends.service.ts`).
 
 **Surfaçage de sévérité pendant blocage (fix Q6b, 2026-07)** — si une dé-escalade est **bloquée** (délai
 non écoulé **ou** données post-changement insuffisantes) mais qu'une **hypo sévère** (`< 0,54 g/L`,
-`hasSevereHypo`) est présente sur la fenêtre, l'événement n'est **jamais tu silencieusement** : levée d'un
-flag de revue clinique (`highVariabilityPostCorrection` ISF, `nocturnalHypoHighFasting` basal). Garantit
-qu'un anti-ratchet ne masque jamais un signal de danger patient.
+`hasSevereHypo`) est présente sur la fenêtre (jugée sur la **fenêtre entière**, superset du post-changement),
+l'événement n'est **jamais tu silencieusement** : levée d'un flag de revue clinique. Couverture **symétrique
+sur les 4 leviers** (parité stricte — un anti-ratchet ne masque jamais un signal de danger patient) :
+
+| Levier | Flag levé | Chemins Q6b couverts |
+|--------|-----------|----------------------|
+| ICR | `highVariabilityPostMeal` | dé-escalade bloquée (délai/post-changement) **+** hypo sévère post-repas **isolée** (in-band, non récurrente) |
+| ISF | `highVariabilityPostCorrection` | dé-escalade bloquée **+** hypo sévère post-correction **isolée** |
+| Basal | `nocturnalHypoHighFasting` | dé-escalade bloquée **+** hypo nocturne sévère **isolée** |
+| FixedDose | `highVariabilityFixedDose` | dé-escalade bloquée / dose non réductible (≤ plancher) **+** relevé sévère **isolé** |
+
+**Limite connue (sémantique du cooldown)** — le « dernier changement accepté » qui arme le cooldown et fixe
+le `cutoff` est lu **uniquement** sur `AdjustmentProposal { status: "accepted" }` (`lastAcceptedChangeAt`).
+Une acceptation **groupée** `SlotSetProposal` (édition patient CONFIRMÉ, ADR #23) sur le même créneau ne
+réarme **pas** le cooldown moteur. Défendable pour l'objectif du fix (empêcher l'empilement des dé-escalades
+**moteur** avant observation) ; à revisiter si l'anti-ratchet doit couvrir aussi les remplacements groupés.
 
 **Three new contextual flag types** (`reviewFlags` namespace i18n FR/EN/AR) :
 - `highVariabilityPostCorrection` — ISF : pics + creux post-correction → revue (pas de dose)

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -348,7 +348,7 @@ sur les 4 leviers** (parité stricte — un anti-ratchet ne masque jamais un sig
 
 | Levier | Flag levé | Chemins Q6b couverts |
 |--------|-----------|----------------------|
-| ICR | `highVariabilityPostMeal` | dé-escalade bloquée (délai/post-changement) **+** hypo sévère post-repas **isolée** (in-band, non récurrente) |
+| ICR | `highVariabilityPostMeal` | dé-escalade bloquée (délai/post-changement) **+** hypo sévère post-repas **isolée** non récurrente (in-band, sous borne basse, ou plafond avec baisse annulée par la garde-hypo) |
 | ISF | `highVariabilityPostCorrection` | dé-escalade bloquée **+** hypo sévère post-correction **isolée** |
 | Basal | `nocturnalHypoHighFasting` | dé-escalade bloquée **+** hypo nocturne sévère **isolée** |
 | FixedDose | `highVariabilityFixedDose` | dé-escalade bloquée / dose non réductible (≤ plancher) **+** relevé sévère **isolé** |

--- a/src/lib/services/analytics.service.ts
+++ b/src/lib/services/analytics.service.ts
@@ -449,7 +449,9 @@ export const analyticsService = {
    * @param period Période d'analyse (défaut appelant : 14 j).
    * @param auditUserId Acteur d'audit (système `null` pour le cron).
    * @param ctx Contexte requête (audit).
-   * @returns Par moment, la liste des creux g/L (peut être vide → l'analyseur renverra `null`).
+   * @returns Par moment, la liste des creux `{ gl, dayIso }` — `gl` en g/L, `dayIso` (`YYYY-MM-DD`) = jour
+   *          du relevé, porté pour le filtre POST-changement de l'anti-ratchet (US-2653). Peut être vide
+   *          → l'analyseur renverra `null`.
    */
   async fixedDoseTrend(
     patientId: number,
@@ -457,7 +459,7 @@ export const analyticsService = {
     auditUserId: number | null,
     ctx?: AuditContext,
     opts?: { skipAudit?: boolean },
-  ): Promise<Record<DoseMoment, number[]>> {
+  ): Promise<Record<DoseMoment, { gl: number; dayIso: string }[]>> {
     const days = parsePeriod(period)
     const now = new Date()
     const since = new Date(now.getTime() - days * 24 * 3600_000)
@@ -515,9 +517,11 @@ export const analyticsService = {
     }
 
     // Shift : la dose du moment M est jugée sur les creux (earliest/jour) de la fenêtre SUIVANTE.
-    const out: Record<DoseMoment, number[]> = { morning: [], noon: [], evening: [], night: [] }
+    // US-2653 (fix cooldown) — on porte `dayIso` (jour du relevé) pour filtrer les observations
+    // POST-changement au moment de re-titrer (jamais re-titrer sur des creux d'avant le dernier ajustement).
+    const out: Record<DoseMoment, { gl: number; dayIso: string }[]> = { morning: [], noon: [], evening: [], night: [] }
     for (const dose of DAY_MOMENTS) {
-      out[dose] = [...earliestByWindow[FIXED_DOSE_NEXT_WINDOW[dose]].values()].map((v) => v.gl)
+      out[dose] = [...earliestByWindow[FIXED_DOSE_NEXT_WINDOW[dose]].entries()].map(([dayIso, v]) => ({ gl: v.gl, dayIso }))
     }
     return out
   },

--- a/src/lib/services/analytics.service.ts
+++ b/src/lib/services/analytics.service.ts
@@ -12,6 +12,7 @@ import { prisma } from "@/lib/db/client"
 import { auditService } from "./audit.service"
 import type { AuditContext } from "./audit.service"
 import { getCgmDefaults } from "./objectives.service"
+import { localDay } from "./meal-trends.service"
 import {
   mean, glToMgdl, glucoseManagementIndicator, coefficientOfVariation, stddev,
   computeTir, assessTirQuality, computeAgp, detectHypoEpisodes,
@@ -511,7 +512,10 @@ export const analyticsService = {
       if (!r.time) continue
       const minutesOfDay = r.time.getUTCHours() * 60 + r.time.getUTCMinutes()
       const window = momentForHour(minutesOfDay / 60, bounds)
-      const dayIso = r.date.toISOString().slice(0, 10)
+      // US-2653 (fix TZ) — jour dérivé via `localDay` (Europe/Paris), MÊME base que le `cutoff` du
+      // générateur et que les 3 autres leviers. La colonne `GlycemiaEntry.date` (@db.Date) est à minuit
+      // UTC ; `localDay` la ramène au jour calendaire local → cohérence stricte du filtre post-changement.
+      const dayIso = localDay(r.date.getTime())
       const cur = earliestByWindow[window].get(dayIso)
       if (!cur || minutesOfDay < cur.min) earliestByWindow[window].set(dayIso, { min: minutesOfDay, gl })
     }

--- a/src/lib/services/analytics.service.ts
+++ b/src/lib/services/analytics.service.ts
@@ -515,6 +515,8 @@ export const analyticsService = {
       // US-2653 (fix TZ) — jour dérivé via `localDay` (Europe/Paris), MÊME base que le `cutoff` du
       // générateur et que les 3 autres leviers. La colonne `GlycemiaEntry.date` (@db.Date) est à minuit
       // UTC ; `localDay` la ramène au jour calendaire local → cohérence stricte du filtre post-changement.
+      // NB : correct tant que `CLINICAL_TZ` est à l'EST d'UTC (Europe/Paris = UTC+1/+2) — minuit UTC reste
+      // le même jour local. Un fuseau à l'ouest d'UTC décalerait ce `@db.Date` d'un jour (à revoir alors).
       const dayIso = localDay(r.date.getTime())
       const cur = earliestByWindow[window].get(dayIso)
       if (!cur || minutesOfDay < cur.min) earliestByWindow[window].set(dayIso, { min: minutesOfDay, gl })

--- a/src/lib/services/meal-trends.service.ts
+++ b/src/lib/services/meal-trends.service.ts
@@ -111,6 +111,9 @@ export interface FastingDay {
  */
 export interface CorrectionPoint {
   localHour: number
+  /** US-2653 (fix cooldown) — jour local de la correction (`YYYY-MM-DD`), pour filtrer les observations
+   *  POST-changement (datées après le dernier ajustement accepté) au moment de re-titrer. */
+  dayIso: string
   postGlucoseGl: number
   targetGl: number
   nadirGl: number | null
@@ -132,8 +135,9 @@ function localHour(ms: number): number {
   const m = Number(p.find((x) => x.type === "minute")?.value ?? "0")
   return h + m / 60
 }
-/** Jour calendaire local `YYYY-MM-DD`. */
-function localDay(ms: number): string {
+/** Jour calendaire local `YYYY-MM-DD`. Exporté (US-2653 fix) pour aligner le `cutoff` post-changement
+ *  du générateur sur la même base jour que le `dayIso` des observations (TZ locale, pas UTC). */
+export function localDay(ms: number): string {
   return dayFmt.format(new Date(ms)) // en-CA → ISO
 }
 
@@ -389,6 +393,7 @@ function computeCorrectionTrend(
     const nadirMgdl = minReadingIn(c.readings, t0, windowEnd)
     out.push({
       localHour: localHour(t0),
+      dayIso: localDay(t0),
       postGlucoseGl: postMgdl / 100,
       targetGl: b.targetGl,
       nadirGl: nadirMgdl !== null ? nadirMgdl / 100 : null,

--- a/src/lib/services/proposal-generator.service.ts
+++ b/src/lib/services/proposal-generator.service.ts
@@ -347,6 +347,10 @@ export const proposalGeneratorService = {
       if (isDeescalation && (withinCooldown || candidate === null)) {
         candidate = null
         if (hasSevereHypo(nadirsGl)) await raiseIcrFlag()
+      } else if (!isDeescalation && candidate === null && hasSevereHypo(nadirsGl)) {
+        // Hypo sévère post-repas ISOLÉE (in-band, non récurrente) → surface, jamais silencieuse.
+        // Parité avec ISF/basal/fixedDose (US-2653 fix Q6b) — un anti-cliquet ne masque aucun danger.
+        await raiseIcrFlag()
       }
 
       if (candidate && (await persist(candidate, slot))) created++

--- a/src/lib/services/proposal-generator.service.ts
+++ b/src/lib/services/proposal-generator.service.ts
@@ -39,7 +39,7 @@ import { analyticsService } from "@/lib/services/analytics.service"
 import { clinicalReviewFlagService } from "@/lib/services/clinical-review-flag.service"
 import { treatmentModeService } from "@/lib/services/treatment-mode.service"
 import { insulinTherapyService } from "@/lib/services/insulin-therapy.service"
-import { mealtimePattern, type JournalMeal, type CorrectionPoint } from "@/lib/services/meal-trends.service"
+import { mealtimePattern, localDay, type JournalMeal, type CorrectionPoint } from "@/lib/services/meal-trends.service"
 import { getCgmDefaults, objectivesService } from "@/lib/services/objectives.service"
 import { adjustmentService } from "@/lib/services/adjustment.service"
 import { auditService } from "@/lib/services/audit.service"
@@ -100,21 +100,47 @@ const EMPTY = (skipped: string): GenerateResult =>
  * @param slotWhere Discriminateur de créneau du paramètre (ICR: `carbRatioSlot*` ; ISF: `timeSlot*` ;
  *   basal: `pumpBasalSlotId` ; fixedDose: `moment`).
  */
-async function deescalationOnCooldown(
+async function lastAcceptedChangeAt(
   patientId: number,
   parameterType: AdjustableParameter,
   slotWhere: Prisma.AdjustmentProposalWhereInput,
-): Promise<boolean> {
+): Promise<Date | null> {
   const last = await prisma.adjustmentProposal.findFirst({
     // `reviewedAt: { not: null }` — sous PG `ORDER BY ... DESC` place les NULL en premier ; sans ce filtre
     // une ligne `accepted` à `reviewedAt` NULL (ne devrait pas exister — l'acceptation le pose) masquerait
-    // une acceptation récente ⇒ contournement du cooldown. Ceinture-et-bretelles.
+    // une acceptation récente. Ceinture-et-bretelles.
     where: { patientId, parameterType, status: "accepted", reviewedAt: { not: null }, ...slotWhere },
     orderBy: { reviewedAt: "desc" },
     select: { reviewedAt: true },
   })
-  if (!last?.reviewedAt) return false
-  return Date.now() - last.reviewedAt.getTime() < CLINICAL_BOUNDS.ENGINE_DEESCALATION_COOLDOWN_HOURS * 3_600_000
+  return last?.reviewedAt ?? null
+}
+
+/**
+ * US-2653 (fix Q6a) — **temporalité anti-cliquet** d'une dé-escalade sur un `(patient × paramètre × créneau)`.
+ * Le cooldown est un **plancher temporel**, pas la vraie porte : la porte est le **compte d'observations
+ * POST-changement** (appliquée côté appelant en filtrant les nadirs à `dayIso > cutoff` avant l'analyseur).
+ *  - `cutoff` : jour local du dernier changement ACCEPTÉ (`null` si aucun → première dé-escalade, fenêtre entière) ;
+ *  - `withinCooldown` : `true` si ce changement date de < `ENGINE_DEESCALATION_COOLDOWN_HOURS` (délai non écoulé).
+ * Une dé-escalade ne se persiste que si `!withinCooldown` **ET** le signal récurrent tient sur le POST-changement.
+ */
+async function deescalationTiming(
+  patientId: number,
+  parameterType: AdjustableParameter,
+  slotWhere: Prisma.AdjustmentProposalWhereInput,
+): Promise<{ cutoff: string | null; withinCooldown: boolean }> {
+  const at = await lastAcceptedChangeAt(patientId, parameterType, slotWhere)
+  if (at === null) return { cutoff: null, withinCooldown: false }
+  return {
+    cutoff: localDay(at.getTime()),
+    withinCooldown: Date.now() - at.getTime() < CLINICAL_BOUNDS.ENGINE_DEESCALATION_COOLDOWN_HOURS * 3_600_000,
+  }
+}
+
+/** US-2653 (fix Q6a) — observations datées APRÈS le dernier changement accepté (par jour local). `cutoff`
+ *  `null` → toutes (aucun changement antérieur). */
+function afterCutoff<T extends { dayIso: string }>(obs: T[], cutoff: string | null): T[] {
+  return cutoff === null ? obs : obs.filter((o) => o.dayIso > cutoff)
 }
 
 /** Construit les entrées `analyzeIcrSlot` d'un créneau pour une cible donnée (deadband). */
@@ -283,38 +309,44 @@ export const proposalGeneratorService = {
         .filter((n): n is number => n !== null)
         .map((n) => n / 100)
       const recurrentHypo = recurrentPostMealHypo(nadirsGl)
+      const icrBucket = `${slot.startHour}-${slot.endHour}`
+      const raiseIcrFlag = () =>
+        clinicalReviewFlagService.raise(patientId, "highVariabilityPostMeal", auditUserId, ctx)
+          .then(() => { flagged++ })
+          .catch((err) => logger.error("proposal-generator", "raise flag failed", { patientId, bucket: icrBucket }, err as Error))
 
       // Haute variabilité → FLAG d'orientation, pas de dose (intercepté AVANT tout builder).
       if (avgPostGl > ceilingGl && recurrentHypo) {
-        await clinicalReviewFlagService.raise(patientId, "highVariabilityPostMeal", auditUserId, ctx)
-          .then(() => { flagged++ })
-          .catch((err) => logger.error("proposal-generator", "raise flag failed",
-            { patientId, bucket: `${slot.startHour}-${slot.endHour}` }, err as Error))
+        await raiseIcrFlag()
         continue
       }
 
+      // US-2653 (fix Q6a) — la dé-escalade se juge sur les nadirs DATÉS APRÈS le dernier changement accepté
+      // (jamais re-titrer sur des hypos périmées) ; `withinCooldown` = plancher temporel séparé.
+      const { cutoff, withinCooldown } = await deescalationTiming(patientId, "insulinToCarbRatio", { carbRatioSlotStart: slot.startHour, carbRatioSlotEnd: slot.endHour })
+      const postNadirsGl = afterCutoff(meals, cutoff).map((m) => m.nadirMgdl).filter((n): n is number => n !== null).map((n) => n / 100)
+
       // Sinon : deadband (baisse si > plafond ; hausse si < borne basse) OU, dans la bande, dé-escalade
-      // sur hypos récurrentes (hausse ICR fixe = moins d'insuline).
+      // sur hypos récurrentes POST-changement (hausse ICR fixe = moins d'insuline).
       let candidate: ProposalCandidate | null = null
       let isDeescalation = false
       if (avgPostGl > ceilingGl) {
-        candidate = analyzeIcrSlot(slot, buildIcrMeals(meals, ceilingGl)) // baisse (deadband)
+        candidate = analyzeIcrSlot(slot, buildIcrMeals(meals, ceilingGl)) // baisse (deadband, non gaté)
       } else if (avgPostGl < lowerGl) {
         candidate = analyzeIcrSlot(slot, buildIcrMeals(meals, lowerGl)) // hausse (deadband)
         // Fallback (validé medical) : moyenne juste sous la borne (deadband < 2 % → null) MAIS hypos
-        // récurrentes → la dé-escalade fixe +10 % (même sens sûr, plus protecteur). Ne pas laisser
-        // ce sliver sans proposition pour un patient à hypos récurrentes.
-        if (!candidate && recurrentHypo) { candidate = analyzeIcrHypoDeescalation(slot, nadirsGl); isDeescalation = true }
+        // récurrentes POST-changement → dé-escalade fixe +10 % (même sens sûr, plus protecteur).
+        if (!candidate && recurrentHypo) { candidate = analyzeIcrHypoDeescalation(slot, postNadirsGl); isDeescalation = true }
       } else if (recurrentHypo) {
-        candidate = analyzeIcrHypoDeescalation(slot, nadirsGl) // in-band + récurrent → hausse +10 %
+        candidate = analyzeIcrHypoDeescalation(slot, postNadirsGl) // in-band + récurrent POST-changement → +10 %
         isDeescalation = true
       }
 
-      // Cooldown anti-cliquet (US-2653) : une dé-escalade FIXE n'est pas re-proposée tant que le dernier
-      // changement ACCEPTÉ sur ce créneau date de < ENGINE_DEESCALATION_COOLDOWN_HOURS (skip silencieux).
-      if (candidate && isDeescalation &&
-        (await deescalationOnCooldown(patientId, "insulinToCarbRatio", { carbRatioSlotStart: slot.startHour, carbRatioSlotEnd: slot.endHour }))) {
+      // Dé-escalade bloquée (délai non écoulé OU signal insuffisant sur le POST-changement) → ne pas
+      // re-titrer ; mais ne JAMAIS taire un nadir SÉVÈRE → flag de revue (US-2653 fix Q6b).
+      if (isDeescalation && (withinCooldown || candidate === null)) {
         candidate = null
+        if (hasSevereHypo(nadirsGl)) await raiseIcrFlag()
       }
 
       if (candidate && (await persist(candidate, slot))) created++
@@ -351,6 +383,12 @@ export const proposalGeneratorService = {
         const avgFasting = fastingValues.length > 0 ? mean(fastingValues) : 0
         const recurrentNoct = recurrentPostMealHypo(nocturnalNadirs)
         const severeNoct = hasSevereHypo(nocturnalNadirs)
+        // US-2653 (fix Q6a) — nadirs nocturnes POST-changement (datés après le dernier ajustement accepté).
+        const { cutoff: basalCutoff, withinCooldown } = await deescalationTiming(patientId, "basalRate", { pumpBasalSlotId: nocturnalSlot.id })
+        const postNocturnalNadirs = afterCutoff(fasting, basalCutoff)
+          .map((f) => f.nocturnalNadirMgdl)
+          .filter((v): v is number => v !== null && Number.isFinite(v))
+          .map((v) => v / 100)
         const basalBucket = `basal:${nocturnalSlot.startHour}-${nocturnalSlot.endHour}`
 
         // Flag nocturne CONTEXTUEL (Somogyi / non-actionnable / sévère isolé) — orientation, jamais une dose.
@@ -399,14 +437,15 @@ export const proposalGeneratorService = {
           if (candidate && !(isIncrease && nocturnalNadirs.length < MIN_NADIR_NIGHTS)) {
             await persistBasal(candidate) // deadband (proportionnel, auto-limité → pas de cooldown)
           } else if (recurrentNoct) {
-            // Dans la bande + hypo nocturne récurrente → baisse FIXE −10 % (dé-escalade), cooldown-gated.
-            const de = analyzeBasalHypoDeescalation(nocturnalSlot.rate, nocturnalNadirs)
-            if (de.kind === "proposal") {
-              if (!(await deescalationOnCooldown(patientId, "basalRate", { pumpBasalSlotId: nocturnalSlot.id }))) {
-                await persistBasal(de.candidate)
-              }
+            // Dans la bande + hypo nocturne récurrente → baisse FIXE −10 % (dé-escalade). Jugée sur les
+            // nadirs POST-changement (Q6a) + plancher temporel `withinCooldown`.
+            const de = analyzeBasalHypoDeescalation(nocturnalSlot.rate, postNocturnalNadirs)
+            if (de.kind === "proposal" && !withinCooldown) {
+              await persistBasal(de.candidate)
             } else if (de.kind === "flagNonActionable") {
               await raiseNocturnalFlag() // débit trop bas pour titrer d'un incrément → restructuration = revue
+            } else if (severeNoct) {
+              await raiseNocturnalFlag() // dé-escalade bloquée (délai/post-changement) mais nadir SÉVÈRE → jamais tu (Q6b)
             }
           } else if (severeNoct) {
             await raiseNocturnalFlag() // hypo sévère nocturne ISOLÉE → surface, jamais silencieuse
@@ -444,6 +483,9 @@ export const proposalGeneratorService = {
         const severe = hasSevereHypo(nadirsGl)
         const avgPost = mean(points.map((p) => p.postGlucoseGl))
         const avgTarget = mean(points.map((p) => p.targetGl))
+        // US-2653 (fix Q6a) — nadirs post-correction DATÉS APRÈS le dernier changement accepté.
+        const { cutoff: isfCutoff, withinCooldown: isfWithinCooldown } = await deescalationTiming(patientId, "insulinSensitivityFactor", { timeSlotStartHour: slot.startHour, timeSlotEndHour: slot.endHour })
+        const postNadirsGl = afterCutoff(points, isfCutoff).map((p) => p.nadirGl).filter((n): n is number => n != null)
 
         const raiseIsfFlag = () =>
           clinicalReviewFlagService.raise(patientId, "highVariabilityPostCorrection", auditUserId, ctx)
@@ -492,10 +534,13 @@ export const proposalGeneratorService = {
           if (candidate) {
             await persistIsf(candidate) // deadband (proportionnel, auto-limité → pas de cooldown)
           } else if (recurrent) {
-            // Dans la bande + hypos post-correction récurrentes → hausse ISF FIXE +10 % (dé-escalade), cooldown-gated.
-            const de = analyzeIsfHypoDeescalation(slot, nadirsGl)
-            if (de && !(await deescalationOnCooldown(patientId, "insulinSensitivityFactor", { timeSlotStartHour: slot.startHour, timeSlotEndHour: slot.endHour }))) {
+            // Dans la bande + hypos post-correction récurrentes → hausse ISF FIXE +10 % (dé-escalade). Jugée
+            // sur les nadirs POST-changement (Q6a) + plancher temporel.
+            const de = analyzeIsfHypoDeescalation(slot, postNadirsGl)
+            if (de && !isfWithinCooldown) {
               await persistIsf(de)
+            } else if (severe) {
+              await raiseIsfFlag() // dé-escalade bloquée (délai/post-changement) mais nadir SÉVÈRE → jamais tu (Q6b)
             }
           } else if (severe) {
             await raiseIsfFlag() // hypo sévère post-correction ISOLÉE → surface, jamais silencieuse
@@ -559,11 +604,15 @@ export const proposalGeneratorService = {
     for (const slot of fixedSlots) {
       const bucket = `fixedDose:${slot.moment}`
       const valueU = Number(slot.valueU)
-      const readingsGl = troughs[slot.moment] ?? []
-      const readings = readingsGl.map((g) => ({ postGlucoseGl: g, targetGl }))
-      const recurrent = recurrentPostMealHypo(readingsGl)
-      const severe = hasSevereHypo(readingsGl)
-      const avgReading = readingsGl.length > 0 ? mean(readingsGl) : 0
+      const troughRows = troughs[slot.moment] ?? []
+      const glValues = troughRows.map((r) => r.gl)
+      const readings = glValues.map((g) => ({ postGlucoseGl: g, targetGl }))
+      const recurrent = recurrentPostMealHypo(glValues)
+      const severe = hasSevereHypo(glValues)
+      const avgReading = glValues.length > 0 ? mean(glValues) : 0
+      // US-2653 (fix Q6a) — relevés du moment DATÉS APRÈS le dernier changement accepté.
+      const { cutoff: fdCutoff, withinCooldown: fdWithinCooldown } = await deescalationTiming(patientId, "fixedDose", { moment: slot.moment })
+      const postGlValues = afterCutoff(troughRows, fdCutoff).map((r) => r.gl)
 
       const raiseFixedFlag = () =>
         clinicalReviewFlagService.raise(patientId, "highVariabilityFixedDose", auditUserId, ctx)
@@ -607,17 +656,18 @@ export const proposalGeneratorService = {
         if (candidate) {
           await persistFixed(candidate) // deadband (proportionnel, auto-limité → pas de cooldown)
         } else if (recurrent) {
-          // Dans la bande + relevés du moment récurremment bas → baisse FIXE bornée (dé-escalade), cooldown-gated.
-          const de = analyzeFixedDoseHypoDeescalation({ moment: slot.moment, valueU }, readingsGl)
-          if (de.kind === "proposal") {
-            if (!(await deescalationOnCooldown(patientId, "fixedDose", { moment: slot.moment }))) {
-              await persistFixed(de.candidate)
-            }
-          } else {
-            // `flagNonActionable` (dose au plancher) OU `none` (dose SOUS le plancher clinique 0,5 U) : dans
-            // les deux cas la baisse est impossible → FLAG de revue (arrêt/restructuration), JAMAIS un silence
-            // sur une hypo récurrente avérée (US-2653, validé medical). `recurrent` est déjà vrai ici.
+          // Dans la bande + relevés récurremment bas → baisse FIXE bornée (dé-escalade). Jugée sur les
+          // relevés POST-changement (Q6a) + plancher temporel `fdWithinCooldown`.
+          const de = analyzeFixedDoseHypoDeescalation({ moment: slot.moment, valueU }, postGlValues)
+          const recurrentPost = recurrentPostMealHypo(postGlValues)
+          if (de.kind === "proposal" && !fdWithinCooldown) {
+            await persistFixed(de.candidate)
+          } else if (de.kind === "flagNonActionable" || (recurrentPost && valueU < CLINICAL_BOUNDS.FIXED_DOSE_MIN)) {
+            // Non réductible POST-changement (dose au/sous plancher clinique 0,5 U) → FLAG de revue
+            // (arrêt/restructuration), jamais un silence sur une hypo récurrente avérée.
             await raiseFixedFlag()
+          } else if (severe) {
+            await raiseFixedFlag() // dé-escalade bloquée (délai/post-changement) mais relevé SÉVÈRE → jamais tu (Q6b)
           }
         } else if (severe) {
           await raiseFixedFlag() // hypo sévère du moment ISOLÉE → surface, jamais silencieuse

--- a/src/lib/services/proposal-generator.service.ts
+++ b/src/lib/services/proposal-generator.service.ts
@@ -348,8 +348,11 @@ export const proposalGeneratorService = {
         candidate = null
         if (hasSevereHypo(nadirsGl)) await raiseIcrFlag()
       } else if (!isDeescalation && candidate === null && hasSevereHypo(nadirsGl)) {
-        // Hypo sévère post-repas ISOLÉE (in-band, non récurrente) → surface, jamais silencieuse.
-        // Parité avec ISF/basal/fixedDose (US-2653 fix Q6b) — un anti-cliquet ne masque aucun danger.
+        // Hypo sévère post-repas ISOLÉE (non récurrente) sans dose produite → surface, jamais silencieuse.
+        // Couvre les 3 régions de moyenne : in-band, sous la borne basse, OU au-dessus du plafond quand le
+        // candidate « baisse » est annulé par la garde-hypo interne d'`analyzeIcrSlot` (plus d'insuline
+        // interdit en présence d'un nadir sévère). Parité stricte avec ISF/basal/fixedDose (US-2653 fix Q6b)
+        // — un anti-cliquet ne masque aucun danger.
         await raiseIcrFlag()
       }
 

--- a/tests/unit/analytics.service.test.ts
+++ b/tests/unit/analytics.service.test.ts
@@ -374,7 +374,10 @@ describe("analyticsService.fixedDoseTrend (US-2652 — assemblage dose fixe par 
     const out = await analyticsService.fixedDoseTrend(42, "14d", 1)
     expect(out.morning).toHaveLength(1)
     expect(out.morning[0].gl).toBeCloseTo(1.2)
-    expect(out.morning[0].dayIso).toMatch(/^\d{4}-\d{2}-\d{2}$/) // dayIso propagé (format ISO jour)
+    // Jour EXACT (pas seulement le format) : la colonne `@db.Date` à minuit UTC doit ressortir sur le même
+    // jour calendaire via `localDay` (Europe/Paris) — verrou anti-régression du fix TZ (garde contre un
+    // retour silencieux à une dérivation UTC divergente).
+    expect(out.morning[0].dayIso).toBe("2026-07-01")
   })
 
   it("accumule un creux PAR JOUR (3 jours → 3 relevés pour la dose)", async () => {

--- a/tests/unit/analytics.service.test.ts
+++ b/tests/unit/analytics.service.test.ts
@@ -359,10 +359,11 @@ describe("analyticsService.fixedDoseTrend (US-2652 — assemblage dose fixe par 
       gEntry("2026-07-01", 23, 0.9), // fenêtre night → juge la dose EVENING
     ])
     const out = await analyticsService.fixedDoseTrend(42, "14d", 1)
-    expect(out.night[0]).toBeCloseTo(1.1)
-    expect(out.morning[0]).toBeCloseTo(1.6)
-    expect(out.noon[0]).toBeCloseTo(1.4)
-    expect(out.evening[0]).toBeCloseTo(0.9)
+    // US-2653 : chaque relevé porte désormais `{ gl, dayIso }` (dayIso pour le filtre post-changement).
+    expect(out.night[0].gl).toBeCloseTo(1.1)
+    expect(out.morning[0].gl).toBeCloseTo(1.6)
+    expect(out.noon[0].gl).toBeCloseTo(1.4)
+    expect(out.evening[0].gl).toBeCloseTo(0.9)
   })
 
   it("retient le relevé le plus TÔT par jour (proxy creux, évite le post-prandial)", async () => {
@@ -372,7 +373,8 @@ describe("analyticsService.fixedDoseTrend (US-2652 — assemblage dose fixe par 
     ])
     const out = await analyticsService.fixedDoseTrend(42, "14d", 1)
     expect(out.morning).toHaveLength(1)
-    expect(out.morning[0]).toBeCloseTo(1.2)
+    expect(out.morning[0].gl).toBeCloseTo(1.2)
+    expect(out.morning[0].dayIso).toMatch(/^\d{4}-\d{2}-\d{2}$/) // dayIso propagé (format ISO jour)
   })
 
   it("accumule un creux PAR JOUR (3 jours → 3 relevés pour la dose)", async () => {

--- a/tests/unit/proposal-generator.service.test.ts
+++ b/tests/unit/proposal-generator.service.test.ts
@@ -16,6 +16,9 @@ vi.mock("@/lib/services/insulin-therapy.service", () => ({
 }))
 vi.mock("@/lib/services/meal-trends.service", () => ({
   mealtimePattern: { dailyJournal: vi.fn(), fastingTrend: vi.fn(), correctionTrend: vi.fn() },
+  // US-2653 (fix cooldown) — le générateur importe `localDay` pour aligner le cutoff post-changement
+  // sur la base jour des observations. En test : jour UTC de l'instant (suffit aux comparaisons de fixtures).
+  localDay: (ms: number) => new Date(ms).toISOString().slice(0, 10),
 }))
 vi.mock("@/lib/services/adjustment.service", () => ({
   adjustmentService: { createEngineProposal: vi.fn() },
@@ -56,10 +59,26 @@ const correctionTrend = vi.mocked(mealtimePattern.correctionTrend)
 const fixedDoseTrend = vi.mocked(analyticsService.fixedDoseTrend)
 const createEngine = vi.mocked(adjustmentService.createEngineProposal)
 
-/** Repas exploitable par défaut : midi (13 h), glucides/bolus OK, pré-repas 1,0 g/L (en bande). */
+const DAY_MS = 86_400_000
+/** Jour ISO (UTC) il y a `n` jours — pour dater les observations relativement à « maintenant »
+ *  (le filtre post-changement US-2653 compare `dayIso > cutoff`). Défaut fixtures : hier. */
+const isoDaysAgo = (n: number) => new Date(Date.now() - n * DAY_MS).toISOString().slice(0, 10)
+
+/** `number[]` → forme `{gl, dayIso}[]` attendue de `fixedDoseTrend` (US-2653 fix). `dayIso` = hier par défaut,
+ *  ou une liste de jours fournie (pour dater les relevés dans les tests post-changement). */
+const toTroughs = (
+  m: Record<string, number[]>,
+  days?: string[],
+): Record<string, { gl: number; dayIso: string }[]> =>
+  Object.fromEntries(
+    Object.entries(m).map(([k, gls]) => [k, gls.map((gl, i) => ({ gl, dayIso: days?.[i] ?? isoDaysAgo(1) }))]),
+  )
+
+/** Repas exploitable par défaut : midi (13 h), glucides/bolus OK, pré-repas 1,0 g/L (en bande).
+ *  `dayIso` = hier par défaut (récent → passe le filtre post-changement quand aucun changement récent). */
 function meal(over: Partial<Record<string, unknown>> = {}) {
   return {
-    mealId: "m", dayIso: "2026-07-01", localHour: 13, moment: "noon",
+    mealId: "m", dayIso: isoDaysAgo(1), localHour: 13, moment: "noon",
     preMgdl: 100, postMgdl: 200, nadirMgdl: 160, carbs: 45, bolus: 6, ...over,
   } as never
 }
@@ -250,7 +269,7 @@ describe("proposalGeneratorService.generateForPatient — chemin basal (US-2651)
   const basalCalls = () =>
     createEngine.mock.calls.map((c) => c[0] as Record<string, unknown>).filter((a) => a.parameterType === "basalRate")
   const fastingNights = (fastingMgdl: number, nocturnalNadirMgdl: number | null) =>
-    Array.from({ length: 3 }, () => ({ fastingMgdl, nocturnalNadirMgdl }))
+    Array.from({ length: 3 }, (_, i) => ({ fastingMgdl, nocturnalNadirMgdl, dayIso: isoDaysAgo(i + 1) }))
 
   it("pompe : à jeun haut + ≥3 nadirs sûrs → proposition basalRate (hausse) sur le créneau nocturne", async () => {
     setup({ meals: [], basalConfig: pump(), fasting: fastingNights(150, 120) }) // 1,50 g/L vs défaut 1,00
@@ -312,7 +331,7 @@ describe("proposalGeneratorService.generateForPatient — mode fixedDose (US-265
     prismaMock.fixedDoseSlot.findMany.mockResolvedValue((opts.slots ?? []) as never)
     prismaMock.patient.findFirst.mockResolvedValue({ pathology: opts.pathology ?? "DT2", pregnancyMode: opts.pregnancyMode ?? false } as never)
     prismaMock.glucoseTarget.findFirst.mockResolvedValue((opts.target ?? null) as never)
-    fixedDoseTrend.mockResolvedValue((opts.troughs ?? emptyTroughs) as never)
+    fixedDoseTrend.mockResolvedValue(toTroughs(opts.troughs ?? emptyTroughs) as never)
     createEngine.mockResolvedValue({ id: "e1" } as never)
   }
 
@@ -369,7 +388,7 @@ describe("proposalGeneratorService.generateForPatient — chemin ISF (US-2651)",
   const isfCalls = () =>
     createEngine.mock.calls.map((c) => c[0] as Record<string, unknown>).filter((a) => a.parameterType === "insulinSensitivityFactor")
   const corrections = (post: number, nadir: number | null, n = 4) =>
-    Array.from({ length: n }, () => ({ localHour: 9, postGlucoseGl: post, targetGl: 1.2, nadirGl: nadir }))
+    Array.from({ length: n }, (_, i) => ({ localHour: 9, dayIso: isoDaysAgo(i), postGlucoseGl: post, targetGl: 1.2, nadirGl: nadir }))
 
   it("corrections au-dessus de la cible → proposition isfTooHigh (baisse) sur le créneau ISF appliqué", async () => {
     setup({ meals: [], sensitivityFactors: [ISF_SLOT], corrections: corrections(1.8, 1.4) })
@@ -435,6 +454,28 @@ describe("proposalGeneratorService.generateForPatient — chemin ISF (US-2651)",
     prismaMock.adjustmentProposal.findFirst.mockResolvedValue({ reviewedAt: new Date(Date.now() - 72 * 3_600_000) } as never)
     await proposalGeneratorService.generateForPatient(1, 99)
     expect(isfCalls()).toHaveLength(1)
+  })
+
+  it("fix Q6a — délai écoulé (100 h) MAIS toutes les hypos datées AVANT le changement → PAS de dé-escalade (données périmées)", async () => {
+    // 3 hypos récurrentes mais toutes antérieures (J-5..J-7) au dernier changement accepté (il y a 100 h ≈ J-4) :
+    // la fenêtre post-changement est vide → l'analyseur ne re-titre jamais sur du pré-changement.
+    const stale = Array.from({ length: 3 }, (_, i) => ({ localHour: 9, dayIso: isoDaysAgo(i + 5), postGlucoseGl: 1.2, targetGl: 1.2, nadirGl: 0.6 }))
+    setup({ meals: [], sensitivityFactors: [ISF_SLOT], corrections: stale })
+    prismaMock.adjustmentProposal.findFirst.mockResolvedValue({ reviewedAt: new Date(Date.now() - 100 * 3_600_000) } as never)
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(isfCalls()).toHaveLength(0) // délai écoulé mais aucune observation post-changement → jamais de dose
+    expect(raiseFlag).not.toHaveBeenCalledWith(1, "highVariabilityPostCorrection", 99, undefined) // nadir 0,6 non sévère
+  })
+
+  it("fix Q6b — dé-escalade bloquée par le cooldown MAIS nadir SÉVÈRE (< 0,54 g/L) présent → FLAG (jamais silencieux)", async () => {
+    // Changement accepté à l'instant → cooldown actif, dé-escalade bloquée ; mais une hypo sévère récurrente
+    // ne doit jamais être tue → surfaçage en flag de revue clinique.
+    const severeSet = Array.from({ length: 3 }, (_, i) => ({ localHour: 9, dayIso: isoDaysAgo(i), postGlucoseGl: 1.2, targetGl: 1.2, nadirGl: 0.5 }))
+    setup({ meals: [], sensitivityFactors: [ISF_SLOT], corrections: severeSet })
+    prismaMock.adjustmentProposal.findFirst.mockResolvedValue({ reviewedAt: new Date() } as never)
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(isfCalls()).toHaveLength(0) // dé-escalade bloquée (cooldown actif)
+    expect(raiseFlag).toHaveBeenCalledWith(1, "highVariabilityPostCorrection", 99, undefined) // sévérité surfacée (Q6b)
   })
 
   it("cooldown : la requête filtre status=accepted + le BON créneau (anti mauvais-créneau / anti-pending)", async () => {
@@ -503,7 +544,7 @@ describe("proposalGeneratorService — dé-escalade basal/fixedDose (US-2653)", 
   const NOCTURNAL = { id: "noct", rate: 0.8, startHour: 0, endHour: 6 }
   const pump = () => ({ configType: "pump", pumpSlots: [NOCTURNAL] })
   const nights = (fastingMgdl: number, nadirMgdl: number | null) =>
-    Array.from({ length: 3 }, () => ({ fastingMgdl, nocturnalNadirMgdl: nadirMgdl }))
+    Array.from({ length: 3 }, (_, i) => ({ fastingMgdl, nocturnalNadirMgdl: nadirMgdl, dayIso: isoDaysAgo(i + 1) }))
   const basalCalls = () =>
     createEngine.mock.calls.map((c) => c[0] as Record<string, unknown>).filter((a) => a.parameterType === "basalRate")
 
@@ -531,13 +572,23 @@ describe("proposalGeneratorService — dé-escalade basal/fixedDose (US-2653)", 
     expect(basalCalls()).toHaveLength(0)
   })
 
+  it("fix Q6b (basal) — dé-escalade bloquée par le cooldown MAIS hypo nocturne SÉVÈRE (0,50 g/L) → FLAG", async () => {
+    // À jeun en cible mais nadir nocturne sévère récurrent, changement accepté à l'instant (cooldown actif) :
+    // la baisse est bloquée mais une hypo nocturne sévère ne doit jamais être tue → surfaçage en flag.
+    setup({ meals: [], basalConfig: pump(), fasting: nights(100, 50) })
+    prismaMock.adjustmentProposal.findFirst.mockResolvedValue({ reviewedAt: new Date() } as never)
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(basalCalls()).toHaveLength(0) // dé-escalade bloquée (cooldown actif)
+    expect(raiseFlag).toHaveBeenCalledWith(1, "nocturnalHypoHighFasting", 99, undefined) // sévérité nocturne surfacée
+  })
+
   it("fixedDose : moyenne du moment > cible + hypos récurrentes → FLAG highVariabilityFixedDose", async () => {
     mode.mockResolvedValue({ mode: "fixedDose", coherent: true } as never)
     prismaMock.fixedDoseSlot.findMany.mockResolvedValue([{ moment: "morning", valueU: 10 }] as never)
     prismaMock.patient.findFirst.mockResolvedValue({ pathology: "DT2", pregnancyMode: false } as never)
     prismaMock.glucoseTarget.findFirst.mockResolvedValue(null as never)
     // moyenne ~1,04 > cible 1,00, 2 relevés < 0,70 (récurrent) → flag.
-    fixedDoseTrend.mockResolvedValue({ morning: [0.6, 0.6, 1.9], noon: [], evening: [], night: [] } as never)
+    fixedDoseTrend.mockResolvedValue(toTroughs({ morning: [0.6, 0.6, 1.9], noon: [], evening: [], night: [] }) as never)
     createEngine.mockResolvedValue({ id: "e1" } as never)
     await proposalGeneratorService.generateForPatient(1, 99)
     expect(createEngine.mock.calls.filter((c) => (c[0] as Record<string, unknown>).parameterType === "fixedDose")).toHaveLength(0)
@@ -581,7 +632,7 @@ describe("proposalGeneratorService — dé-escalade basal/fixedDose (US-2653)", 
     prismaMock.fixedDoseSlot.findMany.mockResolvedValue(slots as never)
     prismaMock.patient.findFirst.mockResolvedValue({ pathology: "DT2", pregnancyMode: false } as never)
     prismaMock.glucoseTarget.findFirst.mockResolvedValue(null as never)
-    fixedDoseTrend.mockResolvedValue({ morning: [], noon: [], evening: [], night: [], ...troughs } as never)
+    fixedDoseTrend.mockResolvedValue(toTroughs({ morning: [], noon: [], evening: [], night: [], ...troughs }) as never)
     createEngine.mockResolvedValue({ id: "e1" } as never)
   }
 

--- a/tests/unit/proposal-generator.service.test.ts
+++ b/tests/unit/proposal-generator.service.test.ts
@@ -529,7 +529,7 @@ describe("proposalGeneratorService.generateForPatient — chemin ISF (US-2651)",
       meals: hypoMeals, // nadirs repas 0,60 récurrents (déclenchent l'ICR, PAS l'ISF/basal)
       sensitivityFactors: [ISF_SLOT], corrections: corrections(1.2, 1.4), // corrections PROPRES → pas de dé-escalade ISF
       basalConfig: { configType: "pump", pumpSlots: [{ id: "noct", rate: 0.8, startHour: 0, endHour: 6 }] },
-      fasting: Array.from({ length: 3 }, () => ({ fastingMgdl: 100, nocturnalNadirMgdl: 120 })), // nocturne sain
+      fasting: Array.from({ length: 3 }, (_, i) => ({ fastingMgdl: 100, nocturnalNadirMgdl: 120, dayIso: isoDaysAgo(i + 1) })), // nocturne sain
     })
     await proposalGeneratorService.generateForPatient(1, 99)
     expect(icrCalls().length).toBeGreaterThanOrEqual(1) // les nadirs repas déclenchent BIEN l'ICR (pas de pass vide)
@@ -598,9 +598,9 @@ describe("proposalGeneratorService — dé-escalade basal/fixedDose (US-2653)", 
   it("basal : hypo nocturne sévère ISOLÉE (in-band, non récurrente) → FLAG, aucune dose", async () => {
     // 1 nadir sévère 0,50 + 2 sains ; à jeun = cible → in-band ; non récurrent.
     const fasting = [
-      { fastingMgdl: 100, nocturnalNadirMgdl: 50 },
-      { fastingMgdl: 100, nocturnalNadirMgdl: 120 },
-      { fastingMgdl: 100, nocturnalNadirMgdl: 120 },
+      { fastingMgdl: 100, nocturnalNadirMgdl: 50, dayIso: isoDaysAgo(1) },
+      { fastingMgdl: 100, nocturnalNadirMgdl: 120, dayIso: isoDaysAgo(2) },
+      { fastingMgdl: 100, nocturnalNadirMgdl: 120, dayIso: isoDaysAgo(3) },
     ]
     setup({ meals: [], basalConfig: pump(), fasting })
     await proposalGeneratorService.generateForPatient(1, 99)
@@ -674,6 +674,30 @@ describe("proposalGeneratorService — dé-escalade basal/fixedDose (US-2653)", 
     expect(fixedCalls()).toHaveLength(0)
   })
 
+  it("fix Q6a (fixedDose) — délai écoulé (100 h) mais relevés PÉRIMÉS (avant le changement) → PAS de dé-escalade", async () => {
+    // Moyenne à la cible (deadband nul) + relevés récurremment bas mais TOUS datés J-5..J-7 (< cutoff J-4) →
+    // fenêtre post-changement vide → jamais re-titrer malgré le délai écoulé.
+    mode.mockResolvedValue({ mode: "fixedDose", coherent: true } as never)
+    prismaMock.fixedDoseSlot.findMany.mockResolvedValue([{ moment: "morning", valueU: 10 }] as never)
+    prismaMock.patient.findFirst.mockResolvedValue({ pathology: "DT2", pregnancyMode: false } as never)
+    prismaMock.glucoseTarget.findFirst.mockResolvedValue(null as never)
+    fixedDoseTrend.mockResolvedValue(toTroughs({ morning: [0.6, 0.6, 1.8], noon: [], evening: [], night: [] }, [isoDaysAgo(5), isoDaysAgo(6), isoDaysAgo(7)]) as never)
+    createEngine.mockResolvedValue({ id: "e1" } as never)
+    prismaMock.adjustmentProposal.findFirst.mockResolvedValue({ reviewedAt: new Date(Date.now() - 100 * 3_600_000) } as never)
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(fixedCalls()).toHaveLength(0) // délai écoulé mais aucun relevé post-changement
+    expect(raiseFlag).not.toHaveBeenCalledWith(1, "highVariabilityFixedDose", 99, undefined) // 0,60 non sévère
+  })
+
+  it("fix Q6b (fixedDose) — dé-escalade bloquée par le cooldown MAIS relevé SÉVÈRE (0,50 g/L) → FLAG", async () => {
+    // Moyenne à la cible (deadband nul), relevés récurrents dont un sévère, changement à l'instant (cooldown actif).
+    setupFixed([{ moment: "morning", valueU: 10 }], { morning: [0.5, 0.5, 2.0] })
+    prismaMock.adjustmentProposal.findFirst.mockResolvedValue({ reviewedAt: new Date() } as never)
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(fixedCalls()).toHaveLength(0) // dé-escalade bloquée (cooldown actif)
+    expect(raiseFlag).toHaveBeenCalledWith(1, "highVariabilityFixedDose", 99, undefined) // sévérité surfacée (Q6b)
+  })
+
   it("cooldown ICR : dé-escalade ICR sautée si dernier changement accepté < 72 h", async () => {
     const inBandHypoMeals = Array.from({ length: 3 }, () => meal({ postMgdl: 150, nadirMgdl: 60, localHour: 13 }))
     const icrCalls = () =>
@@ -682,6 +706,39 @@ describe("proposalGeneratorService — dé-escalade basal/fixedDose (US-2653)", 
     prismaMock.adjustmentProposal.findFirst.mockResolvedValue({ reviewedAt: new Date() } as never)
     await proposalGeneratorService.generateForPatient(1, 99)
     expect(icrCalls()).toHaveLength(0)
+  })
+
+  const icrCalls = () =>
+    createEngine.mock.calls.map((c) => c[0] as Record<string, unknown>).filter((a) => a.parameterType === "insulinToCarbRatio")
+
+  it("fix Q6b (ICR) — hypo post-repas sévère ISOLÉE (in-band, non récurrente) → FLAG (parité ISF/basal/fixedDose)", async () => {
+    // 1 nadir sévère 0,50 + 2 sains ; PPG 1,40 dans la bande ; non récurrent. Sans le fix, l'ICR taisait ce
+    // danger (seul levier sans branche « sévère isolé ») → régression de sécurité corrigée.
+    setup({ meals: [
+      meal({ postMgdl: 140, nadirMgdl: 50, localHour: 13 }),
+      meal({ postMgdl: 140, nadirMgdl: 160, localHour: 13 }),
+      meal({ postMgdl: 140, nadirMgdl: 160, localHour: 13 }),
+    ] })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(icrCalls()).toHaveLength(0)
+    expect(raiseFlag).toHaveBeenCalledWith(1, "highVariabilityPostMeal", 99, undefined)
+  })
+
+  it("fix Q6b (ICR) — dé-escalade bloquée par le cooldown MAIS nadir SÉVÈRE récurrent → FLAG", async () => {
+    setup({ meals: Array.from({ length: 3 }, () => meal({ postMgdl: 140, nadirMgdl: 50, localHour: 13 })) })
+    prismaMock.adjustmentProposal.findFirst.mockResolvedValue({ reviewedAt: new Date() } as never)
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(icrCalls()).toHaveLength(0) // dé-escalade bloquée (cooldown actif)
+    expect(raiseFlag).toHaveBeenCalledWith(1, "highVariabilityPostMeal", 99, undefined) // sévérité surfacée
+  })
+
+  it("fix Q6a (ICR) — délai écoulé (100 h) mais hypos PÉRIMÉES (avant le changement) → PAS de dé-escalade", async () => {
+    const stale = Array.from({ length: 3 }, (_, i) => meal({ postMgdl: 140, nadirMgdl: 60, localHour: 13, dayIso: isoDaysAgo(i + 5) }))
+    setup({ meals: stale })
+    prismaMock.adjustmentProposal.findFirst.mockResolvedValue({ reviewedAt: new Date(Date.now() - 100 * 3_600_000) } as never)
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(icrCalls()).toHaveLength(0) // délai écoulé mais aucune observation post-changement → jamais de dose
+    expect(raiseFlag).not.toHaveBeenCalledWith(1, "highVariabilityPostMeal", 99, undefined) // nadir 0,60 non sévère
   })
 })
 


### PR DESCRIPTION
## Contexte

Correctif de **deux défauts de sécurité** du cooldown anti-ratchet livré en US-2653 (`ENGINE_DEESCALATION_COOLDOWN_HOURS = 72 h`), identifiés lors de la validation médicale. Portée : **Correctif complet** sur les 4 leviers de dé-escalade (ICR / ISF / basal / fixedDose).

## Q6a (HIGH) — dé-escalade sur données périmées

La récurrence d'hypos (`recurrentPostMealHypo`) se mesurait sur la **fenêtre entière** (14 j / 30 j), sans tenir compte du dernier changement accepté. Conséquence : une fois le délai de 72 h écoulé, une dé-escalade pouvait se **re-déclencher sur des hypos antérieures au changement** — alors même que l'effet du dernier ajustement n'a pas encore pu être observé (≥ 3 j).

**Correctif** : la dé-escalade à magnitude fixe ne se juge **que sur les observations datées APRÈS le dernier changement accepté** (`dayIso > cutoff`, `cutoff` = jour local du `reviewedAt` de l'ACCEPTÉE précédente). Deux verrous **cumulatifs** :
1. délai `≥ 72 h` écoulé (`withinCooldown === false`) **ET**
2. signal récurrent tenant sur **≥ 3 observations post-changement**.

`cutoff = null` (aucun changement antérieur) → première dé-escalade jugée sur la fenêtre entière (comportement inchangé).

## Q6b (MEDIUM) — hypo sévère masquée pendant le blocage

Une **hypo sévère** (`< 0,54 g/L`) survenant pendant que la dé-escalade est bloquée (délai non écoulé **ou** données post-changement insuffisantes) était **silencieusement sautée**.

**Correctif** : levée systématique d'un flag de revue clinique (`highVariabilityPostCorrection` ISF, `nocturnalHypoHighFasting` basal, `highVariabilityFixedDose`) quand la dé-escalade est bloquée mais qu'un nadir sévère est présent. Un anti-ratchet ne masque **jamais** un signal de danger patient.

## Plomberie `dayIso`

- `meal-trends.service.ts` : `dayIso` ajouté à `CorrectionPoint` ; export de `localDay` (base jour local **partagée** entre observations et cutoff — TZ Europe/Paris, pas UTC).
- `analytics.service.ts` : `fixedDoseTrend` renvoie désormais `{ gl, dayIso }[]` par moment.
- `proposal-generator.service.ts` : helpers `lastAcceptedChangeAt` / `deescalationTiming` / `afterCutoff` ; les 4 blocs de dé-escalade filtrent le POST-changement (`afterCutoff`) et surfacent la sévérité en cas de blocage.

## Tests

- **Q6a** : délai écoulé (100 h) mais toutes les hypos antérieures au changement → **pas de dé-escalade** (ISF).
- **Q6b** : dé-escalade bloquée + nadir sévère → **flag** (ISF `highVariabilityPostCorrection` + basal `nocturnalHypoHighFasting`).
- Bornes cooldown (< 72 h skip / = 72 h / expiré) recadrées avec fixtures **datées relativement à « maintenant »**.
- `analytics.service.test.ts` mis à jour pour la forme `{ gl, dayIso }`.
- Suite : 216 tests verts sur les 4 fichiers impactés ; `tsc` 0 erreur ; eslint clean.

## Doc

Catalogue clinique `docs/clinical-logic/regles-et-constantes-diabete.md` — invariants **porte d'observation POST-changement (Q6a)** + **surfaçage de sévérité pendant blocage (Q6b)** ajoutés à la section anti-ratchet ; JSDoc à jour (`localDay`, `CorrectionPoint.dayIso`, `fixedDoseTrend`).

## Revue attendue

- `medical-domain-validator` — sécurité clinique de la porte post-changement + surfaçage sévère
- `code-reviewer` — qualité, cohérence des 4 leviers
- `healthcare-security-auditor` — traçabilité (flags de revue, jamais de silence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)