### PR TITLE
US-2663 (S3a) — Re-source de l'anti-cliquet : inclure les acceptations groupées (garde-fou #4)

### DIFF
--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -351,6 +351,14 @@ même si la moyenne est « normale ». **Extension complète à 4 leviers** : ch
 n'est pas gatée (self-limiting par les bornes cliniques). Prévient l'accumulation itérative 10%+10%+10% avant 
 jugement de l'effet sur ≥ 3 j CGM/BGM.
 
+**Re-source de l'anti-cliquet — acceptations GROUPÉES incluses (US-2663 S3a, garde-fou #4)** : le « dernier
+changement accepté » (`lastAcceptedChangeAt`, `proposal-generator.service.ts`) considère désormais **les DEUX
+modèles** — `AdjustmentProposal accepted` (par-valeur, par créneau) **ET** `SlotSetProposal accepted` (d'ensemble
+ISF/ICR, sans granularité créneau car elle remplace tout le jeu) — et retient le **plus récent**. Sans ce terme,
+une édition groupée acceptée (patient ISF/ICR aujourd'hui, moteur groupé en S3+) était **invisible** au cooldown,
+qui pouvait empiler une dé-escalade juste après. Hors ISF/ICR (basalRate/fixedDose) : aucune `SlotSetProposal`,
+terme nul. Prérequis de la bascule moteur groupé (S3+).
+
 **Porte d'observation POST-changement (fix Q6a, 2026-07)** — invariant de sécurité complétant le délai :
 une dé-escalade à magnitude fixe ne se juge **que sur les observations datées APRÈS le dernier changement
 accepté** (`dayIso > cutoff`, `cutoff` = jour local du `reviewedAt` de l'ACCEPTÉE précédente). Le délai des

--- a/docs/clinical-logic/regles-et-constantes-diabete.md
+++ b/docs/clinical-logic/regles-et-constantes-diabete.md
@@ -384,11 +384,15 @@ sur les 4 leviers** (parité stricte — un anti-ratchet ne masque jamais un sig
 | Basal stylo (matin / pré-dîner, US-2661) | `daytimeHypoHighPreDinner` | **dose MATIN** du split_injection : signal DIURNE (titrée pré-dîner, garde nadirs de jour) — dé-escalade bloquée, confondeur bolus-midi (flag-only), hypo de jour sévère isolée |
 | FixedDose | `highVariabilityFixedDose` | dé-escalade bloquée / dose non réductible (≤ plancher) **+** relevé sévère **isolé** |
 
-**Limite connue (sémantique du cooldown)** — le « dernier changement accepté » qui arme le cooldown et fixe
-le `cutoff` est lu **uniquement** sur `AdjustmentProposal { status: "accepted" }` (`lastAcceptedChangeAt`).
-Une acceptation **groupée** `SlotSetProposal` (édition patient CONFIRMÉ, ADR #23) sur le même créneau ne
-réarme **pas** le cooldown moteur. Défendable pour l'objectif du fix (empêcher l'empilement des dé-escalades
-**moteur** avant observation) ; à revisiter si l'anti-ratchet doit couvrir aussi les remplacements groupés.
+**Sémantique du cooldown — RÉSOLU (US-2663 S3a)** : le « dernier changement accepté » qui arme le cooldown et
+fixe le `cutoff` est lu sur **les DEUX modèles** — `AdjustmentProposal { status: "accepted" }` (par-valeur, par
+créneau) **ET** `SlotSetProposal { status: "accepted" }` (groupé ISF/ICR, sans granularité créneau car il
+remplace tout le jeu), en retenant le **plus récent** (`lastAcceptedChangeAt`, cf. §Re-source ci-dessus). Une
+acceptation groupée réarme donc bien le cooldown moteur. **Écart résiduel connu (pré-existant, hors S3a)** :
+l'écriture DIRECTE DOCTOR (`PUT sensitivity-factors`/`carb-ratios` → `replaceSlotSet`) mute la config **sans**
+créer de ligne `accepted` → reste invisible au cooldown. Piste de fond (suivi S3+) : sourcer le cooldown sur
+l'**horodatage de mutation de config** (`updatedAt` des lignes ISF/ICR ou audit `CONFIG_APPLIED`) plutôt que
+sur les propositions comme proxy.
 
 **Contextual flag types** (`reviewFlags` namespace i18n FR/EN/AR) :
 - `highVariabilityPostCorrection` — ISF : pics + creux post-correction → revue (pas de dose)

--- a/src/lib/services/proposal-generator.service.ts
+++ b/src/lib/services/proposal-generator.service.ts
@@ -106,15 +106,33 @@ async function lastAcceptedChangeAt(
   parameterType: AdjustableParameter,
   slotWhere: Prisma.AdjustmentProposalWhereInput,
 ): Promise<Date | null> {
-  const last = await prisma.adjustmentProposal.findFirst({
-    // `reviewedAt: { not: null }` — sous PG `ORDER BY ... DESC` place les NULL en premier ; sans ce filtre
-    // une ligne `accepted` à `reviewedAt` NULL (ne devrait pas exister — l'acceptation le pose) masquerait
-    // une acceptation récente. Ceinture-et-bretelles.
-    where: { patientId, parameterType, status: "accepted", reviewedAt: { not: null }, ...slotWhere },
-    orderBy: { reviewedAt: "desc" },
-    select: { reviewedAt: true },
-  })
-  return last?.reviewedAt ?? null
+  const [perValue, grouped] = await Promise.all([
+    prisma.adjustmentProposal.findFirst({
+      // `reviewedAt: { not: null }` — sous PG `ORDER BY ... DESC` place les NULL en premier ; sans ce filtre
+      // une ligne `accepted` à `reviewedAt` NULL (ne devrait pas exister — l'acceptation le pose) masquerait
+      // une acceptation récente. Ceinture-et-bretelles.
+      where: { patientId, parameterType, status: "accepted", reviewedAt: { not: null }, ...slotWhere },
+      orderBy: { reviewedAt: "desc" },
+      select: { reviewedAt: true },
+    }),
+    // US-2663 (S3a, garde-fou #4 — re-source anti-cliquet) : une acceptation GROUPÉE (`SlotSetProposal`,
+    // ISF/ICR) remplace TOUT le jeu de créneaux du paramètre (`replaceSlotSet`) → elle constitue un
+    // « dernier changement accepté » pour CHAQUE créneau, au même titre qu'une acceptation par-valeur. Sans
+    // ce terme, le cooldown du moteur ne verrait pas une édition groupée acceptée (patient ISF/ICR aujourd'hui,
+    // moteur groupé en S3+) et pourrait empiler une baisse juste après. Pas de `slotWhere` : le modèle groupé
+    // n'a pas de granularité créneau (une acceptation couvre tous les créneaux). Hors ISF/ICR → aucune ligne.
+    prisma.slotSetProposal.findFirst({
+      where: { patientId, parameterType, status: "accepted", reviewedAt: { not: null } },
+      orderBy: { reviewedAt: "desc" },
+      select: { reviewedAt: true },
+    }),
+  ])
+  const a = perValue?.reviewedAt ?? null
+  const b = grouped?.reviewedAt ?? null
+  if (a === null) return b
+  if (b === null) return a
+  // Le plus RÉCENT des deux (par-valeur vs groupé) borne le cooldown — on attend l'effet du dernier changement.
+  return a.getTime() >= b.getTime() ? a : b
 }
 
 /**

--- a/tests/unit/proposal-generator.service.test.ts
+++ b/tests/unit/proposal-generator.service.test.ts
@@ -721,6 +721,26 @@ describe("proposalGeneratorService.generateForPatient — chemin ISF (US-2651)",
     prismaMock.slotSetProposal.findFirst.mockResolvedValue({ reviewedAt: new Date(Date.now() - 80 * 3_600_000) } as never)
     await proposalGeneratorService.generateForPatient(1, 99)
     expect(isfCalls()).toHaveLength(1)
+    // NIT revue — le re-source cible bien le paramètre ISF + status accepted (pas une groupée d'un autre param).
+    expect(prismaMock.slotSetProposal.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ patientId: 1, parameterType: "insulinSensitivityFactor", status: "accepted" }) }),
+    )
+  })
+
+  it("US-2663 (S3a) `max` : par-valeur ANCIENNE (> 72 h) + groupée RÉCENTE (< 72 h) → dé-escalade SAUTÉE (le plus récent gagne)", async () => {
+    setup({ meals: [], sensitivityFactors: [ISF_SLOT], corrections: corrections(1.2, 0.6) })
+    prismaMock.adjustmentProposal.findFirst.mockResolvedValue({ reviewedAt: new Date(Date.now() - 100 * 3_600_000) } as never)
+    prismaMock.slotSetProposal.findFirst.mockResolvedValue({ reviewedAt: new Date() } as never)
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(isfCalls()).toHaveLength(0)
+  })
+
+  it("US-2663 (S3a) `max` : par-valeur RÉCENTE (< 72 h) + groupée ANCIENNE (> 72 h) → dé-escalade SAUTÉE (le plus récent gagne)", async () => {
+    setup({ meals: [], sensitivityFactors: [ISF_SLOT], corrections: corrections(1.2, 0.6) })
+    prismaMock.adjustmentProposal.findFirst.mockResolvedValue({ reviewedAt: new Date() } as never)
+    prismaMock.slotSetProposal.findFirst.mockResolvedValue({ reviewedAt: new Date(Date.now() - 100 * 3_600_000) } as never)
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(isfCalls()).toHaveLength(0)
   })
 
   it("cooldown exactement 72 h (borne stricte <) → dé-escalade proposée (pas bloquée)", async () => {

--- a/tests/unit/proposal-generator.service.test.ts
+++ b/tests/unit/proposal-generator.service.test.ts
@@ -705,6 +705,24 @@ describe("proposalGeneratorService.generateForPatient — chemin ISF (US-2651)",
     expect(isfCalls()).toHaveLength(1)
   })
 
+  it("US-2663 (S3a) re-source anti-cliquet : acceptation GROUPÉE ISF récente (< 72 h), AUCUNE par-valeur → dé-escalade SAUTÉE (garde-fou #4)", async () => {
+    setup({ meals: [], sensitivityFactors: [ISF_SLOT], corrections: corrections(1.2, 0.6) })
+    // Aucune acceptation par-valeur, mais une acceptation d'ENSEMBLE (`SlotSetProposal`) récente du paramètre :
+    // le cooldown DOIT désormais la voir (elle a remplacé tout le jeu ISF). Sans le re-source, isfCalls() = 1 (bug).
+    prismaMock.adjustmentProposal.findFirst.mockResolvedValue(null as never)
+    prismaMock.slotSetProposal.findFirst.mockResolvedValue({ reviewedAt: new Date() } as never)
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(isfCalls()).toHaveLength(0)
+  })
+
+  it("US-2663 (S3a) : acceptation groupée ANCIENNE (> 72 h) + aucune par-valeur → dé-escalade de nouveau proposée", async () => {
+    setup({ meals: [], sensitivityFactors: [ISF_SLOT], corrections: corrections(1.2, 0.6) })
+    prismaMock.adjustmentProposal.findFirst.mockResolvedValue(null as never)
+    prismaMock.slotSetProposal.findFirst.mockResolvedValue({ reviewedAt: new Date(Date.now() - 80 * 3_600_000) } as never)
+    await proposalGeneratorService.generateForPatient(1, 99)
+    expect(isfCalls()).toHaveLength(1)
+  })
+
   it("cooldown exactement 72 h (borne stricte <) → dé-escalade proposée (pas bloquée)", async () => {
     setup({ meals: [], sensitivityFactors: [ISF_SLOT], corrections: corrections(1.2, 0.6) })
     prismaMock.adjustmentProposal.findFirst.mockResolvedValue({ reviewedAt: new Date(Date.now() - 72 * 3_600_000) } as never)


### PR DESCRIPTION
## Contexte — Épic US-2663, amorce de la bascule moteur (S3)

S3 (« le moteur émet du groupé ») est un slice **XL** couvrant tous les leviers. Cette PR livre son **socle non négociable** : le **garde-fou #4** (« re-source l'anti-ratchet, **même slice** que la bascule moteur »).

**C'est aussi un correctif d'un trou déjà présent aujourd'hui** : `lastAcceptedChangeAt` (le cooldown anti-cliquet du générateur) ne lit que `AdjustmentProposal accepted` (par-valeur). Or une acceptation **GROUPÉE** ISF/ICR (soumission patient acceptée par le médecin via `acceptSetProposal` → `replaceSlotSet`) **n'écrit pas** d'`AdjustmentProposal accepted` → elle est **invisible** au cooldown. Conséquence : le moteur peut proposer/empiler une dé-escalade juste après qu'un médecin a accepté une édition groupée du même paramètre.

## Changement

`lastAcceptedChangeAt(patientId, parameterType, slotWhere)` interroge désormais **les deux modèles** et retient le **plus récent** :
- `AdjustmentProposal accepted` (par-valeur, avec `slotWhere` par créneau) — inchangé ;
- **`SlotSetProposal accepted`** (d'ensemble ISF/ICR) — **sans** `slotWhere` : le modèle groupé n'a pas de granularité créneau (une acceptation remplace **tout** le jeu → elle réinitialise le cooldown de **chaque** créneau du paramètre).

Hors ISF/ICR (`basalRate`/`fixedDose`) : aucune `SlotSetProposal` → terme nul, comportement strictement inchangé.

## Pourquoi maintenant (garde-fou #4)
Prérequis de S3b+ (moteur émettant du groupé) : dès que le moteur créera des `SlotSetProposal(source=algorithm)`, le cooldown devra voir ses **propres** acceptations groupées, sinon l'anti-empilement se défait silencieusement. On pose le socle **avant** la bascule — et on ferme le trou déjà exploitable côté patient.

## Validation (test d'intégration exigé par le garde-fou #4)
- Acceptation **groupée** ISF récente (< 72 h, **aucune** par-valeur) → dé-escalade **SAUTÉE** (le cooldown la voit).
- Acceptation groupée **ancienne** (> 72 h) → dé-escalade **de nouveau proposée**.
- **122 tests** générateur verts (dont ces 2), 201 avec l'algorithme. `tsc` + eslint OK. Aucune migration.

## Doc
Catalogue §anti-ratchet — re-source documentée (les deux modèles, plus récent).

## Suite (S3, à venir)
- **S3b** : le générateur assemble la disposition ISF/ICR et émet `createSetProposal(source=algorithm)` au lieu des N `createEngineProposal` par créneau (feature-flaggable, réversible ; logique de décision inchangée).
- **S3c/S3d** : étendre `SlotSetProposal` + CAS + apply au basal (pompe/stylo) et à la dose fixe, puis basculer ces leviers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)