### PR TITLE
ops(supervision) — runbook supervision VPS + dead-man's-switch backup + alarmes netdata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ releases, so entries are grouped by merged PR and calendar date.
 
 ## [Unreleased]
 
+### Added
+
+- **Supervision VPS** (`docs/runbook/supervision.md`) — stack Tier 0 pour serveur
+  unique : moniteur uptime externe sur `/api/health`, **netdata** (métriques hôte +
+  alarmes) et **dead-man's-switch** de backup. Alarmes netdata versionnées dans
+  `ops/netdata/` (disque/inodes, connexions Postgres, collecteur `pg_monitor`
+  lecture seule). `deploy.sh backup` pinge Healthchecks.io via `BACKUP_PING_URL`
+  (start/succès/`fail`). Tier 1 prod (LDP, Sentry/GlitchTip scrubbé, fail2ban)
+  référencé. Pas de Prometheus/Grafana (surdimensionné pour un VPS unique).
+
 ### Changed
 
 - **Déploiement consolidé sur `deploy.sh` (racine, systemd)** — le legacy

--- a/deploy.sh
+++ b/deploy.sh
@@ -33,6 +33,10 @@ GIT_REF="${GIT_REF:-main}"
 S3_BUCKET_BACKUPS="${S3_BUCKET_BACKUPS:-diabeo-backups-${APP_ENV}}"
 HEALTH_URL="${HEALTH_URL:-http://localhost:3000/api/health}"
 HEALTH_TIMEOUT_SEC="${HEALTH_TIMEOUT_SEC:-30}"
+# Dead-man's-switch backup (optionnel) : URL de ping Healthchecks.io (ou compatible).
+# Vide = désactivé. Si renseignée : ping /start au début, base=succès, /fail à l'échec
+# → alerte si le backup n'a PAS tourné. Cf. docs/runbook/supervision.md.
+BACKUP_PING_URL="${BACKUP_PING_URL:-}"
 
 log()  { printf '\033[36m[deploy]\033[0m %s\n' "$*"; }
 warn() { printf '\033[33m[deploy][WARN]\033[0m %s\n' "$*" >&2; }
@@ -133,8 +137,25 @@ cmd_migrate() {
   pnpm prisma migrate status
 }
 
