### PR TITLE
US-2659 (slice S2) — titration de la basale STYLO split_injection (soir=à jeun, matin=pré-dîner)

### DIFF
--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -573,9 +573,14 @@ surfaçage Q6b). Le service (`resolveCurrentValue` → `morning`/`eveningDose`, 
   un split **basal-seul** titre les deux. *Limite S2 : le pré-dîner est lu sur le journal CGM ; un split BGM-only
   n'obtient pas de proposition matin (fail-closed).*
 
+Le signal pré-dîner et la garde de jour sont lus sur un **journal dédié fenêtre 7 j** (`MDI_BASAL_ANALYSIS_DAYS`,
+comme la dose du soir), distinct du `journal` ICR (14 j) — la fenêtre analysée == `analysisPeriod` persisté (traçabilité).
+
 **Orchestration (D4 raffiné, Q5)** — **une seule proposition basale/run**, priorité **sécurité-d'abord** :
 dé-escalade (soir ou matin) > titration ; à égalité, **soir/à jeun** (nocturne = pire mode d'échec). Les **flags**
-sont toujours levés (revue, pas un changement de dose). **Verrou « 1 basale stylo pending »** (Q6) : au plus une
+sont toujours levés (revue, pas un changement de dose) ; si **les deux** doses dé-escaladent, la winner est
+persistée et la dé-escalade **perdante est immédiatement flaggée** (fail-loud — jamais un drop silencieux d'un
+signal de sécurité ; une titration perdante défère). **Verrou « 1 basale stylo pending »** (Q6) : au plus une
 proposition stylo `pending` par patient, toutes cibles confondues (changer les 2 doses d'un coup détruit
 l'attribution + risque l'empilement). Double couche : garde **applicative** (le générateur vérifie une pending
 avant de créer) + **index unique partiel base** `adjustment_proposals_one_pending_stylo_basal`

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -555,6 +555,34 @@ délivrable demi-unité, pas de plafond dur) et non pompe (U/h). **Application d
 d'une proposition stylo **lève `styloBasalApplyNotSupported`** (fail-closed — jamais un « accepté + appliqué » fantôme
 sans écriture) ; l'écriture groupée de `dailyDose` arrive dans une slice ultérieure. Le médecin accepte SANS apply.
 
