### PR TITLE
ops — préparation déploiement recette : unités glycémie g/L (pré-vol + rollback + runbook)

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════
+# deploy.sh — script de déploiement Diabeo Backoffice (VPS OVHcloud)
+#
+# Script de RÉFÉRENCE, versionné avec le code. À adapter à ton VPS (chemins,
+# nom du service systemd, outil S3). Modèle : Next.js (Node 22) derrière nginx,
+# PostgreSQL 16, Redis Upstash + OVH Object Storage managés. Déploiement manuel.
+#
+#   ./deploy.sh update    # pull + install + prisma generate + migrate deploy + build + restart
+#   ./deploy.sh migrate   # prisma migrate deploy uniquement (+ status)
+#   ./deploy.sh backup    # pg_dump gzip → OVH Object Storage
+#   ./deploy.sh status    # santé service + DB + migrations
+#
+# Prérequis : /etc/diabeo/${APP_ENV}.env (chmod 600) contenant TOUTES les vars
+# obligatoires (cf. docs/runbook/vps-setup.md + src/lib/env.ts).
+# ═══════════════════════════════════════════════════════════════════════════
+set -Eeuo pipefail
+
+# ── Config (à adapter) ──────────────────────────────────────────────────────
+APP_DIR="${APP_DIR:-/opt/diabeo}"
+APP_ENV="${APP_ENV:-recette}"
+ENV_FILE="${ENV_FILE:-/etc/diabeo/${APP_ENV}.env}"
+SERVICE="${SERVICE:-diabeo-${APP_ENV}}"          # unité systemd
+GIT_REF="${GIT_REF:-main}"
+S3_BUCKET_BACKUPS="${S3_BUCKET_BACKUPS:-diabeo-backups-${APP_ENV}}"
+
+log()  { printf '\033[36m[deploy]\033[0m %s\n' "$*"; }
+fail() { printf '\033[31m[deploy][ERREUR]\033[0m %s\n' "$*" >&2; exit 1; }
+
+load_env() {
+  [ -f "$ENV_FILE" ] || fail "Fichier d'env introuvable : $ENV_FILE"
+  set -a; # shellcheck disable=SC1090
+  source "$ENV_FILE"; set +a
+  : "${DATABASE_URL:?DATABASE_URL manquant dans $ENV_FILE}"
+}
+
+cmd_update() {
+  load_env
+  cd "$APP_DIR"
+  log "Pull $GIT_REF"
+  git fetch --quiet origin "$GIT_REF"
+  git checkout --quiet "$GIT_REF"
+  git reset --hard --quiet "origin/$GIT_REF"
+
+  log "Install (frozen lockfile)"
+  pnpm install --frozen-lockfile
+
+  log "Prisma generate"
+  pnpm prisma generate
+
+  # ⚠️ Migrations AVANT le build/restart : le nouveau code peut dépendre du
+  #    nouveau schéma. Pour une release à migration DESTRUCTIVE (ex. glycémie
+  #    g/L, DROP glycemia_mgdl), passer d'abord le pré-vol + backup :
+  #    ./deploy.sh backup && psql "$DATABASE_URL" -f ops/preflight/<...>.sql
+  log "Migrations (prisma migrate deploy — idempotent)"
+  pnpm prisma migrate deploy
+
+  log "Build (next build)"
+  pnpm build
+
+  log "Restart service $SERVICE"
+  sudo systemctl restart "$SERVICE"
+
+  cmd_status
+  log "✅ Déploiement terminé."
+}
+
+cmd_migrate() {
+  load_env
+  cd "$APP_DIR"
+  pnpm prisma migrate deploy
+  pnpm prisma migrate status
+}
+
+cmd_backup() {
+  load_env
+  local ts stamp dump
+  ts="$(date -u +%Y/%m/%d)"; stamp="$(date -u +%H%M%S)"
+  dump="/tmp/diabeo-${APP_ENV}-${stamp}.sql.gz"
+  log "pg_dump → $dump"
+  pg_dump "$DATABASE_URL" | gzip -9 > "$dump" || fail "pg_dump a échoué"
+  # Upload S3 (OVH). Adapter à ton outil (aws-cli/rclone/s3cmd) et tes creds S3.
+  if command -v aws >/dev/null; then
+    log "Upload s3://${S3_BUCKET_BACKUPS}/${ts}/"
+    aws --endpoint-url "${OVH_S3_ENDPOINT:?}" s3 cp "$dump" \
+      "s3://${S3_BUCKET_BACKUPS}/${ts}/diabeo-backup-${stamp}.sql.gz"
+  else
+    log "aws-cli absent — dump laissé sur $dump (uploader manuellement)."
+  fi
+  log "✅ Backup OK."
+}
+
+cmd_status() {
+  load_env
+  cd "$APP_DIR"
+  log "Service :"; systemctl is-active "$SERVICE" || true
+  log "Postgres :"; pg_isready -d "$DATABASE_URL" || true
+  log "Migrations :"; pnpm prisma migrate status || true
+}
+
+case "${1:-}" in
+  update)  cmd_update ;;
+  migrate) cmd_migrate ;;
+  backup)  cmd_backup ;;
+  status)  cmd_status ;;
+  *) echo "Usage: $0 {update|migrate|backup|status}"; exit 2 ;;
+esac

