### PR TITLE
docs — VPS : DNS (domaine + sous-domaine recette) + séquence de bring-up de zéro

### DIFF
--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -1,16 +1,20 @@
 # Operational Runbook
 
 Day-to-day operations playbook for the Diabeo Backoffice on OVHcloud GRA
-(Docker Compose + managed PostgreSQL + Upstash Redis + Object Storage).
+(Node.js + systemd + managed PostgreSQL + Upstash Redis + Object Storage).
 
 > **Audience**: on-call engineers. Assumes SSH access to the VPS, `gh` CLI
 > authentication, and access to the shared 1Password vault for secrets.
 >
-> **Status markers**: sections tagged **[TODO — not yet implemented]** describe
-> target procedures; the referenced scripts / endpoints do NOT exist yet.
-> See [scripts-index.md](./scripts-index.md) for implementation status.
-> Operators: do NOT rely on those sections in an incident — fall back to
-> manual `git pull` + `pnpm build` until the scripts are shipped.
+> **Authority**: This runbook covers **day-2 operations** (backups, secrets,
+> monitoring, drills). For **provisioning and deployment**, the authoritative
+> sources are:
+> - **Systemd + VPS setup**: [`docs/runbook/vps-setup.md`](./vps-setup.md) (§6–8)
+> - **Database migrations**: [`docs/runbook/migrations.md`](./migrations.md) (versioned Prisma 7, `migrate deploy`)
+> - **Deployment script**: [`deploy.sh`](../../deploy.sh) (repo root — `./deploy.sh update/migrate/backup/status`)
+>
+> **Update history**: This runbook was corrected 2026-07-19 to remove obsolete
+> mechanics (`prisma db push`, `pm2`, Docker-based prod deployment).
 
 - [Environments](#environments)
 - [Deployment](#deployment)
@@ -37,7 +41,8 @@ Each env has its own:
 - PostgreSQL instance (OVH managed DB in prod/recette, local container in dev).
 - Upstash Redis (free tier for recette, paid tier for prod).
 - Object Storage bucket (`diabeo-prod-documents`, `diabeo-staging-documents`).
-- Env-file (`.env.production`, `.env.staging`) — never committed.
+- Env-file `/etc/diabeo/<env>.env` (`prod.env` / `recette.env`, chmod 600, owner
+  `diabeo`) — never committed, sourced by the systemd unit (cf. `vps-setup.md §4/§6`).
 
 ---
 
@@ -46,48 +51,47 @@ Each env has its own:
 ### Prerequisites
 
 - Main branch green on GitHub Actions (E2E + unit + lint/typecheck).
-- Every migration listed in `prisma/sql/` that is not yet applied has been
-  reviewed with SQL-pro and medical-domain-validator agents.
+- All versioned migrations in `prisma/migrations/` have been reviewed with
+  SQL-pro and medical-domain-validator agents.
 - ChangeLog updated for the release.
 
-### Standard deploy (prod)
+### Standard deploy (prod/recette)
 
-`scripts/deploy.sh` ships in-repo. Complete the [Manual setup
-checklist](#manual-setup-checklist) once per host before the first run.
+The deployment script `deploy.sh` is in the **repo root** (not `scripts/`).
+Complete the [Manual setup checklist](#manual-setup-checklist) once per host
+before the first run.
 
 ```sh
 ssh diabeo@app.diabeo.fr
 
-cd /opt/diabeo/backoffice
+cd /opt/diabeo
 git fetch origin main
 git log HEAD..origin/main --oneline   # review incoming commits
 
-# Apply any raw SQL migrations FIRST (Prisma db push will fail otherwise
-# for column type changes like VARCHAR → enum).
-psql $DATABASE_URL < prisma/sql/<new_migration>.sql
+# Single command: pull + install + generate + migrate deploy + build + restart
+./deploy.sh update
 
-# Pull + build + swap containers
-./scripts/deploy.sh update     # [TODO]
-
-# Health check (endpoint exists — implemented in PR #107)
+# Health check
 curl -sf https://app.diabeo.fr/api/health || echo "DEPLOY FAILED"
 ```
 
-`scripts/deploy.sh update` runs, in order:
+`./deploy.sh update` executes, in order:
 
-1. `git fetch origin main` + warns on any new `prisma/sql/*.sql` (operator
-   must apply those with `psql` BEFORE acknowledging via `APPLIED_SQL=1`)
-2. `git pull --ff-only origin main`
-3. `pnpm install --frozen-lockfile`
-4. `pnpm prisma generate`
-5. `pnpm prisma db push --accept-data-loss=false`
-6. `pnpm tsc --noEmit` + `pnpm test` (hard gate)
-7. `pnpm build`
-8. `pm2 restart $PM2_PROCESS --update-env`
-9. Health probe on `/api/health` with up to 30 s retry window
+1. `git fetch origin main` + `git reset --hard origin/main`
+2. `pnpm install --frozen-lockfile`
+3. `pnpm prisma generate`
+4. **`pnpm prisma migrate deploy`** — applies versioned migrations (idempotent,
+   see [`docs/runbook/migrations.md`](./migrations.md) for details and rollback)
+5. `pnpm build` (requires full env: `DATABASE_URL` mandatory)
+6. `sudo systemctl restart diabeo-${APP_ENV}` (systemd service)
+7. Health probe on `/api/health`
 
-Exit code 3 means the health probe failed — manual rollback required
-(see [Rollback](#rollback)).
+For releases with **destructive migrations** (e.g. `DROP COLUMN`), pre-run:
+```sh
+./deploy.sh backup                                # backup before the risky migration
+psql "$DATABASE_URL" -f ops/preflight/preflight.sql  # any pre-flight SQL
+./deploy.sh update                                # run the deploy
+```
 
 ### Emergency hotfix (skipping CI)
 
@@ -96,7 +100,7 @@ necessary:
 
 ```sh
 git cherry-pick <hotfix-sha>
-./scripts/deploy.sh update
+./deploy.sh update
 # Open a post-mortem issue within 24 h.
 ```
 
@@ -104,68 +108,82 @@ git cherry-pick <hotfix-sha>
 
 ## Rollback
 
+See [`docs/runbook/migrations.md` §5](./migrations.md#5-plan-de-rollback) for
+detailed rollback procedures under Prisma 7 versioned migrations. Below is a
+quick reference.
+
 ### Fast rollback (same day, no schema change)
 
 ```sh
 ssh diabeo@app.diabeo.fr
-cd /opt/diabeo/backoffice
+cd /opt/diabeo
 git reset --hard <previous-sha>
-./scripts/deploy.sh update
+./deploy.sh update
 ```
 
 Uses the same build pipeline; takes ~2 min.
 
 ### Rollback across a migration
 
-If the deploy that introduced the issue also ran a migration, you **cannot**
-simply `git reset` the code — the DB is still on the new schema.
+If the deploy included a migration, you **cannot** simply `git reset` — the DB
+is still on the new schema. Prisma 7 migrations are forward-only.
 
-Steps:
+**Steps**:
 
-1. Check `prisma/sql/` for the migration that landed in the bad release.
-2. Write a manual rollback script (never relies on Prisma to generate it —
-   Prisma `db push` is forward-only on the POC). Place in
-   `prisma/sql/rollback_<migration_name>.sql`.
-3. Apply the rollback: `psql $DATABASE_URL < prisma/sql/rollback_<name>.sql`.
-4. `git reset --hard <previous-sha>` then `./scripts/deploy.sh update`.
+1. Identify the bad migration: `pnpm prisma migrate status`
+2. Write a **manual rollback SQL** (Prisma does not generate reverses).
+   Place in `ops/rollback/<timestamp>_<feature>_down.sql`.
+3. Apply the rollback: `psql $DATABASE_URL < ops/rollback/<timestamp>_down.sql`
+4. Mark the migration as rolled back: `pnpm prisma migrate resolve --rolled-back <timestamp>_<feature>`
+5. Revert code: `git reset --hard <previous-sha>`
+6. Deploy: `./deploy.sh update`
 
-**Safe migrations** (additive, nullable columns, additive enum values, new
-indexes) do not require a rollback script — the app code simply stops using
-the new column.
+**Safe migrations** (additive columns, new indexes, additive enum values) do
+not require a rollback script — the old code simply ignores the new column.
 
-**Unsafe migrations** (column drops, type conversions, NOT NULL additions,
-enum value removals) MUST ship with a rollback script reviewed during PR.
+**Unsafe migrations** (column drops, type conversions, NOT NULL constraints,
+enum removals) **MUST ship with a reviewed rollback script** in the PR.
+
+See [`docs/runbook/migrations.md` §7.3](./migrations.md#73--checklist-1er-deploy-prod-us-2267-blocker-pre-prod)
+for pre-prod checklist including rollback test.
 
 ---
 
 ## Database migrations
 
-The project uses `prisma db push` for the POC phase — no Prisma migrations
-directory. Column-type changes, enum additions, and any operation Prisma
-can't infer from the schema are hand-written in `prisma/sql/`:
+**Authoritative source**: [`docs/runbook/migrations.md`](./migrations.md) — this
+section is a summary only.
 
-| File                           | Purpose                                            |
-|--------------------------------|----------------------------------------------------|
-| `audit_immutability.sql`       | Postgres trigger preventing UPDATE/DELETE on `audit_logs` (HDS §IV.3) |
-| `cgm_partitioning.sql`         | Monthly partitions on `cgm_entries` — applied before seeding |
-| `basal_config_check.sql`       | Check constraints on basal dose fields             |
-| `patient_insulin_constraints.sql` | Referential + range constraints on therapy settings |
-| `period_type_enum.sql`         | `AverageData.periodType` VARCHAR → enum (PR #105)  |
-| `audit_log_request_id.sql`     | `AuditLog.requestId` column + index (PR #105)      |
-| `mfa_hardening.sql`            | `User.mfaLastUsedStep` + `Session.mfaVerified` (PR #106) |
+The project uses **versioned Prisma 7 migrations** (ADR #17). Every schema change
+lives in `prisma/migrations/<timestamp>_<name>/migration.sql` and is applied
+by `pnpm prisma migrate deploy` (idempotent).
 
-**Apply order** on a fresh env:
+Historical `.sql` scripts in `prisma/sql/` (audit triggers, CGM partitioning,
+constraints) have been **integrated into the baseline migration**
+(`20260508140000_post_deploy_sql`) or superseded. They remain for reference
+but **must not be re-applied on a new DB** — the baseline covers them.
+
+**On a fresh database**, the full schema is created and all constraints applied
+by the migration chain:
 
 ```sh
-pnpm prisma db push             # creates all tables
-psql $DATABASE_URL < prisma/sql/audit_immutability.sql
-psql $DATABASE_URL < prisma/sql/cgm_partitioning.sql
-psql $DATABASE_URL < prisma/sql/basal_config_check.sql
-psql $DATABASE_URL < prisma/sql/patient_insulin_constraints.sql
-psql $DATABASE_URL < prisma/sql/period_type_enum.sql
-psql $DATABASE_URL < prisma/sql/audit_log_request_id.sql
-psql $DATABASE_URL < prisma/sql/mfa_hardening.sql
+# Handled by deploy.sh automatically; never run manually in prod
+cd /opt/diabeo
+pnpm prisma migrate deploy    # applies all migrations to current state
+pnpm prisma migrate status    # verify "Database schema is up to date"
 ```
+
+**CGM partitioning** (`prisma/sql/cgm_partitioning.sql`) is **not** versioned
+because Prisma cannot model PostgreSQL partitioning. Apply only when volume
+justifies it (>10M entries):
+
+```sh
+psql $DATABASE_URL < prisma/sql/cgm_partitioning.sql
+```
+
+See **[`docs/runbook/migrations.md` §6–7](./migrations.md#6-cas-particuliers)**
+for partial indexes, CHECK constraints, and transitioning an existing DB from
+`db push` to versioned migrations.
 
 ---
 
@@ -185,7 +203,7 @@ pg_dump \
   $PG_DB
 ```
 
-Cron: `0 2 * * * /opt/diabeo/backoffice/scripts/backup-postgres.sh >> /var/log/diabeo-backup.log 2>&1`.
+Cron: `0 2 * * * /opt/diabeo/scripts/backup-postgres.sh >> /var/log/diabeo-backup.log 2>&1`.
 Setup steps in [Manual setup checklist](#manual-setup-checklist).
 
 Backups are rsync'd to OVH Object Storage bucket `diabeo-backups-prod`
@@ -276,8 +294,10 @@ be created on first drill).
 
 ## Secrets
 
-Stored in OVH Secret Manager (prod/recette) and synced to the VPS as
-Docker secrets (files mounted at `/run/secrets/<name>`).
+Stored in OVH Secret Manager (prod/recette) and deployed to each VPS as
+an **environment file** `/etc/diabeo/<env>.env` (permissions `chmod 600`,
+owned by `diabeo` user). See [`docs/runbook/vps-setup.md` §4](./vps-setup.md#4-variables-denvironnement--etcdiabeoenvenv)
+for generation and setup.
 
 | Secret                        | Purpose                          | Rotation         |
 |-------------------------------|----------------------------------|------------------|
@@ -417,30 +437,33 @@ SELECT * FROM audit_logs WHERE request_id = 'abc12345';
 ## Manual setup checklist
 
 One-time operator actions required before the automation scripts
-(`scripts/deploy.sh`, `scripts/backup-postgres.sh`, `scripts/decrypt-smoke.ts`)
-can run. Keep this list in sync with [scripts-index.md](./scripts-index.md).
+(`deploy.sh` at repo root — systemd, cf. `vps-setup.md`; `scripts/backup-postgres.sh`;
+`scripts/decrypt-smoke.ts`) can run. Keep this list in sync with
+[scripts-index.md](./scripts-index.md).
 
 ### Initial VPS bootstrap (per host)
 
-- [ ] SSH access hardened per Phase 13 US-1109 (keys only, no root login)
-- [ ] Node 22+ and pnpm 10+ in PATH (via Corepack or `curl -fsSL`)
-- [ ] `pm2` installed globally: `npm install -g pm2`
-- [ ] First-run app registration:
-      ```sh
-      cd /opt/diabeo/backoffice
-      pm2 start npm --name diabeo-api -- start
-      pm2 save
-      pm2 startup systemd    # follow the printed command
-      ```
-- [ ] Verify: `pm2 describe diabeo-api` shows "online"
-- [ ] All env vars from `.env.example` exported (validated by the app boot)
+See [`docs/runbook/vps-setup.md`](./vps-setup.md) for the complete provisioning
+sequence (complete, tested, production-ready). Quick checklist:
 
-### `scripts/deploy.sh` prerequisites
+- [ ] SSH access hardened — keys only, no root login
+- [ ] Node 22+ and pnpm 10+ in PATH (via Corepack: `corepack enable && corepack prepare pnpm@10 --activate`)
+- [ ] **Systemd service** configured (`/etc/systemd/system/diabeo-${APP_ENV}.service`)
+      and enabled (`sudo systemctl enable --now diabeo-${APP_ENV}`)
+- [ ] Environment file `/etc/diabeo/${APP_ENV}.env` (chmod 600) containing all
+      9 mandatory vars + functional vars
+- [ ] **Code cloned** into `/opt/diabeo` (not `/opt/diabeo/backoffice`)
+- [ ] `pnpm install --frozen-lockfile` + `pnpm prisma generate` completed
+- [ ] First deployment: `./deploy.sh update`
+- [ ] Service healthy: `systemctl status diabeo-${APP_ENV}` shows "active (running)"
+- [ ] Health endpoint: `curl -I https://${APP_URL}/api/health` returns 200
+
+### `deploy.sh` prerequisites (repo root)
 
 - [ ] Bootstrap above complete
-- [ ] `DATABASE_URL` exported in the deploying operator's shell
-- [ ] `scripts/deploy.sh` is executable (`chmod +x`) — handled by git, verify after first pull
-- [ ] Smoke-test: `./scripts/deploy.sh status` — returns without error
+- [ ] Environment file `/etc/diabeo/${APP_ENV}.env` exists and is readable by `diabeo`
+- [ ] `deploy.sh` is executable (`chmod +x`) — handled by git, verify after first clone
+- [ ] Smoke-test: `./deploy.sh status` — verifies service + DB + migration state
 
 ### `scripts/backup-postgres.sh` prerequisites
 
@@ -525,7 +548,7 @@ can run. Keep this list in sync with [scripts-index.md](./scripts-index.md).
       ```
 - [ ] **Install logrotate config** (prevents /var/log fill-up):
       ```sh
-      sudo cp /opt/diabeo/backoffice/scripts/logrotate.d/diabeo-backup \
+      sudo cp /opt/diabeo/scripts/logrotate.d/diabeo-backup \
         /etc/logrotate.d/diabeo-backup
       sudo chmod 0644 /etc/logrotate.d/diabeo-backup
       sudo touch /var/log/diabeo-backup.log /var/log/diabeo-deploy.log
@@ -534,7 +557,7 @@ can run. Keep this list in sync with [scripts-index.md](./scripts-index.md).
       ```
 - [ ] Dry-run as the backup user:
       ```sh
-      sudo -u diabeo-backup /opt/diabeo/backoffice/scripts/backup-postgres.sh
+      sudo -u diabeo-backup /opt/diabeo/scripts/backup-postgres.sh
       ```
       Exercises the full path: env + dump + sha256 manifest + SSE
       AES256 upload + rotation.
@@ -542,7 +565,7 @@ can run. Keep this list in sync with [scripts-index.md](./scripts-index.md).
       ```sh
       sudo crontab -u diabeo-backup -e
       # Add:
-      0 2 * * * /opt/diabeo/backoffice/scripts/backup-postgres.sh \
+      0 2 * * * /opt/diabeo/scripts/backup-postgres.sh \
         >> /var/log/diabeo-backup.log 2>&1
       ```
 

--- a/docs/operations/scripts-index.md
+++ b/docs/operations/scripts-index.md
@@ -14,8 +14,9 @@ issue so the script can be productionized.
 |---------------------------------------------|--------|-------|-------|
 | `GET /api/health`                           | ✓ | backend | Implemented in PR #107 — `src/app/api/health/route.ts` |
 | `scripts/test-e2e.sh`                       | ✓ | QA | Existing, boots Playwright fixture stack |
-| `scripts/deploy.sh update`                  | ✓ | devops | Wraps manual fallback: git pull + pnpm + migrate + build + pm2 restart + health probe. Manual steps (pm2 setup) in runbook §Manual setup |
-| `docker-compose.prod.yml`                   | ✗ | devops | Prod currently runs `next start` under pm2 directly. Dépend de US-1108 Nginx + US-1107 TLS |
+| `deploy.sh update` (repo root)              | ✓ | devops | **Autorité** : git pull + pnpm + `migrate deploy` + build + **`systemctl restart`** (systemd). Provisioning : `docs/runbook/vps-setup.md`. |
+| ~~`scripts/deploy.sh`~~ (legacy pm2)        | ⚠ | devops | **Périmé** — variante pm2 antérieure, supersédée par `deploy.sh` racine (systemd). Ne pas utiliser en prod ; à retirer. |
+| ~~`docker-compose.prod.yml`~~               | ✗ | devops | **Sans objet** — la prod tourne sous **systemd** (`next start`), pas Docker/pm2. Cf. `vps-setup.md §6`. |
 | `scripts/backup-postgres.sh` (cron 02:00)   | ✓ | devops | pg_dump custom + aws s3 cp + rotation locale 14 jours. Requires one-time OVH bucket + cron + `/etc/diabeo/backup.env` setup (runbook §Manual setup) |
 | `scripts/decrypt-smoke.ts`                  | ✓ | backend | Post-restore validation: samples 5 users × 5 encrypted fields via `safeDecryptField`. Run manually during the quarterly restore drill |
 | `docs/operations/drill-log.md`              | ✗ | on-call | Created on first drill — template in incident-response.md |
@@ -29,12 +30,13 @@ Roughly ordered by impact / effort:
 
 1. **OVH Cloud Monitoring alert on `/api/health`** — endpoint exists, just
    needs a 30 s ping rule + webhook to on-call Slack. ~30 min of ops work.
-2. **`scripts/deploy.sh update`** — wrap the manual fallback from the
-   runbook (8 lines of bash + pm2 reload). Unblocks routine deploys.
+2. ~~**`scripts/deploy.sh update`**~~ — **fait** : le déploiement passe par
+   `deploy.sh` (racine, systemd + `migrate deploy`). La variante `scripts/deploy.sh`
+   (pm2) est périmée.
 3. **`scripts/backup-postgres.sh` + cron** — OVH snapshots are good but
    application-level dumps give faster restore + portability.
-4. **`docker-compose.prod.yml`** — only needed if we move off pm2; not
-   blocking anything today.
+4. ~~**`docker-compose.prod.yml`**~~ — **sans objet** : la prod tourne sous
+   systemd (cf. `vps-setup.md`), pas Docker. Aucun besoin.
 5. **`scripts/decrypt-smoke.ts`** — nice-to-have for the restore drill;
    a `SELECT decrypt(...) FROM users LIMIT 10` does the same job manually.
 6. **`docs/compliance/breach-notification.md`** — DPO-owned, legal doc;

--- a/docs/runbook/release-glycemie-gl.md
+++ b/docs/runbook/release-glycemie-gl.md
@@ -37,13 +37,21 @@ dans les bornes → aucun risque de CHECK) :
 # 1. Déployer le CODE (pull + build + restart) — procédure VPS habituelle
 ./deploy.sh update
 
-# 2. Réinitialiser le schéma sur la version cible + re-seed
-#    (reset = drop + recreate + applique TOUTES les migrations + seed)
-pnpm prisma migrate reset --force        # ⚠️ efface la base recette (assumé jetable)
-# (reset lance le seed via prisma.config migrations.seed ; sinon : pnpm prisma db seed)
+# 2. Réinitialiser le schéma sur la version cible, PUIS re-seed séparément.
+#    ⚠️ Le seed REFUSE NODE_ENV=production (garde anti-prod, seed.ts) → si l'env
+#    recette porte NODE_ENV=production, un `reset` sans --skip-seed échoue sur le
+#    seed (table users vide → login KO). D'où : --skip-seed puis `unset NODE_ENV`.
+sudo -u diabeo bash -lc '
+  set -a; . /etc/diabeo/recette.env; set +a
+  cd /opt/diabeo
+  pnpm prisma migrate reset --force --skip-seed   # ⚠️ efface la base recette (jetable)
+  unset NODE_ENV
+  pnpm prisma db seed                              # CGM 0.40–4.00, dans les bornes
+'
 
 # 3. Vérifier l'état
-pnpm prisma migrate status               # toutes appliquées, aucune pending
+sudo -u diabeo bash -lc 'set -a; . /etc/diabeo/recette.env; set +a; cd /opt/diabeo;
+  pnpm prisma migrate status'               # toutes appliquées, aucune pending
 ```
 
 Puis **smoke tests** (§4).

--- a/docs/runbook/vps-setup.md
+++ b/docs/runbook/vps-setup.md
@@ -20,8 +20,13 @@ Pas de Dockerfile ni de profil compose « prod » dans le dépôt (seul le profi
 ## 2. Prérequis système
 
 ```bash
-sudo apt update && sudo apt install -y nginx postgresql-client git
-corepack enable && corepack prepare pnpm@10 --activate   # Node 22 requis
+sudo apt update && sudo apt install -y nginx postgresql-client git curl ca-certificates
+
+# Node 22 — PAS dans les dépôts APT par défaut. Via NodeSource (dépôt officiel) :
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+sudo apt install -y nodejs
+node -v                                                  # → v22.x
+corepack enable && corepack prepare pnpm@10 --activate   # pnpm via corepack (fourni par Node)
 ```
 
 ## 3. PostgreSQL 16 — création de la base, du rôle & des extensions
@@ -134,9 +139,16 @@ si une variable OBLIGATOIRE manque/est malformée — message clair pointant la 
 | `JWT_PRIVATE_KEY` | PEM RSA privée | `openssl genrsa 2048` |
 | `JWT_PUBLIC_KEY` | PEM RSA publique | `openssl rsa -pubout` |
 
-> Les clés PEM multi-lignes : stocker avec `\n` échappés ou en variable multi-ligne
-> supportée par systemd `EnvironmentFile` (préférer un secret manager si dispo).
-> Générer une paire JWT : `openssl genrsa -out jwt.key 2048 && openssl rsa -in jwt.key -pubout -out jwt.pub`.
+> **Clés PEM sur UNE ligne, `\n` échappés** (format canonique attendu — `jwt.ts`
+> fait `pem.replace(/\\n/g, "\n")`). C'est le **seul** format fiable pour systemd
+> `EnvironmentFile`, qui ne parse pas les valeurs multi-lignes réelles → une clé
+> collée telle quelle (avec de vrais retours) casse le boot du service.
+> Générer la paire puis la convertir en single-line :
+> ```bash
+> openssl genrsa -out jwt.key 2048 && openssl rsa -in jwt.key -pubout -out jwt.pub
+> awk 'NF{printf "%s\\n",$0}' jwt.key   # → coller la sortie dans JWT_PRIVATE_KEY="…"
+> awk 'NF{printf "%s\\n",$0}' jwt.pub   # → coller la sortie dans JWT_PUBLIC_KEY="…"
+> ```
 
 ### 4.2 Fonctionnelles (selon features)
 
@@ -429,8 +441,10 @@ Un domaine pointe vers un VPS via un enregistrement DNS **de type `A`** (IPv4,
 
 ```bash
 # 0. Prérequis (root)
-sudo apt update && sudo apt install -y nginx postgresql-client git certbot python3-certbot-nginx
-corepack enable && corepack prepare pnpm@10 --activate      # Node 22 requis
+sudo apt update && sudo apt install -y nginx postgresql-client git curl ca-certificates certbot python3-certbot-nginx
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -   # Node 22 (NodeSource)
+sudo apt install -y nodejs
+corepack enable && corepack prepare pnpm@10 --activate
 sudo useradd -m -s /bin/bash diabeo
 
 # 1. PostgreSQL 16 : base + extensions (ou OVH DBaaS → récupérer l'URL)
@@ -453,8 +467,8 @@ CONVERSATION_KEY_PEPPER=$(openssl rand -hex 32)
 AUDIT_PEPPER=$(openssl rand -hex 32)
 CRON_SECRET=$(openssl rand -hex 32)
 REDIS_KEY_PREFIX=diabeo:recette:
-JWT_PRIVATE_KEY="$(cat /tmp/jwt.key)"
-JWT_PUBLIC_KEY="$(cat /tmp/jwt.pub)"
+JWT_PRIVATE_KEY="$(awk 'NF{printf "%s\\n",$0}' /tmp/jwt.key)"
+JWT_PUBLIC_KEY="$(awk 'NF{printf "%s\\n",$0}' /tmp/jwt.pub)"
 UPSTASH_REDIS_REST_URL=<...>
 UPSTASH_REDIS_REST_TOKEN=<...>
 OVH_S3_ENDPOINT=https://s3.gra.io.cloud.ovh.net
@@ -465,15 +479,21 @@ OVH_S3_SECRET_KEY=<...>
 EOF
 sudo chmod 600 /etc/diabeo/recette.env && shred -u /tmp/jwt.key /tmp/jwt.pub
 
-# 3. Code + build
-sudo -u diabeo git clone <URL_REPO> /opt/diabeo && cd /opt/diabeo
-sudo -u diabeo pnpm install --frozen-lockfile
-sudo -u diabeo pnpm prisma generate
-sudo -u diabeo pnpm build
+# 3. Code (repo PRIVÉ → Deploy Key, cf. §7.a pour la génération + ajout GitHub)
+#    /opt étant root:root, créer le dossier possédé par diabeo AVANT le clone.
+sudo install -d -o diabeo -g diabeo /opt/diabeo
+sudo -u diabeo git clone git@github.com:freecompub/Diabeo-BackOffice.git /opt/diabeo
+sudo -u diabeo bash -lc 'cd /opt/diabeo && pnpm install --frozen-lockfile && pnpm prisma generate'
 
-# 4. Base recette jetable : schéma cible + seed
-sudo -u diabeo --preserve-env env $(grep -v '^#' /etc/diabeo/recette.env | xargs) \
+# 4. Base recette jetable (schéma cible + seed) puis build — env chargé via
+#    `set -a; . ; set +a` (jamais `env $(grep|xargs)` : casse les PEM JWT_*).
+#    Ordre migrate→build ; build env-chargé (NEXT_PUBLIC_* inliné au build).
+sudo -u diabeo bash -lc '
+  set -a; . /etc/diabeo/recette.env; set +a
+  cd /opt/diabeo
   pnpm prisma migrate reset --force
+  pnpm build
+'
 
 # 5. Service systemd
 sudo tee /etc/systemd/system/diabeo-recette.service >/dev/null <<'EOF'
@@ -494,6 +514,8 @@ EOF
 sudo systemctl daemon-reload && sudo systemctl enable --now diabeo-recette
 
 # 6. nginx + TLS (DNS staging → VPS déjà propagé, cf. §11)
+#    Retirer le vhost par défaut, sinon il capte certbot (page « Welcome to nginx »).
+sudo rm -f /etc/nginx/sites-enabled/default
 sudo tee /etc/nginx/conf.d/diabeo-recette.conf >/dev/null <<'EOF'
 server {
   server_name staging.diabeo.fr;

--- a/docs/runbook/vps-setup.md
+++ b/docs/runbook/vps-setup.md
@@ -165,7 +165,22 @@ PROPOSAL_CRON_ENABLED=false
 > **PROD/recette : `MOCK_MODE` / `MOCK_ANTIVIRUS` NE DOIVENT PAS valoir `true`** —
 > `env.ts` refuse le boot en `NODE_ENV=production` si ces flags fuitent.
 
-Permissions : `sudo install -m 600 -o diabeo -g diabeo <env>.env /etc/diabeo/recette.env`.
+Emplacement + permissions (**créer le dossier `/etc/diabeo` d'abord** — sinon
+`install`/`scp` échoue avec *« No such file or directory »*) :
+
+```bash
+# 1. Créer le dossier (droits 750, propriétaire diabeo)
+sudo install -d -m 750 -o diabeo -g diabeo /etc/diabeo
+
+# 2. Y installer le fichier d'env (600, owner diabeo). Si tu l'as transféré via
+#    scp dans ton home (scp diabeo-vps:~/), pars de ~/recette.env :
+sudo install -m 600 -o diabeo -g diabeo ~/recette.env /etc/diabeo/recette.env
+# (une commande : `sudo install -D -m 600 …` crée aussi les dossiers parents)
+
+# 3. Vérifier + ne pas laisser traîner le secret dans le home
+ls -l /etc/diabeo/recette.env      # -rw------- 1 diabeo diabeo …
+rm ~/recette.env
+```
 
 ## 5. Reverse proxy nginx (TLS + cap corps ≥ 10 Mo)
 

--- a/docs/runbook/vps-setup.md
+++ b/docs/runbook/vps-setup.md
@@ -24,19 +24,63 @@ sudo apt update && sudo apt install -y nginx postgresql-client git
 corepack enable && corepack prepare pnpm@10 --activate   # Node 22 requis
 ```
 
-## 3. PostgreSQL 16 — rôle + extensions
+## 3. PostgreSQL 16 — création de la base, du rôle & des extensions
 
-Les migrations créent `pg_trgm` + `pgcrypto` (baseline) ; l'extension `btree_gist`
-est requise (contrainte anti-chevauchement RDV). Si le rôle applicatif n'a pas
-`CREATE EXTENSION`, les pré-créer en superuser :
+Objectif : disposer d'une **base `diabeo`** + d'un **rôle** (compte user/mot de passe)
+que l'app utilise pour se connecter, avec **3 extensions** activées. Deux cas selon
+que Postgres tourne **sur le VPS** ou est une **base managée OVH (DBaaS)**.
 
-```sql
+> **Rôle** = compte de connexion (login + mot de passe). **Extensions** = plugins
+> Postgres requis : `pg_trgm` (recherche floue patient), `pgcrypto` (chiffrement
+> at-rest, ADR #8), `btree_gist` (contrainte anti-chevauchement des créneaux RDV).
+
+### 3.A — Postgres installé sur le VPS
+
+```bash
+# 1. Installer PostgreSQL 16
+sudo apt install -y postgresql-16
+
+# 2. Créer le rôle applicatif (NON superutilisateur — moindre privilège) + la base
+sudo -u postgres psql <<'SQL'
+CREATE ROLE diabeo LOGIN PASSWORD '<MOT_DE_PASSE_FORT>';
+CREATE DATABASE diabeo OWNER diabeo;
+SQL
+
+# 3. Activer les extensions EN SUPERUTILISATEUR (l'app n'a pas ce droit) — voir note
+sudo -u postgres psql -d diabeo <<'SQL'
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 CREATE EXTENSION IF NOT EXISTS btree_gist;
+SQL
+
+# 4. Vérifier la connexion avec le rôle applicatif
+PGPASSWORD='<MOT_DE_PASSE_FORT>' psql -h 127.0.0.1 -U diabeo -d diabeo -c '\dx'
+#   → doit lister pg_trgm, pgcrypto, btree_gist
 ```
 
-`DATABASE_URL` : `postgresql://<user>:<pwd>@<host>:5432/diabeo?schema=public`.
+> **Pourquoi l'étape 3 en superutilisateur ?** `prisma migrate deploy` tente
+> `CREATE EXTENSION IF NOT EXISTS …`, mais créer une extension exige les droits
+> **superuser** — que le rôle `diabeo` n'a volontairement pas. En les créant
+> d'abord en `postgres`, la migration les trouve déjà présentes et passe sans erreur.
+
+### 3.B — Base managée OVH (DBaaS)
+
+1. Créer une instance **PostgreSQL 16** + une base `diabeo` depuis l'Espace client OVH.
+2. Récupérer les identifiants → construire le `DATABASE_URL` fourni.
+3. **Extensions** : OVH DBaaS pré-installe `pg_trgm`/`pgcrypto`/`btree_gist`. Si le
+   rôle fourni n'a pas `CREATE EXTENSION`, les activer depuis l'interface OVH (ou
+   avec un rôle admin) — mêmes 3 `CREATE EXTENSION IF NOT EXISTS` qu'en 3.A étape 3.
+
+### `DATABASE_URL` (à mettre dans l'env, §4)
+
+```
+postgresql://<user>:<pwd>@<host>:5432/diabeo?schema=public
+             └user┘ └pwd┘ └host┘ └port┘ └base┘ └ schéma ┘
+```
+
+- `user`/`pwd` : le rôle créé (`diabeo` + son mot de passe)
+- `host` : `127.0.0.1` si Postgres sur le même VPS, sinon l'adresse OVH
+- `5432` : port PostgreSQL par défaut · `diabeo` : nom de la base · `schema=public`
 
 ## 4. Variables d'environnement — `/etc/diabeo/<env>.env`
 

--- a/docs/runbook/vps-setup.md
+++ b/docs/runbook/vps-setup.md
@@ -48,7 +48,12 @@ echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] h
   | sudo tee /etc/apt/sources.list.d/pgdg.list
 sudo apt update
 sudo apt install -y postgresql-16
-# (Alternative : base managée OVH DBaaS = aucune install, cf. 3.B.)
+# (Alternative sans install APT : conteneur `postgres:16-alpine`, ou base managée
+#  OVH DBaaS = aucune install, cf. 3.B.)
+
+# 1b. Vérifier l'install
+psql --version                                   # → 16.x
+sudo systemctl status postgresql --no-pager      # → active (running), démarre au boot
 
 # 2. Créer le rôle applicatif (NON superutilisateur — moindre privilège) + la base
 sudo -u postgres psql <<'SQL'
@@ -67,6 +72,15 @@ SQL
 PGPASSWORD='<MOT_DE_PASSE_FORT>' psql -h 127.0.0.1 -U diabeo -d diabeo -c '\dx'
 #   → doit lister pg_trgm, pgcrypto, btree_gist
 ```
+
+> **Authentification (piège classique)** : l'app se connecte en **TCP** (le
+> `DATABASE_URL` porte un `host`). L'install PGDG configure par défaut
+> `host all all 127.0.0.1/32 scram-sha-256` dans `pg_hba.conf` → l'étape 4
+> fonctionne telle quelle. Si tu obtiens *« peer authentication failed »* ou
+> *« no pg_hba.conf entry »*, ajoute/active cette ligne (fichier
+> `/etc/postgresql/16/main/pg_hba.conf`) puis `sudo systemctl reload postgresql`.
+> Postgres sur le même VPS : le garder en écoute **locale** (`listen_addresses =
+> 'localhost'`, défaut) — pas d'exposition réseau.
 
 > **Pourquoi l'étape 3 en superutilisateur ?** `prisma migrate deploy` tente
 > `CREATE EXTENSION IF NOT EXISTS …`, mais créer une extension exige les droits

--- a/docs/runbook/vps-setup.md
+++ b/docs/runbook/vps-setup.md
@@ -190,3 +190,130 @@ sudo systemctl enable --now diabeo-backup.timer
 - [ ] `https://staging.diabeo.fr` répond, login OK.
 - [ ] Boot sans crash env (sinon lire le message d'`assertRequiredEnv`).
 - [ ] `docs/runbook/release-glycemie-gl.md` → smoke tests de la release en cours.
+
+---
+
+## 11. DNS — lier le domaine & créer le sous-domaine recette
+
+Un domaine pointe vers un VPS via un enregistrement DNS **de type `A`** (IPv4,
+`AAAA` pour IPv6) dans la **zone DNS** du domaine. Rappel des cibles Diabeo :
+`app.diabeo.fr` = prod, **`staging.diabeo.fr` = recette**.
+
+1. **IP publique du VPS** : `curl -4 ifconfig.me`.
+2. **Zone DNS de `diabeo.fr`** — chez OVH : *Espace client → Web Cloud → Noms de
+   domaine → `diabeo.fr` → Zone DNS*. (Si les serveurs de noms sont délégués
+   ailleurs, ex. Cloudflare, éditer la zone **là où elle est hébergée**.)
+3. **Ajouter les entrées A** (cible = IP du VPS) :
+
+   | Sous-domaine | Type | Cible | Résout |
+   |---|---|---|---|
+   | *(vide / `@`)* | A | `<IP_PROD>` | `diabeo.fr` |
+   | `app` | A | `<IP_PROD>` | `app.diabeo.fr` (prod) |
+   | **`staging`** | **A** | `<IP_RECETTE>` | **`staging.diabeo.fr` (recette)** |
+
+   → **Créer le sous-domaine recette = ajouter l'entrée A `staging`** (« Ajouter une
+   entrée » → type `A` → sous-domaine `staging` → cible = IP VPS → TTL 3600).
+4. **Propagation** (min → ~1 h selon TTL) puis vérifier :
+   `dig +short staging.diabeo.fr A` (doit renvoyer l'IP du VPS).
+
+> Recette + prod sur le **même VPS** : mettre `staging` et `app` sur la même IP ;
+> nginx distingue par `server_name`, chaque app sur un port distinct (3000/3001)
+> avec 2 services systemd. **`staging.diabeo.fr` doit résoudre AVANT certbot**
+> (validation HTTP-01).
+
+## 12. Séquence complète — VPS vierge → recette en ligne
+
+À exécuter APRÈS avoir créé l'entrée DNS `staging` (§11). Adapter les `<…>`.
+
+```bash
+# 0. Prérequis (root)
+sudo apt update && sudo apt install -y nginx postgresql-client git certbot python3-certbot-nginx
+corepack enable && corepack prepare pnpm@10 --activate      # Node 22 requis
+sudo useradd -m -s /bin/bash diabeo
+
+# 1. PostgreSQL 16 : base + extensions (ou OVH DBaaS → récupérer l'URL)
+sudo -u postgres psql -c "CREATE ROLE diabeo LOGIN PASSWORD '<PWD_DB>';"
+sudo -u postgres psql -c "CREATE DATABASE diabeo OWNER diabeo;"
+sudo -u postgres psql -d diabeo -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;
+  CREATE EXTENSION IF NOT EXISTS pgcrypto; CREATE EXTENSION IF NOT EXISTS btree_gist;"
+
+# 2. Secrets + fichier d'env (9 obligatoires + fonctionnels)
+sudo install -d -m 750 -o diabeo -g diabeo /etc/diabeo
+openssl genrsa -out /tmp/jwt.key 2048 && openssl rsa -in /tmp/jwt.key -pubout -out /tmp/jwt.pub
+sudo -u diabeo tee /etc/diabeo/recette.env >/dev/null <<EOF
+NODE_ENV=production
+APP_ENV=recette
+NEXT_PUBLIC_APP_URL=https://staging.diabeo.fr
+DATABASE_URL=postgresql://diabeo:<PWD_DB>@127.0.0.1:5432/diabeo?schema=public
+HEALTH_DATA_ENCRYPTION_KEY=$(openssl rand -hex 32)
+HMAC_SECRET=$(openssl rand -hex 32)
+CONVERSATION_KEY_PEPPER=$(openssl rand -hex 32)
+AUDIT_PEPPER=$(openssl rand -hex 32)
+CRON_SECRET=$(openssl rand -hex 32)
+REDIS_KEY_PREFIX=diabeo:recette:
+JWT_PRIVATE_KEY="$(cat /tmp/jwt.key)"
+JWT_PUBLIC_KEY="$(cat /tmp/jwt.pub)"
+UPSTASH_REDIS_REST_URL=<...>
+UPSTASH_REDIS_REST_TOKEN=<...>
+OVH_S3_ENDPOINT=https://s3.gra.io.cloud.ovh.net
+OVH_S3_REGION=gra
+OVH_S3_BUCKET=diabeo-documents-recette
+OVH_S3_ACCESS_KEY=<...>
+OVH_S3_SECRET_KEY=<...>
+EOF
+sudo chmod 600 /etc/diabeo/recette.env && shred -u /tmp/jwt.key /tmp/jwt.pub
+
+# 3. Code + build
+sudo -u diabeo git clone <URL_REPO> /opt/diabeo && cd /opt/diabeo
+sudo -u diabeo pnpm install --frozen-lockfile
+sudo -u diabeo pnpm prisma generate
+sudo -u diabeo pnpm build
+
+# 4. Base recette jetable : schéma cible + seed
+sudo -u diabeo --preserve-env env $(grep -v '^#' /etc/diabeo/recette.env | xargs) \
+  pnpm prisma migrate reset --force
+
+# 5. Service systemd
+sudo tee /etc/systemd/system/diabeo-recette.service >/dev/null <<'EOF'
+[Unit]
+Description=Diabeo Backoffice (recette)
+After=network.target
+[Service]
+Type=simple
+User=diabeo
+WorkingDirectory=/opt/diabeo
+EnvironmentFile=/etc/diabeo/recette.env
+ExecStart=/usr/bin/pnpm start
+Restart=on-failure
+RestartSec=5
+[Install]
+WantedBy=multi-user.target
+EOF
+sudo systemctl daemon-reload && sudo systemctl enable --now diabeo-recette
+
+# 6. nginx + TLS (DNS staging → VPS déjà propagé, cf. §11)
+sudo tee /etc/nginx/conf.d/diabeo-recette.conf >/dev/null <<'EOF'
+server {
+  server_name staging.diabeo.fr;
+  client_max_body_size 10m;
+  location / {
+    proxy_pass http://127.0.0.1:3000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+}
+EOF
+sudo nginx -t && sudo systemctl reload nginx
+sudo certbot --nginx -d staging.diabeo.fr
+
+# 7. Vérification
+cd /opt/diabeo && APP_ENV=recette ./deploy.sh status
+curl -I https://staging.diabeo.fr
+```
+
+**Déploiements suivants** : `cd /opt/diabeo && APP_ENV=recette ./deploy.sh update`.
+
+> ⚠️ **Ne jamais régénérer `HEALTH_DATA_ENCRYPTION_KEY` après le 1er boot** sans plan
+> de rotation : il déchiffre les données de santé existantes. **Redis Upstash** et
+> **OVH Object Storage** sont des services managés (créés dans leurs consoles).

--- a/docs/runbook/vps-setup.md
+++ b/docs/runbook/vps-setup.md
@@ -377,10 +377,16 @@ sudo -u diabeo bash -lc '
   set -a; . /etc/diabeo/recette.env; set +a
   cd /opt/diabeo
   pnpm prisma migrate reset --force        # ⚠️ efface la base recette (assumé jetable)
-  pnpm build                               # NEXT_PUBLIC_* inliné ICI → env requis au build
+  pnpm build
 '
 sudo systemctl restart diabeo-recette      # (le service a été créé en §6)
 ```
+
+> ⚠️ **`pnpm build` exige l'env COMPLET, pas seulement `NEXT_PUBLIC_*`.** À la phase
+> « Collecting page data », Next évalue les modules des routes API qui instancient
+> `PrismaClient` → `DATABASE_URL` est requis, sinon échec *« DATABASE_URL is required
+> to instantiate PrismaClient »*. **Ne jamais lancer `pnpm build` nu** : toujours dans
+> le sous-shell env-chargé ci-dessus (c'est aussi ce que fait `deploy.sh`).
 
 Vérifier : `systemctl status diabeo-recette` puis `curl -I http://127.0.0.1:3000`
 (et `curl -I https://staging.diabeo.fr` pour valider la chaîne nginx→app).

--- a/docs/runbook/vps-setup.md
+++ b/docs/runbook/vps-setup.md
@@ -73,6 +73,15 @@ PGPASSWORD='<MOT_DE_PASSE_FORT>' psql -h 127.0.0.1 -U diabeo -d diabeo -c '\dx'
 #   → doit lister pg_trgm, pgcrypto, btree_gist
 ```
 
+> **Mot de passe du rôle (`<MOT_DE_PASSE_FORT>`)** : c'est un secret **machine**
+> (jamais tapé à la main) → **long et aléatoire**, jamais « humain ». Comme il entre
+> dans le `DATABASE_URL`, utiliser un charset **URL-safe** : générer en **hexadécimal**
+> (`openssl rand -hex 24` = 48 car., que des `0-9a-f`) évite d'avoir à URL-encoder des
+> caractères spéciaux (`@ : / + = …`). Coller **la même valeur** dans `CREATE ROLE …
+> PASSWORD` et dans le `DATABASE_URL`. Un mot de passe **différent par environnement**
+> (recette ≠ prod). Ne PAS utiliser `openssl rand -base64` ici (`+ / =` → à encoder).
+> *(OVH DBaaS génère ce mot de passe + le `DATABASE_URL` pour toi.)*
+
 > **Authentification (piège classique)** : l'app se connecte en **TCP** (le
 > `DATABASE_URL` porte un `host`). L'install PGDG configure par défaut
 > `host all all 127.0.0.1/32 scram-sha-256` dans `pg_hba.conf` → l'étape 4

--- a/docs/runbook/vps-setup.md
+++ b/docs/runbook/vps-setup.md
@@ -592,3 +592,76 @@ curl -I https://staging.diabeo.fr
 > ⚠️ **Ne jamais régénérer `HEALTH_DATA_ENCRYPTION_KEY` après le 1er boot** sans plan
 > de rotation : il déchiffre les données de santé existantes. **Redis Upstash** et
 > **OVH Object Storage** sont des services managés (créés dans leurs consoles).
+
+## 13. Préparation PROD — différences avec la recette & pièges à éviter
+
+Les §1-12 valent pour **recette ET prod** ; seule change la valeur des `<…>`
+(`recette`→`prod`, `staging.diabeo.fr`→`app.diabeo.fr`). Mais la **prod ne se
+reset pas** : quelques étapes divergent, et tous les pièges rencontrés en recette
+sont ici en checklist pour ne pas les revivre.
+
+### 13.1 Différences recette → prod
+
+| Aspect | Recette | **Prod** |
+|---|---|---|
+| Domaine / `APP_ENV` | `staging.diabeo.fr` / `recette` | `app.diabeo.fr` / `prod` |
+| Fichier d'env | `/etc/diabeo/recette.env` | `/etc/diabeo/prod.env` (secrets **distincts**) |
+| `REDIS_KEY_PREFIX` | `diabeo:recette:` | `diabeo:prod:` |
+| Service systemd | `diabeo-recette` | `diabeo-prod` (unité, conf nginx, cert dédiés) |
+| Base de données | jetable → `migrate reset` + seed | **`migrate deploy`** (jamais reset) sur **données réelles** |
+| **Seed** | 5 users dev `DEV-ONLY-…` | **JAMAIS** (le garde `NODE_ENV=production` le bloque — c'est voulu) |
+| Migration destructive | reset (données perdues, OK) | **backup + pré-vol** AVANT (cf. `release-*.md`, `migrations.md §7`) |
+| DB / bucket S3 / clés | `-recette` | `-prod` séparés (aucun partage de secret) |
+
+### 13.2 Étapes prod (delta vs §7.c)
+
+En prod on **n'exécute jamais** `migrate reset` ni le seed. À la place :
+
+```bash
+# 1. Backup vérifié restorable AVANT toute migration (surtout si destructive)
+cd /opt/diabeo && APP_ENV=prod ./deploy.sh backup
+
+# 2. Pré-vol si la release porte une migration à CHECK/DROP sur données existantes
+#    (cf. le runbook de la release, ex. docs/runbook/release-glycemie-gl.md)
+sudo -u diabeo bash -lc 'set -a; . /etc/diabeo/prod.env; set +a;
+  psql "$DATABASE_URL" -f ops/preflight/<release>.sql'   # lignes « *_bloquant » = 0
+
+# 3. Migrations versionnées (idempotent, PAS de reset, PAS de db push) + build, env chargé
+sudo -u diabeo bash -lc '
+  set -a; . /etc/diabeo/prod.env; set +a
+  cd /opt/diabeo
+  pnpm prisma migrate deploy          # applique les migrations pending
+  pnpm prisma migrate status          # vérifie : aucune pending
+  pnpm build
+'
+sudo systemctl restart diabeo-prod
+```
+
+Ensuite les déploiements suivants passent par `APP_ENV=prod ./deploy.sh update`
+(qui fait exactement pull + install + generate + **migrate deploy** + build +
+restart, env sourcé — cf. §8).
+
+### 13.3 Checklist anti-pièges (tous rencontrés en recette)
+
+- [ ] **Node 22 installé** (NodeSource) — `corepack` en dépend, absent d'un VPS vierge (§2).
+- [ ] **Postgres** : rôle non-superuser + 3 extensions **pré-créées** en `postgres`
+      + **`GRANT SET ON PARAMETER session_replication_role TO diabeo`** (§3 étape 3b),
+      sinon `migrate deploy` échoue en `42501` (backfill audit) et la rétention CRON casse.
+- [ ] **9 variables obligatoires** présentes et valides (§4). Secrets **distincts** de la recette.
+- [ ] **Clés JWT en single-line `\n`-échappé** (§4) — les PEM multi-lignes sont tolérées
+      car le service source l'env via **bash** (pas `EnvironmentFile`, cf. §6).
+- [ ] **Service systemd = `ExecStart` qui source l'env via bash** (§6), JAMAIS `EnvironmentFile=`
+      (parseur qui drope les variables après une valeur multi-ligne → `… is missing` au boot).
+- [ ] **Dépôt privé** : Deploy Key lecture seule + `install -d -o diabeo /opt/diabeo` avant clone (§7.a/b).
+- [ ] **`pnpm build` toujours env-chargé** (DATABASE_URL requis à « Collecting page data ») (§7.c).
+- [ ] **nginx** : `rm -f /etc/nginx/sites-enabled/default` AVANT certbot, sinon le vhost
+      par défaut capte le cert (§5).
+- [ ] **Base prod** : `migrate deploy` (jamais `reset`, jamais `db push` — ADR #17), **aucun seed**.
+- [ ] **`HEALTH_DATA_ENCRYPTION_KEY` figée** après le 1er boot (déchiffre toute la PHI ;
+      rotation = plan dédié, cf. `docs/operations/runbook.md` §Secrets).
+- [ ] **Backup restorable + pré-vol** avant toute migration destructive (§13.2, `migrations.md §7`).
+
+> **Durcissement HDS optionnel (prod)** : faire posséder `audit_logs` + son trigger
+> d'immutabilité par un rôle **distinct** de `diabeo`, et ne donner à l'app que
+> `INSERT`/`SELECT` (pas de `DISABLE TRIGGER` possible) — immutabilité opposable même
+> au rôle applicatif. Cf. note §3 étape 3b.

--- a/docs/runbook/vps-setup.md
+++ b/docs/runbook/vps-setup.md
@@ -188,6 +188,15 @@ rm ~/recette.env
 transmet à l'app locale `127.0.0.1:3000`. `client_max_body_size 10m` relève la
 limite d'upload (défaut 1 Mo → 413) requise par le sync MyDiabby.
 
+**⚠️ Retirer d'abord le site par défaut.** Sur Debian/Ubuntu, l'install nginx
+pose `/etc/nginx/sites-enabled/default` — un `server` **`default_server`** sur le
+port 80 qui sert des fichiers statiques (`root /var/www/html`). S'il reste, il
+**capte** `certbot` (le certificat s'attache au mauvais bloc) et sert la page
+« Welcome to nginx » au lieu de proxifier vers l'app → symptôme classique.
+```bash
+sudo rm -f /etc/nginx/sites-enabled/default   # désactive le vhost par défaut
+```
+
 **a. Config nginx** (créer le fichier, tester, recharger) :
 ```bash
 sudo tee /etc/nginx/conf.d/diabeo-recette.conf >/dev/null <<'EOF'
@@ -212,9 +221,23 @@ sudo nginx -t && sudo systemctl reload nginx
 sudo apt install -y certbot python3-certbot-nginx
 sudo certbot --nginx -d staging.diabeo.fr
 ```
-`certbot` modifie automatiquement la config (ajout du 443 + redirection 80→443) et
-programme le renouvellement. **Prérequis** : le DNS `staging.diabeo.fr` doit déjà
-pointer vers le VPS (§11) et nginx doit tourner avec ce `server_name`.
+`certbot` modifie automatiquement `diabeo-recette.conf` (ajout du bloc `443 ssl` +
+redirection `80→443`) et programme le renouvellement. **Prérequis** : le DNS
+`staging.diabeo.fr` doit déjà pointer vers le VPS (§11) et nginx doit tourner avec
+ce `server_name`.
+
+**c. Vérifier + dépanner :**
+```bash
+sudo nginx -t                         # syntaxe OK
+sudo certbot renew --dry-run          # renouvellement fonctionnel
+# Le cert doit être attaché à diabeo-recette.conf, PAS au site default :
+grep -rl 'ssl_certificate' /etc/nginx/conf.d/ /etc/nginx/sites-enabled/ 2>/dev/null
+```
+- Un **502 Bad Gateway** en HTTPS = nginx OK mais l'app ne tourne pas encore sur
+  `:3000` (normal tant que le service systemd n'est pas démarré — cf. §6/§7).
+- **« Welcome to nginx » / page statique** = le site `default` a capté certbot :
+  `sudo rm -f /etc/nginx/sites-enabled/default`, puis relancer
+  `sudo certbot --nginx -d staging.diabeo.fr` et `sudo systemctl reload nginx`.
 
 ## 6. Service systemd
 

--- a/docs/runbook/vps-setup.md
+++ b/docs/runbook/vps-setup.md
@@ -73,6 +73,13 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto;
 CREATE EXTENSION IF NOT EXISTS btree_gist;
 SQL
 
+# 3b. Déléguer à diabeo le droit de poser `session_replication_role` (voir note).
+#     REQUIS : une migration (backfill audit_logs) ET la fonction de rétention
+#     SECURITY DEFINER (owned by diabeo) l'utilisent pour franchir le trigger
+#     d'immutabilité. Sans ce GRANT → migrate échoue (P3018, code 42501).
+sudo -u postgres psql -d diabeo -c \
+  "GRANT SET ON PARAMETER session_replication_role TO diabeo;"
+
 # 4. Vérifier la connexion avec le rôle applicatif
 PGPASSWORD='<MOT_DE_PASSE_FORT>' psql -h 127.0.0.1 -U diabeo -d diabeo -c '\dx'
 #   → doit lister pg_trgm, pgcrypto, btree_gist
@@ -101,6 +108,19 @@ PGPASSWORD='<MOT_DE_PASSE_FORT>' psql -h 127.0.0.1 -U diabeo -d diabeo -c '\dx'
 > **superuser** — que le rôle `diabeo` n'a volontairement pas. En les créant
 > d'abord en `postgres`, la migration les trouve déjà présentes et passe sans erreur.
 
+> **Pourquoi l'étape 3b (`GRANT SET ON PARAMETER`) ?** La migration
+> `20260508150000_audit_metadata_patientid_gin` backfille `audit_logs` en
+> franchissant le trigger d'immutabilité via `SET session_replication_role =
+> 'replica'` (superuser-only). La fonction de rétention `audit_log_apply_retention`
+> (`SECURITY DEFINER`, owned by `diabeo`) fait de même **à runtime** (purge CRON).
+> Sans ce grant → `migrate` échoue (`P3018`, `ERROR 42501 permission denied to set
+> parameter`), et la rétention casserait aussi. PostgreSQL **15+** permet cette
+> délégation fine sans faire de `diabeo` un superuser.
+> **Durcissement prod (optionnel)** : pour une immutabilité opposable même au rôle
+> applicatif, faire posséder `audit_logs` (+ trigger) par un rôle **distinct** et
+> ne donner à `diabeo` que `INSERT`/`SELECT` (pas de `DISABLE TRIGGER` possible).
+> Dans ce modèle mono-rôle (diabeo owner), le grant n'affaiblit rien de plus.
+
 ### 3.B — Base managée OVH (DBaaS)
 
 1. Créer une instance **PostgreSQL 16** + une base `diabeo` depuis l'Espace client OVH.
@@ -108,6 +128,11 @@ PGPASSWORD='<MOT_DE_PASSE_FORT>' psql -h 127.0.0.1 -U diabeo -d diabeo -c '\dx'
 3. **Extensions** : OVH DBaaS pré-installe `pg_trgm`/`pgcrypto`/`btree_gist`. Si le
    rôle fourni n'a pas `CREATE EXTENSION`, les activer depuis l'interface OVH (ou
    avec un rôle admin) — mêmes 3 `CREATE EXTENSION IF NOT EXISTS` qu'en 3.A étape 3.
+4. **`session_replication_role`** (cf. 3.A étape 3b) : ⚠️ sur une base **managée**,
+   ce paramètre est souvent **non délégable** (`GRANT SET ON PARAMETER` refusé) voire
+   bloqué. Si `migrate` échoue en `42501`, exécuter le `GRANT` avec le rôle admin
+   OVH ; si impossible, la migration de backfill audit et la rétention CRON ne
+   passeront pas → ouvrir un ticket OVH ou héberger Postgres sur le VPS (3.A).
 
 ### `DATABASE_URL` (à mettre dans l'env, §4)
 
@@ -452,6 +477,8 @@ sudo -u postgres psql -c "CREATE ROLE diabeo LOGIN PASSWORD '<PWD_DB>';"
 sudo -u postgres psql -c "CREATE DATABASE diabeo OWNER diabeo;"
 sudo -u postgres psql -d diabeo -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;
   CREATE EXTENSION IF NOT EXISTS pgcrypto; CREATE EXTENSION IF NOT EXISTS btree_gist;"
+# Droit de poser session_replication_role (backfill audit + rétention) — cf. §3 étape 3b
+sudo -u postgres psql -d diabeo -c "GRANT SET ON PARAMETER session_replication_role TO diabeo;"
 
 # 2. Secrets + fichier d'env (9 obligatoires + fonctionnels)
 sudo install -d -m 750 -o diabeo -g diabeo /etc/diabeo

--- a/docs/runbook/vps-setup.md
+++ b/docs/runbook/vps-setup.md
@@ -241,8 +241,20 @@ grep -rl 'ssl_certificate' /etc/nginx/conf.d/ /etc/nginx/sites-enabled/ 2>/dev/n
 
 ## 6. Service systemd
 
-```ini
-# /etc/systemd/system/diabeo-recette.service
+Fait tourner l'app en tâche de fond : démarrage auto au boot, redémarrage si crash.
+
+**⚠️ Ordre** : `ExecStart=pnpm start` (= `next start`) exige un **build** préalable
+(`.next/`, produit en §7). Active le service **après** le premier `pnpm build`,
+sinon il tourne en **crash-loop** jusqu'à ce que le build existe (comportement
+attendu, pas une erreur de config).
+
+**⚠️ Chemin de `pnpm`** — adapte `ExecStart` au chemin réel : `command -v pnpm`
+(sous l'utilisateur `diabeo`). Avec corepack c'est souvent `/usr/local/bin/pnpm`
+ou un shim `~/.local/...` ; un chemin faux → échec `status=203/EXEC`.
+
+**a. Créer l'unité** :
+```bash
+sudo tee /etc/systemd/system/diabeo-recette.service >/dev/null <<'EOF'
 [Unit]
 Description=Diabeo Backoffice (recette)
 After=network.target
@@ -258,11 +270,24 @@ RestartSec=5
 
 [Install]
 WantedBy=multi-user.target
+EOF
 ```
 
+`EnvironmentFile` charge les **9 variables obligatoires** (§4) : sans elles, l'app
+crashe au boot (`assertRequiredEnv`, ADR #20).
+
+**b. Activer (démarrage auto + lancement immédiat)** :
 ```bash
 sudo systemctl daemon-reload && sudo systemctl enable --now diabeo-recette
 ```
+
+**c. Vérifier** :
+```bash
+systemctl status diabeo-recette                  # active (running) ?
+journalctl -u diabeo-recette -n 50 --no-pager    # logs (diagnostic si crash)
+curl -I http://127.0.0.1:3000                     # 200/redirect = app up
+```
+Après modif de l'unité : `sudo systemctl daemon-reload && sudo systemctl restart diabeo-recette`.
 
 ## 7. Premier déploiement
 

--- a/docs/runbook/vps-setup.md
+++ b/docs/runbook/vps-setup.md
@@ -184,8 +184,13 @@ rm ~/recette.env
 
 ## 5. Reverse proxy nginx (TLS + cap corps ≥ 10 Mo)
 
-```nginx
-# /etc/nginx/conf.d/diabeo.conf
+**Rôle** : nginx écoute sur les ports publics 80/443, gère le **HTTPS**, et
+transmet à l'app locale `127.0.0.1:3000`. `client_max_body_size 10m` relève la
+limite d'upload (défaut 1 Mo → 413) requise par le sync MyDiabby.
+
+**a. Config nginx** (créer le fichier, tester, recharger) :
+```bash
+sudo tee /etc/nginx/conf.d/diabeo-recette.conf >/dev/null <<'EOF'
 server {
   server_name staging.diabeo.fr;
   client_max_body_size 10m;     # OBLIGATOIRE (sync MyDiabby) — cf. infra-body-limits.md
@@ -197,9 +202,19 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
   }
-  # + TLS (certbot / OVH). Écouter en 443, rediriger 80→443.
 }
+EOF
+sudo nginx -t && sudo systemctl reload nginx
 ```
+
+**b. TLS via certbot** (installe certbot + son plugin nginx, puis émet le certificat) :
+```bash
+sudo apt install -y certbot python3-certbot-nginx
+sudo certbot --nginx -d staging.diabeo.fr
+```
+`certbot` modifie automatiquement la config (ajout du 443 + redirection 80→443) et
+programme le renouvellement. **Prérequis** : le DNS `staging.diabeo.fr` doit déjà
+pointer vers le VPS (§11) et nginx doit tourner avec ce `server_name`.
 
 ## 6. Service systemd
 

--- a/docs/runbook/vps-setup.md
+++ b/docs/runbook/vps-setup.md
@@ -38,7 +38,17 @@ que Postgres tourne **sur le VPS** ou est une **base managée OVH (DBaaS)**.
 
 ```bash
 # 1. Installer PostgreSQL 16
+#    ⚠️ postgresql-16 n'est PAS dans les dépôts APT par défaut (Ubuntu 22.04 → PG 14,
+#    Debian 12 → PG 15). Ajouter d'abord le dépôt officiel PostgreSQL (PGDG) :
+sudo apt update && sudo apt install -y curl ca-certificates gnupg lsb-release
+sudo install -d /usr/share/postgresql-common/pgdg
+sudo curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+  -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+  | sudo tee /etc/apt/sources.list.d/pgdg.list
+sudo apt update
 sudo apt install -y postgresql-16
+# (Alternative : base managée OVH DBaaS = aucune install, cf. 3.B.)
 
 # 2. Créer le rôle applicatif (NON superutilisateur — moindre privilège) + la base
 sudo -u postgres psql <<'SQL'

--- a/docs/runbook/vps-setup.md
+++ b/docs/runbook/vps-setup.md
@@ -243,12 +243,40 @@ sudo systemctl daemon-reload && sudo systemctl enable --now diabeo-recette
 
 ## 7. Premier déploiement
 
+### 7.a Accès au dépôt privé — clé de déploiement (Deploy Key)
+
+Le dépôt est **privé** : le VPS a besoin d'un accès **lecture seule**. Méthode
+propre (réutilisée par `deploy.sh` et le CD) = une **Deploy Key SSH** dédiée.
+
 ```bash
-sudo -u diabeo git clone <repo> /opt/diabeo && cd /opt/diabeo
+# 1. Générer une clé dédiée (utilisateur diabeo)
+sudo -u diabeo ssh-keygen -t ed25519 -f /home/diabeo/.ssh/diabeo_deploy -N "" -C "diabeo-vps-recette"
+sudo -u diabeo cat /home/diabeo/.ssh/diabeo_deploy.pub   # ← copier cette clé PUBLIQUE
+
+# 2. GitHub → repo → Settings → Deploy keys → Add deploy key :
+#    Title=vps-recette, Key=<clé publique>, Allow write access = NON (lecture seule)
+
+# 3. Router github.com vers cette clé
+sudo -u diabeo tee -a /home/diabeo/.ssh/config >/dev/null <<'EOF'
+Host github.com
+  IdentityFile ~/.ssh/diabeo_deploy
+  IdentitiesOnly yes
+EOF
+```
+
+### 7.b Clone + build + base
+
+```bash
+# Node 22 + pnpm dispo pour l'utilisateur diabeo ?
+sudo -u diabeo bash -lc 'node -v && pnpm -v'   # sinon: corepack enable && corepack prepare pnpm@10 --activate
+
+sudo -u diabeo git clone git@github.com:freecompub/Diabeo-BackOffice.git /opt/diabeo
+cd /opt/diabeo
 sudo -u diabeo pnpm install --frozen-lockfile
 sudo -u diabeo pnpm prisma generate
 # DB : recette jetable → reset+seed ; sinon migrate deploy (+ pré-vol si données)
-sudo -u diabeo --preserve-env pnpm prisma migrate deploy   # ou migrate reset --force
+sudo -u diabeo --preserve-env env $(grep -v '^#' /etc/diabeo/recette.env | xargs) \
+  pnpm prisma migrate reset --force            # ou `migrate deploy` en prod
 sudo -u diabeo pnpm build
 sudo systemctl restart diabeo-recette
 ```

--- a/docs/runbook/vps-setup.md
+++ b/docs/runbook/vps-setup.md
@@ -3,6 +3,12 @@
 > Guide de mise en place d'un environnement (recette ou prod) sur VPS OVHcloud.
 > Fidèle au dépôt : la liste d'env fait autorité = `src/lib/env.ts`. Déploiement
 > **manuel** via `deploy.sh` (fourni à la racine). Migrations : `docs/runbook/migrations.md`.
+>
+> **Autorité & périmètre** : ce runbook couvre le **provisioning + le déploiement**
+> (systemd, migrations versionnées). Pour l'**exploitation day-2** — rotation des
+> secrets, drills de restauration chiffrés (`age`/`.pgpass`), monitoring `/api/health`,
+> forwarding de logs HDS — voir **[`docs/operations/runbook.md`](../operations/runbook.md)**.
+> Prod : lire d'abord le **§13 (préparation PROD)** ci-dessous.
 
 ## 1. Architecture cible
 
@@ -444,6 +450,12 @@ WantedBy=timers.target
 ```bash
 sudo systemctl enable --now diabeo-backup.timer
 ```
+
+> Ce timer déclenche `deploy.sh backup` (pg_dump gzip → Object Storage) — suffisant
+> en recette. **En prod**, la procédure HDS complète (utilisateur dédié `diabeo-backup`,
+> `.pgpass` 0600, chiffrement client `age`, Object Lock, lifecycle Glacier, **drill de
+> restauration trimestriel** + `decrypt-smoke`) est décrite dans
+> **[`docs/operations/runbook.md`](../operations/runbook.md)** §Backups / §Manual setup.
 
 ## 10. Vérification finale
 

--- a/docs/runbook/vps-setup.md
+++ b/docs/runbook/vps-setup.md
@@ -312,22 +312,41 @@ Host github.com
 EOF
 ```
 
-### 7.b Clone + build + base
+### 7.b Clone + install
 
 ```bash
 # Node 22 + pnpm dispo pour l'utilisateur diabeo ?
 sudo -u diabeo bash -lc 'node -v && pnpm -v'   # sinon: corepack enable && corepack prepare pnpm@10 --activate
 
+# /opt est root:root → créer le dossier POSSÉDÉ par diabeo avant le clone,
+# sinon `sudo -u diabeo git clone … /opt/diabeo` échoue en « Permission denied ».
+sudo install -d -o diabeo -g diabeo /opt/diabeo
 sudo -u diabeo git clone git@github.com:freecompub/Diabeo-BackOffice.git /opt/diabeo
-cd /opt/diabeo
-sudo -u diabeo pnpm install --frozen-lockfile
-sudo -u diabeo pnpm prisma generate
-# DB : recette jetable → reset+seed ; sinon migrate deploy (+ pré-vol si données)
-sudo -u diabeo --preserve-env env $(grep -v '^#' /etc/diabeo/recette.env | xargs) \
-  pnpm prisma migrate reset --force            # ou `migrate deploy` en prod
-sudo -u diabeo pnpm build
-sudo systemctl restart diabeo-recette
+
+sudo -u diabeo bash -lc 'cd /opt/diabeo && pnpm install --frozen-lockfile && pnpm prisma generate'
 ```
+
+### 7.c Base de données + build + démarrage
+
+⚠️ **Charger l'env via `set -a; . fichier; set +a`** (comme `deploy.sh`), **jamais**
+`env $(grep … | xargs)` : les valeurs multi-lignes (`JWT_*` PEM) et à caractères
+spéciaux (`/`, `+`, `=` des secrets) seraient corrompues. Le fichier étant
+`chmod 600` possédé par `diabeo` (§4), on le source **en tant que `diabeo`**.
+
+```bash
+# DB : recette jetable → reset (drop+recreate+migrations+seed).
+#      En prod / base à préserver → `migrate deploy` (+ pré-vol, cf. release-glycemie-gl.md).
+sudo -u diabeo bash -lc '
+  set -a; . /etc/diabeo/recette.env; set +a
+  cd /opt/diabeo
+  pnpm prisma migrate reset --force        # ⚠️ efface la base recette (assumé jetable)
+  pnpm build                               # NEXT_PUBLIC_* inliné ICI → env requis au build
+'
+sudo systemctl restart diabeo-recette      # (le service a été créé en §6)
+```
+
+Vérifier : `systemctl status diabeo-recette` puis `curl -I http://127.0.0.1:3000`
+(et `curl -I https://staging.diabeo.fr` pour valider la chaîne nginx→app).
 
 Checklist 1er deploy prod (backup restorable, rollback testé, smoke tests) :
 `docs/runbook/migrations.md §7.3`.

--- a/docs/runbook/vps-setup.md
+++ b/docs/runbook/vps-setup.md
@@ -164,10 +164,11 @@ si une variable OBLIGATOIRE manque/est malformée — message clair pointant la 
 | `JWT_PRIVATE_KEY` | PEM RSA privée | `openssl genrsa 2048` |
 | `JWT_PUBLIC_KEY` | PEM RSA publique | `openssl rsa -pubout` |
 
-> **Clés PEM sur UNE ligne, `\n` échappés** (format canonique attendu — `jwt.ts`
-> fait `pem.replace(/\\n/g, "\n")`). C'est le **seul** format fiable pour systemd
-> `EnvironmentFile`, qui ne parse pas les valeurs multi-lignes réelles → une clé
-> collée telle quelle (avec de vrais retours) casse le boot du service.
+> **Clés PEM recommandées sur UNE ligne, `\n` échappés** (format canonique —
+> `jwt.ts` fait `pem.replace(/\\n/g, "\n")`). Le service source l'env **via bash**
+> (§6), donc des PEM multi-lignes réelles fonctionnent **aussi** ; mais le single-line
+> est plus robuste (aucun outil ne bute dessus) et **obligatoire** si tu utilisais
+> `EnvironmentFile=` (parseur systemd qui ne gère pas le multi-ligne — cf. §6).
 > Générer la paire puis la convertir en single-line :
 > ```bash
 > openssl genrsa -out jwt.key 2048 && openssl rsa -in jwt.key -pubout -out jwt.pub
@@ -285,9 +286,13 @@ Fait tourner l'app en tâche de fond : démarrage auto au boot, redémarrage si 
 sinon il tourne en **crash-loop** jusqu'à ce que le build existe (comportement
 attendu, pas une erreur de config).
 
-**⚠️ Chemin de `pnpm`** — adapte `ExecStart` au chemin réel : `command -v pnpm`
-(sous l'utilisateur `diabeo`). Avec corepack c'est souvent `/usr/local/bin/pnpm`
-ou un shim `~/.local/...` ; un chemin faux → échec `status=203/EXEC`.
+**⚠️ NE PAS utiliser `EnvironmentFile=`** pour charger `/etc/diabeo/*.env`. Le
+parseur `EnvironmentFile` de systemd **ne gère pas les valeurs multi-lignes**
+(les clés `JWT_*` PEM) : il perd le fil et **drope silencieusement une variable
+suivante** (symptôme observé : `REDIS_KEY_PREFIX is missing` au boot alors que
+`bash` la lit très bien). On fait donc **sourcer le fichier par bash dans
+`ExecStart`** — le **même** chargeur que le build et `deploy.sh` (`set -a; . ;
+set +a`), un seul mécanisme d'env partout, tolérant à tous les formats.
 
 **a. Créer l'unité** :
 ```bash
@@ -300,8 +305,10 @@ After=network.target
 Type=simple
 User=diabeo
 WorkingDirectory=/opt/diabeo
-EnvironmentFile=/etc/diabeo/recette.env
-ExecStart=/usr/bin/pnpm start
+# Source l'env via bash (gère les PEM multi-lignes) puis exec l'app. `exec` fait
+# de next-server le process principal → signaux/arrêt propres. Chemin pnpm : adapte
+# si `command -v pnpm` (sous diabeo) diffère.
+ExecStart=/bin/bash -lc 'set -a; . /etc/diabeo/recette.env; set +a; exec pnpm start'
 Restart=on-failure
 RestartSec=5
 
@@ -310,7 +317,7 @@ WantedBy=multi-user.target
 EOF
 ```
 
-`EnvironmentFile` charge les **9 variables obligatoires** (§4) : sans elles, l'app
+Le fichier d'env fournit les **9 variables obligatoires** (§4) : sans elles, l'app
 crashe au boot (`assertRequiredEnv`, ADR #20).
 
 **b. Activer (démarrage auto + lancement immédiat)** :
@@ -537,8 +544,8 @@ After=network.target
 Type=simple
 User=diabeo
 WorkingDirectory=/opt/diabeo
-EnvironmentFile=/etc/diabeo/recette.env
-ExecStart=/usr/bin/pnpm start
+# bash source l'env (PEM multi-lignes OK) — PAS EnvironmentFile (parseur divergent). Cf. §6.
+ExecStart=/bin/bash -lc 'set -a; . /etc/diabeo/recette.env; set +a; exec pnpm start'
 Restart=on-failure
 RestartSec=5
 [Install]

--- a/docs/runbook/vps-setup.md
+++ b/docs/runbook/vps-setup.md
@@ -378,16 +378,25 @@ spéciaux (`/`, `+`, `=` des secrets) seraient corrompues. Le fichier étant
 `chmod 600` possédé par `diabeo` (§4), on le source **en tant que `diabeo`**.
 
 ```bash
-# DB : recette jetable → reset (drop+recreate+migrations+seed).
+# DB : recette jetable → reset (migrations) + seed (5 users dev, 2 patients, 30j CGM).
 #      En prod / base à préserver → `migrate deploy` (+ pré-vol, cf. release-glycemie-gl.md).
 sudo -u diabeo bash -lc '
   set -a; . /etc/diabeo/recette.env; set +a
   cd /opt/diabeo
-  pnpm prisma migrate reset --force        # ⚠️ efface la base recette (assumé jetable)
+  pnpm prisma migrate reset --force --skip-seed   # ⚠️ efface la base (jetable) — migrations seules
+  unset NODE_ENV                                   # le seed REFUSE NODE_ENV=production (garde anti-prod)
+  pnpm prisma db seed                              # 5 users dev + 2 patients + 30j CGM
   pnpm build
 '
 sudo systemctl restart diabeo-recette      # (le service a été créé en §6)
 ```
+
+> ⚠️ **Le seed refuse `NODE_ENV=production`** (garde-fou `seed.ts` : il crée des
+> comptes à mots de passe connus `DEV-ONLY-…`). Comme l'env recette porte
+> `NODE_ENV=production`, un `migrate reset` **sans** `--skip-seed` échouerait sur
+> l'étape seed (table `users` vide → « Identifiants invalides » au login). D'où :
+> `reset --skip-seed`, puis `unset NODE_ENV` **pour la seule commande de seed**
+> (le service, lui, garde `NODE_ENV=production`). **On ne seed JAMAIS une vraie prod.**
 
 > ⚠️ **`pnpm build` exige l'env COMPLET, pas seulement `NEXT_PUBLIC_*`.** À la phase
 > « Collecting page data », Next évalue les modules des routes API qui instancient
@@ -525,13 +534,15 @@ sudo install -d -o diabeo -g diabeo /opt/diabeo
 sudo -u diabeo git clone git@github.com:freecompub/Diabeo-BackOffice.git /opt/diabeo
 sudo -u diabeo bash -lc 'cd /opt/diabeo && pnpm install --frozen-lockfile && pnpm prisma generate'
 
-# 4. Base recette jetable (schéma cible + seed) puis build — env chargé via
-#    `set -a; . ; set +a` (jamais `env $(grep|xargs)` : casse les PEM JWT_*).
-#    Ordre migrate→build ; build env-chargé (NEXT_PUBLIC_* inliné au build).
+# 4. Base recette jetable + seed + build — env chargé via `set -a; . ; set +a`
+#    (jamais `env $(grep|xargs)` : casse les PEM JWT_*). Le seed refuse
+#    NODE_ENV=production → reset --skip-seed puis `unset NODE_ENV` + `db seed`.
 sudo -u diabeo bash -lc '
   set -a; . /etc/diabeo/recette.env; set +a
   cd /opt/diabeo
-  pnpm prisma migrate reset --force
+  pnpm prisma migrate reset --force --skip-seed
+  unset NODE_ENV
+  pnpm prisma db seed
   pnpm build
 '
 


### PR DESCRIPTION
Complète `docs/runbook/vps-setup.md` avec deux sections demandées :

- **§11 DNS** — lier `diabeo.fr` / `app` / `staging` au VPS via entrées `A` ; **créer le sous-domaine recette** = ajouter l'entrée A `staging` (→ `staging.diabeo.fr`) ; vérif `dig` ; rappel « le DNS doit résoudre avant certbot (HTTP-01) ».
- **§12 Bring-up de zéro** — séquence complète **copiable** VPS vierge → recette en ligne : prérequis, PostgreSQL 16 + extensions, génération des 9 secrets + fichier d'env, build, `migrate reset --force` (+ seed), service systemd, nginx + `certbot` TLS, vérification.

Doc uniquement, fidèle au dépôt (env = `src/lib/env.ts`, nginx = `infra-body-limits.md`, migrations = `migrations.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjfGsaWAwSb1RNFYkRfKt9