+### Titration `split_injection` (US-2659 S2, LIVRÉ, validé medical 2026-07-11)
+
+DEUX doses stylo (matin + soir). La **matrice de titration d'une dose** est factorisée (`decideMdiDose`, pure)
+et **partagée** avec `single_injection` (mêmes bornes, hold zone, snap, dé-escalade `−min`, cooldown post-changement,
+surfaçage Q6b). Le service (`resolveCurrentValue` → `morning`/`eveningDose`, bornes stylo, accept fail-closed) est
+**générique** depuis S1 (S2 n'ajoute pas de code service).
+
+- **Dose du SOIR** (`basalDoseKind="evening"`) → titrée sur la glycémie **à jeun** (= chemin `single_injection` :
+  source CGM→BGM, garde **nocturne**, Somogyi, AC-4).
+- **Dose du MATIN** (`basalDoseKind="morning"`) → titrée sur la glycémie **PRÉ-DÎNER** (`preMgdl` des repas
+  `moment="evening"` de `dailyJournal`). Garde hypo = **nadirs de JOUR** (repas `morning`+`noon`), **jamais** le
+  nadir nocturne (D9 « jamais croisé » — fenêtre de la dose du soir). Cible pré-dîner = `resolveFastingTarget`
+  (préprandiale ADA 80–130, même hold zone). **Confondeur (§3.2)** : un **bolus de midi** (`moment="noon"`,
+  `bolus>0`) contamine le pré-dîner par son IOB → dose du matin **flag-only** (hausse ET dé-escalade), jamais une
+  proposition (décision basale-vs-bolus rendue au médecin). ⇒ un split **basal-bolus** ne titre que le soir ;
+  un split **basal-seul** titre les deux. *Limite S2 : le pré-dîner est lu sur le journal CGM ; un split BGM-only
+  n'obtient pas de proposition matin (fail-closed).*
+
+**Orchestration (D4 raffiné, Q5)** — **une seule proposition basale/run**, priorité **sécurité-d'abord** :
+dé-escalade (soir ou matin) > titration ; à égalité, **soir/à jeun** (nocturne = pire mode d'échec). Les **flags**
+sont toujours levés (revue, pas un changement de dose). **Verrou « 1 basale stylo pending »** (Q6) : au plus une
+proposition stylo `pending` par patient, toutes cibles confondues (changer les 2 doses d'un coup détruit
+l'attribution + risque l'empilement). Double couche : garde **applicative** (le générateur vérifie une pending
+avant de créer) + **index unique partiel base** `adjustment_proposals_one_pending_stylo_basal`
+(`WHERE parameter_type='basalRate' AND basal_dose_kind IS NOT NULL AND status='pending'`, migration `20260720100000`
+— ferme la course inter-run cron/on-demand ; violation P2002 → `duplicatePendingProposal`). **Fail-loud** : si le
+verrou bloque une **dé-escalade** (sécurité), un **flag** est levé (jamais un drop silencieux).
+
 ### Assemblage corrections ISF `correctionTrend` (US-2651 ISF slice 2, validé medical)
 
 Apparie les **corrections propres** (`mealtimePattern.correctionTrend`, CGM only) pour peupler

--- a/prisma/migrations/20260720100000_us2659_s2_one_pending_stylo_basal/migration.sql
+++ b/prisma/migrations/20260720100000_us2659_s2_one_pending_stylo_basal/migration.sql
@@ -1,0 +1,19 @@
+-- ═══════════════════════════════════════════════════════════════
+-- US-2659 (slice S2) — Verrou « UNE seule basale STYLO pending par patient »
+-- ═══════════════════════════════════════════════════════════════
+-- En split_injection, un patient a DEUX doses (matin + soir). L'index anti-spam existant
+-- (`adjustment_proposals_one_pending_per_slot`, tuple avec `basal_dose_kind`, NULLS NOT DISTINCT)
+-- autorise DEUX propositions stylo pending simultanées (matin ET soir, cibles distinctes). Or changer
+-- les DEUX doses en un run détruit l'attribution matin/soir et risque l'empilement (fenêtres d'action qui
+-- se chevauchent). Décision clinique validée (D4 + Q6, medical 2026-07-11) : au plus UNE proposition de
+-- basale stylo pending par patient, quelle que soit la cible.
+--
+-- Le nom contient « one_pending » → la violation P2002 est captée par `isUniqueViolationOn(e, "one_pending")`
+-- (adjustment.service.ts) et remontée en `duplicatePendingProposal` (fail-closed, dans EXPECTED_SKIP).
+-- Défense en profondeur : le générateur applique aussi un verrou APPLICATIF (une proposition/run + priorité
+-- sécurité) ; cet index ferme la course inter-run (cron + on-demand). Ne concerne PAS la pompe
+-- (`basal_dose_kind IS NULL`) ni les autres paramètres. Index partiel non modélisé par Prisma (WHERE) →
+-- invisible au drift-gate, appliqué par `migrate deploy`. Idempotent.
+CREATE UNIQUE INDEX IF NOT EXISTS "adjustment_proposals_one_pending_stylo_basal"
+  ON "adjustment_proposals" ("patient_id")
+  WHERE "parameter_type" = 'basalRate' AND "basal_dose_kind" IS NOT NULL AND "status" = 'pending';

--- a/src/lib/services/adjustment.service.ts
+++ b/src/lib/services/adjustment.service.ts
@@ -674,6 +674,10 @@ export const adjustmentService = {
     const slot = slotFieldsFor(parameterType, asInput)
 
     // 3. Anti-spam (pré-check + index partiel unique via P2002 ci-dessous). Pas de garde patient.
+    //    NB : le pré-check est « 1 pending / (patient × basalDoseKind) » (index `one_pending_per_slot`). Pour la
+    //    basale STYLO, un index PLUS strict « 1 pending stylo / patient toutes cibles » (`one_pending_stylo_basal`,
+    //    US-2659 S2) s'ajoute EN BASE (défense en profondeur, course inter-run) — sa P2002 est aussi captée par
+    //    `isUniqueViolationOn(e, "one_pending")` → `duplicatePendingProposal`.
     const existing = await prisma.adjustmentProposal.findFirst({
       where: {
         patientId,

--- a/src/lib/services/proposal-generator.service.ts
+++ b/src/lib/services/proposal-generator.service.ts
@@ -675,7 +675,11 @@ export const proposalGeneratorService = {
         // Journal dédié fenêtre MDI (7 j) — le `journal` global est chargé en 14 j pour l'ICR. Aligne la fenêtre
         // RÉELLEMENT analysée sur `analysisPeriod` persisté (`mdiPeriod`) et sur la dose du soir (traçabilité HDS +
         // réactivité : ne pas diluer la moyenne pré-dîner avec ~2× de données pré-changement — fix revue medical).
-        const mdiJournal = await mealtimePattern.dailyJournal(patientId, mdiPeriod, auditUserId, ctx, { source: "cgm" })
+        // Court-circuit : en mode fenêtre à la demande (`windowDays` fourni), `mdiPeriod === analysisPeriod` → le
+        // `journal` global est DÉJÀ la bonne fenêtre → on le réutilise (évite une requête + un audit READ redondants).
+        const mdiJournal = mdiPeriod === analysisPeriod
+          ? journal
+          : await mealtimePattern.dailyJournal(patientId, mdiPeriod, auditUserId, ctx, { source: "cgm" })
         const dinners = mdiJournal.filter((m) => m.moment === "evening")
         const dayMeals = mdiJournal.filter((m) => m.moment === "morning" || m.moment === "noon") // garde de JOUR (D9)
         const preDinner = glVals(dinners.map((m) => m.preMgdl))

--- a/src/lib/services/proposal-generator.service.ts
+++ b/src/lib/services/proposal-generator.service.ts
@@ -148,6 +148,67 @@ function afterCutoff<T extends { dayIso: string }>(obs: T[], cutoff: string | nu
   return cutoff === null ? obs : obs.filter((o) => o.dayIso > cutoff)
 }
 
+/** US-2659 — décision de titration d'UNE dose basale STYLO, SANS persistance (l'orchestration décide).
+ *  `isDeesc` distingue une dé-escalade (sécurité, priorité haute) d'une titration treat-to-target. */
+type MdiDoseDecision =
+  | { kind: "proposal"; cand: ProposalCandidate; isDeesc: boolean }
+  | { kind: "flag" }
+  | { kind: "none" }
+
+/**
+ * US-2659 (S1+S2, validé medical) — matrice de titration d'UNE dose basale stylo (daily / evening / morning).
+ * PURE (aucun effet de bord) : renvoie la décision, l'appelant persiste/flague et arbitre « une dose/run ».
+ * Réutilisée par single_injection (daily, signal à jeun, garde nocturne) et split_injection (soir = à jeun/
+ * garde nocturne ; matin = pré-dîner/garde de JOUR, D9 « jamais croisé »).
+ *
+ * @param signalPost  Signal POST-changement (à jeun ou pré-dîner, g/L) — pilote la titration treat-to-target (fix M1).
+ * @param signalFull  Signal pleine fenêtre (g/L) — moyenne pour le seuil Somogyi/rebond + surfaçage sévère.
+ * @param guardNadirs Nadirs de la **fenêtre-suivant-la-dose** (nocturne pour soir/daily, de jour pour matin), pleine fenêtre.
+ * @param guardNadirsPost Idem POST-changement (dé-escalade, fix Q6a).
+ * @param confounded Dose du matin sous IOB du bolus de midi (§3.2) → toute proposition devient un **flag** (Q3b).
+ */
+function decideMdiDose(p: {
+  signalPost: number[]
+  signalFull: number[]
+  guardNadirs: number[]
+  guardNadirsPost: number[]
+  currentDose: number
+  targetGl: number
+  inc: number
+  withinCooldown: boolean
+  coverageOk: boolean
+  confounded: boolean
+}): MdiDoseDecision {
+  const avgSignal = p.signalFull.length > 0 ? p.signalFull.reduce((s, v) => s + v, 0) / p.signalFull.length : 0
+  const recurrentGuard = recurrentPostMealHypo(p.guardNadirs)
+  // Q6b — surfaçage sévère sur la garde (nocturne/jour) **ET** le signal (BGM-only : relevé capillaire sévère
+  // sans nadir CGM correspondant — jamais tu).
+  const severe = hasSevereHypo([...p.guardNadirs, ...p.signalFull])
+  const upperBound = p.targetGl + CLINICAL_BOUNDS.MDI_BASAL_FASTING_DEADBAND_UP_GL
+
+  let decision: MdiDoseDecision = { kind: "none" }
+  if (avgSignal > upperBound && recurrentGuard) {
+    decision = { kind: "flag" } // Somogyi/rebond : signal HAUT + hypo récurrente de la fenêtre → jamais une baisse auto (D10)
+  } else if (recurrentGuard) {
+    // Hypos récurrentes de la fenêtre (in-band ou sous la bande) → dé-escalade PRIME. Nadirs POST-changement + cooldown.
+    const de = analyzeMdiBasalDailyHypoDeescalation(p.currentDose, p.guardNadirsPost, p.inc)
+    if (de.kind === "proposal" && !p.withinCooldown) decision = { kind: "proposal", cand: de.candidate, isDeesc: true }
+    else if (de.kind === "flagNonActionable") decision = { kind: "flag" }
+    else if (severe) decision = { kind: "flag" } // dé-escalade bloquée (délai/post-changement) mais sévère → jamais tu (Q6b)
+  } else {
+    // Pas d'hypo récurrente → titration treat-to-target sur le signal POST-changement (fix M1, anti-empilement).
+    const cand = analyzeMdiBasalDailyTrend(p.signalPost, p.targetGl, p.currentDose, p.guardNadirs, p.inc)
+    const isIncrease = cand?.reason === "basalTooLow"
+    if (cand && isIncrease && !p.coverageOk) decision = { kind: "flag" } // AC-4 : hausse refusée faute de couverture → flag
+    else if (cand && !p.withinCooldown) decision = { kind: "proposal", cand, isDeesc: false }
+    else if (severe) decision = { kind: "flag" } // titration bloquée (cooldown) mais sévère isolé → surface (Q6b)
+  }
+  // Q3b — dose du matin sous IOB du bolus de midi : le pré-dîner n'est pas titrable en sûreté → toute
+  // proposition (hausse comme dé-escalade) devient un FLAG (décision basale-vs-bolus rendue au médecin).
+  if (p.confounded && decision.kind === "proposal") return { kind: "flag" }
+  return decision
+}
+
 /** Construit les entrées `analyzeIcrSlot` d'un créneau pour une cible donnée (deadband). */
 const buildIcrMeals = (meals: JournalMeal[], targetGl: number) =>
   meals.map((m) => ({
@@ -491,12 +552,6 @@ export const proposalGeneratorService = {
           fastingValues = toGl(fasting, "fastingMgdl")
         }
         const nocturnalNadirs = toGl(fasting, "nocturnalNadirMgdl")
-        const avgFasting = fastingValues.length > 0 ? mean(fastingValues) : 0
-        const recurrentNoct = recurrentPostMealHypo(nocturnalNadirs)
-        // Surfaçage Q6b sur hypo sévère NOCTURNE (CGM) **ET** à jeun (BGM-only : un relevé capillaire sévère
-        // au réveil < 0,54 g/L n'a pas de nadir nocturne CGM correspondant — ne jamais le taire).
-        const severeHypo = hasSevereHypo([...nocturnalNadirs, ...fastingValues])
-        const upperBound = targetGl + CLINICAL_BOUNDS.MDI_BASAL_FASTING_DEADBAND_UP_GL
         const coverageOk = nocturnalNadirs.length >= MIN_NADIR_NIGHTS
 
         // Cooldown MDI (72 h V1) + observations POST-changement (fix Q6a) — gate les DEUX sens (divergence
@@ -540,36 +595,122 @@ export const proposalGeneratorService = {
         }
 
         if (fastingValues.length >= MIN_NADIR_NIGHTS) {
-          // 1. Somogyi : à jeun HAUT (> T + Δ_up) + hypo nocturne récurrente → FLAG, jamais une baisse auto (D10).
-          if (avgFasting > upperBound && recurrentNoct) {
-            await raiseMdiFlag()
-          } else if (recurrentNoct) {
-            // 2. Hypos nocturnes récurrentes (à jeun IN-BAND ou sous la bande) → dé-escalade PRIME (plus spécifique,
-            //    couvre la cible grossesse serrée). Jugée sur les nadirs POST-changement + cooldown (Q6a/Q6b).
-            const de = analyzeMdiBasalDailyHypoDeescalation(currentDose, postNocturnalNadirs, inc)
-            if (de.kind === "proposal" && !withinCooldown) {
-              await persistMdi(de.candidate)
-            } else if (de.kind === "flagNonActionable") {
-              await raiseMdiFlag() // dose trop basse pour titrer d'un incrément → restructuration = revue
-            } else if (severeHypo) {
-              await raiseMdiFlag() // dé-escalade bloquée (délai/post-changement) mais sévère → jamais tu (Q6b)
-            }
-          } else {
-            // 3. Pas d'hypo nocturne récurrente → titration treat-to-target sur l'à jeun POST-changement (fix M1 :
-            //    évite l'empilement d'un pas fixe sur une moyenne 7 j contaminée par ~4 j pré-changement, avant
-            //    le steady state 3-4 j). < 3 à jeun post-changement → l'analyseur renvoie null → HOLD (repli sûr).
-            const candidate = analyzeMdiBasalDailyTrend(postFastingValues, targetGl, currentDose, nocturnalNadirs, inc)
-            const isIncrease = candidate?.reason === "basalTooLow"
-            if (candidate && isIncrease && !coverageOk) {
-              // AC-4 : hausse refusée faute de couverture nocturne (coucher/réveil) → FLAG explicite (jamais un
-              // drop muet — une hypo à 3 h masquée par une moyenne à jeun élevée resterait invisible).
-              await raiseMdiFlag()
-            } else if (candidate && !withinCooldown) {
-              await persistMdi(candidate) // hausse (couverture OK) OU baisse treat-to-target ; cooldown 2 sens (Risk #1)
-            } else if (severeHypo) {
-              await raiseMdiFlag() // titration bloquée (cooldown) mais hypo sévère isolée → surface, jamais tu (Q6b)
-            }
-          }
+          // Décision unifiée (matrice validée S1) : Somogyi → dé-escalade → treat-to-target POST-changement (fix M1)
+          // → AC-4/Q6b. Une dose (daily), garde = nadirs nocturnes (fenêtre-suivant-la-dose).
+          const decision = decideMdiDose({
+            signalPost: postFastingValues, signalFull: fastingValues,
+            guardNadirs: nocturnalNadirs, guardNadirsPost: postNocturnalNadirs,
+            currentDose, targetGl, inc, withinCooldown, coverageOk, confounded: false,
+          })
+          if (decision.kind === "proposal") await persistMdi(decision.cand)
+          else if (decision.kind === "flag") await raiseMdiFlag()
+        }
+      }
+    }
+
+    // 6ter. Chemin BASAL STYLO — split_injection (US-2659 S2, validé medical). DEUX doses stylo :
+    //   - SOIR (`basalDoseKind="evening"`) titrée sur la glycémie à JEUN (= chemin single, garde nocturne) ;
+    //   - MATIN (`basalDoseKind="morning"`) titrée sur la glycémie PRÉ-DÎNER (`preMgdl` des repas du soir),
+    //     garde de JOUR (nadirs matin+midi, D9 « jamais croisé » — jamais le nadir nocturne), et **confondue**
+    //     par l'IOB du bolus de MIDI (§3.2) → flag-only (Q3b).
+    // Orchestration : **une seule proposition/run**, priorité SÉCURITÉ-d'abord (dé-escalade > titration ; à
+    // égalité, soir/à jeun — raffinement de D4, Q5) + **verrou « 1 basale stylo pending »** (Q6, applicatif +
+    // index base `one_pending_stylo_basal`), fail-loud si le verrou bloque une dé-escalade (sécurité).
+    if (basalConfig?.configType === "split_injection") {
+      const eveningDose = basalConfig.eveningDose != null ? Number(basalConfig.eveningDose) : null
+      const morningDose = basalConfig.morningDose != null ? Number(basalConfig.morningDose) : null
+      const inc = CLINICAL_BOUNDS.MDI_BASAL_DELIVERY_INCREMENT_U
+      const mdiPeriod = windowDays != null ? `${windowDays}d` : `${CLINICAL_BOUNDS.MDI_BASAL_ANALYSIS_DAYS}d`
+      const rawTarget = settings?.glucoseTargets?.[0]?.targetGlucose
+      const targetGl = resolveFastingTarget(rawTarget != null ? Number(rawTarget) / 100 : null, isPregnancy)
+      const glVals = (nums: (number | null)[]) => nums.filter((v): v is number => v !== null && Number.isFinite(v)).map((v) => v / 100)
+
+      const raiseSplitFlag = (kind: "morning" | "evening") =>
+        clinicalReviewFlagService.raise(patientId, "nocturnalHypoHighFasting", auditUserId, ctx)
+          .then(() => { flagged++ })
+          .catch((err) => logger.error("proposal-generator", "raise flag failed", { patientId, bucket: `basal:stylo:${kind}` }, err as Error))
+
+      const persistSplit = async (cand: ProposalCandidate, kind: "morning" | "evening") => {
+        const bucket = `basal:stylo:${kind}`
+        try {
+          await adjustmentService.createEngineProposal({
+            patientId, parameterType: "basalRate", proposedValue: cand.proposedValue,
+            expectedCurrentValue: cand.currentValue, reason: cand.reason, confidence: cand.confidence,
+            supportingEvents: cand.supportingEvents, totalEventsConsidered: cand.totalEventsConsidered,
+            averageObservedValue: cand.averageObservedValue ?? null, analysisPeriod: mdiPeriod, basalDoseKind: kind,
+          }, ctx)
+          created++
+        } catch (err) {
+          const msg = (err as Error).message
+          if (EXPECTED_SKIP.has(msg)) logger.info("proposal-generator", "engine proposal skipped", { patientId, bucket, failMode: msg })
+          else logger.error("proposal-generator", "unexpected engine proposal error", { patientId, bucket, failMode: "unexpected" }, err as Error)
+        }
+      }
+
+      // ── Dose du SOIR : glycémie à jeun (CGM→BGM), garde nocturne (identique single_injection). ──
+      let evDecision: MdiDoseDecision = { kind: "none" }
+      if (eveningDose != null && Number.isFinite(eveningDose) && eveningDose >= CLINICAL_BOUNDS.MDI_BASAL_MIN_U) {
+        let fasting = await mealtimePattern.fastingTrend(patientId, mdiPeriod, auditUserId, ctx, { source: "cgm" })
+        let fastingValues = glVals(fasting.map((f) => f.fastingMgdl))
+        if (fastingValues.length < MIN_NADIR_NIGHTS) {
+          fasting = await mealtimePattern.fastingTrend(patientId, mdiPeriod, auditUserId, ctx, { source: "bgm" })
+          fastingValues = glVals(fasting.map((f) => f.fastingMgdl))
+        }
+        const nocturnalNadirs = glVals(fasting.map((f) => f.nocturnalNadirMgdl))
+        const { cutoff, withinCooldown } = await deescalationTiming(patientId, "basalRate", { basalDoseKind: "evening" }, CLINICAL_BOUNDS.MDI_BASAL_COOLDOWN_HOURS)
+        const postFast = afterCutoff(fasting, cutoff)
+        if (fastingValues.length >= MIN_NADIR_NIGHTS) {
+          evDecision = decideMdiDose({
+            signalPost: glVals(postFast.map((f) => f.fastingMgdl)), signalFull: fastingValues,
+            guardNadirs: nocturnalNadirs, guardNadirsPost: glVals(postFast.map((f) => f.nocturnalNadirMgdl)),
+            currentDose: eveningDose, targetGl, inc, withinCooldown,
+            coverageOk: nocturnalNadirs.length >= MIN_NADIR_NIGHTS, confounded: false,
+          })
+        }
+      }
+
+      // ── Dose du MATIN : glycémie PRÉ-DÎNER (`preMgdl` des repas du soir), garde de JOUR, confondeur IOB midi. ──
+      let mnDecision: MdiDoseDecision = { kind: "none" }
+      if (morningDose != null && Number.isFinite(morningDose) && morningDose >= CLINICAL_BOUNDS.MDI_BASAL_MIN_U) {
+        const dinners = journal.filter((m) => m.moment === "evening")
+        const dayMeals = journal.filter((m) => m.moment === "morning" || m.moment === "noon") // garde de JOUR (D9)
+        const preDinner = glVals(dinners.map((m) => m.preMgdl))
+        const dayNadirs = glVals(dayMeals.map((m) => m.nadirMgdl))
+        // Confondeur (§3.2/Q3a) : un bolus au DÉJEUNER (midi) contamine le pré-dîner par son IOB → non titrable
+        // en sûreté → dose du matin **flag-only** (Q3b). Le bolus petit-déj (action ~5 h) est éteint avant le dîner.
+        const lunchBolus = journal.some((m) => m.moment === "noon" && (m.bolus ?? 0) > 0)
+        const { cutoff, withinCooldown } = await deescalationTiming(patientId, "basalRate", { basalDoseKind: "morning" }, CLINICAL_BOUNDS.MDI_BASAL_COOLDOWN_HOURS)
+        if (preDinner.length >= MIN_NADIR_NIGHTS) {
+          mnDecision = decideMdiDose({
+            signalPost: glVals(afterCutoff(dinners, cutoff).map((m) => m.preMgdl)), signalFull: preDinner,
+            guardNadirs: dayNadirs, guardNadirsPost: glVals(afterCutoff(dayMeals, cutoff).map((m) => m.nadirMgdl)),
+            currentDose: morningDose, targetGl, inc, withinCooldown,
+            coverageOk: dayNadirs.length >= MIN_NADIR_NIGHTS, confounded: lunchBolus,
+          })
+        }
+      }
+
+      // ── Orchestration : flags toujours levés (revue, pas un changement) ; au plus UNE proposition/run. ──
+      if (evDecision.kind === "flag") await raiseSplitFlag("evening")
+      if (mnDecision.kind === "flag") await raiseSplitFlag("morning")
+
+      const proposals: { d: "morning" | "evening"; cand: ProposalCandidate; isDeesc: boolean }[] = []
+      if (evDecision.kind === "proposal") proposals.push({ d: "evening", cand: evDecision.cand, isDeesc: evDecision.isDeesc })
+      if (mnDecision.kind === "proposal") proposals.push({ d: "morning", cand: mnDecision.cand, isDeesc: mnDecision.isDeesc })
+      if (proposals.length > 0) {
+        // Priorité : dé-escalade (sécurité) d'abord ; à égalité, soir/à jeun (nocturne = pire mode d'échec).
+        proposals.sort((a, b) => Number(b.isDeesc) - Number(a.isDeesc) || (a.d === "evening" ? -1 : 1))
+        const winner = proposals[0]
+        // Verrou Q6 : au plus 1 basale stylo pending (toutes cibles). Applicatif ici + index base (course inter-run).
+        const pending = await prisma.adjustmentProposal.findFirst({
+          where: { patientId, parameterType: "basalRate", status: "pending", NOT: { basalDoseKind: null } },
+          select: { id: true },
+        })
+        if (pending) {
+          if (winner.isDeesc) await raiseSplitFlag(winner.d) // fail-loud : une dé-escalade (sécurité) bloquée par le verrou → flag
+          // sinon (titration) → défer silencieux, repris au prochain run une fois la pending résolue.
+        } else {
+          await persistSplit(winner.cand, winner.d)
         }
       }
     }

--- a/src/lib/services/proposal-generator.service.ts
+++ b/src/lib/services/proposal-generator.service.ts
@@ -672,13 +672,17 @@ export const proposalGeneratorService = {
       // ── Dose du MATIN : glycémie PRÉ-DÎNER (`preMgdl` des repas du soir), garde de JOUR, confondeur IOB midi. ──
       let mnDecision: MdiDoseDecision = { kind: "none" }
       if (morningDose != null && Number.isFinite(morningDose) && morningDose >= CLINICAL_BOUNDS.MDI_BASAL_MIN_U) {
-        const dinners = journal.filter((m) => m.moment === "evening")
-        const dayMeals = journal.filter((m) => m.moment === "morning" || m.moment === "noon") // garde de JOUR (D9)
+        // Journal dédié fenêtre MDI (7 j) — le `journal` global est chargé en 14 j pour l'ICR. Aligne la fenêtre
+        // RÉELLEMENT analysée sur `analysisPeriod` persisté (`mdiPeriod`) et sur la dose du soir (traçabilité HDS +
+        // réactivité : ne pas diluer la moyenne pré-dîner avec ~2× de données pré-changement — fix revue medical).
+        const mdiJournal = await mealtimePattern.dailyJournal(patientId, mdiPeriod, auditUserId, ctx, { source: "cgm" })
+        const dinners = mdiJournal.filter((m) => m.moment === "evening")
+        const dayMeals = mdiJournal.filter((m) => m.moment === "morning" || m.moment === "noon") // garde de JOUR (D9)
         const preDinner = glVals(dinners.map((m) => m.preMgdl))
         const dayNadirs = glVals(dayMeals.map((m) => m.nadirMgdl))
         // Confondeur (§3.2/Q3a) : un bolus au DÉJEUNER (midi) contamine le pré-dîner par son IOB → non titrable
         // en sûreté → dose du matin **flag-only** (Q3b). Le bolus petit-déj (action ~5 h) est éteint avant le dîner.
-        const lunchBolus = journal.some((m) => m.moment === "noon" && (m.bolus ?? 0) > 0)
+        const lunchBolus = mdiJournal.some((m) => m.moment === "noon" && (m.bolus ?? 0) > 0)
         const { cutoff, withinCooldown } = await deescalationTiming(patientId, "basalRate", { basalDoseKind: "morning" }, CLINICAL_BOUNDS.MDI_BASAL_COOLDOWN_HOURS)
         if (preDinner.length >= MIN_NADIR_NIGHTS) {
           mnDecision = decideMdiDose({
@@ -699,7 +703,8 @@ export const proposalGeneratorService = {
       if (mnDecision.kind === "proposal") proposals.push({ d: "morning", cand: mnDecision.cand, isDeesc: mnDecision.isDeesc })
       if (proposals.length > 0) {
         // Priorité : dé-escalade (sécurité) d'abord ; à égalité, soir/à jeun (nocturne = pire mode d'échec).
-        proposals.sort((a, b) => Number(b.isDeesc) - Number(a.isDeesc) || (a.d === "evening" ? -1 : 1))
+        // Comparateur robuste (borné à ≤ 2 cibles distinctes, mais explicite l'intention).
+        proposals.sort((a, b) => Number(b.isDeesc) - Number(a.isDeesc) || (a.d === b.d ? 0 : a.d === "evening" ? -1 : 1))
         const winner = proposals[0]
         // Verrou Q6 : au plus 1 basale stylo pending (toutes cibles). Applicatif ici + index base (course inter-run).
         const pending = await prisma.adjustmentProposal.findFirst({
@@ -711,6 +716,12 @@ export const proposalGeneratorService = {
           // sinon (titration) → défer silencieux, repris au prochain run une fois la pending résolue.
         } else {
           await persistSplit(winner.cand, winner.d)
+        }
+        // Fail-loud : toute AUTRE dé-escalade (perdante du run — les DEUX doses sur-basalisées) est un signal de
+        // SÉCURITÉ → flag immédiat, jamais un drop silencieux (parité avec le chemin single ; ne pas attendre le
+        // run suivant pour surfacer une hypo récurrente sur la 2e dose). Une titration perdante, elle, défère.
+        for (const loser of proposals.slice(1)) {
+          if (loser.isDeesc) await raiseSplitFlag(loser.d)
         }
       }
     }

--- a/tests/unit/proposal-generator.service.test.ts
+++ b/tests/unit/proposal-generator.service.test.ts
@@ -485,6 +485,16 @@ describe("proposalGeneratorService.generateForPatient — basale STYLO split_inj
     await proposalGeneratorService.generateForPatient(1, 99)
     expect(styloCount()).toBe(0) // verrou : une seule basale stylo en vol à la fois
   })
+
+  it("fix MEDIUM #2 : les DEUX doses dé-escaladent → soir persisté, matin (perdante) FLAGGÉ (jamais un drop silencieux)", async () => {
+    // À jeun in-band + nadir nocturne récurrent 0,60 → dé-escalade SOIR ; pré-dîner in-band + nadir de jour
+    // récurrent 0,60 sans bolus midi → dé-escalade MATIN. Priorité soir → soir persisté, matin perdante FLAGGÉE.
+    setup({ basalConfig: split(18, 22), fasting: evFasting(105, 60), meals: [...dinners(105), ...lunches(60, 0)] })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(calls("evening")).toHaveLength(1) // dé-escalade soir persistée (priorité sécurité, nocturne = pire)
+    expect(calls("morning")).toHaveLength(0) // une dose/run : matin non persistée
+    expect(raiseFlag).toHaveBeenCalledWith(1, "nocturnalHypoHighFasting", 99, undefined) // matin perdante → flag fail-loud
+  })
 })
 
 describe("proposalGeneratorService.generateForPatient — mode fixedDose (US-2652)", () => {

--- a/tests/unit/proposal-generator.service.test.ts
+++ b/tests/unit/proposal-generator.service.test.ts
@@ -494,6 +494,7 @@ describe("proposalGeneratorService.generateForPatient — basale STYLO split_inj
     expect(calls("evening")).toHaveLength(1) // dé-escalade soir persistée (priorité sécurité, nocturne = pire)
     expect(calls("morning")).toHaveLength(0) // une dose/run : matin non persistée
     expect(raiseFlag).toHaveBeenCalledWith(1, "nocturnalHypoHighFasting", 99, undefined) // matin perdante → flag fail-loud
+    expect(raiseFlag).toHaveBeenCalledTimes(1) // EXACTEMENT la perdante (jamais le winner, jamais un double-flag)
   })
 })
 

--- a/tests/unit/proposal-generator.service.test.ts
+++ b/tests/unit/proposal-generator.service.test.ts
@@ -89,8 +89,8 @@ function setup(opts: {
   pregnancyMode?: boolean
   carbRatios?: { startHour: number; endHour: number; gramsPerUnit: number }[]
   meals?: unknown[]
-  // US-2659 — `dailyDose` (stylo single_injection) + `pumpSlots` optionnels selon le mode de délivrance.
-  basalConfig?: { configType: string; pumpSlots?: { id: string; rate: number; startHour: number; endHour: number }[]; dailyDose?: number }
+  // US-2659 — `dailyDose` (single_injection) / `morningDose`+`eveningDose` (split_injection) / `pumpSlots` (pompe).
+  basalConfig?: { configType: string; pumpSlots?: { id: string; rate: number; startHour: number; endHour: number }[]; dailyDose?: number; morningDose?: number; eveningDose?: number }
   glucoseTargets?: { targetGlucose: number }[]
   fasting?: { fastingMgdl: number | null; nocturnalNadirMgdl: number | null; dayIso?: string }[]
   sensitivityFactors?: { startHour: number; endHour: number; sensitivityFactorGl: number }[]
@@ -104,8 +104,8 @@ function setup(opts: {
       ? {
           configType: opts.basalConfig.configType,
           dailyDose: opts.basalConfig.dailyDose ?? null,
-          morningDose: null,
-          eveningDose: null,
+          morningDose: opts.basalConfig.morningDose ?? null,
+          eveningDose: opts.basalConfig.eveningDose ?? null,
           pumpSlots: (opts.basalConfig.pumpSlots ?? []).map((s) => ({
             id: s.id, rate: s.rate,
             startTime: new Date(Date.UTC(1970, 0, 1, s.startHour)),
@@ -424,6 +424,66 @@ describe("proposalGeneratorService.generateForPatient — basale STYLO single_in
     await proposalGeneratorService.generateForPatient(1, 99)
     expect(styloCalls()).toHaveLength(0)
     expect(raiseFlag).toHaveBeenCalledWith(1, "nocturnalHypoHighFasting", 99, undefined)
+  })
+})
+
+describe("proposalGeneratorService.generateForPatient — basale STYLO split_injection (US-2659 S2)", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  const split = (morningDose: number, eveningDose: number) => ({ configType: "split_injection", morningDose, eveningDose })
+  const evFasting = (mgdl: number, nadir: number | null) =>
+    Array.from({ length: 3 }, (_, i) => ({ fastingMgdl: mgdl, nocturnalNadirMgdl: nadir, dayIso: isoDaysAgo(i + 1) }))
+  // Repas du soir → `preMgdl` = glycémie PRÉ-DÎNER (signal de la dose du matin).
+  const dinners = (preMgdl: number) =>
+    Array.from({ length: 3 }, (_, i) => meal({ moment: "evening", preMgdl, nadirMgdl: 200, dayIso: isoDaysAgo(i + 1) }))
+  // Repas de midi → `nadirMgdl` = garde de JOUR ; `bolus` > 0 = confondeur pré-dîner (IOB midi).
+  const lunches = (nadirMgdl: number, bolus: number) =>
+    Array.from({ length: 3 }, (_, i) => meal({ moment: "noon", nadirMgdl, bolus, dayIso: isoDaysAgo(i + 1) }))
+  const calls = (kind: "morning" | "evening") =>
+    createEngine.mock.calls.map((c) => c[0] as Record<string, unknown>).filter((a) => a.parameterType === "basalRate" && a.basalDoseKind === kind)
+  const styloCount = () =>
+    createEngine.mock.calls.map((c) => c[0] as Record<string, unknown>).filter((a) => a.parameterType === "basalRate" && (a.basalDoseKind === "morning" || a.basalDoseKind === "evening")).length
+
+  it("dose du SOIR : à jeun HAUT → proposition evening basalTooLow (dose du matin sans signal → silencieuse)", async () => {
+    setup({ basalConfig: split(18, 22), fasting: evFasting(150, 120) }) // pas de repas du soir → matin sans pré-dîner
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(calls("evening")).toHaveLength(1)
+    expect(calls("evening")[0]).toMatchObject({ reason: "basalTooLow", expectedCurrentValue: 22, basalDoseKind: "evening" })
+    expect(calls("morning")).toHaveLength(0)
+  })
+
+  it("dose du MATIN (basal-SEUL, pas de bolus midi) : pré-dîner HAUT + garde de jour → proposition morning basalTooLow", async () => {
+    // Soir HOLD (à jeun in-band) → seule la dose du matin titre. Pré-dîner 1,50 ; garde de jour saine (1,20) ; pas de bolus midi.
+    setup({ basalConfig: split(18, 22), fasting: evFasting(105, 120), meals: [...dinners(150), ...lunches(120, 0)] })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(calls("morning")).toHaveLength(1)
+    expect(calls("morning")[0]).toMatchObject({ reason: "basalTooLow", expectedCurrentValue: 18, basalDoseKind: "morning" })
+    expect(calls("evening")).toHaveLength(0)
+  })
+
+  it("CONFONDEUR (basal-bolus, bolus midi présent) : pré-dîner HAUT → FLAG dose du matin, JAMAIS une proposition (Q3b)", async () => {
+    setup({ basalConfig: split(18, 22), fasting: evFasting(105, 120), meals: [...dinners(150), ...lunches(120, 6)] }) // bolus midi 6 → confondu
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(calls("morning")).toHaveLength(0)
+    expect(raiseFlag).toHaveBeenCalledWith(1, "nocturnalHypoHighFasting", 99, undefined)
+  })
+
+  it("UNE dose/run + priorité SOIR : soir ET matin dévient (hausses) → une seule proposition, la dose du SOIR", async () => {
+    setup({ basalConfig: split(18, 22), fasting: evFasting(150, 120), meals: [...dinners(150), ...lunches(120, 0)] })
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(styloCount()).toBe(1) // pas les deux
+    expect(calls("evening")).toHaveLength(1) // priorité soir/à jeun
+    expect(calls("morning")).toHaveLength(0) // matin déféré au prochain run
+  })
+
+  it("VERROU 1-pending-stylo : une proposition basale stylo pending existe → aucune nouvelle proposition (titration défèrée)", async () => {
+    setup({ basalConfig: split(18, 22), fasting: evFasting(150, 120), meals: [...dinners(150), ...lunches(120, 0)] })
+    // findFirst : `pending` (verrou) → existe ; `accepted` (cooldown) → aucun.
+    prismaMock.adjustmentProposal.findFirst.mockImplementation((args: any) =>
+      Promise.resolve(args?.where?.status === "pending" ? { id: "existing" } : null) as never,
+    )
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(styloCount()).toBe(0) // verrou : une seule basale stylo en vol à la fois
   })
 })
 


### PR DESCRIPTION
## Contexte

Troisième slice de **US-2659** (après S0 #723, S1 #724). Titre la basale **stylo `split_injection`** (2 injections : matin + soir) en propositions `pending` gatées médecin. Design + **6 décisions validés `medical-domain-validator`** (2026-07-11, CHANGES REQUESTED → toutes résolues).

## Réutilisation (peu de code neuf)

- **Service** (`resolveCurrentValue` → `morning`/`eveningDose`, bornes stylo, accept fail-closed) : **générique depuis S1**, aucun ajout.
- **Matrice de titration** factorisée en **`decideMdiDose`** (pure) — **partagée** par `single_injection` (refactoré, non-régression garantie par ses 11 tests) et `split_injection`.

## Les deux doses

- **SOIR** (`basalDoseKind="evening"`) → glycémie **à jeun** (= chemin `single_injection` : CGM→BGM, garde nocturne, Somogyi, AC-4).
- **MATIN** (`basalDoseKind="morning"`) → glycémie **PRÉ-DÎNER** (`preMgdl` des repas `moment="evening"` de `dailyJournal`). Garde hypo = **nadirs de JOUR** (`morning`+`noon`), **jamais** le nadir nocturne (**D9 « jamais croisé »**, correction Q4). Cible pré-dîner = `resolveFastingTarget` (préprandiale ADA 80–130).
  - **Confondeur (§3.2/Q3)** : un **bolus de midi** (`noon`, `bolus>0`) contamine le pré-dîner par son IOB → dose du matin **flag-only** (hausse **ET** dé-escalade). ⇒ split **basal-bolus** = soir seul titré ; split **basal-seul** = les deux. *Limite S2 : pré-dîner lu sur le journal CGM → split BGM-only sans proposition matin (fail-closed).*

## Orchestration (D4 raffiné, Q5) + verrou (Q6)

- **Une seule proposition basale/run**, priorité **sécurité-d'abord** : dé-escalade > titration ; à égalité, **soir/à jeun** (nocturne = pire mode d'échec). Flags toujours levés (revue, pas un changement).
- **Verrou « 1 basale stylo pending »** : garde **applicative** + **index unique partiel base** `adjustment_proposals_one_pending_stylo_basal` (migration `20260720100000` — ferme la course inter-run ; P2002 → `duplicatePendingProposal`). **Fail-loud** : dé-escalade bloquée par le verrou → flag.

## Invariants hérités S1 (inchangés)

Bornes MDI, cap %, snap floor, dé-escalade `−min(20 %, 4 U)`, cooldown post-changement **par `basalDoseKind`**, surfaçage Q6b (nocturne ∪ signal), jamais auto-appliqué, non-régression pompe + single_injection.

## Tests / vérifs

- Titration soir ; titration matin basal-seul ; **confondeur flag** (basal-bolus) ; **une-dose/run priorité soir** ; **verrou 1-pending**. Non-régression single (refactor `decideMdiDose`) + pompe.
- Suite **4061 verts** ; `tsc` 0 ; eslint clean ; `prisma validate` OK. Drift-gate + E2E → CI.

## Points à valider en revue

- `decideMdiDose` : factorisation single↔split fidèle (la non-régression single le garde) ?
- Garde de JOUR de la dose du matin (D9 sans croisement) correctement fenêtrée ?
- Confondeur bolus-midi + flag-only bidirectionnel (Q3b) ?
- Verrou applicatif + index base cohérents (nommage `one_pending` pour `isUniqueViolationOn`) ?

Revue attendue : `medical-domain-validator`, `code-reviewer`, `healthcare-security-auditor`, `prisma-specialist` (migration index).

🤖 Generated with [Claude Code](https://claude.com/claude-code)