### PR TITLE
US-2659 (slice S1) — titration de la basale STYLO single_injection (treat-to-target à jeun)

### DIFF
--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -534,10 +534,16 @@ soir/à jeun). **Jamais auto-appliqué** (ADR #13). Réfs : ADA Standards of Car
 1. **Somogyi** — à jeun HAUT (`> T + 0,30`) + hypo nocturne récurrente → **flag** `nocturnalHypoHighFasting` (D10).
 2. **Dé-escalade** (hypos nocturnes récurrentes, in-band ou sous la bande) — **prime** sur la baisse treat-to-target
    (plus spécifique ; couvre la cible grossesse serrée). Jugée sur les nadirs POST-changement + cooldown (Q6a/Q6b).
-3. **Titration treat-to-target** (pas d'hypo nocturne récurrente) — hausse (si **couverture nocturne** ≥ 3 nadirs,
-   sinon **AC-4 : flag explicite**, jamais un drop muet) OU baisse ; **cooldown 72 h gate les DEUX sens** (Risk #1,
-   divergence assumée vs pompe : steady state 3–4 j + incrément 1 U grossier → anti-empilement). Nadir sévère isolé
-   pendant blocage → flag (Q6b).
+3. **Titration treat-to-target** (pas d'hypo nocturne récurrente) — jugée sur l'**à jeun POST-changement**
+   (`afterCutoff`, fix M1 : évite qu'un pas FIXE s'empile sur une moyenne 7 j contaminée par ~4 j pré-changement
+   avant le steady state ; < 3 à jeun post-changement → l'analyseur renvoie null → **HOLD**). Hausse (si
+   **couverture nocturne** ≥ 3 nadirs, sinon **AC-4 : flag explicite**, jamais un drop muet) OU baisse ;
+   **cooldown `MDI_BASAL_COOLDOWN_HOURS` (72 h V1) gate les DEUX sens** (Risk #1, divergence assumée vs pompe :
+   steady state 3–4 j + incrément 1 U grossier → anti-empilement).
+
+**Surfaçage sévère (Q6b)** — pendant tout blocage (cooldown / dé-escalade non actionnable), une hypo sévère
+(< 0,54 g/L) **nocturne (CGM) OU à jeun (BGM-only, relevé réveil)** est surfacée en flag (`hasSevereHypo` sur
+`nadirs nocturnes ∪ à jeun`) — jamais tue, y compris sans couverture CGM.
 
 **Source du signal à jeun** : **CGM d'abord** (porte les nadirs nocturnes → autorise hausses + Somogyi + dé-escalade),
 **à défaut BGM** (patient MDI souvent BGM → à jeun présent mais aucun nadir → hausses refusées AC-4 → flag, baisses

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -38,12 +38,15 @@ consensus cap bolus 25 U.
 | `PATIENT_MAX_CHANGE_PERCENT` | 10 | % | Cap variation **patient** sur ratios (proposition, US-2649) |
 | `MDI_BASAL_MIN_U` | 0.5 | U | Plancher de sanité basale **stylo (MDI)** (US-2659 ; = `FIXED_DOSE_MIN`) |
 | `MDI_BASAL_WARN_U` | 80 | U | Seuil d'**avertissement** (non bloquant) basale stylo (US-2659 ; = `FIXED_BASAL_WARN_U`) |
-| `MDI_BASAL_STEP_U` | 2 | U | Pas de **hausse** treat-to-target (`max(+2 U, +10 %)`) (US-2659) |
+| `MDI_BASAL_STEP_U` | 2 | U | Composante U du pas de **hausse** treat-to-target (`max(+2 U, +10 %)`) (US-2659) |
+| `MDI_BASAL_STEP_PERCENT` | 10 | % | Composante % du pas de hausse `max(+2 U, +10 %)` (≠ dé-escalade, même valeur) (US-2659) |
 | `MDI_BASAL_MAX_DELTA_U` | 4 | U | Cap absolu de variation par ajustement (= réduction sur hypo) (US-2659) |
 | `MDI_BASAL_MAX_CHANGE_PERCENT` | 20 | % | Cap % (ADA 10–20 %) — la borne la plus protectrice l'emporte (US-2659) |
 | `MDI_BASAL_DELIVERY_INCREMENT_U` | 1 | U | Résolution stylo (défaut fail-closed ; 0,5 si demi-unité) — **jamais** l'incrément pompe (US-2659) |
 | `MDI_BASAL_COOLDOWN_HOURS` | 72 | h | Anti-cliquet (steady state glargine/detemir 3–4 j ; 96 h dégludec = V2) (US-2659) |
 | `MDI_BASAL_ANALYSIS_DAYS` | 7 | j | Fenêtre d'analyse (plus réactive ; ≥ 3 glycémies à jeun) (US-2659) |
+| `MDI_BASAL_FASTING_DEADBAND_UP_GL` | 0.30 | g/L | Demi-bande **haute** de la hold zone (hausse si `avg > T+0,30`) — anti-overshoot du pas fixe (US-2659 S1) |
+| `MDI_BASAL_FASTING_DEADBAND_DOWN_GL` | 0.20 | g/L | Demi-bande **basse** (baisse treat-to-target si `avg < T−0,20`) — plus serrée, sens sûr (US-2659 S1) |
 
 > ⚠️ **Mise à jour 2026-07-10** : les constantes d'auto-application experte gouvernée ont été **supprimées** du code (US-2657 retirée). Les éditions patient ne génèrent désormais qu'une **proposition** (jamais auto-application). Voir « Niveau de maturité du patient » ci-dessous pour la maturité (JUNIOR/INTERMEDIATE/CONFIRME) — elle gouverne les **capacités d'édition** (valeurs vs créneaux), pas une voie d'auto-application.
 
@@ -507,15 +510,44 @@ est invisible au drift-gate — Prisma ne modélise pas les CHECK — mais appli
 (±2 U trop serrées pour une basale adulte). Toutes en **unités totales**. Défaut d'incrément **fail-closed
 = 1 U** (0,5 U seulement si stylo demi-unité lu sur l'appareil).
 
-**Logique de titration** (détaillée dans les slices S1 `single_injection` / S2 `split_injection`, à venir) —
-principes actés : `single` → titrer `dailyDose` sur la **glycémie à jeun** (treat-to-target) ; `split` →
-dose du **soir sur l'à jeun**, dose du **matin sur le pré-dîner**, **une seule dose titrée par run**
-(priorité soir/à jeun) ; **garde BGM** (hausse conditionnée à des relevés coucher + réveil, sinon flag) ;
-**garde hypo** fenêtre-suivant-la-dose (sévère isolée < 0,54 g/L supprime la hausse ; récurrente →
-dé-escalade bornée ; non-actionnable → flag) ; **Somogyi** (à jeun HAUT + hypo nocturne récurrente →
-flag `nocturnalHypoHighFasting`, jamais de baisse auto). **Jamais auto-appliqué** (ADR #13) : toute sortie =
-`AdjustmentProposal` `pending` gatée médecin. Réfs : ADA Standards of Care 2025 §9 ; Riddle Treat-to-Target
+**Logique de titration** — `single_injection` **LIVRÉE en S1** (ci-dessous) ; `split_injection` = S2 (à venir :
+dose du **soir sur l'à jeun**, dose du **matin sur le pré-dîner**, **une seule dose titrée par run**, priorité
+soir/à jeun). **Jamais auto-appliqué** (ADR #13). Réfs : ADA Standards of Care 2025 §9 ; Riddle Treat-to-Target
 2003 ; INSIGHT ; ISPAD (stylos demi-unité).
+
+### Titration `single_injection` (US-2659 S1, LIVRÉ, validé medical 2026-07-11)
+
+**Analyseurs purs** (`proposal-algorithm.ts`) — dose DIRECTE en **unités totales** :
+- `analyzeMdiBasalDailyTrend(fastingValues, T, currentDose, nocturnalNadirs, incrementU)` — treat-to-target sur
+  la **glycémie à jeun**. **Hold zone asymétrique** `[T − 0,20 ; T + 0,30]` g/L (obligatoire pour un pas FIXE :
+  déclencher au seul signe sur-corrigerait ; bande haute plus large = anti-overshoot, bande basse plus serrée =
+  sens sûr). Au-dessus → **hausse** `min(max(+2 U, +10 %), +20 %, +4 U)` (le cap % l'emporte sur le plancher +2 U
+  = protège les petites doses) ; en dessous → **baisse** treat-to-target (symétrique) ; dans la bande → HOLD.
+  **Snap `floor` asymétrique** (arrondi TOUJOURS vers moins d'insuline : hausse jamais au-dessus du cap, baisse vers
+  plus de réduction) à l'incrément stylo (défaut **1 U** fail-closed) ; `|delta| < incrément` → `null` (non
+  actionnable). **Garde hypo** : une hausse est supprimée si un nadir nocturne est en hypo (repli à jeun).
+- `analyzeMdiBasalDailyHypoDeescalation(currentDose, nocturnalNadirs, incrementU)` — **dé-escalade** sur nadirs
+  nocturnes récurrents (indépendante de la hold zone) : `−min(20 %, 4 U)` (**`−min`, jamais `−max`** — `−max`
+  produirait −40 % → rebond hyper/cétose), snap `floor`, plancher 0,5 U ; non actionnable → `flagNonActionable`.
+
+**Matrice générateur** (`proposal-generator.service.ts`, bloc `configType === "single_injection"`, ordre) :
+1. **Somogyi** — à jeun HAUT (`> T + 0,30`) + hypo nocturne récurrente → **flag** `nocturnalHypoHighFasting` (D10).
+2. **Dé-escalade** (hypos nocturnes récurrentes, in-band ou sous la bande) — **prime** sur la baisse treat-to-target
+   (plus spécifique ; couvre la cible grossesse serrée). Jugée sur les nadirs POST-changement + cooldown (Q6a/Q6b).
+3. **Titration treat-to-target** (pas d'hypo nocturne récurrente) — hausse (si **couverture nocturne** ≥ 3 nadirs,
+   sinon **AC-4 : flag explicite**, jamais un drop muet) OU baisse ; **cooldown 72 h gate les DEUX sens** (Risk #1,
+   divergence assumée vs pompe : steady state 3–4 j + incrément 1 U grossier → anti-empilement). Nadir sévère isolé
+   pendant blocage → flag (Q6b).
+
+**Source du signal à jeun** : **CGM d'abord** (porte les nadirs nocturnes → autorise hausses + Somogyi + dé-escalade),
+**à défaut BGM** (patient MDI souvent BGM → à jeun présent mais aucun nadir → hausses refusées AC-4 → flag, baisses
+permises). Fail-closed : jamais de hausse à l'aveugle. Fenêtre **7 j** (`MDI_BASAL_ANALYSIS_DAYS`), ≥ 3 à jeun.
+
+**Contrat service** (`adjustment.service.ts`) : cible `basalDoseKind = "daily"` → `resolveCurrentValue` lit
+`BasalConfiguration.dailyDose` (scopé patient) ; `validateProposedValue` route les bornes **stylo** (`MDI_BASAL_MIN_U`,
+délivrable demi-unité, pas de plafond dur) et non pompe (U/h). **Application différée** : `accept(applyImmediately)`
+d'une proposition stylo **lève `styloBasalApplyNotSupported`** (fail-closed — jamais un « accepté + appliqué » fantôme
+sans écriture) ; l'écriture groupée de `dailyDose` arrive dans une slice ultérieure. Le médecin accepte SANS apply.
 
 ### Assemblage corrections ISF `correctionTrend` (US-2651 ISF slice 2, validé medical)
 

--- a/src/lib/clinical-bounds.ts
+++ b/src/lib/clinical-bounds.ts
@@ -199,11 +199,30 @@ export const CLINICAL_BOUNDS = {
   MDI_BASAL_MIN_U: 0.5,
   MDI_BASAL_WARN_U: 80,
   MDI_BASAL_STEP_U: 2,
+  /** US-2659 — composante % du pas de HAUSSE treat-to-target `max(+MDI_BASAL_STEP_U, +MDI_BASAL_STEP_PERCENT %)`.
+   *  Distincte de `HYPO_DEESCALATION_PERCENT` (dé-escalade) malgré la même valeur — sémantiques indépendantes. */
+  MDI_BASAL_STEP_PERCENT: 10,
   MDI_BASAL_MAX_DELTA_U: 4,
   MDI_BASAL_MAX_CHANGE_PERCENT: 20,
   MDI_BASAL_DELIVERY_INCREMENT_U: 1,
   MDI_BASAL_COOLDOWN_HOURS: 72,
   MDI_BASAL_ANALYSIS_DAYS: 7,
+  /**
+   * US-2659 (S1, validé medical) — **hold zone ASYMÉTRIQUE** de la titration basale STYLO à **pas fixe**.
+   * Un pas fixe (`max(+2 U, +10 %)`) déclenché au seul signe de l'écart sur-corrigerait au 1er tick (contrairement
+   * au pas PROPORTIONNEL de la pompe, dont le deadband 2 % suffit). Bande absolue **ancrée sur la cible à jeun**
+   * `T = resolveFastingTarget(...)` (déjà clampée `[0,80 ; 1,30]`, grossesse `[.. ; 1,00]`) :
+   *   - `avgFasting > T + MDI_BASAL_FASTING_DEADBAND_UP_GL`   → **HAUSSE** (pas fixe) ;
+   *   - `avgFasting < T − MDI_BASAL_FASTING_DEADBAND_DOWN_GL` → **BAISSE** treat-to-target (sens sûr) ;
+   *   - sinon → **HOLD** (aucune titration).
+   * Asymétrie `UP (0,30) > DOWN (0,20)` : bande **haute plus large** (anti-overshoot du pas fixe, une hausse de
+   * +2 U baisse la glycémie à jeun de ~20–40 mg/dL — Riddle TTT 2003) ; bande **basse plus serrée** (sens sûr,
+   * hypo-préventif). À T = 1,00 → hold `[0,80 ; 1,30]` = **cible à jeun ADA 80–130 mg/dL** (Standards of Care 2025).
+   * ⚠️ Le seuil « à jeun HAUT » de la matrice Somogyi utilise `T + UP` (pas `> T`). Sous la bande, la dé-escalade
+   * sur nadirs nocturnes (Q2) **prime** sur la baisse treat-to-target (plus spécifique ; couvre la cible grossesse serrée).
+   */
+  MDI_BASAL_FASTING_DEADBAND_UP_GL: 0.3,
+  MDI_BASAL_FASTING_DEADBAND_DOWN_GL: 0.2,
 } as const
 
 export type ClinicalBounds = typeof CLINICAL_BOUNDS

--- a/src/lib/proposal-algorithm.ts
+++ b/src/lib/proposal-algorithm.ts
@@ -485,6 +485,125 @@ export function analyzeBasalTrend(
 }
 
 /**
+ * US-2659 (S1, validé medical) — titration de la basale STYLO (MDI, `single_injection` : dose lente
+ * une-fois/jour) sur la **glycémie à jeun** (treat-to-target). Dose DIRECTE en **unités totales** (comme
+ * `analyzeFixedDose`, PAS un débit U/h ni un dénominateur). Distinct de la pompe (`analyzeBasalTrend`,
+ * proportionnel, U/h) : ici pas **FIXE** `max(+2 U, +10 %)` plafonné à `min(+20 %, +4 U)`.
+ *
+ * **Hold zone ASYMÉTRIQUE** (obligatoire pour un pas fixe — sinon overshoot au 1er tick) : titrer seulement
+ * hors bande `[T − DEADBAND_DOWN ; T + DEADBAND_UP]` (bande haute plus large = anti-overshoot ; bande basse
+ * plus serrée = sens sûr). Au-dessus → hausse ; en dessous → baisse treat-to-target ; dans la bande → `null`.
+ *
+ * **Snap asymétrique de sécurité** (`Math.floor` uniforme) : l'arrondi à l'incrément stylo `incrementU`
+ * (défaut 1 U fail-closed) erre TOUJOURS vers **moins d'insuline** — une hausse arrondit vers le bas (jamais
+ * au-dessus du cap), une baisse vers plus de réduction. `|delta arrondi| < incrément` → `null` (non actionnable :
+ * une hausse infra-incrément sur une petite dose ne monte pas à l'aveugle). Plancher `MDI_BASAL_MIN_U`.
+ *
+ * **Garde hypo** : une HAUSSE est supprimée si un nadir NOCTURNE est en hypo (repli `fastingValues`) — hypo à
+ * 3 h masquée par une moyenne à jeun élevée (Somogyi). La direction/moyenne reste sur `fastingValues`.
+ *
+ * @param fastingValues Glycémies à jeun (pré-petit-déj, g/L) — pilotent moyenne/direction.
+ * @param targetGl Cible à jeun individualisée (g/L), déjà clampée par l'appelant (`resolveFastingTarget`).
+ * @param currentDose Dose basale stylo courante (U totales).
+ * @param nocturnalNadirs Creux nocturnes (g/L), optionnels — fournis UNIQUEMENT à la garde hypo.
+ * @param incrementU Incrément délivrable du stylo (U ; défaut 1, 0,5 si demi-unité).
+ * @returns Proposition de titration bornée, ou `null` (hold zone / insuffisant / non actionnable).
+ */
+export function analyzeMdiBasalDailyTrend(
+  fastingValues: number[],
+  targetGl: number,
+  currentDose: number,
+  nocturnalNadirs: number[] | undefined,
+  incrementU: number,
+): ProposalCandidate | null {
+  if (fastingValues.length < 3) return null
+  if (!Number.isFinite(currentDose) || currentDose < CLINICAL_BOUNDS.MDI_BASAL_MIN_U) return null
+  if (!Number.isFinite(targetGl) || targetGl <= 0) return null
+
+  const avgFasting = fastingValues.reduce((s, v) => s + v, 0) / fastingValues.length
+
+  // Hold zone asymétrique — titrer seulement HORS bande [T−DOWN ; T+UP].
+  const upperBound = targetGl + CLINICAL_BOUNDS.MDI_BASAL_FASTING_DEADBAND_UP_GL
+  const lowerBound = targetGl - CLINICAL_BOUNDS.MDI_BASAL_FASTING_DEADBAND_DOWN_GL
+  const direction = avgFasting > upperBound ? 1 : avgFasting < lowerBound ? -1 : 0
+  if (direction === 0) return null // HOLD (dans la bande cible)
+
+  // Pas fixe treat-to-target = max(+2 U, +10 %), plafonné min(+20 %, +4 U) — le cap % l'emporte sur le
+  // plancher +2 U (protège les petites doses). Symétrique en baisse (validé medical Q4).
+  const capU = Math.min(
+    (CLINICAL_BOUNDS.MDI_BASAL_MAX_CHANGE_PERCENT / 100) * currentDose,
+    CLINICAL_BOUNDS.MDI_BASAL_MAX_DELTA_U,
+  )
+  const desired = Math.max(CLINICAL_BOUNDS.MDI_BASAL_STEP_U, (CLINICAL_BOUNDS.MDI_BASAL_STEP_PERCENT / 100) * currentDose)
+  const magnitude = Math.min(desired, capU)
+
+  // Snap `floor` uniforme → toujours vers moins d'insuline. Plancher de sanité.
+  const raw = direction > 0 ? currentDose + magnitude : currentDose - magnitude
+  const proposedValue = Math.max(CLINICAL_BOUNDS.MDI_BASAL_MIN_U, Math.floor(raw / incrementU) * incrementU)
+  const effectiveDelta = proposedValue - currentDose
+  if (Math.abs(effectiveDelta) < incrementU - 1e-9) return null // non actionnable après snap
+
+  // Garde HYPO : hausser la basale = plus d'insuline → supprimé si un creux NOCTURNE est en hypo (repli à jeun).
+  const guardValues = nocturnalNadirs && nocturnalNadirs.length > 0 ? nocturnalNadirs : fastingValues
+  if (hypoBlocksProposal("basalRate", currentDose, proposedValue, guardValues)) return null
+
+  const reason: AdjustmentReason = effectiveDelta > 0 ? "basalTooLow" : "basalTooHigh"
+  return {
+    parameterType: "basalRate",
+    reason,
+    currentValue: currentDose,
+    proposedValue,
+    changePercent: Math.round((effectiveDelta / currentDose) * 10000) / 100,
+    confidence: getConfidenceLevel(fastingValues.length),
+    supportingEvents: fastingValues.length,
+    totalEventsConsidered: fastingValues.length,
+    averageObservedValue: Math.round(avgFasting * 10000) / 10000,
+  }
+}
+
+/**
+ * US-2659 (S1, validé medical) — **dé-escalade** de la basale STYLO (moins d'insuline) sur nadirs NOCTURNES
+ * récurrents, **indépendante de la hold zone à jeun** (fasting IN-BAND mais hypos nocturnes avérées). Plus
+ * décisive que la baisse treat-to-target : `−min(20 %, 4 U)` (validé medical Q2 — **`−min`, jamais `−max`** :
+ * `−max` produirait −40 % → rebond hyper/cétose au steady state ; convention `−min` du repo, cf.
+ * `analyzeFixedDoseHypoDeescalation`). Snap `floor` (vers plus de réduction), plancher `MDI_BASAL_MIN_U`.
+ * Dose déjà au plancher / baisse < 1 incrément → `flagNonActionable` (restructuration = décision clinique).
+ * ⚠️ `nocturnalNadirsGl` uniquement (invariant nocturne). Le cas à jeun HAUT + hypo nocturne (Somogyi) est
+ * routé en FLAG par l'appelant, jamais ici.
+ *
+ * @param currentDose Dose basale stylo courante (U totales).
+ * @param nocturnalNadirsGl Creux nocturnes (g/L) POST-changement, non nuls.
+ * @param incrementU Incrément délivrable du stylo (U).
+ */
+export function analyzeMdiBasalDailyHypoDeescalation(
+  currentDose: number,
+  nocturnalNadirsGl: number[],
+  incrementU: number,
+): DeescalationOutcome {
+  if (!Number.isFinite(currentDose) || currentDose < CLINICAL_BOUNDS.MDI_BASAL_MIN_U) return { kind: "none" }
+  if (!recurrentPostMealHypo(nocturnalNadirsGl)) return { kind: "none" }
+  const deltaFromPct = (currentDose * CLINICAL_BOUNDS.MDI_BASAL_MAX_CHANGE_PERCENT) / 100
+  const delta = Math.min(deltaFromPct, CLINICAL_BOUNDS.MDI_BASAL_MAX_DELTA_U) // −min(20 %, 4 U)
+  const raw = Math.max(CLINICAL_BOUNDS.MDI_BASAL_MIN_U, currentDose - delta)
+  const proposedValue = Math.max(CLINICAL_BOUNDS.MDI_BASAL_MIN_U, Math.floor(raw / incrementU) * incrementU)
+  const effectiveDelta = currentDose - proposedValue // > 0 = réduction
+  if (effectiveDelta < incrementU - 1e-9) return { kind: "flagNonActionable" }
+  return {
+    kind: "proposal",
+    candidate: {
+      parameterType: "basalRate",
+      reason: "basalTooHigh",
+      currentValue: currentDose,
+      proposedValue,
+      changePercent: Math.round((-effectiveDelta / currentDose) * 100 * 100) / 100,
+      confidence: getConfidenceLevel(nocturnalNadirsGl.length),
+      supportingEvents: nocturnalNadirsGl.filter((g) => Number.isFinite(g) && g < LEVEL1_HYPO_GL).length,
+      totalEventsConsidered: nocturnalNadirsGl.length,
+    },
+  }
+}
+
+/**
  * Analyse une DOSE FIXE (mode b, US-2651) pour un **moment** (matin/midi/soir/nuit) à partir de
  * la tendance glycémique du carnet (BGM). Une dose fixe est une dose **directe** (comme la basale,
  * PAS un dénominateur) : glycémie systématiquement **au-dessus** de la cible → dose **trop basse**

--- a/src/lib/services/adjustment.service.ts
+++ b/src/lib/services/adjustment.service.ts
@@ -518,6 +518,7 @@ export const adjustmentService = {
           carbRatioSlotStart: slot.carbRatioSlotStart,
           pumpBasalSlotId: slot.pumpBasalSlotId,
           moment: slot.moment, // US-2652 : cooldown PAR MOMENT (sinon morning bloque evening)
+          basalDoseKind: slot.basalDoseKind, // US-2659 : cooldown PAR CIBLE stylo (sinon evening bloque morning en S2)
         },
         orderBy: { createdAt: "desc" },
         select: { reviewedAt: true, createdAt: true },

--- a/src/lib/services/adjustment.service.ts
+++ b/src/lib/services/adjustment.service.ts
@@ -14,11 +14,11 @@ import { clinicalReviewFlagService } from "./clinical-review-flag.service"
 import { fcmService } from "./fcm.service"
 import { logger } from "@/lib/logger"
 import { INSULIN_BOUNDS } from "./insulin-therapy.service"
-import { isDeliverableBasalRate } from "@/lib/clinical-bounds"
+import { isDeliverableBasalRate, isDeliverableFixedDose } from "@/lib/clinical-bounds"
 import { encryptField } from "@/lib/crypto/fields"
 import type { AuditContext } from "./patient.service"
 import type {
-  ProposalStatus, Prisma, AdjustableParameter, AdjustmentReason, ProposalSource, ConfidenceLevel, DoseMoment,
+  ProposalStatus, Prisma, AdjustableParameter, AdjustmentReason, ProposalSource, ConfidenceLevel, DoseMoment, BasalDoseKind,
 } from "@prisma/client"
 
 /**
@@ -46,6 +46,10 @@ export type CreateEngineProposalInput = {
   pumpBasalSlotId?: string | null
   /** Discriminateur de créneau pour la DOSE FIXE (mode « doses simples »). */
   moment?: DoseMoment | null
+  /** US-2659 — discriminateur de CIBLE d'une basale STYLO (MDI). `daily` (single_injection),
+   *  `morning`/`evening` (split_injection) → `BasalConfiguration.dailyDose`/`morning`/`eveningDose`.
+   *  Exclusif de `pumpBasalSlotId` pour `basalRate` (CHECK base). */
+  basalDoseKind?: BasalDoseKind | null
 }
 
 /** Sources humaines d'une proposition (l'algorithme passe par le chemin `algorithm`). */
@@ -65,6 +69,8 @@ export type CreateProposalInput = {
   pumpBasalSlotId?: string | null
   /** Discriminateur de créneau pour la DOSE FIXE (mode « doses simples »). */
   moment?: DoseMoment | null
+  /** US-2659 — discriminateur de CIBLE d'une basale STYLO (MDI). Exclusif de `pumpBasalSlotId`. */
+  basalDoseKind?: BasalDoseKind | null
   /** Justification texte libre — chiffrée AES-256-GCM au stockage. */
   proposerComment?: string | null
 }
@@ -97,16 +103,25 @@ function reasonImpliesIncrease(reason: AdjustmentReason): boolean | null {
   return null
 }
 
-function validateProposedValue(parameterType: string, value: number): boolean {
+function validateProposedValue(
+  parameterType: string,
+  value: number,
+  basalDoseKind?: BasalDoseKind | null,
+): boolean {
   switch (parameterType) {
     case "insulinSensitivityFactor":
       return value >= INSULIN_BOUNDS.ISF_GL_MIN && value <= INSULIN_BOUNDS.ISF_GL_MAX
     case "insulinToCarbRatio":
       return value >= INSULIN_BOUNDS.ICR_MIN && value <= INSULIN_BOUNDS.ICR_MAX
-    // US-2648b — un débit basal doit être PROGRAMMABLE sur la pompe : multiple de
-    // `PUMP_BASAL_INCREMENT` (0,05 U/h). Sinon la valeur passe les bornes mais n'est pas
-    // délivrable (arrondi silencieux / profil rejeté à l'application). Rejet à la création.
     case "basalRate":
+      // US-2659 — basale STYLO (MDI, `basalDoseKind` fourni) : dose en UNITÉS TOTALES. Bornes propres
+      // (`MDI_BASAL_MIN_U`, pas de plafond dur — U300/dégludec légitimes > 80 U ; le WARN est non
+      // bloquant), délivrable à la demi-unité (`isDeliverableFixedDose`). JAMAIS les bornes pompe (U/h).
+      if (basalDoseKind != null) {
+        return value >= INSULIN_BOUNDS.MDI_BASAL_MIN_U && isDeliverableFixedDose(value)
+      }
+      // US-2648b — basale POMPE : débit PROGRAMMABLE = multiple de `PUMP_BASAL_INCREMENT` (0,05 U/h),
+      // dans [BASAL_MIN ; BASAL_MAX]. Rejet à la création si non délivrable (profil rejeté à l'application).
       return (
         value >= INSULIN_BOUNDS.BASAL_MIN &&
         value <= INSULIN_BOUNDS.BASAL_MAX &&
@@ -156,6 +171,22 @@ async function resolveCurrentValue(
       return Number(row.gramsPerUnit)
     }
     case "basalRate": {
+      // US-2659 — basale STYLO (MDI) : ciblée par `basalDoseKind` (daily/morning/evening) sur
+      // `BasalConfiguration` (scopée patient via `settings`, anti-IDOR). Dose en UNITÉS TOTALES.
+      if (input.basalDoseKind != null) {
+        const cfg = await prisma.basalConfiguration.findFirst({
+          where: { settings: { patientId } },
+          select: { dailyDose: true, morningDose: true, eveningDose: true },
+        })
+        if (!cfg) throw new Error("currentValueNotFound")
+        const dose =
+          input.basalDoseKind === "daily" ? cfg.dailyDose
+          : input.basalDoseKind === "morning" ? cfg.morningDose
+          : cfg.eveningDose
+        if (dose == null) throw new Error("currentValueNotFound") // dose non configurée → fail-closed
+        return Number(dose)
+      }
+      // Basale POMPE : ciblée par `pumpBasalSlotId` (créneau U/h), scopée patient.
       if (!input.pumpBasalSlotId) throw new Error("slotRequired")
       const row = await prisma.pumpBasalSlot.findFirst({
         where: { id: input.pumpBasalSlotId, basalConfig: { settings: { patientId } } },
@@ -195,14 +226,18 @@ function slotFieldsFor(parameterType: AdjustableParameter, input: CreateProposal
     carbRatioSlotEnd: null as number | null,
     pumpBasalSlotId: null as string | null,
     moment: null as DoseMoment | null,
+    // US-2659 — discriminateur basale STYLO (exclusif de pumpBasalSlotId pour basalRate).
+    basalDoseKind: null as BasalDoseKind | null,
   }
   switch (parameterType) {
     case "insulinSensitivityFactor":
       return { ...empty, timeSlotStartHour: input.timeSlotStartHour ?? null, timeSlotEndHour: input.timeSlotEndHour ?? null }
     case "insulinToCarbRatio":
       return { ...empty, carbRatioSlotStart: input.carbRatioSlotStart ?? null, carbRatioSlotEnd: input.carbRatioSlotEnd ?? null }
+    // US-2659 — basalRate : POMPE (pumpBasalSlotId, U/h) OU STYLO (basalDoseKind, U totales), exclusif.
+    // On ne conserve que le discriminateur fourni → le tuple d'unicité anti-spam reste correct.
     case "basalRate":
-      return { ...empty, pumpBasalSlotId: input.pumpBasalSlotId ?? null }
+      return { ...empty, pumpBasalSlotId: input.pumpBasalSlotId ?? null, basalDoseKind: input.basalDoseKind ?? null }
     case "fixedDose":
       return { ...empty, moment: input.moment ?? null }
     default:
@@ -318,6 +353,8 @@ export const adjustmentService = {
       // US-2652 : sans `moment`, `resolveCurrentValue` lève `slotRequired` pour une dose fixe → CAS
       // `baselineMoved` inactif (une dose absolue périmée serait écrite). Doit être forwardé.
       moment: DoseMoment | null
+      // US-2659 : idem pour la basale STYLO (résolution `dailyDose`/`morning`/`eveningDose`).
+      basalDoseKind: BasalDoseKind | null
     },
   ): Promise<number | null> {
     try {
@@ -330,6 +367,7 @@ export const adjustmentService = {
         carbRatioSlotStart: proposal.carbRatioSlotStart,
         pumpBasalSlotId: proposal.pumpBasalSlotId,
         moment: proposal.moment,
+        basalDoseKind: proposal.basalDoseKind,
       })
     } catch (err) {
       // Cas ATTENDUS (créneau absent/non résoluble) → null silencieux. Une erreur INATTENDUE
@@ -504,6 +542,7 @@ export const adjustmentService = {
         carbRatioSlotStart: slot.carbRatioSlotStart,
         pumpBasalSlotId: slot.pumpBasalSlotId,
         moment: slot.moment, // US-2652 : 1 pending PAR MOMENT (aligne le pré-check sur l'index partiel)
+        basalDoseKind: slot.basalDoseKind, // US-2659 : 1 pending PAR CIBLE stylo (aligne sur l'index partiel)
       },
       select: { id: true },
     })
@@ -586,8 +625,9 @@ export const adjustmentService = {
     const { mode } = await treatmentModeService.resolveTreatmentMode(patientId)
     if (mode === "nonInsulin") throw new Error("nonInsulinNoDose")
 
-    // 1. Bornes cliniques dures + métriques moteur valides.
-    if (!validateProposedValue(parameterType, proposedValue)) throw new Error("valueOutOfBounds")
+    // 1. Bornes cliniques dures + métriques moteur valides. `basalDoseKind` route les bornes basale
+    //    STYLO (U totales) vs POMPE (U/h) — US-2659.
+    if (!validateProposedValue(parameterType, proposedValue, input.basalDoseKind)) throw new Error("valueOutOfBounds")
     if (!Number.isFinite(input.supportingEvents) || input.supportingEvents <= 0) {
       throw new Error("invalidSupportingEvents") // une proposition à 0 événement n'a aucun sens
     }
@@ -605,6 +645,7 @@ export const adjustmentService = {
       carbRatioSlotEnd: input.carbRatioSlotEnd,
       pumpBasalSlotId: input.pumpBasalSlotId,
       moment: input.moment, // US-2652 : sans ça, `resolveCurrentValue` lève slotRequired → moteur fixedDose mort
+      basalDoseKind: input.basalDoseKind, // US-2659 : sans ça, resolveCurrentValue lit la pompe → basale stylo morte
     }
     const currentValue = await resolveCurrentValue(patientId, parameterType, asInput)
 
@@ -641,6 +682,7 @@ export const adjustmentService = {
         carbRatioSlotStart: slot.carbRatioSlotStart,
         pumpBasalSlotId: slot.pumpBasalSlotId,
         moment: slot.moment, // US-2652 : 1 pending PAR MOMENT (aligne le pré-check sur l'index partiel)
+        basalDoseKind: slot.basalDoseKind, // US-2659 : 1 pending PAR CIBLE stylo (aligne sur l'index partiel)
       },
       select: { id: true },
     })
@@ -716,9 +758,17 @@ export const adjustmentService = {
 
       // Apply the change if requested — validate bounds first
       if (applyImmediately) {
+        // US-2659 (S1) — l'ÉCRITURE groupée de la basale STYLO (`basalDoseKind`) n'est pas encore livrée.
+        // Fail-closed EN TÊTE : sinon aucune branche pump/isf/icr/fixedDose ne matcherait → « accepté +
+        // appliqué » FANTÔME sans écriture (fausse confiance clinique). Le médecin accepte SANS apply
+        // (statut) et ajuste la config à la main tant que l'application groupée n'est pas livrée (slice ultérieure).
+        if (proposal.parameterType === "basalRate" && proposal.basalDoseKind != null) {
+          throw new Error("styloBasalApplyNotSupported")
+        }
+
         const proposed = Number(proposal.proposedValue)
 
-        if (!validateProposedValue(proposal.parameterType, proposed)) {
+        if (!validateProposedValue(proposal.parameterType, proposed, proposal.basalDoseKind)) {
           throw new Error("valueOutOfBounds")
         }
 

--- a/src/lib/services/proposal-generator.service.ts
+++ b/src/lib/services/proposal-generator.service.ts
@@ -33,7 +33,8 @@ import { findSlotForHour } from "@/lib/insulin-slots"
 import {
   analyzeIcrSlot, analyzeIcrHypoDeescalation, recurrentPostMealHypo, hasSevereHypo, analyzeBasalTrend,
   analyzeIsfSlot, analyzeIsfHypoDeescalation, analyzeBasalHypoDeescalation, analyzeFixedDose,
-  analyzeFixedDoseHypoDeescalation, type ProposalCandidate,
+  analyzeFixedDoseHypoDeescalation, analyzeMdiBasalDailyTrend, analyzeMdiBasalDailyHypoDeescalation,
+  type ProposalCandidate,
 } from "@/lib/proposal-algorithm"
 import { analyticsService } from "@/lib/services/analytics.service"
 import { clinicalReviewFlagService } from "@/lib/services/clinical-review-flag.service"
@@ -456,6 +457,107 @@ export const proposalGeneratorService = {
             }
           } else if (severeNoct) {
             await raiseNocturnalFlag() // hypo sévère nocturne ISOLÉE → surface, jamais silencieuse
+          }
+        }
+      }
+    }
+
+    // 6bis. Chemin BASAL STYLO — single_injection (US-2659 S1, validé medical). Titre la dose lente UNIQUE
+    // (`dailyDose`, UNITÉS TOTALES) sur la glycémie à jeun (treat-to-target, pas FIXE + hold zone asymétrique).
+    // Cible `basalDoseKind = "daily"` (jamais un créneau pompe). split_injection = S2. Le chemin pompe
+    // (ci-dessus) est inchangé — routage exclusif sur `configType`.
+    if (basalConfig?.configType === "single_injection") {
+      const currentDose = basalConfig.dailyDose != null ? Number(basalConfig.dailyDose) : null
+      if (currentDose != null && Number.isFinite(currentDose) && currentDose >= CLINICAL_BOUNDS.MDI_BASAL_MIN_U) {
+        const inc = CLINICAL_BOUNDS.MDI_BASAL_DELIVERY_INCREMENT_U // 1 U fail-closed (0,5 demi-unité non câblé S1)
+        // Fenêtre 7 j MDI (plus réactive) ; une fenêtre à la demande (US-2658) l'emporte si fournie.
+        const mdiPeriod = windowDays != null ? `${windowDays}d` : `${CLINICAL_BOUNDS.MDI_BASAL_ANALYSIS_DAYS}d`
+        const rawTarget = settings?.glucoseTargets?.[0]?.targetGlucose
+        const targetGl = resolveFastingTarget(rawTarget != null ? Number(rawTarget) / 100 : null, isPregnancy)
+
+        // Source du signal à jeun : CGM d'abord (porte les nadirs nocturnes → autorise HAUSSES + Somogyi +
+        // dé-escalade) ; à défaut BGM (patient MDI souvent BGM) → à jeun présent mais AUCUN nadir nocturne →
+        // hausses refusées (AC-4) → flag, baisses permises. Fail-closed : jamais de hausse à l'aveugle.
+        const toGl = (arr: { fastingMgdl?: number | null; nocturnalNadirMgdl?: number | null }[], key: "fastingMgdl" | "nocturnalNadirMgdl") =>
+          arr.map((f) => f[key]).filter((v): v is number => v !== null && v !== undefined && Number.isFinite(v)).map((v) => v / 100)
+        let fasting = await mealtimePattern.fastingTrend(patientId, mdiPeriod, auditUserId, ctx, { source: "cgm" })
+        let fastingValues = toGl(fasting, "fastingMgdl")
+        if (fastingValues.length < MIN_NADIR_NIGHTS) {
+          fasting = await mealtimePattern.fastingTrend(patientId, mdiPeriod, auditUserId, ctx, { source: "bgm" })
+          fastingValues = toGl(fasting, "fastingMgdl")
+        }
+        const nocturnalNadirs = toGl(fasting, "nocturnalNadirMgdl")
+        const avgFasting = fastingValues.length > 0 ? mean(fastingValues) : 0
+        const recurrentNoct = recurrentPostMealHypo(nocturnalNadirs)
+        const severeNoct = hasSevereHypo(nocturnalNadirs)
+        const upperBound = targetGl + CLINICAL_BOUNDS.MDI_BASAL_FASTING_DEADBAND_UP_GL
+        const coverageOk = nocturnalNadirs.length >= MIN_NADIR_NIGHTS
+
+        // Cooldown 72 h + nadirs POST-changement (fix Q6a) — gate les DEUX sens (divergence assumée vs pompe :
+        // steady state glargine/detemir 3-4 j + incrément 1 U grossier → anti-empilement, Risk #1).
+        const { cutoff: mdiCutoff, withinCooldown } = await deescalationTiming(patientId, "basalRate", { basalDoseKind: "daily" })
+        const postNocturnalNadirs = toGl(afterCutoff(fasting, mdiCutoff), "nocturnalNadirMgdl")
+        const mdiBucket = "basal:stylo:daily"
+
+        const raiseMdiFlag = () =>
+          clinicalReviewFlagService.raise(patientId, "nocturnalHypoHighFasting", auditUserId, ctx)
+            .then(() => { flagged++ })
+            .catch((err) => logger.error("proposal-generator", "raise flag failed", { patientId, bucket: mdiBucket }, err as Error))
+
+        const persistMdi = async (cand: ProposalCandidate) => {
+          try {
+            await adjustmentService.createEngineProposal({
+              patientId,
+              parameterType: "basalRate",
+              proposedValue: cand.proposedValue,
+              expectedCurrentValue: cand.currentValue,
+              reason: cand.reason,
+              confidence: cand.confidence,
+              supportingEvents: cand.supportingEvents,
+              totalEventsConsidered: cand.totalEventsConsidered,
+              averageObservedValue: cand.averageObservedValue ?? null,
+              analysisPeriod: mdiPeriod,
+              basalDoseKind: "daily",
+            }, ctx)
+            created++
+          } catch (err) {
+            const msg = (err as Error).message
+            if (EXPECTED_SKIP.has(msg)) {
+              logger.info("proposal-generator", "engine proposal skipped", { patientId, bucket: mdiBucket, failMode: msg })
+            } else {
+              logger.error("proposal-generator", "unexpected engine proposal error", { patientId, bucket: mdiBucket, failMode: "unexpected" }, err as Error)
+            }
+          }
+        }
+
+        if (fastingValues.length >= MIN_NADIR_NIGHTS) {
+          // 1. Somogyi : à jeun HAUT (> T + Δ_up) + hypo nocturne récurrente → FLAG, jamais une baisse auto (D10).
+          if (avgFasting > upperBound && recurrentNoct) {
+            await raiseMdiFlag()
+          } else if (recurrentNoct) {
+            // 2. Hypos nocturnes récurrentes (à jeun IN-BAND ou sous la bande) → dé-escalade PRIME (plus spécifique,
+            //    couvre la cible grossesse serrée). Jugée sur les nadirs POST-changement + cooldown (Q6a/Q6b).
+            const de = analyzeMdiBasalDailyHypoDeescalation(currentDose, postNocturnalNadirs, inc)
+            if (de.kind === "proposal" && !withinCooldown) {
+              await persistMdi(de.candidate)
+            } else if (de.kind === "flagNonActionable") {
+              await raiseMdiFlag() // dose trop basse pour titrer d'un incrément → restructuration = revue
+            } else if (severeNoct) {
+              await raiseMdiFlag() // dé-escalade bloquée (délai/post-changement) mais sévère → jamais tu (Q6b)
+            }
+          } else {
+            // 3. Pas d'hypo nocturne récurrente → titration treat-to-target (la hold zone gère le HOLD in-band).
+            const candidate = analyzeMdiBasalDailyTrend(fastingValues, targetGl, currentDose, nocturnalNadirs, inc)
+            const isIncrease = candidate?.reason === "basalTooLow"
+            if (candidate && isIncrease && !coverageOk) {
+              // AC-4 : hausse refusée faute de couverture nocturne (coucher/réveil) → FLAG explicite (jamais un
+              // drop muet — une hypo à 3 h masquée par une moyenne à jeun élevée resterait invisible).
+              await raiseMdiFlag()
+            } else if (candidate && !withinCooldown) {
+              await persistMdi(candidate) // hausse (couverture OK) OU baisse treat-to-target ; cooldown 2 sens (Risk #1)
+            } else if (severeNoct) {
+              await raiseMdiFlag() // titration bloquée (cooldown) mais nadir sévère isolé → surface, jamais tu (Q6b)
+            }
           }
         }
       }

--- a/src/lib/services/proposal-generator.service.ts
+++ b/src/lib/services/proposal-generator.service.ts
@@ -129,12 +129,16 @@ async function deescalationTiming(
   patientId: number,
   parameterType: AdjustableParameter,
   slotWhere: Prisma.AdjustmentProposalWhereInput,
+  // US-2659 — plancher temporel paramétrable : les 4 leviers historiques utilisent
+  // `ENGINE_DEESCALATION_COOLDOWN_HOURS` (72 h) ; la basale STYLO passe `MDI_BASAL_COOLDOWN_HOURS`
+  // (72 h V1, 96 h dégludec V2). Défaut = ENGINE pour ne rien changer aux appelants existants.
+  cooldownHours: number = CLINICAL_BOUNDS.ENGINE_DEESCALATION_COOLDOWN_HOURS,
 ): Promise<{ cutoff: string | null; withinCooldown: boolean }> {
   const at = await lastAcceptedChangeAt(patientId, parameterType, slotWhere)
   if (at === null) return { cutoff: null, withinCooldown: false }
   return {
     cutoff: localDay(at.getTime()),
-    withinCooldown: Date.now() - at.getTime() < CLINICAL_BOUNDS.ENGINE_DEESCALATION_COOLDOWN_HOURS * 3_600_000,
+    withinCooldown: Date.now() - at.getTime() < cooldownHours * 3_600_000,
   }
 }
 
@@ -489,14 +493,19 @@ export const proposalGeneratorService = {
         const nocturnalNadirs = toGl(fasting, "nocturnalNadirMgdl")
         const avgFasting = fastingValues.length > 0 ? mean(fastingValues) : 0
         const recurrentNoct = recurrentPostMealHypo(nocturnalNadirs)
-        const severeNoct = hasSevereHypo(nocturnalNadirs)
+        // Surfaçage Q6b sur hypo sévère NOCTURNE (CGM) **ET** à jeun (BGM-only : un relevé capillaire sévère
+        // au réveil < 0,54 g/L n'a pas de nadir nocturne CGM correspondant — ne jamais le taire).
+        const severeHypo = hasSevereHypo([...nocturnalNadirs, ...fastingValues])
         const upperBound = targetGl + CLINICAL_BOUNDS.MDI_BASAL_FASTING_DEADBAND_UP_GL
         const coverageOk = nocturnalNadirs.length >= MIN_NADIR_NIGHTS
 
-        // Cooldown 72 h + nadirs POST-changement (fix Q6a) — gate les DEUX sens (divergence assumée vs pompe :
-        // steady state glargine/detemir 3-4 j + incrément 1 U grossier → anti-empilement, Risk #1).
-        const { cutoff: mdiCutoff, withinCooldown } = await deescalationTiming(patientId, "basalRate", { basalDoseKind: "daily" })
-        const postNocturnalNadirs = toGl(afterCutoff(fasting, mdiCutoff), "nocturnalNadirMgdl")
+        // Cooldown MDI (72 h V1) + observations POST-changement (fix Q6a) — gate les DEUX sens (divergence
+        // assumée vs pompe : steady state glargine/detemir 3-4 j + incrément 1 U grossier → anti-empilement,
+        // Risk #1). Filtre appliqué AUX DEUX signaux : nadirs (dé-escalade) ET à jeun (treat-to-target, fix M1).
+        const { cutoff: mdiCutoff, withinCooldown } = await deescalationTiming(patientId, "basalRate", { basalDoseKind: "daily" }, CLINICAL_BOUNDS.MDI_BASAL_COOLDOWN_HOURS)
+        const postFast = afterCutoff(fasting, mdiCutoff)
+        const postNocturnalNadirs = toGl(postFast, "nocturnalNadirMgdl")
+        const postFastingValues = toGl(postFast, "fastingMgdl")
         const mdiBucket = "basal:stylo:daily"
 
         const raiseMdiFlag = () =>
@@ -542,12 +551,14 @@ export const proposalGeneratorService = {
               await persistMdi(de.candidate)
             } else if (de.kind === "flagNonActionable") {
               await raiseMdiFlag() // dose trop basse pour titrer d'un incrément → restructuration = revue
-            } else if (severeNoct) {
+            } else if (severeHypo) {
               await raiseMdiFlag() // dé-escalade bloquée (délai/post-changement) mais sévère → jamais tu (Q6b)
             }
           } else {
-            // 3. Pas d'hypo nocturne récurrente → titration treat-to-target (la hold zone gère le HOLD in-band).
-            const candidate = analyzeMdiBasalDailyTrend(fastingValues, targetGl, currentDose, nocturnalNadirs, inc)
+            // 3. Pas d'hypo nocturne récurrente → titration treat-to-target sur l'à jeun POST-changement (fix M1 :
+            //    évite l'empilement d'un pas fixe sur une moyenne 7 j contaminée par ~4 j pré-changement, avant
+            //    le steady state 3-4 j). < 3 à jeun post-changement → l'analyseur renvoie null → HOLD (repli sûr).
+            const candidate = analyzeMdiBasalDailyTrend(postFastingValues, targetGl, currentDose, nocturnalNadirs, inc)
             const isIncrease = candidate?.reason === "basalTooLow"
             if (candidate && isIncrease && !coverageOk) {
               // AC-4 : hausse refusée faute de couverture nocturne (coucher/réveil) → FLAG explicite (jamais un
@@ -555,8 +566,8 @@ export const proposalGeneratorService = {
               await raiseMdiFlag()
             } else if (candidate && !withinCooldown) {
               await persistMdi(candidate) // hausse (couverture OK) OU baisse treat-to-target ; cooldown 2 sens (Risk #1)
-            } else if (severeNoct) {
-              await raiseMdiFlag() // titration bloquée (cooldown) mais nadir sévère isolé → surface, jamais tu (Q6b)
+            } else if (severeHypo) {
+              await raiseMdiFlag() // titration bloquée (cooldown) mais hypo sévère isolée → surface, jamais tu (Q6b)
             }
           }
         }

--- a/tests/unit/adjustment.service.test.ts
+++ b/tests/unit/adjustment.service.test.ts
@@ -369,6 +369,33 @@ describe("adjustmentService", () => {
     })
   })
 
+  describe("accept with basal STYLO apply (US-2659)", () => {
+    const styloProposal = (id: string) => ({
+      id, patientId: 1, status: "pending",
+      parameterType: "basalRate", proposedValue: 20, basalDoseKind: "daily", pumpBasalSlotId: null,
+    })
+
+    it("applyImmediately d'une proposition STYLO → styloBasalApplyNotSupported (fail-closed, jamais d'écriture fantôme)", async () => {
+      const mockTx = {
+        adjustmentProposal: { findUnique: vi.fn().mockResolvedValue(styloProposal("p5")), update: vi.fn().mockResolvedValue({}) },
+        auditLog: { create: vi.fn().mockResolvedValue({}) },
+      }
+      prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+      await expect(adjustmentService.accept("p5", 2, true)).rejects.toThrow("styloBasalApplyNotSupported")
+    })
+
+    it("accept SANS apply d'une proposition STYLO → accepté (statut), non appliqué (aucune écriture)", async () => {
+      const mockTx = {
+        adjustmentProposal: { findUnique: vi.fn().mockResolvedValue(styloProposal("p6")), update: vi.fn().mockResolvedValue({}) },
+        auditLog: { create: vi.fn().mockResolvedValue({}) },
+      }
+      prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+      const result = await adjustmentService.accept("p6", 2, false)
+      expect(result.accepted).toBe(true)
+      expect(result.applied).toBe(false)
+    })
+  })
+
   describe("accept without apply", () => {
     it("accepts without applying changes", async () => {
       const mockTx = {
@@ -454,6 +481,36 @@ describe("adjustmentService", () => {
     it("supportingEvents ≤ 0 → invalidSupportingEvents", async () => {
       await expect(adjustmentService.createEngineProposal(isfInput({ supportingEvents: 0 })))
         .rejects.toThrow("invalidSupportingEvents")
+    })
+
+    it("US-2659 — proposition STYLO daily : lit BasalConfiguration.dailyDose + bornes MDI (U totales), pas les bornes pompe", async () => {
+      prismaMock.basalConfiguration.findFirst.mockResolvedValue({ dailyDose: 22, morningDose: null, eveningDose: null } as never)
+      prismaMock.adjustmentProposal.findFirst.mockResolvedValue(null)
+      const mockTx = {
+        adjustmentProposal: { create: vi.fn().mockResolvedValue({ id: "e2", status: "pending", proposedByUserId: null }) },
+        auditLog: { create: vi.fn().mockResolvedValue({}) },
+      }
+      prismaMock.$transaction.mockImplementation((async (cb: any) => cb(mockTx)) as any)
+
+      // 20 U : REJETÉ par les bornes pompe (> BASAL_MAX 5 U/h) mais valide en stylo (U totales, délivrable).
+      const res = await adjustmentService.createEngineProposal({
+        patientId: 1, parameterType: "basalRate", proposedValue: 20,
+        expectedCurrentValue: 22, reason: "basalTooHigh", confidence: "medium", supportingEvents: 5,
+        basalDoseKind: "daily", analysisPeriod: "7d",
+      })
+      expect(res.id).toBe("e2")
+      const data = mockTx.adjustmentProposal.create.mock.calls[0]![0].data
+      expect(data.basalDoseKind).toBe("daily")
+      expect(data.pumpBasalSlotId).toBeNull() // exclusivité : jamais un créneau pompe sur une cible stylo
+      expect(Number(data.currentValue)).toBe(22) // lu serveur depuis dailyDose
+    })
+
+    it("US-2659 — proposition STYLO non délivrable (20,3 U, pas multiple de 0,5) → valueOutOfBounds", async () => {
+      await expect(adjustmentService.createEngineProposal({
+        patientId: 1, parameterType: "basalRate", proposedValue: 20.3,
+        expectedCurrentValue: 22, reason: "basalTooHigh", confidence: "medium", supportingEvents: 5,
+        basalDoseKind: "daily",
+      })).rejects.toThrow("valueOutOfBounds")
     })
   })
 

--- a/tests/unit/clinical-bounds.test.ts
+++ b/tests/unit/clinical-bounds.test.ts
@@ -95,11 +95,14 @@ describe("CLINICAL_BOUNDS — anti-drift (A3)", () => {
       MDI_BASAL_MIN_U: 0.5,
       MDI_BASAL_WARN_U: 80,
       MDI_BASAL_STEP_U: 2,
+      MDI_BASAL_STEP_PERCENT: 10,
       MDI_BASAL_MAX_DELTA_U: 4,
       MDI_BASAL_MAX_CHANGE_PERCENT: 20,
       MDI_BASAL_DELIVERY_INCREMENT_U: 1,
       MDI_BASAL_COOLDOWN_HOURS: 72,
       MDI_BASAL_ANALYSIS_DAYS: 7,
+      MDI_BASAL_FASTING_DEADBAND_UP_GL: 0.3,
+      MDI_BASAL_FASTING_DEADBAND_DOWN_GL: 0.2,
     })
   })
 
@@ -137,6 +140,12 @@ describe("CLINICAL_BOUNDS — anti-drift (A3)", () => {
     expect(CLINICAL_BOUNDS.MDI_BASAL_WARN_U).toBe(CLINICAL_BOUNDS.FIXED_BASAL_WARN_U)
     expect(CLINICAL_BOUNDS.MDI_BASAL_ANALYSIS_DAYS).toBe(7)
     expect(CLINICAL_BOUNDS.MDI_BASAL_COOLDOWN_HOURS).toBe(CLINICAL_BOUNDS.ENGINE_DEESCALATION_COOLDOWN_HOURS)
+    // Hold zone ASYMÉTRIQUE (US-2659 S1) : bande haute > bande basse (anti-overshoot du pas fixe côté hausse) ;
+    // les deux > 0 ; à T=1,00 la hold zone = cible ADA [0,80 ; 1,30].
+    expect(CLINICAL_BOUNDS.MDI_BASAL_FASTING_DEADBAND_UP_GL).toBeGreaterThan(CLINICAL_BOUNDS.MDI_BASAL_FASTING_DEADBAND_DOWN_GL)
+    expect(CLINICAL_BOUNDS.MDI_BASAL_FASTING_DEADBAND_DOWN_GL).toBeGreaterThan(0)
+    expect(1.0 - CLINICAL_BOUNDS.MDI_BASAL_FASTING_DEADBAND_DOWN_GL).toBeCloseTo(0.8) // borne basse cible ADA
+    expect(1.0 + CLINICAL_BOUNDS.MDI_BASAL_FASTING_DEADBAND_UP_GL).toBeCloseTo(1.3) // borne haute cible ADA
   })
 
   it("US-2651 — deadband ICR : borne basse < plafond adulte (1,80), grossesse plus stricte", () => {

--- a/tests/unit/proposal-algorithm.test.ts
+++ b/tests/unit/proposal-algorithm.test.ts
@@ -44,6 +44,7 @@ import {
   analyzeIsfSlot, analyzeIcrSlot, analyzeBasalTrend, analyzeFixedDose,
   recurrentPostMealHypo, analyzeIcrHypoDeescalation, hasSevereHypo,
   analyzeIsfHypoDeescalation, analyzeBasalHypoDeescalation, analyzeFixedDoseHypoDeescalation,
+  analyzeMdiBasalDailyTrend, analyzeMdiBasalDailyHypoDeescalation,
 } from "@/lib/proposal-algorithm"
 
 describe("proposal-algorithm", () => {
@@ -438,6 +439,75 @@ describe("proposal-algorithm", () => {
     it("snapping : variation qui s'arrondit à zéro (< 1 incrément) → null (non actionnable)", () => {
       // 0,05 × 1,03 = 0,0515 → snap = 0,05 → delta nul → aucune proposition.
       expect(analyzeBasalTrend([1.03, 1.03, 1.03], 1.0, 0.05)).toBeNull()
+    })
+  })
+
+  describe("analyzeMdiBasalDailyTrend (US-2659 S1 — basale stylo single_injection)", () => {
+    const T = 1.0 // cible → hold zone [0,80 ; 1,30]
+    const noHypo = [1.2, 1.3, 1.4] // nadirs nocturnes sans hypo
+
+    it("HOLD : à jeun dans la hold zone [T−0,20 ; T+0,30] → aucune titration", () => {
+      expect(analyzeMdiBasalDailyTrend([1.05, 1.1, 1.2], T, 20, noHypo, 1)).toBeNull() // 1,10 in-band
+      expect(analyzeMdiBasalDailyTrend([1.28, 1.29, 1.3], T, 20, noHypo, 1)).toBeNull() // juste sous T+0,30
+      expect(analyzeMdiBasalDailyTrend([0.82, 0.85, 0.9], T, 20, noHypo, 1)).toBeNull() // juste au-dessus T−0,20
+    })
+
+    it("HAUSSE au-dessus de la bande : pas fixe +2 U (dose 20), reason basalTooLow", () => {
+      const r = analyzeMdiBasalDailyTrend([1.5, 1.55, 1.6], T, 20, noHypo, 1)
+      expect(r).not.toBeNull()
+      expect(r!.reason).toBe("basalTooLow")
+      expect(r!.proposedValue).toBe(22) // 20 + max(2, 10%·20=2) = +2, snap 1 U
+    })
+
+    it("cap % : sur une PETITE dose (5 U), le cap +20 % (1 U) écrase le plancher +2 U", () => {
+      const r = analyzeMdiBasalDailyTrend([1.6, 1.6, 1.6], T, 5, noHypo, 1)
+      expect(r!.proposedValue).toBe(6) // +1 U (+20 %), PAS +2 U (+40 %)
+    })
+
+    it("snap floor : une hausse infra-incrément sur très petite dose → null (jamais d'overshoot à l'aveugle)", () => {
+      // dose 3, cap +20 %=0,6 U → raw 3,6 → floor(3,6/1)=3 → delta 0 < 1 incrément → null.
+      expect(analyzeMdiBasalDailyTrend([1.6, 1.6, 1.6], T, 3, noHypo, 1)).toBeNull()
+    })
+
+    it("BAISSE sous la bande : treat-to-target −2 U (dose 20), reason basalTooHigh", () => {
+      const r = analyzeMdiBasalDailyTrend([0.55, 0.6, 0.62], T, 20, undefined, 1)
+      expect(r!.reason).toBe("basalTooHigh")
+      expect(r!.proposedValue).toBeLessThan(20)
+    })
+
+    it("garde HYPO : un nadir nocturne sévère supprime une HAUSSE que l'à-jeun haut laisserait passer", () => {
+      const severe = [0.5, 1.3, 1.4] // creux nocturne sévère
+      expect(analyzeMdiBasalDailyTrend([1.5, 1.55, 1.6], T, 20, severe, 1)).toBeNull()
+    })
+
+    it("fail-closed : < 3 à jeun, cible ≤ 0, ou dose < plancher → null", () => {
+      expect(analyzeMdiBasalDailyTrend([1.5, 1.6], T, 20, noHypo, 1)).toBeNull()
+      expect(analyzeMdiBasalDailyTrend([1.5, 1.6, 1.7], 0, 20, noHypo, 1)).toBeNull()
+      expect(analyzeMdiBasalDailyTrend([1.5, 1.6, 1.7], T, 0.3, noHypo, 1)).toBeNull()
+    })
+  })
+
+  describe("analyzeMdiBasalDailyHypoDeescalation (US-2659 S1)", () => {
+    const rec = [0.6, 0.6, 1.2] // ≥ 3 nadirs, ≥ 2 niveau-1 → récurrent
+
+    it("hypos nocturnes récurrentes → baisse −min(20 %, 4 U), reason basalTooHigh", () => {
+      const r = analyzeMdiBasalDailyHypoDeescalation(22, rec, 1)
+      expect(r.kind).toBe("proposal")
+      if (r.kind === "proposal") {
+        expect(r.candidate.reason).toBe("basalTooHigh")
+        expect(r.candidate.proposedValue).toBe(18) // 22 − min(4,4)=−4 → 18
+      }
+    })
+
+    it("−min et non −max : dose 10, 20 %=2 U < 4 U → baisse de 2 U (jamais 4)", () => {
+      const r = analyzeMdiBasalDailyHypoDeescalation(10, rec, 1)
+      expect(r.kind).toBe("proposal")
+      if (r.kind === "proposal") expect(r.candidate.proposedValue).toBe(8) // −2 U (−min), pas −4 U (−max)
+    })
+
+    it("non récurrent → none ; dose au plancher / baisse < 1 incrément → flagNonActionable", () => {
+      expect(analyzeMdiBasalDailyHypoDeescalation(22, [0.6, 1.2, 1.3], 1).kind).toBe("none")
+      expect(analyzeMdiBasalDailyHypoDeescalation(0.6, rec, 1).kind).toBe("flagNonActionable")
     })
   })
 

--- a/tests/unit/proposal-generator.service.test.ts
+++ b/tests/unit/proposal-generator.service.test.ts
@@ -92,7 +92,7 @@ function setup(opts: {
   // US-2659 — `dailyDose` (stylo single_injection) + `pumpSlots` optionnels selon le mode de délivrance.
   basalConfig?: { configType: string; pumpSlots?: { id: string; rate: number; startHour: number; endHour: number }[]; dailyDose?: number }
   glucoseTargets?: { targetGlucose: number }[]
-  fasting?: { fastingMgdl: number | null; nocturnalNadirMgdl: number | null }[]
+  fasting?: { fastingMgdl: number | null; nocturnalNadirMgdl: number | null; dayIso?: string }[]
   sensitivityFactors?: { startHour: number; endHour: number; sensitivityFactorGl: number }[]
   corrections?: { localHour: number; postGlucoseGl: number; targetGl: number; nadirGl: number | null }[]
 } = {}) {
@@ -322,9 +322,10 @@ describe("proposalGeneratorService.generateForPatient — basale STYLO single_in
   beforeEach(() => vi.clearAllMocks())
 
   const stylo = (dailyDose: number) => ({ configType: "single_injection", dailyDose })
-  // Fixture à jeun : `nocturnalNadirMgdl` null ⇒ simule le BGM (pas de couverture nocturne).
+  // Fixture à jeun : `nocturnalNadirMgdl` null ⇒ simule le BGM (pas de couverture nocturne). `dayIso` daté
+  // (jours récents) → robuste au filtre POST-changement (fix M1 : la titration juge l'à jeun post-cutoff).
   const nights = (fastingMgdl: number, nadirMgdl: number | null, n = 3) =>
-    Array.from({ length: n }, () => ({ fastingMgdl, nocturnalNadirMgdl: nadirMgdl }))
+    Array.from({ length: n }, (_, i) => ({ fastingMgdl, nocturnalNadirMgdl: nadirMgdl, dayIso: isoDaysAgo(i + 1) }))
   const styloCalls = () =>
     createEngine.mock.calls
       .map((c) => c[0] as Record<string, unknown>)
@@ -365,7 +366,7 @@ describe("proposalGeneratorService.generateForPatient — basale STYLO single_in
 
   it("AC-5 Somogyi : à jeun HAUT + hypo nocturne récurrente → FLAG nocturnalHypoHighFasting, JAMAIS une baisse", async () => {
     setup({ basalConfig: stylo(22), fasting: [
-      { fastingMgdl: 150, nocturnalNadirMgdl: 50 }, { fastingMgdl: 150, nocturnalNadirMgdl: 50 }, { fastingMgdl: 150, nocturnalNadirMgdl: 120 },
+      { fastingMgdl: 150, nocturnalNadirMgdl: 50, dayIso: isoDaysAgo(1) }, { fastingMgdl: 150, nocturnalNadirMgdl: 50, dayIso: isoDaysAgo(2) }, { fastingMgdl: 150, nocturnalNadirMgdl: 120, dayIso: isoDaysAgo(3) },
     ] })
     await proposalGeneratorService.generateForPatient(1, 99)
     expect(styloCalls()).toHaveLength(0)
@@ -374,7 +375,7 @@ describe("proposalGeneratorService.generateForPatient — basale STYLO single_in
 
   it("AC-3 dé-escalade : à jeun IN-BAND + hypo nocturne récurrente → daily basalTooHigh (−min(20 %, 4 U))", async () => {
     setup({ basalConfig: stylo(22), fasting: [
-      { fastingMgdl: 105, nocturnalNadirMgdl: 60 }, { fastingMgdl: 105, nocturnalNadirMgdl: 60 }, { fastingMgdl: 105, nocturnalNadirMgdl: 120 },
+      { fastingMgdl: 105, nocturnalNadirMgdl: 60, dayIso: isoDaysAgo(1) }, { fastingMgdl: 105, nocturnalNadirMgdl: 60, dayIso: isoDaysAgo(2) }, { fastingMgdl: 105, nocturnalNadirMgdl: 120, dayIso: isoDaysAgo(3) },
     ] })
     await proposalGeneratorService.generateForPatient(1, 99)
     const calls = styloCalls()
@@ -394,6 +395,35 @@ describe("proposalGeneratorService.generateForPatient — basale STYLO single_in
     setup({ basalConfig: { configType: "pump", pumpSlots: [{ id: "noct", rate: 0.8, startHour: 0, endHour: 6 }] }, fasting: nights(150, 120) })
     await proposalGeneratorService.generateForPatient(1, 99)
     expect(styloCalls()).toHaveLength(0) // le chemin pompe utilise pumpBasalSlotId, jamais basalDoseKind
+  })
+
+  it("fix M1 : à jeun HAUTS PÉRIMÉS (pré-changement) → PAS de hausse (la titration juge le POST-changement)", async () => {
+    // Changement accepté il y a 100 h (> 72 h → cooldown écoulé). À jeun post-changement IN-BAND (1,05) mais
+    // pré-changement HAUTS (1,80). Sans le fix (moyenne 7 j pleine = 1,42 > T+0,30), une 2e hausse s'empilerait.
+    setup({ basalConfig: stylo(22), fasting: [
+      { fastingMgdl: 105, nocturnalNadirMgdl: 120, dayIso: isoDaysAgo(1) },
+      { fastingMgdl: 105, nocturnalNadirMgdl: 120, dayIso: isoDaysAgo(2) },
+      { fastingMgdl: 105, nocturnalNadirMgdl: 120, dayIso: isoDaysAgo(3) },
+      { fastingMgdl: 180, nocturnalNadirMgdl: 120, dayIso: isoDaysAgo(5) },
+      { fastingMgdl: 180, nocturnalNadirMgdl: 120, dayIso: isoDaysAgo(6) },
+      { fastingMgdl: 180, nocturnalNadirMgdl: 120, dayIso: isoDaysAgo(7) },
+    ] })
+    prismaMock.adjustmentProposal.findFirst.mockResolvedValue({ reviewedAt: new Date(Date.now() - 100 * 3_600_000) } as never)
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(styloCalls()).toHaveLength(0) // à jeun post-changement in-band → HOLD, pas d'empilement
+  })
+
+  it("fix M-med#1 : hypo sévère À JEUN (BGM sans nadir nocturne) pendant HOLD → FLAG (Q6b sur à jeun ∪ nocturne)", async () => {
+    // BGM (nadirs null) : un relevé réveil sévère 0,50 g/L coexiste avec une moyenne in-band → sans le fix
+    // (severeNoct nocturne seul) l'événement était tu ; le fix surface la sévérité à jeun.
+    setup({ basalConfig: stylo(22), fasting: [
+      { fastingMgdl: 50, nocturnalNadirMgdl: null, dayIso: isoDaysAgo(1) },
+      { fastingMgdl: 130, nocturnalNadirMgdl: null, dayIso: isoDaysAgo(2) },
+      { fastingMgdl: 130, nocturnalNadirMgdl: null, dayIso: isoDaysAgo(3) },
+    ] })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(styloCalls()).toHaveLength(0)
+    expect(raiseFlag).toHaveBeenCalledWith(1, "nocturnalHypoHighFasting", 99, undefined)
   })
 })
 

--- a/tests/unit/proposal-generator.service.test.ts
+++ b/tests/unit/proposal-generator.service.test.ts
@@ -89,7 +89,8 @@ function setup(opts: {
   pregnancyMode?: boolean
   carbRatios?: { startHour: number; endHour: number; gramsPerUnit: number }[]
   meals?: unknown[]
-  basalConfig?: { configType: string; pumpSlots: { id: string; rate: number; startHour: number; endHour: number }[] }
+  // US-2659 — `dailyDose` (stylo single_injection) + `pumpSlots` optionnels selon le mode de délivrance.
+  basalConfig?: { configType: string; pumpSlots?: { id: string; rate: number; startHour: number; endHour: number }[]; dailyDose?: number }
   glucoseTargets?: { targetGlucose: number }[]
   fasting?: { fastingMgdl: number | null; nocturnalNadirMgdl: number | null }[]
   sensitivityFactors?: { startHour: number; endHour: number; sensitivityFactorGl: number }[]
@@ -102,7 +103,10 @@ function setup(opts: {
     basalConfiguration: opts.basalConfig
       ? {
           configType: opts.basalConfig.configType,
-          pumpSlots: opts.basalConfig.pumpSlots.map((s) => ({
+          dailyDose: opts.basalConfig.dailyDose ?? null,
+          morningDose: null,
+          eveningDose: null,
+          pumpSlots: (opts.basalConfig.pumpSlots ?? []).map((s) => ({
             id: s.id, rate: s.rate,
             startTime: new Date(Date.UTC(1970, 0, 1, s.startHour)),
             endTime: new Date(Date.UTC(1970, 0, 1, s.endHour)),
@@ -311,6 +315,85 @@ describe("proposalGeneratorService.generateForPatient — chemin basal (US-2651)
     const res = await proposalGeneratorService.generateForPatient(1, 99)
     expect(res.skipped).toBe("noCarbRatios") // le early-return ICR gate le chemin basal
     expect(basalCalls()).toHaveLength(0)
+  })
+})
+
+describe("proposalGeneratorService.generateForPatient — basale STYLO single_injection (US-2659 S1)", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  const stylo = (dailyDose: number) => ({ configType: "single_injection", dailyDose })
+  // Fixture à jeun : `nocturnalNadirMgdl` null ⇒ simule le BGM (pas de couverture nocturne).
+  const nights = (fastingMgdl: number, nadirMgdl: number | null, n = 3) =>
+    Array.from({ length: n }, () => ({ fastingMgdl, nocturnalNadirMgdl: nadirMgdl }))
+  const styloCalls = () =>
+    createEngine.mock.calls
+      .map((c) => c[0] as Record<string, unknown>)
+      .filter((a) => a.parameterType === "basalRate" && a.basalDoseKind === "daily")
+
+  it("AC-1 HAUSSE : à jeun HAUT + couverture nocturne CGM saine → proposition daily basalTooLow (U totales)", async () => {
+    setup({ basalConfig: stylo(22), fasting: nights(150, 120) }) // 1,50 g/L > T+0,30 ; nadir 1,20 sain
+    await proposalGeneratorService.generateForPatient(1, 99)
+    const calls = styloCalls()
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({ reason: "basalTooLow", expectedCurrentValue: 22, basalDoseKind: "daily" })
+    expect(Number(calls[0].proposedValue)).toBeGreaterThan(22)
+    expect(raiseFlag).not.toHaveBeenCalled()
+  })
+
+  it("AC-4 garde BGM : à jeun HAUT mais AUCUN nadir nocturne (BGM) → hausse refusée → FLAG, pas de dose", async () => {
+    setup({ basalConfig: stylo(22), fasting: nights(150, null) }) // à jeun présent, nadir null (BGM)
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(styloCalls()).toHaveLength(0)
+    expect(raiseFlag).toHaveBeenCalledWith(1, "nocturnalHypoHighFasting", 99, undefined)
+  })
+
+  it("HOLD : à jeun dans la bande [T−0,20 ; T+0,30] → aucune proposition ni flag", async () => {
+    setup({ basalConfig: stylo(22), fasting: nights(105, 120) }) // 1,05 g/L in-band
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(styloCalls()).toHaveLength(0)
+    expect(raiseFlag).not.toHaveBeenCalled()
+  })
+
+  it("BAISSE treat-to-target : à jeun SOUS la bande, pas d'hypo récurrente → daily basalTooHigh (sens sûr, sans couverture)", async () => {
+    setup({ basalConfig: stylo(22), fasting: nights(65, null) }) // 0,65 g/L < T−0,20 ; BGM
+    await proposalGeneratorService.generateForPatient(1, 99)
+    const calls = styloCalls()
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({ reason: "basalTooHigh" })
+    expect(Number(calls[0].proposedValue)).toBeLessThan(22)
+  })
+
+  it("AC-5 Somogyi : à jeun HAUT + hypo nocturne récurrente → FLAG nocturnalHypoHighFasting, JAMAIS une baisse", async () => {
+    setup({ basalConfig: stylo(22), fasting: [
+      { fastingMgdl: 150, nocturnalNadirMgdl: 50 }, { fastingMgdl: 150, nocturnalNadirMgdl: 50 }, { fastingMgdl: 150, nocturnalNadirMgdl: 120 },
+    ] })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(styloCalls()).toHaveLength(0)
+    expect(raiseFlag).toHaveBeenCalledWith(1, "nocturnalHypoHighFasting", 99, undefined)
+  })
+
+  it("AC-3 dé-escalade : à jeun IN-BAND + hypo nocturne récurrente → daily basalTooHigh (−min(20 %, 4 U))", async () => {
+    setup({ basalConfig: stylo(22), fasting: [
+      { fastingMgdl: 105, nocturnalNadirMgdl: 60 }, { fastingMgdl: 105, nocturnalNadirMgdl: 60 }, { fastingMgdl: 105, nocturnalNadirMgdl: 120 },
+    ] })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    const calls = styloCalls()
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({ reason: "basalTooHigh", basalDoseKind: "daily" })
+    expect(Number(calls[0].proposedValue)).toBe(18) // 22 − min(4,4) = 18
+  })
+
+  it("dailyDose non configurée (null) → aucune proposition, aucun crash", async () => {
+    setup({ basalConfig: { configType: "single_injection" }, fasting: nights(150, 120) })
+    const res = await proposalGeneratorService.generateForPatient(1, 99)
+    expect(styloCalls()).toHaveLength(0)
+    expect(res).toBeDefined()
+  })
+
+  it("non-régression : un patient POMPE n'emprunte pas le chemin stylo (basalDoseKind jamais posé)", async () => {
+    setup({ basalConfig: { configType: "pump", pumpSlots: [{ id: "noct", rate: 0.8, startHour: 0, endHour: 6 }] }, fasting: nights(150, 120) })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(styloCalls()).toHaveLength(0) // le chemin pompe utilise pumpBasalSlotId, jamais basalDoseKind
   })
 })
 


### PR DESCRIPTION
## Contexte

Deuxième slice de **US-2659** (après S0 socle #723). Titre la basale **stylo `single_injection`** (dose lente une-fois/jour, `dailyDose`, **unités totales**) sur la glycémie à jeun — treat-to-target, en propositions `pending` gatées médecin (ADR #13). Cadrage + formules **validés `medical-domain-validator`** (2026-07-11 + 2e passe sur le deadband).

## Analyseurs purs (`proposal-algorithm.ts`)

- **`analyzeMdiBasalDailyTrend`** — treat-to-target sur l'à jeun. **Hold zone ASYMÉTRIQUE** `[T−0,20 ; T+0,30]` g/L (obligatoire pour un pas FIXE : déclencher au seul signe sur-corrigerait ; bande haute plus large = anti-overshoot). Hausse `min(max(+2 U, +10 %), +20 %, +4 U)` — le **cap % l'emporte** sur le plancher +2 U (protège les petites doses) ; baisse symétrique. **Snap `floor` asymétrique** (arrondi toujours vers moins d'insuline : une hausse ne dépasse jamais le cap). Garde hypo nocturne.
- **`analyzeMdiBasalDailyHypoDeescalation`** — dé-escalade sur nadirs nocturnes récurrents : **`−min(20 %, 4 U)`** (jamais `−max` → éviterait le rebond hyper/cétose), snap floor, plancher 0,5 U, non actionnable → flag.

## Générateur (`proposal-generator.service.ts`, bloc `configType === "single_injection"`)

Matrice **ordonnée** (validée medical) : **Somogyi** (à jeun > T+0,30 + hypo nocturne récurrente → flag) → **dé-escalade** (prime sur la baisse treat-to-target) → **titration** (hausse gatée par la **couverture nocturne**, sinon **AC-4 : flag explicite**, jamais un drop muet ; **cooldown 72 h sur les DEUX sens** — divergence assumée vs pompe : steady state 3–4 j + incrément 1 U grossier).

**Source du signal à jeun** : **CGM d'abord** (nadirs nocturnes → autorise hausses / Somogyi / dé-escalade), **à défaut BGM** (baisses + AC-4 flags, jamais de hausse à l'aveugle). Fenêtre 7 j. **Chemin pompe inchangé** (routage exclusif sur `configType` — tests de parité).

## Service (`adjustment.service.ts`)

- `createEngineProposal` accepte `basalDoseKind` ; `resolveCurrentValue` lit `BasalConfiguration.dailyDose` (scopé patient) ; `validateProposedValue` route les **bornes stylo** (U totales, délivrable demi-unité, pas de plafond dur) vs pompe (U/h) ; pré-checks anti-spam alignés sur l'index partiel S0.
- **Application différée (fail-closed)** : `accept(applyImmediately=true)` d'une proposition stylo **lève `styloBasalApplyNotSupported`** — jamais un « accepté + appliqué » fantôme sans écriture. L'écriture groupée de `dailyDose` arrive dans une slice ultérieure ; le médecin accepte **SANS** apply.

## Constantes (catalogue + verrou anti-drift, même PR)

`MDI_BASAL_FASTING_DEADBAND_UP_GL` (0,30) / `_DOWN_GL` (0,20) — ancrage ADA 80–130, asymétrie anti-overshoot ; `MDI_BASAL_STEP_PERCENT` (10) — composante % du pas de hausse (≠ dé-escalade).

## Tests / vérifs

- Analyseurs (hold zone, cap %, snap floor, garde hypo, `−min` vs `−max`) ; générateur single_injection (**AC-1** hausse, **AC-3** dé-escalade, **AC-4** garde BGM, **AC-5** Somogyi, hold, baisse, non-régression pompe) ; service (dailyDose read, bornes MDI, accept fail-closed).
- Suite **4054 verts** ; `tsc` 0 ; eslint clean.

## Points à valider en revue

- Réutilisation du flag `nocturnalHypoHighFasting` pour l'AC-4 (« hausse refusée faute de couverture nocturne ») — sémantiquement défendable (concern = hypo nocturne masquée) mais imprécis ; un flag dédié serait un follow-up.
- La fenêtre à la demande US-2658 (`windowDays`) l'emporte sur les 7 j MDI si fournie (cohérent avec la pompe ; choix explicite médecin).
- Application groupée `dailyDose` **différée** (validé medical Q5) — accept-with-apply fail-closed en attendant.

Revue attendue : `medical-domain-validator` (formules + invariants de sécurité), `code-reviewer` (qualité, parité pompe), `healthcare-security-auditor` (traçabilité, fail-closed, PHI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)