+# Ping du dead-man's-switch. $1 = suffixe (start|fail|"" pour succès). No-op si
+# BACKUP_PING_URL vide ou curl absent ; jamais fatal (ne casse pas le backup).
+ping_backup() {
+  [ -n "$BACKUP_PING_URL" ] || return 0
+  command -v curl >/dev/null || return 0
+  curl -fsS -m 10 -o /dev/null "${BACKUP_PING_URL}${1:+/$1}" || true
+}
+
+# Trap EXIT (posé par cmd_backup) : pinge succès si BACKUP_DONE=1, sinon /fail.
+# Fire aussi bien sur `fail` (exit 1) que sur fin normale → alerte fiable.
+on_backup_exit() {
+  if [ "${BACKUP_DONE:-0}" = 1 ]; then ping_backup; else ping_backup fail; fi
+}
+
 cmd_backup() {
   load_env
+  BACKUP_DONE=0
+  ping_backup start
+  trap on_backup_exit EXIT
   local ts stamp dump
   ts="$(date -u +%Y/%m/%d)"; stamp="$(date -u +%H%M%S)"
   dump="/tmp/diabeo-${APP_ENV}-${stamp}.sql.gz"
@@ -144,10 +165,11 @@ cmd_backup() {
   if command -v aws >/dev/null; then
     log "Upload s3://${S3_BUCKET_BACKUPS}/${ts}/"
     aws --endpoint-url "${OVH_S3_ENDPOINT:?}" s3 cp "$dump" \
-      "s3://${S3_BUCKET_BACKUPS}/${ts}/diabeo-backup-${stamp}.sql.gz"
+      "s3://${S3_BUCKET_BACKUPS}/${ts}/diabeo-backup-${stamp}.sql.gz" || fail "upload S3 a échoué"
   else
     log "aws-cli absent — dump laissé sur $dump (uploader manuellement)."
   fi
+  BACKUP_DONE=1            # succès → le trap EXIT pinge le succès
   log "✅ Backup OK."
 }
 

--- a/docs/runbook/supervision.md
+++ b/docs/runbook/supervision.md
@@ -1,0 +1,152 @@
+# Runbook — Supervision du VPS Diabeo
+
+> Quoi installer sur le VPS (recette/prod) pour **savoir que ça tourne** et **être
+> alerté avant l'incident**. Pensé pour un **VPS unique** (app Node/systemd +
+> PostgreSQL + nginx ; Redis Upstash & Object Storage OVH **managés**). Complète la
+> section *Monitoring* de [`docs/operations/runbook.md`](../operations/runbook.md)
+> (sémantique `/api/health`, logs, audit) et le §9 backups de
+> [`vps-setup.md`](./vps-setup.md).
+
+## Principe
+
+Trois questions, trois outils. On installe le **strict nécessaire** — pas de stack
+Prometheus/Grafana/Loki (surdimensionnée pour un serveur unique).
+
+| Question | Outil | Portée |
+|---|---|---|
+| L'app répond-elle ? | **Moniteur uptime externe** sur `/api/health` | Tier 0 |
+| Le VPS va-t-il tomber ? (disque/RAM/CPU/Postgres) | **netdata** (local, alarmes) | Tier 0 |
+| Le backup a-t-il tourné ? | **Dead-man's-switch** (Healthchecks.io) | Tier 0 |
+| Trail HDS / erreurs app / brute-force | LDP, Sentry/GlitchTip, fail2ban | Tier 1 (prod) |
+
+---
+
+## Tier 0 — indispensable (à faire d'abord)
+
+### 1. Moniteur uptime externe (`/api/health`)
+
+**Pourquoi externe** : un check lancé **depuis le VPS** ne détecte pas un VPS
+totalement down. Un moniteur externe teste **DNS + TLS + nginx + app** d'un coup.
+
+- Service : UptimeRobot / BetterStack / Healthchecks (n'importe quel free tier).
+- URL à surveiller : `https://staging.diabeo.fr/api/health` (prod :
+  `https://app.diabeo.fr/api/health`).
+- Intervalle : 60 s. Alerte sur : non-`200` **3 fois de suite**, et **expiration TLS**
+  proche (la plupart des moniteurs le font nativement — filet en plus de certbot).
+- Sémantique de la réponse (cf. `operations/runbook.md` §Monitoring) :
+  `200 ok` · `503 degraded` (Redis down, app debout) · `503 down` (DB down).
+
+> Rien à installer sur le VPS pour ce point — c'est un service tiers qui **appelle**
+> l'endpoint public.
+
+### 2. netdata — métriques hôte + alarmes
+
+**Pourquoi** : sur un VPS unique, le risque n°1 est le **disque plein** (Postgres +
+dumps `/tmp` + logs) puis l'**OOM**. netdata = binaire unique, per-seconde, alarmes
+intégrées, empreinte faible.
+
+```bash
+# Install (paquet officiel netdata, dépôt géré par le script kickstart)
+wget -qO /tmp/netdata-kickstart.sh https://get.netdata.cloud/kickstart.sh
+sh /tmp/netdata-kickstart.sh --stable-channel --disable-telemetry
+# → écoute en local sur 127.0.0.1:19999
+```
+
+> ⚠️ **Ne PAS exposer `:19999` publiquement.** Le dashboard netdata n'a pas d'auth.
+> Y accéder via **tunnel SSH** (`ssh -L 19999:127.0.0.1:19999 diabeo-vps`) ou le
+> mettre derrière nginx + Basic Auth. Vérifier qu'il n'écoute que sur loopback :
+> `ss -ltnp | grep 19999`.
+
+**Alarmes Diabeo** (modèles versionnés dans `ops/netdata/`) :
+
+```bash
+sudo cp ops/netdata/health.d/diabeo-disk.conf     /etc/netdata/health.d/
+sudo cp ops/netdata/health.d/diabeo-postgres.conf /etc/netdata/health.d/
+sudo netdatacli reload-health
+```
+- `diabeo-disk.conf` — WARN 80 % / CRIT 90 % sur l'espace **et** les inodes de `/`.
+- `diabeo-postgres.conf` — saturation du pool de connexions (WARN 75 % / CRIT 90 %).
+- OOM / RAM dispo / charge CPU / swap : **alarmes natives** netdata (rien à ajouter).
+
+**Collecteur PostgreSQL** (si Postgres est **sur le VPS**) :
+```bash
+# Rôle de monitoring LECTURE SEULE (jamais le rôle applicatif diabeo)
+sudo -u postgres psql -c "CREATE ROLE netdata LOGIN PASSWORD '<PWD_NETDATA>';"
+sudo -u postgres psql -c "GRANT pg_monitor TO netdata;"
+sudo cp ops/netdata/go.d/postgres.conf /etc/netdata/go.d/postgres.conf
+sudo sed -i 's/<PWD_NETDATA>/<le_mot_de_passe_réel>/' /etc/netdata/go.d/postgres.conf
+sudo systemctl restart netdata
+```
+> Postgres en **DBaaS OVH** : sauter ce collecteur (métriques dans la console OVH).
+
+**Notifications** (email/Slack/Discord) — sinon les alarmes restent dans le dashboard :
+```bash
+sudo "$(dirname "$(command -v netdata)")/../libexec/netdata/plugins.d/health_alarm_notify.sh" test 2>/dev/null || true
+sudo nano /etc/netdata/health_alarm_notify.conf   # renseigner p.ex. DISCORD_WEBHOOK_URL / SLACK_WEBHOOK_URL / EMAIL
+# rôle "sysadmin" (utilisé par les alarmes Diabeo) → destinataire par défaut
+sudo systemctl restart netdata
+```
+
+### 3. Dead-man's-switch backup (Healthchecks.io)
+
+**Pourquoi** : un backup **silencieusement cassé** est pire que pas de backup. Le
+dead-man's-switch alerte quand le ping **n'arrive pas** à l'heure prévue.
+
+Câblé dans `deploy.sh backup` (variable `BACKUP_PING_URL`, cf. §9 `vps-setup.md`) :
+il pinge `/start` au début, l'URL de base au **succès**, `/fail` en **échec**.
+
+```bash
+# 1. Créer un check sur https://healthchecks.io (schedule : daily, grâce 1h)
+#    → récupérer l'URL de ping : https://hc-ping.com/<uuid>
+
+# 2. L'ajouter à l'env du service de backup (NON committé)
+echo 'BACKUP_PING_URL=https://hc-ping.com/<uuid>' | sudo tee -a /etc/diabeo/recette.env >/dev/null
+# (ou dans une Environment= du service systemd de backup)
+
+# 3. Tester une exécution manuelle
+sudo -u diabeo bash -lc 'set -a; . /etc/diabeo/recette.env; set +a; cd /opt/diabeo; ./deploy.sh backup'
+#    → le check passe "up" sur healthchecks.io ; si pg_dump/S3 échoue → "down" (alerte)
+```
+
+> Le timer systemd `diabeo-backup` (§9 `vps-setup.md`) déclenche ce même
+> `deploy.sh backup` à 02:00 : le ping part automatiquement à chaque exécution.
+
+---
+
+## Tier 1 — prod / conformité HDS
+
+À activer avant la mise en production (inutile de tout monter en recette).
+
+- **Trail d'actions opérateur (HDS §IV.3, rétention 5 ans)** — forwarding
+  `rsyslog → OVH LDP` : procédure complète dans
+  [`operations/runbook.md`](../operations/runbook.md) §« Centralized log forwarding ».
+  C'est l'exigence **réglementaire** ; c'est le vrai « must » du Tier 1.
+- **Erreurs applicatives** — Sentry (SaaS) ou **GlitchTip** (self-host).
+  ⚠️ **PII/santé** : scrubbing strict obligatoire (aucune glycémie/identité dans la
+  stack d'erreurs). En cas de doute réglementaire → GlitchTip self-hosted (données
+  gardées chez nous). Cf. [`.claude`/team] `healthcare-security-auditor` avant activation.
+- **Brute-force / durcissement** — `fail2ban` (jails `sshd` + nginx). SSH est déjà
+  key-only ; fail2ban ajoute la protection sur l'auth applicative et nginx.
+- **PostgreSQL managé (DBaaS)** — activer les query logs OVH
+  (`logsLevel=queries`) → LDP (cf. `operations/runbook.md` §« DB-level audit »).
+
+---
+
+## Ce qu'on n'installe **pas** (et pourquoi)
+
+- **Prometheus + Grafana + Loki + Alertmanager** : conçu pour un parc/cluster.
+  Sur un VPS unique, coût d'exploitation > valeur — netdata couvre le même besoin.
+- **Agent de supervision pour Redis / Object Storage** : services **managés**
+  (Upstash / OVH) → supervision et alertes dans leurs consoles respectives
+  (ex. Upstash : alerte eval-error-rate, cf. `operations/runbook.md`).
+
+---
+
+## Checklist de mise en place (Tier 0)
+
+- [ ] Moniteur uptime externe sur `/api/health` (alerte non-200 ×3 + expiration TLS).
+- [ ] netdata installé, **loopback only** (`ss -ltnp | grep 19999` = 127.0.0.1).
+- [ ] Alarmes `diabeo-disk.conf` (+ `diabeo-postgres.conf` si Postgres local) chargées.
+- [ ] Notifications netdata configurées (rôle `sysadmin` → Slack/Discord/email).
+- [ ] `BACKUP_PING_URL` renseignée + un `deploy.sh backup` manuel fait passer le check.
+- [ ] (prod) LDP forwarding, Sentry/GlitchTip avec scrubbing, fail2ban.

--- a/docs/runbook/vps-setup.md
+++ b/docs/runbook/vps-setup.md
@@ -437,6 +437,9 @@ Type=oneshot
 User=diabeo
 WorkingDirectory=/opt/diabeo
 Environment=APP_ENV=recette
+# Dead-man's-switch (optionnel) : ping Healthchecks.io → alerte si le backup n'a
+# PAS tourné. Cf. docs/runbook/supervision.md. (ou mettre BACKUP_PING_URL dans l'env-file)
+# Environment=BACKUP_PING_URL=https://hc-ping.com/<uuid>
 ExecStart=/opt/diabeo/deploy.sh backup
 ```
 ```ini
@@ -456,6 +459,9 @@ sudo systemctl enable --now diabeo-backup.timer
 > `.pgpass` 0600, chiffrement client `age`, Object Lock, lifecycle Glacier, **drill de
 > restauration trimestriel** + `decrypt-smoke`) est décrite dans
 > **[`docs/operations/runbook.md`](../operations/runbook.md)** §Backups / §Manual setup.
