### PR TITLE
ci(cd) — déploiement continu recette (runner self-hosted, auto sur merge main)

### DIFF
--- a/.github/workflows/deploy-recette.yml
+++ b/.github/workflows/deploy-recette.yml
@@ -1,0 +1,60 @@
+name: Deploy recette
+
+# Déploiement AUTOMATIQUE de la recette à chaque merge sur `main`, UNIQUEMENT si
+# la CI (workflow « CI ») est verte. Exécuté sur un runner self-hosted installé
+# SUR le VPS recette (pas de clé SSH exposée). Voir docs/runbook/cd-recette.md.
+#
+# Prérequis (une seule fois) :
+#   - runner GitHub self-hosted enregistré sur le VPS avec le label `recette`,
+#     tournant sous l'utilisateur `diabeo` ;
+#   - /opt/diabeo déjà bootstrappé (clone + env + service systemd) — cf.
+#     docs/runbook/vps-setup.md ;
+#   - sudoers NOPASSWD pour `systemctl restart diabeo-recette` (le runner en a besoin) ;
+#   - Environment GitHub `recette` créé (Settings → Environments) — protections optionnelles.
+
+on:
+  # Se déclenche à la FIN du workflow CI (donc après les tests) sur main.
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  # Ré-déclenchement manuel depuis l'onglet Actions (ex. après un incident).
+  workflow_dispatch: {}
+
+# Un seul déploiement à la fois ; on n'interrompt pas un deploy en cours.
+concurrency:
+  group: deploy-recette
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    # Auto : seulement si la CI a réussi. Manuel (workflow_dispatch) : toujours.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    runs-on: [self-hosted, recette]
+    environment: recette
+    timeout-minutes: 20
+    steps:
+      - name: Déploiement recette (deploy.sh update sur le VPS)
+        # Le runner tourne sur le VPS : on invoque le deploy.sh DÉJÀ déployé dans
+        # /opt/diabeo, qui fait pull(main) + install + generate + migrate deploy +
+        # build + restart du service. Idempotent ; la recette est re-seedable.
+        run: |
+          set -euo pipefail
+          test -x /opt/diabeo/deploy.sh || { echo "::error::/opt/diabeo/deploy.sh introuvable — bootstrap VPS requis (docs/runbook/vps-setup.md)"; exit 1; }
+          cd /opt/diabeo
+          APP_ENV=recette ./deploy.sh update
+
+      - name: Récapitulatif
+        if: always()
+        run: |
+          {
+            echo "### Déploiement recette"
+            echo "- Statut : ${{ job.status }}"
+            echo "- Déclencheur : ${{ github.event_name }}"
+            echo "- Commit : \`${{ github.sha }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/runbook/cd-recette.md
+++ b/docs/runbook/cd-recette.md
@@ -1,0 +1,95 @@
+# Runbook — Déploiement continu (CD) recette via GitHub Actions
+
+> Déploie **automatiquement la recette** à chaque merge sur `main`, si la CI est
+> verte. Exécution sur un **runner self-hosted** installé sur le VPS recette
+> (aucune clé SSH exposée). Workflow : `.github/workflows/deploy-recette.yml`.
+
+## 1. Comment ça marche
+
+```
+merge sur main  →  workflow "CI" (tests)  ──verte──▶  workflow "Deploy recette"
+                                                        └─ runner self-hosted (VPS)
+                                                           └─ /opt/diabeo/deploy.sh update
+                                                              (pull + migrate deploy + build + restart)
+```
+
+- Déclencheur : `workflow_run` sur la **fin** du workflow `CI` (branche `main`) —
+  le deploy ne part **que si `conclusion == success`** (CI verte). Plus un
+  `workflow_dispatch` (ré-exécution manuelle depuis l'onglet Actions).
+- `concurrency: deploy-recette` : un seul déploiement à la fois.
+- `environment: recette` : permet d'ajouter des règles de protection (Settings →
+  Environments) et de scoper des secrets si besoin.
+
+## 2. Installation du runner self-hosted (une seule fois, sur le VPS)
+
+Dans GitHub : *Settings → Actions → Runners → New self-hosted runner* (Linux x64) —
+suivre les commandes fournies, **en ajoutant le label `recette`** et en installant
+le service sous l'utilisateur applicatif :
+
+```bash
+# En tant qu'utilisateur `diabeo` (celui qui possède /opt/diabeo)
+sudo -u diabeo -i
+mkdir -p ~/actions-runner && cd ~/actions-runner
+# … télécharger le runner (commandes exactes données par GitHub) …
+./config.sh --url https://github.com/freecompub/Diabeo-BackOffice \
+            --token <TOKEN_FOURNI_PAR_GITHUB> \
+            --labels recette \
+            --name vps-recette --unattended
+exit
+
+# Installer en service systemd (démarre au boot, redémarre en cas de crash)
+cd /home/diabeo/actions-runner
+sudo ./svc.sh install diabeo
+sudo ./svc.sh start
+```
+
+> Le job tourne donc **sous l'utilisateur `diabeo`**, dans le contexte du VPS — il
+> peut lancer `/opt/diabeo/deploy.sh` directement.
+
+## 3. Autorisation sudo requise
+
+`deploy.sh update` redémarre le service via `sudo systemctl restart`. Le runner
+(user `diabeo`) doit pouvoir le faire **sans mot de passe** — règle sudoers ciblée
+(principe du moindre privilège, PAS de `NOPASSWD: ALL`) :
+
+```bash
+# /etc/sudoers.d/diabeo-deploy  (via `sudo visudo -f /etc/sudoers.d/diabeo-deploy`)
+diabeo ALL=(root) NOPASSWD: /usr/bin/systemctl restart diabeo-recette
+```
+
+## 4. Prérequis côté VPS
+
+- `/opt/diabeo` **déjà bootstrappé** (clone + `/etc/diabeo/recette.env` + service
+  systemd `diabeo-recette`) — cf. `docs/runbook/vps-setup.md` §7/§12. Le workflow
+  échoue proprement si `/opt/diabeo/deploy.sh` est absent.
+- Node 22 + pnpm 10 disponibles pour l'utilisateur `diabeo`.
+- Le runner a accès réseau à la DB (migrations) et au registre npm (install/build).
+
+## 5. Environment GitHub `recette` (optionnel mais recommandé)
+
+*Settings → Environments → New environment → `recette`*. Permet, si voulu :
+- des **secrets** scopés recette,
+- une **règle de protection** (ex. limiter aux branches `main`),
+- un **historique de déploiements** visible dans l'onglet Environments.
+
+## 6. Exploitation
+
+- **Déclenchement normal** : automatique après chaque merge sur `main` (CI verte).
+- **Rejouer un déploiement** : onglet *Actions → Deploy recette → Run workflow*
+  (`workflow_dispatch`).
+- **Logs** : onglet Actions (+ `journalctl -u diabeo-recette` sur le VPS).
+- **Rollback** : la recette est jetable → `git revert` + re-run, ou
+  `prisma migrate reset --force` (cf. `docs/runbook/release-glycemie-gl.md §5`).
+
+## 7. Sécurité (rappels HDS)
+
+- **Aucune clé SSH exposée** (runner local au VPS) ni secret d'infra dans le repo.
+- Le runner tourne en utilisateur **non-root** applicatif ; sudo **ciblé** au seul
+  `systemctl restart`.
+- Les **migrations** sont appliquées par `migrate deploy` (idempotent) ; en recette
+  jetable, une migration destructive est sans enjeu. ⚠️ **Ne PAS réutiliser ce
+  modèle auto pour la PROD** : y prévoir approbation manuelle (Environment protégé
+  + reviewers) + backup + pré-vol avant toute migration destructive.
+- Runner self-hosted : ne l'exposer **qu'à un repo de confiance** (pas de fork PR
+  exécutant du code arbitraire — ici le trigger est `workflow_run`/`dispatch` sur
+  `main`, jamais un `pull_request` de fork).

--- a/docs/runbook/cd-recette.md
+++ b/docs/runbook/cd-recette.md
@@ -22,6 +22,27 @@ merge sur main  →  workflow "CI" (tests)  ──verte──▶  workflow "Depl
 
 ## 2. Installation du runner self-hosted (une seule fois, sur le VPS)
 
+> ### 🔑 Quel token ? — **Registration token, PAS un PAT**
+>
+> Cette architecture **ne nécessite AUCUN Personal Access Token (PAT)**. Le
+> `<TOKEN_FOURNI_PAR_GITHUB>` de la commande `config.sh` ci-dessous est un
+> **registration token** :
+> - il est **affiché tout prêt** par GitHub dans *Settings → Actions → Runners →
+>   New self-hosted runner* (page de création du runner) ;
+> - **aucune permission à choisir** — il ne sert qu'à enregistrer le runner ;
+> - il est **jetable** (expire en ~1 h ; il en faut un nouveau à chaque
+>   ré-enregistrement).
+>
+> Le reste du CD fonctionne **sans secret longue-durée** : le workflow utilise le
+> `GITHUB_TOKEN` auto-injecté (`permissions: contents: read`), et le `deploy.sh`
+> tire le code via la **Deploy Key SSH** déjà posée (`vps-setup.md §7.a`).
+>
+> **Si (et seulement si)** tu veux scripter l'enregistrement/rotation du runner via
+> l'API GitHub, un fine-grained PAT **scopé au seul repo `Diabeo-BackOffice`** avec
+> **Repository permissions → Administration : Read and write** (et *rien* d'autre)
+> suffit. Sinon, reste sur le registration token de l'UI — c'est le sens du choix
+> « runner self-hosted » : pas de PAT à gérer.
+
 Dans GitHub : *Settings → Actions → Runners → New self-hosted runner* (Linux x64) —
 suivre les commandes fournies, **en ajoutant le label `recette`** et en installant
 le service sous l'utilisateur applicatif :


### PR DESCRIPTION
## Déploiement continu recette via GitHub Actions

Oui, c'est possible — voici l'implémentation demandée : **recette auto uniquement**, via **runner self-hosted** (aucune clé SSH exposée).

### Contenu
- **`.github/workflows/deploy-recette.yml`** — sur la fin du workflow `CI` (branche `main`) **réussie** (`workflow_run` + `conclusion == success`) ou un `workflow_dispatch` manuel → exécute `/opt/diabeo/deploy.sh update` sur un runner **self-hosted** labellisé `recette` (installé sur le VPS). `concurrency` (1 deploy à la fois) + `environment: recette`.
- **`docs/runbook/cd-recette.md`** — installation du runner (label `recette`, user `diabeo`), sudoers **ciblé** (`systemctl restart` uniquement), prérequis VPS, exploitation, rappels sécurité HDS.

### Fonctionnement
```
merge main → CI (tests) ──verte──▶ Deploy recette → runner VPS → deploy.sh update
```

### ⚠️ À configurer par l'opérateur (hors repo, je ne peux pas)
- Enregistrer le **runner self-hosted** sur le VPS avec le label `recette` (procédure dans le runbook).
- Créer l'**Environment GitHub `recette`** (Settings → Environments).
- Règle **sudoers** `NOPASSWD` ciblée sur `systemctl restart diabeo-recette`.
- Le VPS doit être **bootstrappé** (`/opt/diabeo` + `deploy.sh`) — cf. `vps-setup.md`.

### Sécurité
- Runner **local au VPS** (pas de SSH exposé), user **non-root**, sudo **ciblé**.
- Trigger sur `workflow_run`/`dispatch` de `main` — **jamais** un `pull_request` de fork.
- **Ne pas réutiliser tel quel pour la PROD** : y prévoir approbation manuelle (Environment protégé + reviewers) + backup + pré-vol avant migration destructive.

Doc + workflow uniquement. YAML validé (`yaml.safe_load`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjfGsaWAwSb1RNFYkRfKt9