### PR TITLE
US-2659 (slice S0) — socle schéma titration basale stylo (MDI) : discriminateur basalDoseKind + constantes MDI_BASAL_*

### DIFF
--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -480,6 +480,28 @@ identifie la dose visée sur `BasalConfiguration` (`daily` → `dailyDose` ; `mo
 différentes (matin vs soir) ne se collisionnent plus à tort. Migration `20260719100000`. **Contrat iOS**
 (nouveau discriminateur) → coordination `swift-expert`.
 
+**Table de décision — `parameterType` → discriminateur autoritaire → unité** (contrat partagé back ↔ iOS).
+`AdjustmentProposal` empile désormais **5 discriminateurs de cible mutuellement exclusifs** ; `parameterType`
+seul ne suffit plus à désambiguïser `basalRate` (pompe vs stylo). Le client lit le discriminateur **non-NULL**
+selon la ligne :
+
+| `parameterType` | Discriminateur non-NULL | Cible | Unité de `current/proposedValue` |
+|---|---|---|---|
+| `insulinSensitivityFactor` | `timeSlotStartHour` (+ `timeSlotEndHour`) | créneau ISF | g/L·U (ou mg/dL·U) |
+| `insulinToCarbRatio` | `carbRatioSlotStart` (+ `carbRatioSlotEnd`) | créneau ICR | g/U |
+| `fixedDose` | `moment` | `FixedDoseSlot` | U (dose totale) |
+| `basalRate` **+ pompe** | `pumpBasalSlotId` | `PumpBasalSlot` | **U/h** (débit) |
+| `basalRate` **+ stylo (MDI)** | `basalDoseKind` (`daily`/`morning`/`evening`) | `BasalConfiguration.dailyDose`/`morning`/`eveningDose` | **U** (dose totale) |
+
+> ⚠️ **Piège d'unité** : une proposition `basalRate` est en **U/h** (pompe) OU en **U totales** (stylo) — ne
+> jamais supposer « U/h » pour tout `basalRate`. Brancher l'affichage sur le discriminateur présent.
+
+**Invariant d'exclusivité verrouillé en base** (CHECK `adjustment_proposals_basal_target_exclusivity_check`,
+migration `20260719100000`) : pour `parameter_type = 'basalRate'`, **exactement un** de (`pump_basal_slot_id`,
+`basal_dose_kind`) est non-NULL (XOR) ; hors `basalRate`, `basal_dose_kind` est **toujours** NULL. Le client
+peut donc router l'affichage sur la simple présence du discriminateur sans heuristique divergente. (Le CHECK
+est invisible au drift-gate — Prisma ne modélise pas les CHECK — mais appliqué par `migrate deploy`.)
+
 **Constantes dédiées `MDI_BASAL_*`** (table §1) — sémantique et magnitudes propres à la basale stylo :
 **jamais** l'incrément pompe (0,05 U/h, mismatch U/h vs U totales), **jamais** les magnitudes dose fixe
 (±2 U trop serrées pour une basale adulte). Toutes en **unités totales**. Défaut d'incrément **fail-closed

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -36,6 +36,14 @@ consensus cap bolus 25 U.
 | `FIXED_DOSE_MAX_DELTA_U` | 2.0 | U | Variation max par ajustement (titration lente) |
 | `FIXED_DOSE_PATIENT_MAX_DELTA_U` | 1.0 | U | Cap variation **patient** dose fixe (< moteur) |
 | `PATIENT_MAX_CHANGE_PERCENT` | 10 | % | Cap variation **patient** sur ratios (proposition, US-2649) |
+| `MDI_BASAL_MIN_U` | 0.5 | U | Plancher de sanité basale **stylo (MDI)** (US-2659 ; = `FIXED_DOSE_MIN`) |
+| `MDI_BASAL_WARN_U` | 80 | U | Seuil d'**avertissement** (non bloquant) basale stylo (US-2659 ; = `FIXED_BASAL_WARN_U`) |
+| `MDI_BASAL_STEP_U` | 2 | U | Pas de **hausse** treat-to-target (`max(+2 U, +10 %)`) (US-2659) |
+| `MDI_BASAL_MAX_DELTA_U` | 4 | U | Cap absolu de variation par ajustement (= réduction sur hypo) (US-2659) |
+| `MDI_BASAL_MAX_CHANGE_PERCENT` | 20 | % | Cap % (ADA 10–20 %) — la borne la plus protectrice l'emporte (US-2659) |
+| `MDI_BASAL_DELIVERY_INCREMENT_U` | 1 | U | Résolution stylo (défaut fail-closed ; 0,5 si demi-unité) — **jamais** l'incrément pompe (US-2659) |
+| `MDI_BASAL_COOLDOWN_HOURS` | 72 | h | Anti-cliquet (steady state glargine/detemir 3–4 j ; 96 h dégludec = V2) (US-2659) |
+| `MDI_BASAL_ANALYSIS_DAYS` | 7 | j | Fenêtre d'analyse (plus réactive ; ≥ 3 glycémies à jeun) (US-2659) |
 
 > ⚠️ **Mise à jour 2026-07-10** : les constantes d'auto-application experte gouvernée ont été **supprimées** du code (US-2657 retirée). Les éditions patient ne génèrent désormais qu'une **proposition** (jamais auto-application). Voir « Niveau de maturité du patient » ci-dessous pour la maturité (JUNIOR/INTERMEDIATE/CONFIRME) — elle gouverne les **capacités d'édition** (valeurs vs créneaux), pas une voie d'auto-application.
 
@@ -455,6 +463,37 @@ variation qui s'arrondit à < 1 incrément → aucune proposition. (Mirror `anal
 - **Cible non fasting-scoped** : la cible individualisée lit `glucoseTargets[0]` (1re cible active, pas
   forcément à jeun) ; sûr car clampée `[0,80 ; 1,30]`. Préférer un champ fasting dédié si disponible.
 - **Seuil couverture** `MIN_NADIR_NIGHTS = 3` (constante locale, distincte de `MIN_MEALS_PER_SLOT`).
+
+### Titration basale STYLO (MDI) — socle S0 (US-2659, cadrage validé medical 2026-07-11)
+
+**Motivation** : le générateur ci-dessus ne titre que la basale **pompe** (`configType === "pump"`). Un
+patient sous **stylo** (`single_injection` = 1 dose lente/j ; `split_injection` = matin + soir) n'obtient
+**aucune** proposition basale — c'est la « limite connue » que US-2659 comble. La basale stylo se distingue
+de la pompe par le **geste**, la **granularité** (unités TOTALES, pas U/h) et le **risque**.
+
+**Discriminateur de cible `AdjustmentProposal.basalDoseKind`** (`daily`/`morning`/`evening`, enum
+`BasalDoseKind`, NULL pour pompe/ISF/ICR/fixedDose) — **pré-requis** de toute proposition stylo : la basale
+pompe cible un `PumpBasalSlot`, la basale stylo n'a **pas de créneau adressable** ; ce discriminateur
+identifie la dose visée sur `BasalConfiguration` (`daily` → `dailyDose` ; `morning`/`evening` →
+`morningDose`/`eveningDose`). Il **étend le tuple de l'index unique partiel** `adjustment_proposals_one_pending_per_slot`
+(`NULLS NOT DISTINCT`, `WHERE status = 'pending'`) → deux propositions stylo pending sur des doses
+différentes (matin vs soir) ne se collisionnent plus à tort. Migration `20260719100000`. **Contrat iOS**
+(nouveau discriminateur) → coordination `swift-expert`.
+
+**Constantes dédiées `MDI_BASAL_*`** (table §1) — sémantique et magnitudes propres à la basale stylo :
+**jamais** l'incrément pompe (0,05 U/h, mismatch U/h vs U totales), **jamais** les magnitudes dose fixe
+(±2 U trop serrées pour une basale adulte). Toutes en **unités totales**. Défaut d'incrément **fail-closed
+= 1 U** (0,5 U seulement si stylo demi-unité lu sur l'appareil).
+
+**Logique de titration** (détaillée dans les slices S1 `single_injection` / S2 `split_injection`, à venir) —
+principes actés : `single` → titrer `dailyDose` sur la **glycémie à jeun** (treat-to-target) ; `split` →
+dose du **soir sur l'à jeun**, dose du **matin sur le pré-dîner**, **une seule dose titrée par run**
+(priorité soir/à jeun) ; **garde BGM** (hausse conditionnée à des relevés coucher + réveil, sinon flag) ;
+**garde hypo** fenêtre-suivant-la-dose (sévère isolée < 0,54 g/L supprime la hausse ; récurrente →
+dé-escalade bornée ; non-actionnable → flag) ; **Somogyi** (à jeun HAUT + hypo nocturne récurrente →
+flag `nocturnalHypoHighFasting`, jamais de baisse auto). **Jamais auto-appliqué** (ADR #13) : toute sortie =
+`AdjustmentProposal` `pending` gatée médecin. Réfs : ADA Standards of Care 2025 §9 ; Riddle Treat-to-Target
+2003 ; INSIGHT ; ISPAD (stylos demi-unité).
 
 ### Assemblage corrections ISF `correctionTrend` (US-2651 ISF slice 2, validé medical)
 

--- a/prisma/migrations/20260719100000_us2659_s0_basal_dose_kind/migration.sql
+++ b/prisma/migrations/20260719100000_us2659_s0_basal_dose_kind/migration.sql
@@ -31,3 +31,21 @@ CREATE UNIQUE INDEX IF NOT EXISTS "adjustment_proposals_one_pending_per_slot"
   )
   NULLS NOT DISTINCT
   WHERE "status" = 'pending';
+
+-- CHECK — EXCLUSIVITÉ de la cible basale (revue swift-expert S0). `parameter_type = 'basalRate'` est
+-- surchargé : cible POMPE (`pump_basal_slot_id`, U/h) OU cible STYLO (`basal_dose_kind`, U totales), jamais
+-- les deux, jamais aucune. L'index unique partiel garantit l'anti-collision, PAS l'exclusivité de
+-- remplissage → un client (iOS/back) pourrait lire le mauvais discriminateur ou afficher la mauvaise unité.
+-- Ce CHECK verrouille l'invariant EN BASE (défense en profondeur). Hors basalRate, `basal_dose_kind` doit
+-- rester NULL (discriminateur propre à la basale stylo). Validé inline : le chemin `basalRate` existant exige
+-- déjà `pump_basal_slot_id` (adjustment.service.ts `getCurrentValue`) → toutes les lignes legacy conforment
+-- (XOR vrai). Prisma ne modélise pas les CHECK → invisible au drift-gate, appliqué par `migrate deploy`. Idempotent.
+ALTER TABLE "adjustment_proposals" DROP CONSTRAINT IF EXISTS "adjustment_proposals_basal_target_exclusivity_check";
+ALTER TABLE "adjustment_proposals" ADD CONSTRAINT "adjustment_proposals_basal_target_exclusivity_check"
+  CHECK (
+    CASE
+      WHEN "parameter_type" = 'basalRate'
+        THEN ("pump_basal_slot_id" IS NOT NULL) <> ("basal_dose_kind" IS NOT NULL)
+      ELSE "basal_dose_kind" IS NULL
+    END
+  );

--- a/prisma/migrations/20260719100000_us2659_s0_basal_dose_kind/migration.sql
+++ b/prisma/migrations/20260719100000_us2659_s0_basal_dose_kind/migration.sql
@@ -1,0 +1,33 @@
+-- ═══════════════════════════════════════════════════════════════
+-- US-2659 (slice S0) — Socle de titration de la basale STYLO (MDI)
+-- ═══════════════════════════════════════════════════════════════
+-- Débloque la titration de la basale stylo (single/split) et la proposition patient de baisse basale :
+-- sans discriminateur de CIBLE, aucune proposition ne peut adresser une `dailyDose`/`morningDose`/
+-- `eveningDose` (la basale pompe cible un `PumpBasalSlot`, la basale stylo n'a pas de créneau adressable).
+-- Additif, non destructif. Contrat iOS (nouveau discriminateur) → coordination swift-expert.
+
+-- CreateEnum — cible d'une proposition de basale stylo (NULL pour pompe/ISF/ICR/fixedDose).
+CREATE TYPE "BasalDoseKind" AS ENUM ('daily', 'morning', 'evening');
+
+-- AlterTable — colonne NULLABLE (les autres paramètres restent `basal_dose_kind` NULL).
+ALTER TABLE "adjustment_proposals" ADD COLUMN "basal_dose_kind" "BasalDoseKind";
+
+-- L'index UNIQUE PARTIEL anti-spam (1 pending / cible) doit inclure `basal_dose_kind` : sinon deux
+-- propositions de basale stylo pending sur des doses DIFFÉRENTES (matin vs soir en split_injection)
+-- violeraient l'unicité à tort. Drop + recreate avec `basal_dose_kind` ajouté au tuple. `NULLS NOT
+-- DISTINCT` conservé : pour pompe/ISF/ICR/fixedDose, `basal_dose_kind` vaut NULL et ne doit pas casser
+-- l'unicité existante (deux NULL comptent comme égaux). Index partiel non modélisé par Prisma (WHERE)
+-- → invisible au drift-gate, livré en migration versionnée (auto-appliqué par `migrate deploy`).
+DROP INDEX IF EXISTS "adjustment_proposals_one_pending_per_slot";
+CREATE UNIQUE INDEX IF NOT EXISTS "adjustment_proposals_one_pending_per_slot"
+  ON "adjustment_proposals" (
+    "patient_id",
+    "parameter_type",
+    "time_slot_start_hour",
+    "carb_ratio_slot_start",
+    "pump_basal_slot_id",
+    "moment",
+    "basal_dose_kind"
+  )
+  NULLS NOT DISTINCT
+  WHERE "status" = 'pending';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,6 +94,17 @@ enum BasalConfigType {
   split_injection
 }
 
+// US-2659 — discriminateur de CIBLE d'une proposition de basale STYLO (MDI). La basale pompe cible un
+// `PumpBasalSlot` (créneau U/h) ; la basale stylo n'a pas de créneau adressable → ce discriminateur
+// identifie la dose visée sur `BasalConfiguration` : `daily` (single_injection → dailyDose),
+// `morning`/`evening` (split_injection → morningDose/eveningDose). NULL pour pompe/ISF/ICR/fixedDose.
+// Étend l'index unique partiel « 1 pending / (patient × paramètre × cible) ».
+enum BasalDoseKind {
+  daily
+  morning
+  evening
+}
+
 enum GlucoseTargetPreset {
   standard
   tight
@@ -1414,6 +1425,10 @@ model AdjustmentProposal {
   // (morning/noon/evening/night) cible/dédoublonne une `FixedDoseSlot`. Fait partie du tuple d'unicité
   // anti-spam (index partiel `adjustment_proposals_one_pending_per_slot`).
   moment                DoseMoment?         @map("moment")
+  // US-2659 — discriminateur de cible pour la basale STYLO (MDI) : `daily` (single_injection),
+  // `morning`/`evening` (split_injection). NULL pour pompe (ciblée par `pumpBasalSlotId`) et pour
+  // ISF/ICR/fixedDose. Fait partie du tuple d'unicité anti-spam (index partiel `one_pending_per_slot`).
+  basalDoseKind         BasalDoseKind?      @map("basal_dose_kind")
   analysisPeriod        String?             @map("analysis_period") @db.VarChar(10)
   dataQuality           String?             @map("data_quality") @db.VarChar(20)
   status                ProposalStatus      @default(pending)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1428,6 +1428,9 @@ model AdjustmentProposal {
   // US-2659 — discriminateur de cible pour la basale STYLO (MDI) : `daily` (single_injection),
   // `morning`/`evening` (split_injection). NULL pour pompe (ciblée par `pumpBasalSlotId`) et pour
   // ISF/ICR/fixedDose. Fait partie du tuple d'unicité anti-spam (index partiel `one_pending_per_slot`).
+  // EXCLUSIVITÉ (CHECK `adjustment_proposals_basal_target_exclusivity_check`, migration 20260719100000,
+  // non modélisé par Prisma) : pour `basalRate`, exactement un de (`pumpBasalSlotId`, `basalDoseKind`) est
+  // non-NULL (pompe U/h XOR stylo U totales) ; hors `basalRate`, `basalDoseKind` reste NULL.
   basalDoseKind         BasalDoseKind?      @map("basal_dose_kind")
   analysisPeriod        String?             @map("analysis_period") @db.VarChar(10)
   dataQuality           String?             @map("data_quality") @db.VarChar(20)

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -6,6 +6,7 @@ import {
   Sex,
   InsulinDeliveryMethod,
   BasalConfigType,
+  BasalDoseKind,
   GlucoseTargetPreset,
   DayMomentType,
   EmergencyAlertType,
@@ -1152,7 +1153,10 @@ async function main() {
       await prisma.adjustmentProposal.createMany({
         data: [
           { patientId: patientDT1.id, parameterType: AdjustableParameter.insulinToCarbRatio, currentValue: 12, proposedValue: 10, changePercent: -16.67, confidence: ConfidenceLevel.high, reason: AdjustmentReason.icrTooLow, supportingEvents: 14, totalEventsConsidered: 18, status: ProposalStatus.pending, carbRatioSlotStart: 12, carbRatioSlotEnd: 14, analysisPeriod: "14d", dataQuality: "good" },
-          { patientId: patientDT2.id, parameterType: AdjustableParameter.basalRate, currentValue: 0.9, proposedValue: 0.8, changePercent: -11.11, confidence: ConfidenceLevel.medium, reason: AdjustmentReason.basalTooHigh, supportingEvents: 9, totalEventsConsidered: 12, status: ProposalStatus.pending, timeSlotStartHour: 0, timeSlotEndHour: 6, analysisPeriod: "14d", dataQuality: "moderate" },
+          // US-2659 — basale STYLO (DT2 = single_injection, dailyDose 22 U) : ciblée par `basalDoseKind` (daily),
+          // JAMAIS `pumpBasalSlotId` (DT2 n'a pas de pompe) ni `timeSlotStartHour` (discriminateur ISF). Valeurs en
+          // U TOTALES (pas U/h). Respecte le CHECK d'exclusivité basalRate (daily non-NULL ⊕ pumpBasalSlotId NULL).
+          { patientId: patientDT2.id, parameterType: AdjustableParameter.basalRate, currentValue: 22, proposedValue: 20, changePercent: -9.09, confidence: ConfidenceLevel.medium, reason: AdjustmentReason.basalTooHigh, supportingEvents: 9, totalEventsConsidered: 12, status: ProposalStatus.pending, basalDoseKind: BasalDoseKind.daily, analysisPeriod: "7d", dataQuality: "moderate" },
         ],
       })
       console.log("  ✓ 2 adjustment proposals seeded")

--- a/src/lib/clinical-bounds.ts
+++ b/src/lib/clinical-bounds.ts
@@ -179,6 +179,31 @@ export const CLINICAL_BOUNDS = {
   CORRECTION_MIN_ELEVATION_GL: 0.3,
   CORRECTION_SETTLE_TOL_MIN: 30,
   CORRECTION_COB_LOOKBACK_MIN: 180,
+  /**
+   * US-2659 — titration de la basale **stylo (MDI)** (single/split), distincte de la basale POMPE
+   * (créneaux U/h, `PUMP_BASAL_INCREMENT`) et de la dose fixe (`FIXED_DOSE_*`, magnitudes trop serrées
+   * pour une basale adulte). Sémantique treat-to-target (ADA 2025 §9 ; Riddle 2003 ; INSIGHT). Toutes en
+   * UNITÉS TOTALES (U), jamais en U/h. Validé medical (cadrage 2026-07-11). Source de vérité unique —
+   * catalogue : `docs/clinical-logic/regles-et-constantes-diabete.md` (verrou anti-drift `clinical-bounds.test.ts`).
+   *
+   * - `MDI_BASAL_MIN_U` — plancher de sanité (= `FIXED_DOSE_MIN`) ; une dose proposée sous ce seuil = non actionnable → flag.
+   * - `MDI_BASAL_WARN_U` — seuil d'AVERTISSEMENT non bloquant (= `FIXED_BASAL_WARN_U`) : DT2 insulino-résistant / U300 / dégludec.
+   * - `MDI_BASAL_STEP_U` — pas de HAUSSE treat-to-target (`max(+2 U, +10 %)`, cf. INSIGHT/ADA).
+   * - `MDI_BASAL_MAX_DELTA_U` — cap ABSOLU de variation par ajustement (= amplitude de la réduction sur hypo).
+   * - `MDI_BASAL_MAX_CHANGE_PERCENT` — cap % (ADA 10–20 %) ; la proposition retient la borne la plus protectrice.
+   * - `MDI_BASAL_DELIVERY_INCREMENT_U` — résolution du stylo : **1 U défaut fail-closed** ; 0,5 U seulement si
+   *   le dispositif est un stylo demi-unité (lu sur l'appareil, jamais supposé). JAMAIS l'incrément pompe (0,05 U/h).
+   * - `MDI_BASAL_COOLDOWN_HOURS` — anti-cliquet (steady state glargine/detemir 3–4 j). 96 h dégludec = V2 (P3).
+   * - `MDI_BASAL_ANALYSIS_DAYS` — fenêtre d'analyse (7 j, plus réactive que 14 j ; ≥ 3 glycémies à jeun valides).
+   */
+  MDI_BASAL_MIN_U: 0.5,
+  MDI_BASAL_WARN_U: 80,
+  MDI_BASAL_STEP_U: 2,
+  MDI_BASAL_MAX_DELTA_U: 4,
+  MDI_BASAL_MAX_CHANGE_PERCENT: 20,
+  MDI_BASAL_DELIVERY_INCREMENT_U: 1,
+  MDI_BASAL_COOLDOWN_HOURS: 72,
+  MDI_BASAL_ANALYSIS_DAYS: 7,
 } as const
 
 export type ClinicalBounds = typeof CLINICAL_BOUNDS

--- a/tests/unit/clinical-bounds.test.ts
+++ b/tests/unit/clinical-bounds.test.ts
@@ -91,6 +91,15 @@ describe("CLINICAL_BOUNDS — anti-drift (A3)", () => {
       CORRECTION_MIN_ELEVATION_GL: 0.3,
       CORRECTION_SETTLE_TOL_MIN: 30,
       CORRECTION_COB_LOOKBACK_MIN: 180,
+      // US-2659 — titration basale STYLO (MDI), unités totales (jamais U/h)
+      MDI_BASAL_MIN_U: 0.5,
+      MDI_BASAL_WARN_U: 80,
+      MDI_BASAL_STEP_U: 2,
+      MDI_BASAL_MAX_DELTA_U: 4,
+      MDI_BASAL_MAX_CHANGE_PERCENT: 20,
+      MDI_BASAL_DELIVERY_INCREMENT_U: 1,
+      MDI_BASAL_COOLDOWN_HOURS: 72,
+      MDI_BASAL_ANALYSIS_DAYS: 7,
     })
   })
 
@@ -110,6 +119,24 @@ describe("CLINICAL_BOUNDS — anti-drift (A3)", () => {
     expect(CLINICAL_BOUNDS.FIXED_BOLUS_WARN_U).toBeLessThan(CLINICAL_BOUNDS.FIXED_BASAL_WARN_U)
     // cap de variation patient strictement plus strict que le cap moteur
     expect(CLINICAL_BOUNDS.FIXED_DOSE_PATIENT_MAX_DELTA_U).toBeLessThan(CLINICAL_BOUNDS.FIXED_DOSE_MAX_DELTA_U)
+  })
+
+  it("US-2659 — basale MDI : plancher > 0, incrément ≠ incrément pompe, cap % ≥ cap dose fixe, cooldown = steady state", () => {
+    // Plancher de sanité strictement positif (aligné sur la dose fixe).
+    expect(CLINICAL_BOUNDS.MDI_BASAL_MIN_U).toBeGreaterThan(0)
+    expect(CLINICAL_BOUNDS.MDI_BASAL_MIN_U).toBe(CLINICAL_BOUNDS.FIXED_DOSE_MIN)
+    // Incrément stylo (unités totales) JAMAIS l'incrément pompe (U/h) — invariant de sûreté D6.
+    expect(CLINICAL_BOUNDS.MDI_BASAL_DELIVERY_INCREMENT_U).not.toBe(CLINICAL_BOUNDS.PUMP_BASAL_INCREMENT)
+    expect(CLINICAL_BOUNDS.MDI_BASAL_DELIVERY_INCREMENT_U).toBeGreaterThanOrEqual(CLINICAL_BOUNDS.FIXED_DOSE_DELIVERY_INCREMENT_U)
+    // Basale adulte titrée plus large que la dose fixe (magnitudes dose fixe trop serrées) : cap % et delta ≥.
+    expect(CLINICAL_BOUNDS.MDI_BASAL_MAX_CHANGE_PERCENT).toBeGreaterThanOrEqual(CLINICAL_BOUNDS.FIXED_DOSE_MAX_CHANGE_PERCENT)
+    expect(CLINICAL_BOUNDS.MDI_BASAL_MAX_DELTA_U).toBeGreaterThan(CLINICAL_BOUNDS.FIXED_DOSE_MAX_DELTA_U)
+    // Le pas de hausse treat-to-target reste sous le cap absolu de variation.
+    expect(CLINICAL_BOUNDS.MDI_BASAL_STEP_U).toBeLessThanOrEqual(CLINICAL_BOUNDS.MDI_BASAL_MAX_DELTA_U)
+    // Avertissement basale aligné sur la dose fixe basale ; fenêtre d'analyse plus courte que le mois AGP.
+    expect(CLINICAL_BOUNDS.MDI_BASAL_WARN_U).toBe(CLINICAL_BOUNDS.FIXED_BASAL_WARN_U)
+    expect(CLINICAL_BOUNDS.MDI_BASAL_ANALYSIS_DAYS).toBe(7)
+    expect(CLINICAL_BOUNDS.MDI_BASAL_COOLDOWN_HOURS).toBe(CLINICAL_BOUNDS.ENGINE_DEESCALATION_COOLDOWN_HOURS)
   })
 
   it("US-2651 — deadband ICR : borne basse < plafond adulte (1,80), grossesse plus stricte", () => {


### PR DESCRIPTION
## Contexte

Première slice de **US-2659** (titration de la basale **stylo/MDI** + proposition patient de baisse basale). **Socle uniquement** — aucune logique de titration (slices S1 `single_injection` / S2 `split_injection` / S3 baisse patient à venir). Cadrage clinique validé (`medical-domain-validator`, 2026-07-11).

## Pourquoi

Le générateur ne titre aujourd'hui que la basale **pompe** (`configType === "pump"`). Un patient sous **stylo** (`single_injection` / `split_injection`) n'obtient **aucune** proposition basale — la basale stylo n'a pas de créneau adressable (`PumpBasalSlot`), donc rien à cibler. Ce socle rend la dose stylo adressable.

## Schéma — contrat iOS (⚠️ `swift-expert`)

- **Enum `BasalDoseKind`** (`daily`/`morning`/`evening`) + colonne **nullable** `AdjustmentProposal.basalDoseKind`. Identifie la dose visée sur `BasalConfiguration` : `daily` → `dailyDose` (single) ; `morning`/`evening` → `morning`/`eveningDose` (split). NULL pour pompe (ciblée par `pumpBasalSlotId`) / ISF / ICR / fixedDose.
- **Migration `20260719100000`** : `CREATE TYPE` + `ADD COLUMN` + **rebuild de l'index unique partiel** `adjustment_proposals_one_pending_per_slot` avec `basal_dose_kind` ajouté au tuple (`NULLS NOT DISTINCT`, `WHERE status = 'pending'`). Sans ça, deux propositions stylo pending sur des doses différentes (matin vs soir en split) violeraient l'unicité à tort. Même pattern que le discriminateur `moment` (US-2652, migration `20260710100000`).

## Constantes `MDI_BASAL_*` (`clinical-bounds.ts` + catalogue, même PR)

Unités **totales** (jamais U/h) ; magnitudes propres à la basale adulte — **ni** l'incrément pompe (0,05 U/h, mismatch U/h vs U), **ni** les magnitudes dose fixe (±2 U trop serrées).

| Constante | Valeur | Sens |
|---|---|---|
| `MDI_BASAL_MIN_U` | 0,5 U | Plancher de sanité (= `FIXED_DOSE_MIN`) |
| `MDI_BASAL_WARN_U` | 80 U | Avertissement non bloquant (= `FIXED_BASAL_WARN_U`) |
| `MDI_BASAL_STEP_U` | +2 U | Pas de hausse treat-to-target |
| `MDI_BASAL_MAX_DELTA_U` | 4 U | Cap absolu par ajustement (= réduction sur hypo) |
| `MDI_BASAL_MAX_CHANGE_PERCENT` | 20 % | Cap % (ADA 10–20 %) |
| `MDI_BASAL_DELIVERY_INCREMENT_U` | 1 U | Résolution stylo (défaut fail-closed ; 0,5 si demi-unité) |
| `MDI_BASAL_COOLDOWN_HOURS` | 72 h | Steady state 3–4 j (96 h dégludec = V2) |
| `MDI_BASAL_ANALYSIS_DAYS` | 7 j | Fenêtre d'analyse (≥ 3 à jeun) |

## Décisions produit tranchées

- **P1** baisse patient proposable = **oui** (médecin garde-fou, anti-ETP d'interdire).
- **P2** gates : **Pompe INTERMEDIATE** (≤ 10 %) / **Stylo CONFIRME** (≤ min(10 %, 2 U)).
- **P3** cooldown **72 h partout en V1** ; dégludec 96 h → V2.

## Tests / vérifs

- Verrou anti-drift `clinical-bounds.test.ts` : `toEqual` étendu aux 8 constantes + invariants (incrément MDI ≠ incrément pompe, cap % ≥ dose fixe, plancher = FIXED_DOSE_MIN, cooldown = steady state).
- Suite : **4032 tests verts** ; `tsc` 0 ; eslint clean ; `prisma validate` OK.
- ⚠️ Drift-gate schema↔migrations : **couvert par la CI** (shadow DB indispo en local).

## Revue attendue

- `prisma-specialist` — migration (enum + index partiel rebuild), non-destructivité, ordre
- `swift-expert` — contrat iOS (nouveau discriminateur `basalDoseKind`)
- `medical-domain-validator` — transcription fidèle des constantes `MDI_BASAL_*` (valeurs + sens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)