--- a/docs/runbook/release-glycemie-gl.md
+++ b/docs/runbook/release-glycemie-gl.md
@@ -1,0 +1,114 @@
+# Runbook de release — Normalisation unités glycémie **g/L** (ADR #32)
+
+> Déploiement de l'épic « g/L canonique » + docs + correctifs home médecin.
+> Cible immédiate : **recette** (`staging.diabeo.fr`). Réutilisable pour la prod.
+> Déploiement **manuel** (`deploy.sh` sur le VPS) — pas de CI/CD de deploy.
+
+## 1. Périmètre livré
+
+| PR | Contenu | Migration ? |
+|---|---|---|
+| **#753** | Unités glycémie **g/L canonique** (stockage + API), module `glucose/units.ts`, affichage par préférence | **Oui — 2 migrations** |
+| #754 | Doc `docs/reference/homes-par-role.html` | non |
+| #755 | Correctifs home médecin (D1–D9 hors D4) + route `POST /api/dashboard/recall` | non |
+
+**Migrations à appliquer** (ordre `migrate deploy` = timestamp) :
+1. `20260731100000_glycemia_unit_s1_cgm_check_bgm_backfill` — **additif** : backfill
+   `glycemia_gl = COALESCE(…, glycemia_mgdl/100)` + `CHECK value_gl 0.20–6.00` (CGM).
+2. `20260801100000_glycemia_unit_s4_drop_mgdl` — **DESTRUCTIF** : `CHECK glycemia_gl`
+   (NULL-toléré) + **`DROP COLUMN glycemia_mgdl`** (irréversible).
+
+**Env** : aucune nouvelle variable. **Contrat API** : `valueGl`/`glycemiaGl` en g/L
+(le champ `glycemiaMgdl` disparaît de l'API) — front web déployé dans le même lot,
+contrat iOS hors périmètre (ADR #31).
+
+## 2. ⚠️ Risque migration — CHECK sur données existantes
+
+Les `ADD CONSTRAINT CHECK` **échouent** (et interrompent le deploy) si une seule
+ligne viole les bornes `[0.20 ; 6.00]` g/L (= 20–600 mg/dL). Toujours passer le
+**pré-vol** avant `migrate deploy` sur une base porteuse de données.
+
+## 3A. Chemin RECETTE — base jetable/re-seedable (RECOMMANDÉ)
+
+La recette étant re-seedable, on repart propre (le seed génère du CGM 0.40–4.00,
+dans les bornes → aucun risque de CHECK) :
+
+```bash
+# 1. Déployer le CODE (pull + build + restart) — procédure VPS habituelle
+./deploy.sh update
+
+# 2. Réinitialiser le schéma sur la version cible + re-seed
+#    (reset = drop + recreate + applique TOUTES les migrations + seed)
+pnpm prisma migrate reset --force        # ⚠️ efface la base recette (assumé jetable)
+# (reset lance le seed via prisma.config migrations.seed ; sinon : pnpm prisma db seed)
+
+# 3. Vérifier l'état
+pnpm prisma migrate status               # toutes appliquées, aucune pending
+```
+
+Puis **smoke tests** (§4).
+
+## 3B. Chemin DONNÉES PRÉSERVÉES (prod future, ou recette non re-seedée)
+
+```bash
+# 1. Backup vérifié et restorable (cf. migrations.md §5 cas 2)
+./deploy.sh backup                       # dump → OVH Object Storage
+
+# 2. PRÉ-VOL — toutes les lignes « *_bloquant » DOIVENT valoir 0
+psql "$DATABASE_URL" -f ops/preflight/glycemia-gl-preflight.sql
+
+# 3. Si [1]/[2]/[4] > 0 : remédier AVANT (purge ciblée des lignes hors bornes,
+#    ou clamp validé medical) — cf. bloc « REMÉDIATION » du pré-vol.
+
+# 4. Appliquer les migrations (S1 puis S4, idempotent, non transactionnel/fichier)
+pnpm prisma migrate deploy
+
+# 5. Déployer le code APRÈS (l'API g/L-only ne doit pas tourner avant le DROP)
+./deploy.sh update
+
+# 6. Vérifs post-migration
+pnpm prisma migrate status
+psql "$DATABASE_URL" -c "\d glycemia_entries"   # glycemia_mgdl absente, glycemia_gl + CHECK
+```
+
+## 4. Smoke tests (post-déploiement)
+
+- [ ] **Login** OK pour chaque rôle → atterrissage sur la bonne home (`/medecin`,
+      `/infirmier`, `/admin`, `/patient/dashboard`).
+- [ ] **CGM** : `GET /api/patients/:id/cgm` renvoie `valueGl` (g/L) ; le dashboard
+      affiche la glycémie **selon la préférence** `unitGlycemia` (g/L / mg/dL / mmol/L).
+- [ ] **BGM** : `POST /api/patients/:id/glycemia` accepte `glycemiaGl` (0.20–6.00) et
+      **refuse** un ancien payload `glycemiaMgdl` (400). `GET` renvoie `glycemiaGl` seul.
+- [ ] **Home médecin** : un **NURSE** ne voit plus « Patients à suivre » ni les KPI
+      cabinet (pas d'erreur 403). Un DOCTOR les voit.
+- [ ] **Relance** : clic « Appeler »/« SMS » → une ligne `AuditLog action=RECALL_INITIATED`
+      apparaît (`resource=PATIENT`, `metadata.channel`).
+- [ ] **Routes supprimées** : `/dashboard` et `/events/new` renvoient **404** (legacy retiré).
+- [ ] **Export RGPD** : contient l'annotation `measurementUnits: { glucose: "g/L" }`.
+
+## 5. Rollback
+
+Prisma ne rollback pas automatiquement. Down-scripts fournis (**testés PG 16,
+cycle down→up validé, drift 0**) :
+
+```bash
+# Ordre INVERSE du deploy : S4 down (restaure glycemia_mgdl dérivé de g/L) puis S1 down
+psql "$DATABASE_URL" -f ops/rollback/20260801100000_glycemia_unit_s4_drop_mgdl_down.sql
+psql "$DATABASE_URL" -f ops/rollback/20260731100000_glycemia_unit_s1_cgm_check_bgm_backfill_down.sql
+
+# Marquer rolled-back dans _prisma_migrations
+pnpm prisma migrate resolve --rolled-back 20260801100000_glycemia_unit_s4_drop_mgdl
+pnpm prisma migrate resolve --rolled-back 20260731100000_glycemia_unit_s1_cgm_check_bgm_backfill
+
+# ⚠️ Rollback DB SEUL ≠ suffisant : redéployer AUSSI le code pré-#753 (schéma +
+# services lisant glycemia_mgdl), sinon le client ignore la colonne restaurée.
+```
+
+En recette jetable, le rollback = simplement `git revert` + `prisma migrate reset --force`.
+
+## 6. Artefacts de cette release
+
+- `ops/preflight/glycemia-gl-preflight.sql` — détection pré-migration des lignes bloquantes.
+- `ops/rollback/20260731100000_*_down.sql` — rollback S1 (drop CHECK CGM).
+- `ops/rollback/20260801100000_*_down.sql` — rollback S4 (restaure `glycemia_mgdl`).
+- ADR : `docs/architecture/adr-normalisation-unites-glycemie.md`.

--- a/docs/runbook/vps-setup.md
+++ b/docs/runbook/vps-setup.md
@@ -1,0 +1,192 @@
+# Runbook — Configuration d'un VPS pour le déploiement Diabeo
+
+> Guide de mise en place d'un environnement (recette ou prod) sur VPS OVHcloud.
+> Fidèle au dépôt : la liste d'env fait autorité = `src/lib/env.ts`. Déploiement
+> **manuel** via `deploy.sh` (fourni à la racine). Migrations : `docs/runbook/migrations.md`.
+
+## 1. Architecture cible
+
+| Composant | Emplacement | Détail |
+|---|---|---|
+| App **Next.js 16** (Node 22, pnpm 10) | **VPS** | derrière reverse proxy nginx/Traefik + TLS |
+| **PostgreSQL 16** | OVH DBaaS **ou** VPS | Prisma 7 + `@prisma/adapter-pg` |
+| **Redis** | **Upstash** (managé) | rate-limit, révocation session, cache |
+| **Object Storage** | **OVH** (S3-compatible) | documents (ClamAV), backups DB |
+| Email / Push | Resend / Firebase | optionnels selon features |
+
+Pas de Dockerfile ni de profil compose « prod » dans le dépôt (seul le profil
+`local` pour le dev). L'app tourne en Node sous un service **systemd**.
+
+## 2. Prérequis système
+
+```bash
+sudo apt update && sudo apt install -y nginx postgresql-client git
+corepack enable && corepack prepare pnpm@10 --activate   # Node 22 requis
+```
+
+## 3. PostgreSQL 16 — rôle + extensions
+
+Les migrations créent `pg_trgm` + `pgcrypto` (baseline) ; l'extension `btree_gist`
+est requise (contrainte anti-chevauchement RDV). Si le rôle applicatif n'a pas
+`CREATE EXTENSION`, les pré-créer en superuser :
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+```
+
+`DATABASE_URL` : `postgresql://<user>:<pwd>@<host>:5432/diabeo?schema=public`.
+
+## 4. Variables d'environnement — `/etc/diabeo/<env>.env`
+
+`assertRequiredEnv()` (ADR #20, `instrumentation.ts`) **fait crasher l'app au boot**
+si une variable OBLIGATOIRE manque/est malformée — message clair pointant la cause.
+
+### 4.1 Obligatoires (9 — source : `src/lib/env.ts` `REQUIRED_FULL`)
+
+| Variable | Format | Génération |
+|---|---|---|
+| `DATABASE_URL` | URL Postgres | — |
+| `HEALTH_DATA_ENCRYPTION_KEY` | **64 hex exact** (32 o) | `openssl rand -hex 32` |
+| `HMAC_SECRET` | 64+ hex | `openssl rand -hex 32` |
+| `CONVERSATION_KEY_PEPPER` | 64+ hex | `openssl rand -hex 32` |
+| `AUDIT_PEPPER` | 64+ hex (≠ HMAC) | `openssl rand -hex 32` |
+| `CRON_SECRET` | 64+ hex | `openssl rand -hex 32` |
+| `REDIS_KEY_PREFIX` | `diabeo:<env>:` | ex. `diabeo:recette:` |
+| `JWT_PRIVATE_KEY` | PEM RSA privée | `openssl genrsa 2048` |
+| `JWT_PUBLIC_KEY` | PEM RSA publique | `openssl rsa -pubout` |
+
+> Les clés PEM multi-lignes : stocker avec `\n` échappés ou en variable multi-ligne
+> supportée par systemd `EnvironmentFile` (préférer un secret manager si dispo).
+> Générer une paire JWT : `openssl genrsa -out jwt.key 2048 && openssl rsa -in jwt.key -pubout -out jwt.pub`.
+
+### 4.2 Fonctionnelles (selon features)
+
+```dotenv
+NODE_ENV=production
+APP_ENV=recette
+NEXT_PUBLIC_APP_URL=https://staging.diabeo.fr
+# Redis Upstash
+UPSTASH_REDIS_REST_URL=...
+UPSTASH_REDIS_REST_TOKEN=...
+# OVH Object Storage (S3)
+OVH_S3_ENDPOINT=https://s3.gra.io.cloud.ovh.net
+OVH_S3_REGION=gra
+OVH_S3_BUCKET=diabeo-documents-recette
+OVH_S3_ACCESS_KEY=...
+OVH_S3_SECRET_KEY=...
+# Email / Push (optionnels)
+RESEND_API_KEY=...
+EMAIL_FROM="Diabeo <no-reply@diabeo.fr>"
+FIREBASE_PROJECT_ID=...
+FIREBASE_SERVICE_ACCOUNT_KEY=...
+# Flags
+PROPOSAL_CRON_ENABLED=false
+```
+
+> **PROD/recette : `MOCK_MODE` / `MOCK_ANTIVIRUS` NE DOIVENT PAS valoir `true`** —
+> `env.ts` refuse le boot en `NODE_ENV=production` si ces flags fuitent.
+
+Permissions : `sudo install -m 600 -o diabeo -g diabeo <env>.env /etc/diabeo/recette.env`.
+
+## 5. Reverse proxy nginx (TLS + cap corps ≥ 10 Mo)
+
+```nginx
+# /etc/nginx/conf.d/diabeo.conf
+server {
+  server_name staging.diabeo.fr;
+  client_max_body_size 10m;     # OBLIGATOIRE (sync MyDiabby) — cf. infra-body-limits.md
+  client_body_buffer_size 1m;
+  client_body_timeout 30s;
+  location / {
+    proxy_pass http://127.0.0.1:3000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+  # + TLS (certbot / OVH). Écouter en 443, rediriger 80→443.
+}
+```
+
+## 6. Service systemd
+
+```ini
+# /etc/systemd/system/diabeo-recette.service
+[Unit]
+Description=Diabeo Backoffice (recette)
+After=network.target
+
+[Service]
+Type=simple
+User=diabeo
+WorkingDirectory=/opt/diabeo
+EnvironmentFile=/etc/diabeo/recette.env
+ExecStart=/usr/bin/pnpm start
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload && sudo systemctl enable --now diabeo-recette
+```
+
+## 7. Premier déploiement
+
+```bash
+sudo -u diabeo git clone <repo> /opt/diabeo && cd /opt/diabeo
+sudo -u diabeo pnpm install --frozen-lockfile
+sudo -u diabeo pnpm prisma generate
+# DB : recette jetable → reset+seed ; sinon migrate deploy (+ pré-vol si données)
+sudo -u diabeo --preserve-env pnpm prisma migrate deploy   # ou migrate reset --force
+sudo -u diabeo pnpm build
+sudo systemctl restart diabeo-recette
+```
+
+Checklist 1er deploy prod (backup restorable, rollback testé, smoke tests) :
+`docs/runbook/migrations.md §7.3`.
+
+## 8. Déploiements suivants — `deploy.sh`
+
+Le script `deploy.sh` (racine du dépôt) encapsule le cycle. Adapter les variables
+en tête (`APP_DIR`, `SERVICE`, `S3_BUCKET_BACKUPS`).
+
+```bash
+./deploy.sh update     # pull + install + generate + migrate deploy + build + restart
+./deploy.sh migrate    # migrations seules (+ status)
+./deploy.sh backup     # pg_dump gzip → OVH Object Storage
+./deploy.sh status     # santé service + DB + migrations
+```
+
+## 9. Backups automatiques (timer systemd)
+
+```ini
+# /etc/systemd/system/diabeo-backup.service
+[Service]
+Type=oneshot
+User=diabeo
+WorkingDirectory=/opt/diabeo
+Environment=APP_ENV=recette
+ExecStart=/opt/diabeo/deploy.sh backup
+```
+```ini
+# /etc/systemd/system/diabeo-backup.timer
+[Timer]
+OnCalendar=*-*-* 02:00:00
+Persistent=true
+[Install]
+WantedBy=timers.target
+```
+```bash
+sudo systemctl enable --now diabeo-backup.timer
+```
+
+## 10. Vérification finale
+
+- [ ] `./deploy.sh status` → service `active`, `pg_isready` OK, migrations toutes appliquées.
+- [ ] `https://staging.diabeo.fr` répond, login OK.
+- [ ] Boot sans crash env (sinon lire le message d'`assertRequiredEnv`).
+- [ ] `docs/runbook/release-glycemie-gl.md` → smoke tests de la release en cours.

--- a/ops/preflight/glycemia-gl-preflight.sql
+++ b/ops/preflight/glycemia-gl-preflight.sql
@@ -1,0 +1,61 @@
+-- ═══════════════════════════════════════════════════════════════════════════
+-- PRÉ-VOL — Release « unités glycémie g/L canonique » (ADR #32, PR #753)
+-- Migrations : 20260731100000 (S1, additif) + 20260801100000 (S4, DROP destructif)
+--
+-- À exécuter AVANT `prisma migrate deploy` sur une base contenant des données
+-- (prod, ou recette non re-seedée). Objectif : détecter ce qui ferait ÉCHOUER
+-- les `ADD CONSTRAINT CHECK` (la migration s'interrompt sur une seule ligne
+-- hors-bornes) et mesurer l'ampleur du backfill / du DROP.
+--
+-- Usage :  psql "$DATABASE_URL" -f ops/preflight/glycemia-gl-preflight.sql
+-- Lecture : toutes les lignes « *_bloquant » DOIVENT valoir 0 avant de migrer.
+-- ═══════════════════════════════════════════════════════════════════════════
+
+\echo '--- [1] CGM hors bornes (bloquant S1 : CHECK value_gl 0.20–6.00) ---'
+SELECT count(*) AS cgm_hors_bornes_bloquant
+FROM cgm_entries
+WHERE value_gl < 0.20 OR value_gl > 6.00;
+
+\echo '--- [2] BGM g/L hors bornes (bloquant S4 : CHECK glycemia_gl 0.20–6.00) ---'
+SELECT count(*) AS bgm_gl_hors_bornes_bloquant
+FROM glycemia_entries
+WHERE glycemia_gl IS NOT NULL
+  AND (glycemia_gl < 0.20 OR glycemia_gl > 6.00);
+
+\echo '--- [3] BGM mg/dL-only : seront backfillées en g/L par S1 (informatif) ---'
+SELECT count(*) AS bgm_mgdl_only_a_backfiller
+FROM glycemia_entries
+WHERE glycemia_gl IS NULL
+  AND glycemia_mgdl IS NOT NULL;
+
+\echo '--- [4] BGM mg/dL-only HORS bornes après conversion (bloquant S4 post-backfill) ---'
+-- Une ligne mg/dL-only dont mg/dL/100 sort de [0.20,6.00] serait backfillée
+-- en g/L hors bornes par S1, puis ferait échouer le CHECK S4.
+SELECT count(*) AS bgm_mgdl_only_hors_bornes_bloquant
+FROM glycemia_entries
+WHERE glycemia_gl IS NULL
+  AND glycemia_mgdl IS NOT NULL
+  AND (round(glycemia_mgdl / 100.0, 4) < 0.20 OR round(glycemia_mgdl / 100.0, 4) > 6.00);
+
+\echo '--- [5] Volume de la colonne supprimée par S4 (glycemia_mgdl non-null) ---'
+SELECT count(*) AS bgm_mgdl_non_null_a_dropper
+FROM glycemia_entries
+WHERE glycemia_mgdl IS NOT NULL;
+
+\echo '--- [6] État des migrations attendues comme NON encore appliquées ---'
+SELECT migration_name, finished_at
+FROM _prisma_migrations
+WHERE migration_name IN (
+  '20260731100000_glycemia_unit_s1_cgm_check_bgm_backfill',
+  '20260801100000_glycemia_unit_s4_drop_mgdl'
+)
+ORDER BY migration_name;
+-- Attendu : 0 ligne (migrations pas encore déployées). Si présentes → déjà appliquées.
+
+-- ── REMÉDIATION si [1], [2] ou [4] > 0 ──────────────────────────────────────
+-- Les valeurs hors [0.20,6.00] g/L sont non-physiologiques (< 20 ou > 600 mg/dL) :
+-- soit des erreurs capteur/saisie, soit des extrêmes « LO/HI ». Décider AVANT deploy :
+--   (a) purge ciblée (DELETE) des lignes hors bornes en recette, OU
+--   (b) clamp aux bornes si cliniquement justifié (à valider medical), OU
+--   (c) recette jetable → `prisma migrate reset` + `prisma db seed` (le seed
+--       génère du CGM 0.40–4.00, dans les bornes) : chemin recommandé en recette.

--- a/ops/rollback/20260731100000_glycemia_unit_s1_cgm_check_bgm_backfill_down.sql
+++ b/ops/rollback/20260731100000_glycemia_unit_s1_cgm_check_bgm_backfill_down.sql
@@ -1,0 +1,20 @@
+-- ═══════════════════════════════════════════════════════════════════════════
+-- ROLLBACK (down) de la migration 20260731100000_glycemia_unit_s1_cgm_check_bgm_backfill
+-- (ADR #32). Script inverse manuel (Prisma ne rollback pas automatiquement).
+--
+-- La migration S1 était ADDITIVE : (a) backfill glycemia_gl depuis glycemia_mgdl,
+-- (b) ajout du CHECK de bornes CGM. Ce down retire le CHECK. Le backfill (b)
+-- n'est PAS annulé : il n'existe aucun marqueur des lignes backfillées, et une
+-- valeur g/L correcte laissée en place est inoffensive (données enrichies, pas
+-- corrompues). Ne PAS tenter de re-NULLer glycemia_gl (perte d'info + on ne
+-- sait pas distinguer backfill vs saisie native).
+--
+-- Usage :
+--   psql "$DATABASE_URL" -f ops/rollback/20260731100000_glycemia_unit_s1_cgm_check_bgm_backfill_down.sql
+--   pnpm prisma migrate resolve --rolled-back 20260731100000_glycemia_unit_s1_cgm_check_bgm_backfill
+-- ⚠️ Si la migration S4 a déjà été appliquée, appliquer d'ABORD son down
+--    (restaure glycemia_mgdl) — l'ordre inverse du deploy.
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- Retirer le CHECK de bornes CGM ajouté par S1.
+ALTER TABLE "cgm_entries" DROP CONSTRAINT IF EXISTS "cgm_entries_value_gl_bounds";

--- a/ops/rollback/20260801100000_glycemia_unit_s4_drop_mgdl_down.sql
+++ b/ops/rollback/20260801100000_glycemia_unit_s4_drop_mgdl_down.sql
@@ -1,0 +1,36 @@
+-- ═══════════════════════════════════════════════════════════════════════════
+-- ROLLBACK (down) de la migration 20260801100000_glycemia_unit_s4_drop_mgdl
+-- (ADR #32). Prisma ne fournit PAS de rollback auto — script inverse manuel.
+--
+-- ⚠️ La migration S4 est DESTRUCTIVE (DROP COLUMN glycemia_mgdl) : les valeurs
+-- mg/dL d'origine ont été perdues au DROP. Ce down-script RESTAURE la colonne et
+-- la REPEUPLE de façon DÉRIVÉE depuis l'unité canonique g/L (mg/dL = g/L × 100).
+-- La valeur clinique est préservée (conversion sans perte 1 g/L = 100 mg/dL) ;
+-- seuls d'éventuels arrondis d'origine < 0,01 mg/dL ne sont pas restitués à
+-- l'identique. Acceptable (une entrée BGM mg/dL est un entier en pratique).
+--
+-- Usage :
+--   psql "$DATABASE_URL" -f ops/rollback/20260801100000_glycemia_unit_s4_drop_mgdl_down.sql
+--   pnpm prisma migrate resolve --rolled-back 20260801100000_glycemia_unit_s4_drop_mgdl
+-- ⚠️ Rollbacker ce down SANS le down S1 laisse le CHECK CGM en place (voulu :
+--    ils sont indépendants). Pour un rollback complet, appliquer AUSSI le down S1.
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- 1) Restaurer la colonne mg/dL (même type qu'avant : Decimal(6,2), nullable).
+ALTER TABLE "glycemia_entries" ADD COLUMN IF NOT EXISTS "glycemia_mgdl" DECIMAL(6,2);
+
+-- 2) Repeupler depuis g/L (dérivé, sans perte). Seules les lignes portant une
+--    glycémie (glycemia_gl non-null) reçoivent une valeur mg/dL ; les entrées
+--    sans glycémie (poids/HbA1c seuls) restent NULL, comme à l'origine.
+UPDATE "glycemia_entries"
+SET "glycemia_mgdl" = round("glycemia_gl" * 100.0, 2)
+WHERE "glycemia_gl" IS NOT NULL
+  AND "glycemia_mgdl" IS NULL;
+
+-- 3) Retirer le CHECK BGM ajouté par S4.
+ALTER TABLE "glycemia_entries" DROP CONSTRAINT IF EXISTS "glycemia_entries_glycemia_gl_bounds";
+
+-- NB : après ce rollback, remettre AUSSI le code applicatif sur la version
+-- pré-#753 (schéma Prisma avec glycemiaMgdl, services lisant les 2 colonnes) —
+-- sinon le client ignore glycemia_mgdl (grouped-only g/L). Le rollback DB seul
+-- ne suffit pas ; coordonner avec un rollback de déploiement du code.


### PR DESCRIPTION
## Préparation du déploiement en recette — épic unités glycémie g/L (ADR #32)

Artefacts de déploiement pour la release des PR **#753** (2 migrations, dont un DROP destructif), #754, #755. Recette **jetable/re-seedable** → chemin simple documenté ; artefacts robustes fournis pour la prod future.

### Contenu (documentation + ops, aucun code applicatif)
- **`docs/runbook/release-glycemie-gl.md`** — runbook de release :
  - Chemin **recette re-seedable** (recommandé) : `deploy.sh update` + `prisma migrate reset --force` (+ seed) + smoke tests.
  - Chemin **données préservées** (prod) : backup → pré-vol → `migrate deploy` → deploy code → vérifs.
  - **Smoke tests** concrets (login par rôle, CGM/BGM en g/L, préférence d'unité, NURSE ne voit plus les 2 cartes DOCTOR-only, audit relance `RECALL_INITIATED`, routes legacy en 404).
  - **Rollback** pas-à-pas.
- **`ops/preflight/glycemia-gl-preflight.sql`** — détecte AVANT `migrate deploy` les lignes hors bornes qui feraient **échouer les `ADD CONSTRAINT CHECK`** (CGM `value_gl` / BGM `glycemia_gl`), compte les mg/dL-only à backfiller + le volume droppé.
- **`ops/rollback/…_down.sql`** (S1 + S4) — scripts inverses (S4 restaure `glycemia_mgdl` dérivé de g/L). Convention runbook §5.

### ⚠️ Points de vigilance de cette release
- Migration **S4 destructive** : `DROP COLUMN glycemia_mgdl` (irréversible ; le down-script re-dérive la colonne depuis g/L).
- Les **CHECK** échouent sur une seule ligne hors `[0.20 ; 6.00]` g/L → le pré-vol est obligatoire sur une base porteuse de données.
- Ordre imposé : **S1 (backfill) avant S4 (drop)** — respecté par `migrate deploy` (timestamps).

### Validation
Tous les scripts SQL **testés sur Postgres 16** : cycle rollback **down→up validé** (glycemia_mgdl restaurée puis re-droppée), migrations forward **idempotentes**, **drift = 0**.

### Hors périmètre
- Déploiement **manuel** (`deploy.sh` sur le VPS, hors dépôt) — je n'ai pas accès à `staging.diabeo.fr` ; les commandes sont prêtes à copier.
- Pas de workflow CI/CD de deploy (aucun n'existe aujourd'hui).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjfGsaWAwSb1RNFYkRfKt9