+>
+> **Supervision** (uptime `/api/health`, netdata disque/RAM/Postgres,
+> dead-man's-switch backup) : voir **[`docs/runbook/supervision.md`](./supervision.md)**.
 
 ## 10. Vérification finale
 

--- a/ops/netdata/go.d/postgres.conf
+++ b/ops/netdata/go.d/postgres.conf
@@ -1,0 +1,22 @@
+# ═══════════════════════════════════════════════════════════════════════════
+# netdata — collecteur PostgreSQL (go.d)
+# Copier sur le VPS dans /etc/netdata/go.d/postgres.conf puis
+# `sudo systemctl restart netdata`. Cf. docs/runbook/supervision.md.
+#
+# ⚠️ Utiliser un rôle de monitoring EN LECTURE SEULE, PAS le rôle applicatif
+# `diabeo` (moindre privilège). Créer une fois, en superuser :
+#   CREATE ROLE netdata LOGIN PASSWORD '<mot_de_passe_fort>';
+#   GRANT pg_monitor TO netdata;   -- vues de stats sans accès aux données
+#
+# ⚠️ NE PAS committer le vrai mot de passe : ce fichier est un MODÈLE de référence.
+# Sur le VPS, remplacer <PWD_NETDATA> par le secret réel (fichier lisible par
+# l'utilisateur netdata uniquement).
+#
+# DSN sans `?schema=` (paramètre Prisma, non-libpq — inutile ici).
+# ═══════════════════════════════════════════════════════════════════════════
+
+jobs:
+  - name: diabeo
+    dsn: 'postgres://netdata:<PWD_NETDATA>@127.0.0.1:5432/diabeo?sslmode=disable'
+    timeout: 2
+    collect_databases_matching: 'diabeo'

--- a/ops/netdata/health.d/diabeo-disk.conf
+++ b/ops/netdata/health.d/diabeo-disk.conf
@@ -1,0 +1,32 @@
+# ═══════════════════════════════════════════════════════════════════════════
+# netdata — alarme DISQUE PLEIN (risque n°1 sur ce VPS : Postgres + dumps + logs)
+# Copier sur le VPS dans /etc/netdata/health.d/ puis `sudo netdatacli reload-health`.
+# Cf. docs/runbook/supervision.md.
+#
+# Ajuste `on` au point de montage qui porte /var/lib/postgresql et /tmp (souvent
+# `/`). netdata fournit déjà des alarmes disque génériques ; celle-ci est resserrée
+# pour prévenir AVANT saturation (un disque plein = Postgres en écriture refusée +
+# backups qui échouent).
+# ═══════════════════════════════════════════════════════════════════════════
+
+ template: diabeo_disk_space_usage
+       on: disk_space./
+    calc: $used * 100 / ($avail + $used)
+    units: %
+    every: 60s
+     warn: $this > 80
+     crit: $this > 90
+    delay: up 2m down 5m multiplier 1.5 max 1h
+     info: Espace disque de la partition racine (Postgres/dumps/logs)
+       to: sysadmin
+
+ template: diabeo_disk_inodes_usage
+       on: disk_inodes./
+    calc: $used * 100 / ($avail + $used)
+    units: %
+    every: 60s
+     warn: $this > 80
+     crit: $this > 90
+    delay: up 2m down 5m
+     info: Inodes de la partition racine (beaucoup de petits fichiers = WAL/logs)
+       to: sysadmin

--- a/ops/netdata/health.d/diabeo-postgres.conf
+++ b/ops/netdata/health.d/diabeo-postgres.conf
@@ -1,0 +1,20 @@
+# ═══════════════════════════════════════════════════════════════════════════
+# netdata — alarme SATURATION CONNEXIONS PostgreSQL
+# Requiert le collecteur postgres activé (voir ops/netdata/go.d/postgres.conf).
+# Copier dans /etc/netdata/health.d/ puis `sudo netdatacli reload-health`.
+# Cf. docs/runbook/supervision.md.
+#
+# Prisma + adapter-pg ouvre un pool ; une fuite de connexions ou un pic de charge
+# peut approcher `max_connections` → nouvelles connexions refusées (app en 503).
+# ═══════════════════════════════════════════════════════════════════════════
+
+ template: diabeo_postgres_connections
+       on: postgres.connections_utilization
+    calc: $used
+    units: %
+    every: 30s
+     warn: $this > 75
+     crit: $this > 90
+    delay: up 1m down 5m
+     info: Utilisation du pool de connexions PostgreSQL (vs max_connections)
+       to: sysadmin


### PR DESCRIPTION
Réponse à « quels outils de supervision installer sur le VPS » — **3 livrables, 1 PR**.

## 1. `docs/runbook/supervision.md`
Stack **opinionnée** pour un **VPS unique** (app systemd + Postgres + nginx ; Redis/Object Storage **managés**), par ordre de valeur :

**Tier 0 (indispensable)**
- **Moniteur uptime externe** sur `/api/health` (teste DNS+TLS+nginx+app, détecte un VPS totalement down).
- **netdata** (métriques hôte + alarmes ; risque n°1 = disque plein). Loopback-only + notif Slack/Discord/email.
- **Dead-man's-switch** de backup (alerte si le backup n'a PAS tourné).

**Tier 1 (prod/HDS)** : LDP (trail opérateur 5 ans), Sentry/GlitchTip **avec scrubbing PII**, fail2ban.

**Explicitement écarté** : Prometheus/Grafana/Loki (surdimensionné pour 1 VPS) ; Redis/S3 supervisés côté consoles managées.

## 2. Dead-man's-switch dans `deploy.sh backup`
Variable `BACKUP_PING_URL` (Healthchecks.io) : ping `/start` au début, base=**succès**, `/fail` à l'échec — via un **trap EXIT** qui fire aussi bien sur `fail` (exit 1) que sur fin normale. No-op si non renseignée (jamais fatal). Câblage documenté au §9 de `vps-setup.md`.

## 3. Alarmes netdata versionnées (`ops/netdata/`)
Modèles de référence à copier sur le VPS :
- `health.d/diabeo-disk.conf` — espace **et** inodes de `/` (WARN 80 / CRIT 90).
- `health.d/diabeo-postgres.conf` — saturation pool connexions.
- `go.d/postgres.conf` — collecteur via rôle **`pg_monitor` lecture seule** (jamais le rôle applicatif ; mot de passe en **placeholder**, non committé).

## Sécurité
- Rôle monitoring Postgres **lecture seule** distinct de `diabeo`.
- netdata **loopback-only** (dashboard sans auth → jamais exposé).
- Aucun secret committé (placeholders `<PWD_NETDATA>`, `<uuid>`).
- Rappel scrubbing PII avant toute stack d'erreurs tierce (contexte santé/HDS).

## Vérifs
- `bash -n deploy.sh` OK.
- Fences Markdown équilibrés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)